### PR TITLE
perf: speed up dromaeo cube hot path

### DIFF
--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
@@ -174,7 +174,8 @@ internal sealed partial class LIRToILCompiler
                                 ilEncoder,
                                 allocation,
                                 methodDescriptor,
-                                callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {callableId.DisplayName}."));
+                                callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {callableId.DisplayName}."),
+                                stackifyResult);
                         }
                         else
                         {
@@ -230,20 +231,11 @@ internal sealed partial class LIRToILCompiler
                             ilEncoder,
                             allocation,
                             methodDescriptor,
-                            callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {callableId.DisplayName}."));
+                            callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {callableId.DisplayName}."),
+                            stackifyResult);
                     }
-                    else
+                    else if (requiresScopes)
                     {
-                        ilEncoder.OpCode(ILOpCode.Ldnull);
-                    }
-                    ilEncoder.OpCode(ILOpCode.Ldftn);
-                    ilEncoder.Token(methodHandle);
-                    ilEncoder.OpCode(ILOpCode.Newobj);
-                    ilEncoder.Token(_bclReferences.GetFuncCtorRef(jsParamCount, delegateRequiresScopeArray));
-
-                    if (delegateRequiresScopeArray)
-                    {
-                        // Load scopes array only when required by callee ABI.
                         EmitLoadTemp(callFunc.ScopesArray, ilEncoder, allocation, methodDescriptor);
                     }
 
@@ -253,7 +245,10 @@ internal sealed partial class LIRToILCompiler
                     // Load all arguments
                     for (int i = 0; i < argsToPass; i++)
                     {
-                        EmitLoadTemp(callFunc.Arguments[i], ilEncoder, allocation, methodDescriptor);
+                        var parameterClrType = callableSignature?.ParameterClrTypes != null && i < callableSignature.ParameterClrTypes.Count
+                            ? callableSignature.ParameterClrTypes[i]
+                            : null;
+                        EmitLoadTempAsParameterType(callFunc.Arguments[i], parameterClrType, ilEncoder, allocation, methodDescriptor);
                     }
 
                     // Pad missing parameters with null (supports default parameter initialization).
@@ -262,9 +257,8 @@ internal sealed partial class LIRToILCompiler
                         ilEncoder.OpCode(ILOpCode.Ldnull);
                     }
 
-                    // Invoke: callvirt Func<object[], [object, ...], object>::Invoke
-                    ilEncoder.OpCode(ILOpCode.Callvirt);
-                    ilEncoder.Token(_bclReferences.GetFuncInvokeRef(jsParamCount, delegateRequiresScopeArray));
+                    ilEncoder.OpCode(ILOpCode.Call);
+                    ilEncoder.Token(methodHandle);
 
                     if (IsMaterialized(callFunc.Result, allocation))
                     {
@@ -309,7 +303,8 @@ internal sealed partial class LIRToILCompiler
                             ilEncoder,
                             allocation,
                             methodDescriptor,
-                            callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {tailCall.CallableId.DisplayName}."));
+                            callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {tailCall.CallableId.DisplayName}."),
+                            stackifyResult);
                     }
                     else
                     {
@@ -380,7 +375,8 @@ internal sealed partial class LIRToILCompiler
                             ilEncoder,
                             allocation,
                             methodDescriptor,
-                            callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {callableId.DisplayName}."));
+                            callableSignature ?? throw new InvalidOperationException($"Missing SingleScope signature metadata for callable {callableId.DisplayName}."),
+                            stackifyResult);
                     }
                     else
                     {

--- a/src/Compiler/IL/LIRToILCompiler.cs
+++ b/src/Compiler/IL/LIRToILCompiler.cs
@@ -171,7 +171,8 @@ internal sealed partial class LIRToILCompiler
         InstructionEncoder ilEncoder,
         TempLocalAllocation allocation,
         MethodDescriptor methodDescriptor,
-        CallableSignature signature)
+        CallableSignature signature,
+        StackifyResult? stackifyResult = null)
     {
         if (signature.ScopeAbiKind != Jroc.Runtime.CallableScopeAbiKind.SingleScope)
         {
@@ -183,11 +184,45 @@ internal sealed partial class LIRToILCompiler
             throw new InvalidOperationException("SingleScope callable signature is missing its scope type identity.");
         }
 
+        if (TryEmitSingleScopeProducerDirect(scopesArray, ilEncoder, allocation, methodDescriptor, signature, stackifyResult))
+        {
+            return;
+        }
+
         EmitLoadTemp(scopesArray, ilEncoder, allocation, methodDescriptor);
         ilEncoder.LoadConstantI4(0);
         ilEncoder.OpCode(ILOpCode.Ldelem_ref);
         ilEncoder.OpCode(ILOpCode.Castclass);
         ilEncoder.Token(_scopeMetadataRegistry.GetScopeTypeHandle(signature.SingleScopeScopeName));
+    }
+
+    private bool TryEmitSingleScopeProducerDirect(
+        TempVariable scopesArray,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation,
+        MethodDescriptor methodDescriptor,
+        CallableSignature signature,
+        StackifyResult? stackifyResult)
+    {
+        if (stackifyResult is not { } result || !result.IsStackable(scopesArray))
+        {
+            return false;
+        }
+
+        foreach (var instruction in MethodBody.Instructions)
+        {
+            if (instruction is LIRBuildScopesArray buildScopes
+                && buildScopes.Result.Equals(scopesArray)
+                && buildScopes.Slots.Count == 1)
+            {
+                EmitLoadScopeInstance(ilEncoder, buildScopes.Slots[0], methodDescriptor, allocation);
+                ilEncoder.OpCode(ILOpCode.Castclass);
+                ilEncoder.Token(_scopeMetadataRegistry.GetScopeTypeHandle(signature.SingleScopeScopeName!));
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private Type GetDeclaredScopeFieldClrType(string scopeName, string fieldName)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -498,6 +498,31 @@ public sealed partial class HIRToLIRLowerer
                 }
             }
 
+            if (!hasSpreadArgs
+                && TryCreateCallableIdForConstInitializedArrow(symbol, out var constArrowCallableId, out var constArrowScope))
+            {
+                var constArrowArguments = new List<TempVariable>(callExpr.Arguments.Length);
+                foreach (var arg in callExpr.Arguments)
+                {
+                    if (!TryLowerExpression(arg, out var argTemp))
+                    {
+                        return false;
+                    }
+                    constArrowArguments.Add(EnsureObject(argTemp));
+                }
+
+                var constArrowScopesTemp = CreateTempVariable();
+                if (!TryBuildScopesArrayForClosureBinding(constArrowScope, constArrowScopesTemp))
+                {
+                    return false;
+                }
+                DefineTempStorage(constArrowScopesTemp, new ValueStorage(ValueStorageKind.Reference, typeof(object[])));
+
+                _methodBodyIR.Instructions.Add(new LIRCallFunction(symbol, constArrowScopesTemp, constArrowArguments, resultTempVar, constArrowCallableId));
+                DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+                return true;
+            }
+
             // If the callee is not a direct function binding (e.g., it's a local/const holding a closure),
             // invoke via runtime dispatch (Closure.InvokeWithArgs).
             if (symbol.Kind != BindingKind.Function)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -1271,6 +1271,80 @@ public sealed partial class HIRToLIRLowerer
         }
     }
 
+    private bool TryCreateCallableIdForConstInitializedArrow(
+        Symbol symbol,
+        out TwoPhase.CallableId callableId,
+        out Scope bodyScope)
+    {
+        callableId = null!;
+        bodyScope = null!;
+
+        if (_scope == null
+            || symbol.BindingInfo.Kind != BindingKind.Const
+            || symbol.BindingInfo.RequiresRuntimeTemporalDeadZoneChecks
+            || symbol.BindingInfo.DeclarationNode is not VariableDeclarator { Init: ArrowFunctionExpression arrowExpr })
+        {
+            return false;
+        }
+
+        if (ArrowRequiresRuntimeClosureInvocation(arrowExpr))
+        {
+            return false;
+        }
+
+        var root = _scope;
+        while (root.Parent != null)
+        {
+            root = root.Parent;
+        }
+
+        var arrowScope = FindScopeByDeclarationNode(arrowExpr, root);
+        if (arrowScope == null || arrowScope.Parent == null)
+        {
+            return false;
+        }
+
+        var declaringScope = arrowScope.Parent;
+        var moduleName = root.Name;
+        var declaringScopeName = declaringScope.Kind == ScopeKind.Global
+            ? moduleName
+            : $"{moduleName}/{declaringScope.GetQualifiedName()}";
+
+        bodyScope = arrowScope;
+        callableId = new TwoPhase.CallableId
+        {
+            Kind = TwoPhase.CallableKind.Arrow,
+            DeclaringScopeName = declaringScopeName,
+            Name = null,
+            Location = TwoPhase.SourceLocation.FromNode(arrowExpr),
+            JsParamCount = CountNonRestParameters(arrowExpr.Params),
+            NeedsArgumentsObject = false,
+            HasRestParameters = arrowScope.HasRestParameters,
+            UsesMappedArgumentsObject = false,
+            ArgumentsParameterNames = Array.Empty<string>(),
+            IncludeCalleeInArgumentsObject = false,
+            HasRestrictedFunctionProperties = true,
+            AstNode = arrowExpr
+        };
+        return true;
+    }
+
+    private static bool ArrowRequiresRuntimeClosureInvocation(ArrowFunctionExpression arrowExpr)
+    {
+        var requiresRuntimeClosure = false;
+        var walker = new AstWalker();
+        walker.Visit(arrowExpr.Body, node =>
+        {
+            if (node is ThisExpression
+                || node is MetaProperty
+                || node is Identifier { Name: "arguments" })
+            {
+                requiresRuntimeClosure = true;
+            }
+        });
+        return requiresRuntimeClosure;
+    }
+
     private Scope? FindDeclaringScope(BindingInfo binding)
     {
         if (binding.DeclaringScope != null)

--- a/src/JavaScriptRuntime/Closure.cs
+++ b/src/JavaScriptRuntime/Closure.cs
@@ -686,16 +686,19 @@ namespace JavaScriptRuntime
             return InvokeWithArgsCore(target, scopes, newTarget, args);
         }
 
-        private static object InvokeAsFunctionCall(object target, Func<object> invoke)
+        private static object? ResolveFunctionCallThis(object target)
         {
-            object? thisValue = target is Delegate del && UsesEcmaScriptThisBinding(del)
+            return target is Delegate del && UsesEcmaScriptThisBinding(del)
                 ? GlobalThis.globalThis
                 : null;
+        }
 
-            var previousThis = RuntimeServices.SetCurrentThis(thisValue);
+        public static object InvokeFunctionCallWithArgs(object target, object[] scopes, params object?[] args)
+        {
+            var previousThis = RuntimeServices.SetCurrentThis(ResolveFunctionCallThis(target));
             try
             {
-                return invoke();
+                return InvokeWithArgsCore(target, scopes, newTarget: null, args);
             }
             finally
             {
@@ -703,29 +706,56 @@ namespace JavaScriptRuntime
             }
         }
 
-        public static object InvokeFunctionCallWithArgs(object target, object[] scopes, params object?[] args)
-        {
-            return InvokeAsFunctionCall(target, () => InvokeWithArgsCore(target, scopes, newTarget: null, args));
-        }
-
         public static object InvokeFunctionCallWithArgs0(object target, object[] scopes)
         {
-            return InvokeAsFunctionCall(target, () => InvokeWithArgs0(target, scopes));
+            var previousThis = RuntimeServices.SetCurrentThis(ResolveFunctionCallThis(target));
+            try
+            {
+                return InvokeWithArgs0(target, scopes);
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
         }
 
         public static object InvokeFunctionCallWithArgs1(object target, object[] scopes, object? a0)
         {
-            return InvokeAsFunctionCall(target, () => InvokeWithArgs1(target, scopes, a0));
+            var previousThis = RuntimeServices.SetCurrentThis(ResolveFunctionCallThis(target));
+            try
+            {
+                return InvokeWithArgs1(target, scopes, a0);
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
         }
 
         public static object InvokeFunctionCallWithArgs2(object target, object[] scopes, object? a0, object? a1)
         {
-            return InvokeAsFunctionCall(target, () => InvokeWithArgs2(target, scopes, a0, a1));
+            var previousThis = RuntimeServices.SetCurrentThis(ResolveFunctionCallThis(target));
+            try
+            {
+                return InvokeWithArgs2(target, scopes, a0, a1);
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
         }
 
         public static object InvokeFunctionCallWithArgs3(object target, object[] scopes, object? a0, object? a1, object? a2)
         {
-            return InvokeAsFunctionCall(target, () => InvokeWithArgs3(target, scopes, a0, a1, a2));
+            var previousThis = RuntimeServices.SetCurrentThis(ResolveFunctionCallThis(target));
+            try
+            {
+                return InvokeWithArgs3(target, scopes, a0, a1, a2);
+            }
+            finally
+            {
+                RuntimeServices.SetCurrentThis(previousThis);
+            }
         }
 
         private static bool TryInvokeProxyCallFastPath(object target, object[] scopes, object?[] args, out object result)

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -645,6 +645,21 @@ namespace JavaScriptRuntime
 
             if (obj is Array array)
             {
+                if (!double.IsNaN(index)
+                    && !double.IsInfinity(index)
+                    && index % 1.0 == 0.0
+                    && index >= 0
+                    && index <= int.MaxValue
+                    && !PropertyDescriptorStore.HasAny(array))
+                {
+                    if (intIndex >= array.Count)
+                    {
+                        return null!; // undefined
+                    }
+
+                    return array[intIndex]!;
+                }
+
                 var propName = Object.ToPropertyKeyString(index);
                 if (PropertyDescriptorStore.TryGetOwn(array, propName, out _))
                 {
@@ -1093,7 +1108,6 @@ namespace JavaScriptRuntime
                 throw new JavaScriptRuntime.TypeError("Cannot set properties of null");
             }
 
-            var indexKey = DotNet2JSConversions.ToString(index);
             var isCanonicalArrayIndex = !double.IsNaN(index)
                 && !double.IsInfinity(index)
                 && index % 1.0 == 0.0
@@ -1112,11 +1126,19 @@ namespace JavaScriptRuntime
             {
                 if (!isCanonicalArrayIndex)
                 {
-                    return SetProperty(array, indexKey, value, throwOnError) ?? value;
+                    var nonCanonicalIndexKey = DotNet2JSConversions.ToString(index);
+                    return SetProperty(array, nonCanonicalIndexKey, value, throwOnError) ?? value;
                 }
 
+                if (!PropertyDescriptorStore.HasAny(array) && array.HasOwnIndex(intIndex))
+                {
+                    array[intIndex] = value;
+                    return value;
+                }
+
+                var canonicalIndexKey = DotNet2JSConversions.ToString(index);
                 if (!array.HasOwnIndex(intIndex)
-                    && JavaScriptRuntime.Object.TrySetPropertyViaPrototypeOrThrow(array, indexKey, value, throwOnError))
+                    && JavaScriptRuntime.Object.TrySetPropertyViaPrototypeOrThrow(array, canonicalIndexKey, value, throwOnError))
                 {
                     return value;
                 }

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -74,6 +74,14 @@ internal static class PropertyDescriptorStore
         return false;
     }
 
+    public static bool HasAny(object target)
+    {
+        if (target == null) throw new ArgumentNullException(nameof(target));
+
+        return _slots.TryGetValue(target, out var slot)
+            && slot.Descriptors.Count != 0;
+    }
+
     public static void DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor)
     {
         if (target == null) throw new ArgumentNullException(nameof(target));

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_Test262Bootstrap
+﻿// IL code: Compile_Scripts_Test262Bootstrap
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5039
+				// Method begins at RVA 0x4d49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5054
+						// Method begins at RVA 0x4d64
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x505d
+						// Method begins at RVA 0x4d6d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5066
+						// Method begins at RVA 0x4d76
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x506f
+						// Method begins at RVA 0x4d7f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5078
+						// Method begins at RVA 0x4d88
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5081
+						// Method begins at RVA 0x4d91
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x504b
+					// Method begins at RVA 0x4d5b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5042
+				// Method begins at RVA 0x4d52
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -209,7 +209,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x274c
+			// Method begins at RVA 0x2734
 			// Header size: 12
 			// Code size: 701 (0x2bd)
 			.maxstack 8
@@ -503,7 +503,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x508a
+				// Method begins at RVA 0x4d9a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -526,7 +526,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a18
+			// Method begins at RVA 0x2a00
 			// Header size: 12
 			// Code size: 184 (0xb8)
 			.maxstack 8
@@ -604,7 +604,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5093
+				// Method begins at RVA 0x4da3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -630,7 +630,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2adc
+			// Method begins at RVA 0x2ac4
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50a5
+					// Method begins at RVA 0x4db5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -712,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x509c
+				// Method begins at RVA 0x4dac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -739,7 +739,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2b3c
+			// Method begins at RVA 0x2b24
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -815,7 +815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ae
+				// Method begins at RVA 0x4dbe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -839,7 +839,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bc0
+			// Method begins at RVA 0x2ba8
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -878,7 +878,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50b7
+				// Method begins at RVA 0x4dc7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -905,7 +905,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2bf8
+			// Method begins at RVA 0x2be0
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -965,7 +965,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50c9
+					// Method begins at RVA 0x4dd9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -983,7 +983,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50c0
+				// Method begins at RVA 0x4dd0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1008,7 +1008,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c60
+			// Method begins at RVA 0x2c48
 			// Header size: 12
 			// Code size: 188 (0xbc)
 			.maxstack 8
@@ -1117,7 +1117,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50db
+					// Method begins at RVA 0x4deb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1135,7 +1135,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50d2
+				// Method begins at RVA 0x4de2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1163,7 +1163,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x50f6
+						// Method begins at RVA 0x4e06
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1181,7 +1181,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50ed
+					// Method begins at RVA 0x4dfd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1199,7 +1199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50e4
+				// Method begins at RVA 0x4df4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1224,7 +1224,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d28
+			// Method begins at RVA 0x2d10
 			// Header size: 12
 			// Code size: 501 (0x1f5)
 			.maxstack 8
@@ -1461,7 +1461,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ff
+				// Method begins at RVA 0x4e0f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1489,7 +1489,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x511a
+						// Method begins at RVA 0x4e2a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1507,7 +1507,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5111
+					// Method begins at RVA 0x4e21
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1525,7 +1525,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5108
+				// Method begins at RVA 0x4e18
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1552,7 +1552,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2f48
+			// Method begins at RVA 0x2f30
 			// Header size: 12
 			// Code size: 207 (0xcf)
 			.maxstack 8
@@ -1680,7 +1680,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x512c
+					// Method begins at RVA 0x4e3c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1700,7 +1700,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5135
+					// Method begins at RVA 0x4e45
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1720,7 +1720,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x513e
+					// Method begins at RVA 0x4e4e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1738,7 +1738,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5123
+				// Method begins at RVA 0x4e33
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1765,9 +1765,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3034
+			// Method begins at RVA 0x301c
 			// Header size: 12
-			// Code size: 936 (0x3a8)
+			// Code size: 914 (0x392)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L124C39,
@@ -2040,76 +2040,67 @@
 			IL_02d7: ldstr "excludedFromMvp"
 			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_02e1: stloc.s 11
-			IL_02e3: ldc.i4.1
-			IL_02e4: newarr [System.Runtime]System.Object
-			IL_02e9: dup
-			IL_02ea: ldc.i4.0
-			IL_02eb: ldarg.0
-			IL_02ec: stelem.ref
-			IL_02ed: ldc.i4.0
-			IL_02ee: ldelem.ref
-			IL_02ef: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_02f4: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_02fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_02e3: ldarg.0
+			IL_02e4: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_02e9: ldnull
+			IL_02ea: ldloc.s 11
+			IL_02ec: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_02f1: pop
+			IL_02f2: ldarg.2
+			IL_02f3: ldstr "attributionFiles"
+			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fd: stloc.s 11
 			IL_02ff: ldnull
 			IL_0300: ldloc.s 11
-			IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0307: pop
-			IL_0308: ldarg.2
-			IL_0309: ldstr "attributionFiles"
-			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0313: stloc.s 11
-			IL_0315: ldnull
-			IL_0316: ldloc.s 11
-			IL_0318: ldstr "attributionFiles"
-			IL_031d: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_0322: pop
-			IL_0323: ldstr "^[0-9a-f]{40}$"
-			IL_0328: ldstr "i"
-			IL_032d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0332: stloc.s 13
-			IL_0334: ldloc.s 13
-			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_033b: stloc.s 11
-			IL_033d: ldloc.s 11
-			IL_033f: ldstr "test"
-			IL_0344: ldarg.2
-			IL_0345: ldstr "upstream"
-			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_034f: ldstr "commit"
-			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_035e: stloc.s 11
-			IL_0360: ldloc.s 11
-			IL_0362: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0367: ldc.i4.0
-			IL_0368: ceq
-			IL_036a: stloc.s 6
-			IL_036c: ldloc.s 6
-			IL_036e: brfalse IL_03a6
+			IL_0302: ldstr "attributionFiles"
+			IL_0307: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
+			IL_030c: pop
+			IL_030d: ldstr "^[0-9a-f]{40}$"
+			IL_0312: ldstr "i"
+			IL_0317: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_031c: stloc.s 13
+			IL_031e: ldloc.s 13
+			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0325: stloc.s 11
+			IL_0327: ldloc.s 11
+			IL_0329: ldstr "test"
+			IL_032e: ldarg.2
+			IL_032f: ldstr "upstream"
+			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0339: ldstr "commit"
+			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0348: stloc.s 11
+			IL_034a: ldloc.s 11
+			IL_034c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0351: ldc.i4.0
+			IL_0352: ceq
+			IL_0354: stloc.s 6
+			IL_0356: ldloc.s 6
+			IL_0358: brfalse IL_0390
 
-			IL_0373: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L149C52::.ctor()
-			IL_0378: stloc.s 4
-			IL_037a: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_037f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0384: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0389: stloc.s 11
-			IL_038b: ldloc.s 11
-			IL_038d: stloc.s 5
-			IL_038f: ldloc.s 5
-			IL_0391: isinst [System.Runtime]System.Exception
-			IL_0396: dup
-			IL_0397: brtrue IL_03a5
+			IL_035d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L149C52::.ctor()
+			IL_0362: stloc.s 4
+			IL_0364: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_0369: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_036e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0373: stloc.s 11
+			IL_0375: ldloc.s 11
+			IL_0377: stloc.s 5
+			IL_0379: ldloc.s 5
+			IL_037b: isinst [System.Runtime]System.Exception
+			IL_0380: dup
+			IL_0381: brtrue IL_038f
 
-			IL_039c: pop
-			IL_039d: ldloc.s 5
-			IL_039f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03a4: throw
+			IL_0386: pop
+			IL_0387: ldloc.s 5
+			IL_0389: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_038e: throw
 
-			IL_03a5: throw
+			IL_038f: throw
 
-			IL_03a6: ldnull
-			IL_03a7: ret
+			IL_0390: ldnull
+			IL_0391: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -2125,7 +2116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5147
+				// Method begins at RVA 0x4e57
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2152,9 +2143,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x33e8
+			// Method begins at RVA 0x33bc
 			// Header size: 12
-			// Code size: 79 (0x4f)
+			// Code size: 57 (0x39)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2179,23 +2170,14 @@
 			IL_0026: stloc.2
 			IL_0027: ldloc.2
 			IL_0028: stloc.1
-			IL_0029: ldc.i4.1
-			IL_002a: newarr [System.Runtime]System.Object
-			IL_002f: dup
-			IL_0030: ldc.i4.0
-			IL_0031: ldarg.0
-			IL_0032: stelem.ref
-			IL_0033: ldc.i4.0
-			IL_0034: ldelem.ref
-			IL_0035: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_003a: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0045: ldnull
-			IL_0046: ldloc.1
-			IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_004c: pop
-			IL_004d: ldloc.1
-			IL_004e: ret
+			IL_0029: ldarg.0
+			IL_002a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_002f: ldnull
+			IL_0030: ldloc.1
+			IL_0031: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0036: pop
+			IL_0037: ldloc.1
+			IL_0038: ret
 		} // end of method loadPin::__js_call__
 
 	} // end of class loadPin
@@ -2211,7 +2193,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5150
+				// Method begins at RVA 0x4e60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2239,7 +2221,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3444
+			// Method begins at RVA 0x3404
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -2296,7 +2278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5159
+				// Method begins at RVA 0x4e69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2323,9 +2305,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x34a8
+			// Method begins at RVA 0x3468
 			// Header size: 12
-			// Code size: 127 (0x7f)
+			// Code size: 105 (0x69)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2343,46 +2325,37 @@
 			IL_0017: ldstr "managedRoot"
 			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0021: stloc.1
-			IL_0022: ldc.i4.1
-			IL_0023: newarr [System.Runtime]System.Object
-			IL_0028: dup
-			IL_0029: ldc.i4.0
-			IL_002a: ldarg.0
-			IL_002b: stelem.ref
-			IL_002c: ldc.i4.0
-			IL_002d: ldelem.ref
-			IL_002e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0033: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0039: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_003e: ldnull
-			IL_003f: ldloc.1
-			IL_0040: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0045: stloc.1
-			IL_0046: ldloc.0
-			IL_0047: ldstr "join"
-			IL_004c: ldloc.1
-			IL_004d: ldarg.2
-			IL_004e: ldstr "upstream"
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0058: ldstr "commit"
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0067: stloc.1
-			IL_0068: ldc.i4.1
-			IL_0069: newarr [System.Runtime]System.Object
-			IL_006e: dup
-			IL_006f: ldc.i4.0
-			IL_0070: ldarg.0
-			IL_0071: stelem.ref
-			IL_0072: stloc.2
-			IL_0073: ldnull
-			IL_0074: ldloc.1
-			IL_0075: tail.
-			IL_0077: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_007c: ret
+			IL_0022: ldarg.0
+			IL_0023: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0028: ldnull
+			IL_0029: ldloc.1
+			IL_002a: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_002f: stloc.1
+			IL_0030: ldloc.0
+			IL_0031: ldstr "join"
+			IL_0036: ldloc.1
+			IL_0037: ldarg.2
+			IL_0038: ldstr "upstream"
+			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0042: ldstr "commit"
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0051: stloc.1
+			IL_0052: ldc.i4.1
+			IL_0053: newarr [System.Runtime]System.Object
+			IL_0058: dup
+			IL_0059: ldc.i4.0
+			IL_005a: ldarg.0
+			IL_005b: stelem.ref
+			IL_005c: stloc.2
+			IL_005d: ldnull
+			IL_005e: ldloc.1
+			IL_005f: tail.
+			IL_0061: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_0066: ret
 
-			IL_007d: ldnull
-			IL_007e: ret
+			IL_0067: ldnull
+			IL_0068: ret
 		} // end of method resolveManagedCheckoutLabel::__js_call__
 
 	} // end of class resolveManagedCheckoutLabel
@@ -2402,7 +2375,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x516b
+					// Method begins at RVA 0x4e7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2420,7 +2393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5162
+				// Method begins at RVA 0x4e72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2448,9 +2421,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3534
+			// Method begins at RVA 0x34e0
 			// Header size: 12
-			// Code size: 252 (0xfc)
+			// Code size: 230 (0xe6)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2533,33 +2506,24 @@
 			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_00b5: stloc.2
 
-			IL_00b6: ldc.i4.1
-			IL_00b7: newarr [System.Runtime]System.Object
-			IL_00bc: dup
-			IL_00bd: ldc.i4.0
-			IL_00be: ldarg.0
-			IL_00bf: stelem.ref
-			IL_00c0: ldc.i4.0
-			IL_00c1: ldelem.ref
-			IL_00c2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00c7: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d2: ldnull
-			IL_00d3: ldloc.0
-			IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00d9: stloc.3
-			IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00df: dup
-			IL_00e0: ldstr "source"
-			IL_00e5: ldloc.2
-			IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00eb: dup
-			IL_00ec: ldstr "rootPath"
-			IL_00f1: ldloc.3
-			IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00f7: stloc.s 9
-			IL_00f9: ldloc.s 9
-			IL_00fb: ret
+			IL_00b6: ldarg.0
+			IL_00b7: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00bc: ldnull
+			IL_00bd: ldloc.0
+			IL_00be: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00c3: stloc.3
+			IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00c9: dup
+			IL_00ca: ldstr "source"
+			IL_00cf: ldloc.2
+			IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00d5: dup
+			IL_00d6: ldstr "rootPath"
+			IL_00db: ldloc.3
+			IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00e1: stloc.s 9
+			IL_00e3: ldloc.s 9
+			IL_00e5: ret
 		} // end of method resolveOverrideRoot::__js_call__
 
 	} // end of class resolveOverrideRoot
@@ -2579,7 +2543,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x517d
+					// Method begins at RVA 0x4e8d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2597,7 +2561,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5174
+				// Method begins at RVA 0x4e84
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2625,9 +2589,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x363c
+			// Method begins at RVA 0x35d4
 			// Header size: 12
-			// Code size: 1080 (0x438)
+			// Code size: 1058 (0x422)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2722,279 +2686,270 @@
 			IL_00d7: ldloc.s 9
 			IL_00d9: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00de: stloc.s 9
-			IL_00e0: ldc.i4.1
-			IL_00e1: newarr [System.Runtime]System.Object
-			IL_00e6: dup
-			IL_00e7: ldc.i4.0
-			IL_00e8: ldarg.0
-			IL_00e9: stelem.ref
-			IL_00ea: ldc.i4.0
-			IL_00eb: ldelem.ref
-			IL_00ec: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00f1: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00fc: ldnull
-			IL_00fd: ldarg.2
-			IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0103: stloc.s 8
-			IL_0105: ldloc.s 8
-			IL_0107: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_010c: stloc.s 10
-			IL_010e: ldstr "checkoutDir "
-			IL_0113: ldloc.s 10
-			IL_0115: call string [System.Runtime]System.String::Concat(string, string)
-			IL_011a: stloc.s 10
-			IL_011c: ldarg.2
-			IL_011d: ldstr "localOverrideEnvVar"
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0127: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_012c: stloc.s 11
-			IL_012e: ldstr "overrideEnv "
-			IL_0133: ldloc.s 11
-			IL_0135: call string [System.Runtime]System.String::Concat(string, string)
-			IL_013a: stloc.s 11
-			IL_013c: ldarg.2
-			IL_013d: ldstr "lineEndings"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0147: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_014c: stloc.s 12
-			IL_014e: ldstr "lineEndings "
-			IL_0153: ldloc.s 12
-			IL_0155: call string [System.Runtime]System.String::Concat(string, string)
-			IL_015a: stloc.s 12
-			IL_015c: ldarg.2
-			IL_015d: ldstr "updateStrategy"
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0167: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_016c: stloc.s 13
-			IL_016e: ldstr "updateStrategy "
-			IL_0173: ldloc.s 13
-			IL_0175: call string [System.Runtime]System.String::Concat(string, string)
-			IL_017a: stloc.s 13
-			IL_017c: ldarg.2
-			IL_017d: ldstr "includeFiles"
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: stloc.s 8
-			IL_018e: ldloc.s 8
-			IL_0190: ldstr "join"
-			IL_0195: ldstr ", "
-			IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_019f: stloc.s 8
-			IL_01a1: ldloc.s 8
-			IL_01a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a8: stloc.s 14
-			IL_01aa: ldstr "includeFiles "
-			IL_01af: ldloc.s 14
-			IL_01b1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b6: stloc.s 14
-			IL_01b8: ldarg.2
-			IL_01b9: ldstr "includeDirectories"
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c8: stloc.s 8
-			IL_01ca: ldloc.s 8
-			IL_01cc: ldstr "join"
-			IL_01d1: ldstr ", "
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01db: stloc.s 8
-			IL_01dd: ldloc.s 8
-			IL_01df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01e4: stloc.s 15
-			IL_01e6: ldstr "includeDirectories "
-			IL_01eb: ldloc.s 15
-			IL_01ed: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f2: stloc.s 15
-			IL_01f4: ldarg.2
-			IL_01f5: ldstr "requiredFiles"
-			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0204: stloc.s 8
-			IL_0206: ldloc.s 8
-			IL_0208: ldstr "join"
-			IL_020d: ldstr ", "
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0217: stloc.s 8
-			IL_0219: ldloc.s 8
-			IL_021b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0220: stloc.s 16
-			IL_0222: ldstr "requiredFiles "
-			IL_0227: ldloc.s 16
-			IL_0229: call string [System.Runtime]System.String::Concat(string, string)
-			IL_022e: stloc.s 16
-			IL_0230: ldarg.2
-			IL_0231: ldstr "requiredDirectories"
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0240: stloc.s 8
-			IL_0242: ldloc.s 8
-			IL_0244: ldstr "join"
-			IL_0249: ldstr ", "
-			IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0253: stloc.s 8
-			IL_0255: ldloc.s 8
-			IL_0257: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_025c: stloc.s 17
-			IL_025e: ldstr "requiredDirectories "
-			IL_0263: ldloc.s 17
-			IL_0265: call string [System.Runtime]System.String::Concat(string, string)
-			IL_026a: stloc.s 17
-			IL_026c: ldarg.2
-			IL_026d: ldstr "defaultHarnessFiles"
-			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027c: stloc.s 8
-			IL_027e: ldloc.s 8
-			IL_0280: ldstr "join"
-			IL_0285: ldstr ", "
-			IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_028f: stloc.s 8
-			IL_0291: ldloc.s 8
-			IL_0293: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0298: stloc.s 18
-			IL_029a: ldstr "defaultHarnessFiles "
-			IL_029f: ldloc.s 18
-			IL_02a1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02a6: stloc.s 18
-			IL_02a8: ldarg.2
-			IL_02a9: ldstr "excludedFromMvp"
-			IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b8: stloc.s 8
-			IL_02ba: ldloc.s 8
-			IL_02bc: ldstr "join"
-			IL_02c1: ldstr "; "
-			IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02cb: stloc.s 8
-			IL_02cd: ldloc.s 8
-			IL_02cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02d4: stloc.s 19
-			IL_02d6: ldstr "excludedFromMvp "
-			IL_02db: ldloc.s 19
-			IL_02dd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02e2: stloc.s 19
-			IL_02e4: ldarg.2
-			IL_02e5: ldstr "attributionFiles"
-			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02f4: stloc.s 8
-			IL_02f6: ldloc.s 8
-			IL_02f8: ldstr "join"
-			IL_02fd: ldstr ", "
-			IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0307: stloc.s 8
-			IL_0309: ldloc.s 8
-			IL_030b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0310: stloc.s 20
-			IL_0312: ldstr "attributionFiles "
-			IL_0317: ldloc.s 20
-			IL_0319: call string [System.Runtime]System.String::Concat(string, string)
-			IL_031e: stloc.s 20
-			IL_0320: ldc.i4.s 16
-			IL_0322: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0327: dup
-			IL_0328: ldloc.s 4
-			IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_032f: dup
-			IL_0330: ldloc.s 5
-			IL_0332: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0337: dup
-			IL_0338: ldloc.s 6
-			IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_033f: dup
-			IL_0340: ldloc.s 7
-			IL_0342: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0347: dup
-			IL_0348: ldloc.s 9
-			IL_034a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_034f: dup
-			IL_0350: ldloc.s 10
-			IL_0352: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0357: dup
-			IL_0358: ldloc.s 11
-			IL_035a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_035f: dup
-			IL_0360: ldloc.s 12
-			IL_0362: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0367: dup
-			IL_0368: ldloc.s 13
-			IL_036a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_036f: dup
-			IL_0370: ldloc.s 14
-			IL_0372: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0377: dup
-			IL_0378: ldloc.s 15
-			IL_037a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_037f: dup
-			IL_0380: ldloc.s 16
-			IL_0382: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0387: dup
-			IL_0388: ldloc.s 17
-			IL_038a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_038f: dup
-			IL_0390: ldloc.s 18
-			IL_0392: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0397: dup
-			IL_0398: ldloc.s 19
-			IL_039a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_039f: dup
-			IL_03a0: ldloc.s 20
-			IL_03a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03a7: stloc.s 21
-			IL_03a9: ldloc.s 21
-			IL_03ab: stloc.1
-			IL_03ac: ldarg.3
-			IL_03ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03b2: stloc.3
-			IL_03b3: ldloc.3
-			IL_03b4: brfalse IL_041f
+			IL_00e0: ldarg.0
+			IL_00e1: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00e6: ldnull
+			IL_00e7: ldarg.2
+			IL_00e8: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00ed: stloc.s 8
+			IL_00ef: ldloc.s 8
+			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00f6: stloc.s 10
+			IL_00f8: ldstr "checkoutDir "
+			IL_00fd: ldloc.s 10
+			IL_00ff: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0104: stloc.s 10
+			IL_0106: ldarg.2
+			IL_0107: ldstr "localOverrideEnvVar"
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0116: stloc.s 11
+			IL_0118: ldstr "overrideEnv "
+			IL_011d: ldloc.s 11
+			IL_011f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0124: stloc.s 11
+			IL_0126: ldarg.2
+			IL_0127: ldstr "lineEndings"
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0136: stloc.s 12
+			IL_0138: ldstr "lineEndings "
+			IL_013d: ldloc.s 12
+			IL_013f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0144: stloc.s 12
+			IL_0146: ldarg.2
+			IL_0147: ldstr "updateStrategy"
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0151: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0156: stloc.s 13
+			IL_0158: ldstr "updateStrategy "
+			IL_015d: ldloc.s 13
+			IL_015f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0164: stloc.s 13
+			IL_0166: ldarg.2
+			IL_0167: ldstr "includeFiles"
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0176: stloc.s 8
+			IL_0178: ldloc.s 8
+			IL_017a: ldstr "join"
+			IL_017f: ldstr ", "
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0189: stloc.s 8
+			IL_018b: ldloc.s 8
+			IL_018d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0192: stloc.s 14
+			IL_0194: ldstr "includeFiles "
+			IL_0199: ldloc.s 14
+			IL_019b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a0: stloc.s 14
+			IL_01a2: ldarg.2
+			IL_01a3: ldstr "includeDirectories"
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b2: stloc.s 8
+			IL_01b4: ldloc.s 8
+			IL_01b6: ldstr "join"
+			IL_01bb: ldstr ", "
+			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01c5: stloc.s 8
+			IL_01c7: ldloc.s 8
+			IL_01c9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ce: stloc.s 15
+			IL_01d0: ldstr "includeDirectories "
+			IL_01d5: ldloc.s 15
+			IL_01d7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01dc: stloc.s 15
+			IL_01de: ldarg.2
+			IL_01df: ldstr "requiredFiles"
+			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ee: stloc.s 8
+			IL_01f0: ldloc.s 8
+			IL_01f2: ldstr "join"
+			IL_01f7: ldstr ", "
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0201: stloc.s 8
+			IL_0203: ldloc.s 8
+			IL_0205: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_020a: stloc.s 16
+			IL_020c: ldstr "requiredFiles "
+			IL_0211: ldloc.s 16
+			IL_0213: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0218: stloc.s 16
+			IL_021a: ldarg.2
+			IL_021b: ldstr "requiredDirectories"
+			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_022a: stloc.s 8
+			IL_022c: ldloc.s 8
+			IL_022e: ldstr "join"
+			IL_0233: ldstr ", "
+			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_023d: stloc.s 8
+			IL_023f: ldloc.s 8
+			IL_0241: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0246: stloc.s 17
+			IL_0248: ldstr "requiredDirectories "
+			IL_024d: ldloc.s 17
+			IL_024f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0254: stloc.s 17
+			IL_0256: ldarg.2
+			IL_0257: ldstr "defaultHarnessFiles"
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0266: stloc.s 8
+			IL_0268: ldloc.s 8
+			IL_026a: ldstr "join"
+			IL_026f: ldstr ", "
+			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0279: stloc.s 8
+			IL_027b: ldloc.s 8
+			IL_027d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0282: stloc.s 18
+			IL_0284: ldstr "defaultHarnessFiles "
+			IL_0289: ldloc.s 18
+			IL_028b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0290: stloc.s 18
+			IL_0292: ldarg.2
+			IL_0293: ldstr "excludedFromMvp"
+			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a2: stloc.s 8
+			IL_02a4: ldloc.s 8
+			IL_02a6: ldstr "join"
+			IL_02ab: ldstr "; "
+			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02b5: stloc.s 8
+			IL_02b7: ldloc.s 8
+			IL_02b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02be: stloc.s 19
+			IL_02c0: ldstr "excludedFromMvp "
+			IL_02c5: ldloc.s 19
+			IL_02c7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02cc: stloc.s 19
+			IL_02ce: ldarg.2
+			IL_02cf: ldstr "attributionFiles"
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02de: stloc.s 8
+			IL_02e0: ldloc.s 8
+			IL_02e2: ldstr "join"
+			IL_02e7: ldstr ", "
+			IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02f1: stloc.s 8
+			IL_02f3: ldloc.s 8
+			IL_02f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02fa: stloc.s 20
+			IL_02fc: ldstr "attributionFiles "
+			IL_0301: ldloc.s 20
+			IL_0303: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0308: stloc.s 20
+			IL_030a: ldc.i4.s 16
+			IL_030c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0311: dup
+			IL_0312: ldloc.s 4
+			IL_0314: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0319: dup
+			IL_031a: ldloc.s 5
+			IL_031c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0321: dup
+			IL_0322: ldloc.s 6
+			IL_0324: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0329: dup
+			IL_032a: ldloc.s 7
+			IL_032c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0331: dup
+			IL_0332: ldloc.s 9
+			IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0339: dup
+			IL_033a: ldloc.s 10
+			IL_033c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0341: dup
+			IL_0342: ldloc.s 11
+			IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0349: dup
+			IL_034a: ldloc.s 12
+			IL_034c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0351: dup
+			IL_0352: ldloc.s 13
+			IL_0354: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0359: dup
+			IL_035a: ldloc.s 14
+			IL_035c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0361: dup
+			IL_0362: ldloc.s 15
+			IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0369: dup
+			IL_036a: ldloc.s 16
+			IL_036c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0371: dup
+			IL_0372: ldloc.s 17
+			IL_0374: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0379: dup
+			IL_037a: ldloc.s 18
+			IL_037c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0381: dup
+			IL_0382: ldloc.s 19
+			IL_0384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0389: dup
+			IL_038a: ldloc.s 20
+			IL_038c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0391: stloc.s 21
+			IL_0393: ldloc.s 21
+			IL_0395: stloc.1
+			IL_0396: ldarg.3
+			IL_0397: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_039c: stloc.3
+			IL_039d: ldloc.3
+			IL_039e: brfalse IL_0409
 
-			IL_03b9: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/Scope/Block_L202C16::.ctor()
-			IL_03be: stloc.2
-			IL_03bf: ldarg.3
-			IL_03c0: ldstr "source"
-			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ca: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03cf: stloc.s 20
-			IL_03d1: ldstr "overrideSource "
-			IL_03d6: ldloc.s 20
-			IL_03d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03dd: stloc.s 20
-			IL_03df: ldloc.1
-			IL_03e0: ldloc.s 20
-			IL_03e2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03e7: pop
-			IL_03e8: ldarg.3
-			IL_03e9: ldstr "rootPath"
-			IL_03ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03f3: stloc.s 8
-			IL_03f5: ldnull
-			IL_03f6: ldloc.s 8
-			IL_03f8: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_03fd: stloc.s 8
-			IL_03ff: ldloc.s 8
-			IL_0401: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0406: stloc.s 20
-			IL_0408: ldstr "overrideRoot "
-			IL_040d: ldloc.s 20
-			IL_040f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0414: stloc.s 20
-			IL_0416: ldloc.1
-			IL_0417: ldloc.s 20
-			IL_0419: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_041e: pop
+			IL_03a3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/Scope/Block_L202C16::.ctor()
+			IL_03a8: stloc.2
+			IL_03a9: ldarg.3
+			IL_03aa: ldstr "source"
+			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03b9: stloc.s 20
+			IL_03bb: ldstr "overrideSource "
+			IL_03c0: ldloc.s 20
+			IL_03c2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03c7: stloc.s 20
+			IL_03c9: ldloc.1
+			IL_03ca: ldloc.s 20
+			IL_03cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03d1: pop
+			IL_03d2: ldarg.3
+			IL_03d3: ldstr "rootPath"
+			IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03dd: stloc.s 8
+			IL_03df: ldnull
+			IL_03e0: ldloc.s 8
+			IL_03e2: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_03e7: stloc.s 8
+			IL_03e9: ldloc.s 8
+			IL_03eb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03f0: stloc.s 20
+			IL_03f2: ldstr "overrideRoot "
+			IL_03f7: ldloc.s 20
+			IL_03f9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03fe: stloc.s 20
+			IL_0400: ldloc.1
+			IL_0401: ldloc.s 20
+			IL_0403: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0408: pop
 
-			IL_041f: ldloc.1
-			IL_0420: ldc.i4.1
-			IL_0421: newarr [System.Runtime]System.Object
-			IL_0426: dup
-			IL_0427: ldc.i4.0
-			IL_0428: ldstr "\n"
-			IL_042d: stelem.ref
-			IL_042e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0433: stloc.s 20
-			IL_0435: ldloc.s 20
-			IL_0437: ret
+			IL_0409: ldloc.1
+			IL_040a: ldc.i4.1
+			IL_040b: newarr [System.Runtime]System.Object
+			IL_0410: dup
+			IL_0411: ldc.i4.0
+			IL_0412: ldstr "\n"
+			IL_0417: stelem.ref
+			IL_0418: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_041d: stloc.s 20
+			IL_041f: ldloc.s 20
+			IL_0421: ret
 		} // end of method describePlan::__js_call__
 
 	} // end of class describePlan
@@ -3010,7 +2965,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5186
+				// Method begins at RVA 0x4e96
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3037,7 +2992,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3a80
+			// Method begins at RVA 0x3a04
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -3080,7 +3035,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5198
+					// Method begins at RVA 0x4ea8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3098,7 +3053,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x518f
+				// Method begins at RVA 0x4e9f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3125,7 +3080,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3ab8
+			// Method begins at RVA 0x3a3c
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -3196,7 +3151,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51aa
+					// Method begins at RVA 0x4eba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3216,7 +3171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51b3
+					// Method begins at RVA 0x4ec3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3234,7 +3189,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51a1
+				// Method begins at RVA 0x4eb1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3262,7 +3217,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3b30
+			// Method begins at RVA 0x3ab4
 			// Header size: 12
 			// Code size: 678 (0x2a6)
 			.maxstack 8
@@ -3539,7 +3494,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51bc
+				// Method begins at RVA 0x4ecc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3563,7 +3518,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51ce
+					// Method begins at RVA 0x4ede
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3581,7 +3536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51c5
+				// Method begins at RVA 0x4ed5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3605,7 +3560,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51e0
+					// Method begins at RVA 0x4ef0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3623,7 +3578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51d7
+				// Method begins at RVA 0x4ee7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3650,9 +3605,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3de4
+			// Method begins at RVA 0x3d68
 			// Header size: 12
-			// Code size: 441 (0x1b9)
+			// Code size: 397 (0x18d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3694,7 +3649,7 @@
 					IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_002b: stloc.s 13
 					IL_002d: ldloc.s 13
-					IL_002f: brtrue IL_00a0
+					IL_002f: brtrue IL_008a
 
 					IL_0034: ldloc.s 12
 					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -3703,161 +3658,143 @@
 					IL_003f: stloc.s 4
 					IL_0041: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L247C7/Block_L247C43::.ctor()
 					IL_0046: stloc.s 5
-					IL_0048: ldc.i4.1
-					IL_0049: newarr [System.Runtime]System.Object
-					IL_004e: dup
-					IL_004f: ldc.i4.0
-					IL_0050: ldarg.0
-					IL_0051: stelem.ref
-					IL_0052: ldc.i4.0
-					IL_0053: ldelem.ref
-					IL_0054: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_0059: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_005f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_0064: ldnull
-					IL_0065: ldloc.s 4
-					IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_006c: stloc.s 12
-					IL_006e: ldloc.s 12
-					IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0075: stloc.s 14
-					IL_0077: ldstr "/"
-					IL_007c: ldloc.s 14
-					IL_007e: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0083: stloc.s 14
-					IL_0085: ldloc.0
-					IL_0086: ldloc.s 14
-					IL_0088: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_008d: pop
-					IL_008e: br IL_001c
+					IL_0048: ldarg.0
+					IL_0049: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_004e: ldnull
+					IL_004f: ldloc.s 4
+					IL_0051: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_0056: stloc.s 12
+					IL_0058: ldloc.s 12
+					IL_005a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_005f: stloc.s 14
+					IL_0061: ldstr "/"
+					IL_0066: ldloc.s 14
+					IL_0068: call string [System.Runtime]System.String::Concat(string, string)
+					IL_006d: stloc.s 14
+					IL_006f: ldloc.0
+					IL_0070: ldloc.s 14
+					IL_0072: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0077: pop
+					IL_0078: br IL_001c
 				// end loop
-				IL_0093: ldloc.1
-				IL_0094: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0099: ldc.i4.1
-				IL_009a: stloc.3
-				IL_009b: leave IL_00ba
+				IL_007d: ldloc.1
+				IL_007e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0083: ldc.i4.1
+				IL_0084: stloc.3
+				IL_0085: leave IL_00a4
 
-				IL_00a0: ldc.i4.1
-				IL_00a1: stloc.2
-				IL_00a2: leave IL_00ba
+				IL_008a: ldc.i4.1
+				IL_008b: stloc.2
+				IL_008c: leave IL_00a4
 			} // end .try
 			finally
 			{
-				IL_00a7: ldloc.2
-				IL_00a8: brtrue IL_00b9
+				IL_0091: ldloc.2
+				IL_0092: brtrue IL_00a3
 
-				IL_00ad: ldloc.3
-				IL_00ae: brtrue IL_00b9
+				IL_0097: ldloc.3
+				IL_0098: brtrue IL_00a3
 
-				IL_00b3: ldloc.1
-				IL_00b4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_009d: ldloc.1
+				IL_009e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00b9: endfinally
+				IL_00a3: endfinally
 			} // end handler
 
-			IL_00ba: ldarg.2
-			IL_00bb: ldstr "includeDirectories"
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_00ca: stloc.s 6
-			IL_00cc: ldc.i4.0
-			IL_00cd: stloc.s 7
-			IL_00cf: ldc.i4.0
-			IL_00d0: stloc.s 8
+			IL_00a4: ldarg.2
+			IL_00a5: ldstr "includeDirectories"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00b4: stloc.s 6
+			IL_00b6: ldc.i4.0
+			IL_00b7: stloc.s 7
+			IL_00b9: ldc.i4.0
+			IL_00ba: stloc.s 8
 			.try
 			{
-				// loop start (head: IL_00d2)
-					IL_00d2: ldloc.s 6
-					IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_00d9: stloc.s 12
-					IL_00db: ldloc.s 12
-					IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_00e2: stloc.s 13
-					IL_00e4: ldloc.s 13
-					IL_00e6: brtrue IL_0199
+				// loop start (head: IL_00bc)
+					IL_00bc: ldloc.s 6
+					IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_00c3: stloc.s 12
+					IL_00c5: ldloc.s 12
+					IL_00c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_00cc: stloc.s 13
+					IL_00ce: ldloc.s 13
+					IL_00d0: brtrue IL_016d
 
-					IL_00eb: ldloc.s 12
-					IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_00f2: stloc.s 12
-					IL_00f4: ldloc.s 12
-					IL_00f6: stloc.s 9
-					IL_00f8: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54::.ctor()
-					IL_00fd: stloc.s 10
-					IL_00ff: ldc.i4.1
-					IL_0100: newarr [System.Runtime]System.Object
-					IL_0105: dup
-					IL_0106: ldc.i4.0
-					IL_0107: ldarg.0
-					IL_0108: stelem.ref
-					IL_0109: ldc.i4.0
-					IL_010a: ldelem.ref
-					IL_010b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_0110: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_0116: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_011b: ldnull
-					IL_011c: ldloc.s 9
-					IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_0123: stloc.s 12
-					IL_0125: ldloc.s 12
-					IL_0127: stloc.s 11
-					IL_0129: ldloc.s 11
-					IL_012b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0130: stloc.s 14
-					IL_0132: ldstr "/"
-					IL_0137: ldloc.s 14
-					IL_0139: call string [System.Runtime]System.String::Concat(string, string)
-					IL_013e: stloc.s 14
-					IL_0140: ldloc.s 14
-					IL_0142: ldstr "/"
-					IL_0147: call string [System.Runtime]System.String::Concat(string, string)
-					IL_014c: stloc.s 14
-					IL_014e: ldloc.0
-					IL_014f: ldloc.s 14
-					IL_0151: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0156: pop
-					IL_0157: ldloc.s 11
-					IL_0159: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_015e: stloc.s 14
-					IL_0160: ldstr "/"
-					IL_0165: ldloc.s 14
-					IL_0167: call string [System.Runtime]System.String::Concat(string, string)
-					IL_016c: stloc.s 14
-					IL_016e: ldloc.s 14
-					IL_0170: ldstr "/**"
-					IL_0175: call string [System.Runtime]System.String::Concat(string, string)
-					IL_017a: stloc.s 14
-					IL_017c: ldloc.0
-					IL_017d: ldloc.s 14
-					IL_017f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0184: pop
-					IL_0185: br IL_00d2
+					IL_00d5: ldloc.s 12
+					IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_00dc: stloc.s 12
+					IL_00de: ldloc.s 12
+					IL_00e0: stloc.s 9
+					IL_00e2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54::.ctor()
+					IL_00e7: stloc.s 10
+					IL_00e9: ldarg.0
+					IL_00ea: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_00ef: ldnull
+					IL_00f0: ldloc.s 9
+					IL_00f2: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_00f7: stloc.s 12
+					IL_00f9: ldloc.s 12
+					IL_00fb: stloc.s 11
+					IL_00fd: ldloc.s 11
+					IL_00ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0104: stloc.s 14
+					IL_0106: ldstr "/"
+					IL_010b: ldloc.s 14
+					IL_010d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0112: stloc.s 14
+					IL_0114: ldloc.s 14
+					IL_0116: ldstr "/"
+					IL_011b: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0120: stloc.s 14
+					IL_0122: ldloc.0
+					IL_0123: ldloc.s 14
+					IL_0125: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_012a: pop
+					IL_012b: ldloc.s 11
+					IL_012d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0132: stloc.s 14
+					IL_0134: ldstr "/"
+					IL_0139: ldloc.s 14
+					IL_013b: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0140: stloc.s 14
+					IL_0142: ldloc.s 14
+					IL_0144: ldstr "/**"
+					IL_0149: call string [System.Runtime]System.String::Concat(string, string)
+					IL_014e: stloc.s 14
+					IL_0150: ldloc.0
+					IL_0151: ldloc.s 14
+					IL_0153: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0158: pop
+					IL_0159: br IL_00bc
 				// end loop
-				IL_018a: ldloc.s 6
-				IL_018c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0191: ldc.i4.1
-				IL_0192: stloc.s 8
-				IL_0194: leave IL_01b7
+				IL_015e: ldloc.s 6
+				IL_0160: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0165: ldc.i4.1
+				IL_0166: stloc.s 8
+				IL_0168: leave IL_018b
 
-				IL_0199: ldc.i4.1
-				IL_019a: stloc.s 7
-				IL_019c: leave IL_01b7
+				IL_016d: ldc.i4.1
+				IL_016e: stloc.s 7
+				IL_0170: leave IL_018b
 			} // end .try
 			finally
 			{
-				IL_01a1: ldloc.s 7
-				IL_01a3: brtrue IL_01b6
+				IL_0175: ldloc.s 7
+				IL_0177: brtrue IL_018a
 
-				IL_01a8: ldloc.s 8
-				IL_01aa: brtrue IL_01b6
+				IL_017c: ldloc.s 8
+				IL_017e: brtrue IL_018a
 
-				IL_01af: ldloc.s 6
-				IL_01b1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0183: ldloc.s 6
+				IL_0185: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_01b6: endfinally
+				IL_018a: endfinally
 			} // end handler
 
-			IL_01b7: ldloc.0
-			IL_01b8: ret
+			IL_018b: ldloc.0
+			IL_018c: ret
 		} // end of method buildSparsePatterns::__js_call__
 
 	} // end of class buildSparsePatterns
@@ -3881,7 +3818,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5231
+						// Method begins at RVA 0x4f41
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3901,7 +3838,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x523a
+						// Method begins at RVA 0x4f4a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3919,7 +3856,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5228
+					// Method begins at RVA 0x4f38
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3939,7 +3876,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5243
+					// Method begins at RVA 0x4f53
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3957,7 +3894,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51e9
+				// Method begins at RVA 0x4ef9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3985,7 +3922,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5204
+						// Method begins at RVA 0x4f14
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4003,7 +3940,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x51fb
+					// Method begins at RVA 0x4f0b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4021,7 +3958,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x51f2
+				// Method begins at RVA 0x4f02
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4049,7 +3986,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x521f
+						// Method begins at RVA 0x4f2f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4067,7 +4004,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5216
+					// Method begins at RVA 0x4f26
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4085,7 +4022,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x520d
+				// Method begins at RVA 0x4f1d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4113,9 +4050,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3fc8
+			// Method begins at RVA 0x3f20
 			// Header size: 12
-			// Code size: 1647 (0x66f)
+			// Code size: 1603 (0x643)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4185,7 +4122,7 @@
 					IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0033: stloc.s 25
 					IL_0035: ldloc.s 25
-					IL_0037: brtrue IL_019f
+					IL_0037: brtrue IL_0189
 
 					IL_003c: ldloc.s 24
 					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -4204,566 +4141,548 @@
 					IL_0064: ldarg.2
 					IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 					IL_006a: stloc.s 26
-					IL_006c: ldc.i4.1
-					IL_006d: newarr [System.Runtime]System.Object
-					IL_0072: dup
-					IL_0073: ldc.i4.0
-					IL_0074: ldarg.0
-					IL_0075: stelem.ref
-					IL_0076: ldc.i4.0
-					IL_0077: ldelem.ref
-					IL_0078: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_007d: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_0083: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_0088: ldnull
-					IL_0089: ldloc.s 5
-					IL_008b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_0090: stloc.s 27
-					IL_0092: ldloc.s 27
-					IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0099: stloc.s 27
-					IL_009b: ldloc.s 27
-					IL_009d: ldstr "split"
-					IL_00a2: ldstr "/"
-					IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00ac: stloc.s 27
-					IL_00ae: ldloc.s 26
-					IL_00b0: ldloc.s 27
-					IL_00b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_00b7: ldloc.s 26
-					IL_00b9: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00be: stloc.s 28
-					IL_00c0: ldloc.s 24
-					IL_00c2: ldstr "join"
-					IL_00c7: ldloc.s 28
-					IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_00ce: stloc.s 24
-					IL_00d0: ldloc.s 24
-					IL_00d2: stloc.s 7
-					IL_00d4: ldarg.0
-					IL_00d5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00df: stloc.s 24
-					IL_00e1: ldloc.s 24
-					IL_00e3: ldstr "existsSync"
-					IL_00e8: ldloc.s 7
-					IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00ef: stloc.s 24
-					IL_00f1: ldloc.s 24
-					IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_00f8: ldc.i4.0
-					IL_00f9: ceq
-					IL_00fb: stloc.s 25
-					IL_00fd: ldloc.s 25
-					IL_00ff: box [System.Runtime]System.Boolean
-					IL_0104: stloc.s 29
-					IL_0106: ldloc.s 29
-					IL_0108: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_010d: stloc.s 25
-					IL_010f: ldloc.s 25
-					IL_0111: brtrue IL_0168
+					IL_006c: ldarg.0
+					IL_006d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_0072: ldnull
+					IL_0073: ldloc.s 5
+					IL_0075: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_007a: stloc.s 27
+					IL_007c: ldloc.s 27
+					IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0083: stloc.s 27
+					IL_0085: ldloc.s 27
+					IL_0087: ldstr "split"
+					IL_008c: ldstr "/"
+					IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0096: stloc.s 27
+					IL_0098: ldloc.s 26
+					IL_009a: ldloc.s 27
+					IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00a1: ldloc.s 26
+					IL_00a3: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00a8: stloc.s 28
+					IL_00aa: ldloc.s 24
+					IL_00ac: ldstr "join"
+					IL_00b1: ldloc.s 28
+					IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_00b8: stloc.s 24
+					IL_00ba: ldloc.s 24
+					IL_00bc: stloc.s 7
+					IL_00be: ldarg.0
+					IL_00bf: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00c9: stloc.s 24
+					IL_00cb: ldloc.s 24
+					IL_00cd: ldstr "existsSync"
+					IL_00d2: ldloc.s 7
+					IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00d9: stloc.s 24
+					IL_00db: ldloc.s 24
+					IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_00e2: ldc.i4.0
+					IL_00e3: ceq
+					IL_00e5: stloc.s 25
+					IL_00e7: ldloc.s 25
+					IL_00e9: box [System.Runtime]System.Boolean
+					IL_00ee: stloc.s 29
+					IL_00f0: ldloc.s 29
+					IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00f7: stloc.s 25
+					IL_00f9: ldloc.s 25
+					IL_00fb: brtrue IL_0152
 
-					IL_0116: ldarg.0
-					IL_0117: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0121: stloc.s 24
-					IL_0123: ldloc.s 24
-					IL_0125: ldstr "statSync"
-					IL_012a: ldloc.s 7
-					IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0131: stloc.s 24
-					IL_0133: ldloc.s 24
-					IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_013a: stloc.s 24
-					IL_013c: ldloc.s 24
-					IL_013e: ldstr "isFile"
-					IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0148: stloc.s 24
-					IL_014a: ldloc.s 24
-					IL_014c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0151: ldc.i4.0
-					IL_0152: ceq
-					IL_0154: stloc.s 25
-					IL_0156: ldloc.s 25
-					IL_0158: box [System.Runtime]System.Boolean
-					IL_015d: stloc.s 30
-					IL_015f: ldloc.s 30
-					IL_0161: stloc.s 32
-					IL_0163: br IL_016c
+					IL_0100: ldarg.0
+					IL_0101: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_010b: stloc.s 24
+					IL_010d: ldloc.s 24
+					IL_010f: ldstr "statSync"
+					IL_0114: ldloc.s 7
+					IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_011b: stloc.s 24
+					IL_011d: ldloc.s 24
+					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0124: stloc.s 24
+					IL_0126: ldloc.s 24
+					IL_0128: ldstr "isFile"
+					IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0132: stloc.s 24
+					IL_0134: ldloc.s 24
+					IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_013b: ldc.i4.0
+					IL_013c: ceq
+					IL_013e: stloc.s 25
+					IL_0140: ldloc.s 25
+					IL_0142: box [System.Runtime]System.Boolean
+					IL_0147: stloc.s 30
+					IL_0149: ldloc.s 30
+					IL_014b: stloc.s 32
+					IL_014d: br IL_0156
 
-					IL_0168: ldloc.s 29
-					IL_016a: stloc.s 32
+					IL_0152: ldloc.s 29
+					IL_0154: stloc.s 32
 
-					IL_016c: ldloc.s 32
-					IL_016e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0173: stloc.s 25
-					IL_0175: ldloc.s 25
-					IL_0177: brfalse IL_018c
+					IL_0156: ldloc.s 32
+					IL_0158: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_015d: stloc.s 25
+					IL_015f: ldloc.s 25
+					IL_0161: brfalse IL_0176
 
-					IL_017c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
-					IL_0181: stloc.s 8
-					IL_0183: ldloc.0
-					IL_0184: ldloc.s 5
-					IL_0186: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_018b: pop
+					IL_0166: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
+					IL_016b: stloc.s 8
+					IL_016d: ldloc.0
+					IL_016e: ldloc.s 5
+					IL_0170: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0175: pop
 
-					IL_018c: br IL_0024
+					IL_0176: br IL_0024
 				// end loop
-				IL_0191: ldloc.2
-				IL_0192: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0197: ldc.i4.1
-				IL_0198: stloc.s 4
-				IL_019a: leave IL_01ba
+				IL_017b: ldloc.2
+				IL_017c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0181: ldc.i4.1
+				IL_0182: stloc.s 4
+				IL_0184: leave IL_01a4
 
-				IL_019f: ldc.i4.1
-				IL_01a0: stloc.3
-				IL_01a1: leave IL_01ba
+				IL_0189: ldc.i4.1
+				IL_018a: stloc.3
+				IL_018b: leave IL_01a4
 			} // end .try
 			finally
 			{
-				IL_01a6: ldloc.3
-				IL_01a7: brtrue IL_01b9
+				IL_0190: ldloc.3
+				IL_0191: brtrue IL_01a3
 
-				IL_01ac: ldloc.s 4
-				IL_01ae: brtrue IL_01b9
+				IL_0196: ldloc.s 4
+				IL_0198: brtrue IL_01a3
 
-				IL_01b3: ldloc.2
-				IL_01b4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_019d: ldloc.2
+				IL_019e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_01b9: endfinally
+				IL_01a3: endfinally
 			} // end handler
 
-			IL_01ba: ldarg.3
-			IL_01bb: ldstr "requiredDirectories"
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_01ca: stloc.s 9
-			IL_01cc: ldc.i4.0
-			IL_01cd: stloc.s 10
-			IL_01cf: ldc.i4.0
-			IL_01d0: stloc.s 11
+			IL_01a4: ldarg.3
+			IL_01a5: ldstr "requiredDirectories"
+			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_01b4: stloc.s 9
+			IL_01b6: ldc.i4.0
+			IL_01b7: stloc.s 10
+			IL_01b9: ldc.i4.0
+			IL_01ba: stloc.s 11
 			.try
 			{
-				// loop start (head: IL_01d2)
-					IL_01d2: ldloc.s 9
-					IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_01d9: stloc.s 24
-					IL_01db: ldloc.s 24
-					IL_01dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_01e2: stloc.s 25
-					IL_01e4: ldloc.s 25
-					IL_01e6: brtrue IL_034f
+				// loop start (head: IL_01bc)
+					IL_01bc: ldloc.s 9
+					IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_01c3: stloc.s 24
+					IL_01c5: ldloc.s 24
+					IL_01c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_01cc: stloc.s 25
+					IL_01ce: ldloc.s 25
+					IL_01d0: brtrue IL_0323
 
-					IL_01eb: ldloc.s 24
-					IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_01f2: stloc.s 24
-					IL_01f4: ldloc.s 24
-					IL_01f6: stloc.s 12
-					IL_01f8: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
-					IL_01fd: stloc.s 13
-					IL_01ff: ldarg.0
-					IL_0200: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_020a: stloc.s 24
-					IL_020c: ldc.i4.1
-					IL_020d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_0212: dup
-					IL_0213: ldarg.2
-					IL_0214: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0219: stloc.s 26
-					IL_021b: ldc.i4.1
-					IL_021c: newarr [System.Runtime]System.Object
-					IL_0221: dup
-					IL_0222: ldc.i4.0
-					IL_0223: ldarg.0
-					IL_0224: stelem.ref
-					IL_0225: ldc.i4.0
-					IL_0226: ldelem.ref
-					IL_0227: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_022c: ldftn object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_0232: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_0237: ldnull
-					IL_0238: ldloc.s 12
-					IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_023f: stloc.s 27
-					IL_0241: ldloc.s 27
-					IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0248: stloc.s 27
-					IL_024a: ldloc.s 27
-					IL_024c: ldstr "split"
-					IL_0251: ldstr "/"
-					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_025b: stloc.s 27
-					IL_025d: ldloc.s 26
-					IL_025f: ldloc.s 27
-					IL_0261: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_0266: ldloc.s 26
-					IL_0268: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_026d: stloc.s 28
-					IL_026f: ldloc.s 24
-					IL_0271: ldstr "join"
-					IL_0276: ldloc.s 28
-					IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_027d: stloc.s 24
-					IL_027f: ldloc.s 24
-					IL_0281: stloc.s 14
-					IL_0283: ldarg.0
-					IL_0284: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_028e: stloc.s 24
-					IL_0290: ldloc.s 24
-					IL_0292: ldstr "existsSync"
-					IL_0297: ldloc.s 14
-					IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_029e: stloc.s 24
-					IL_02a0: ldloc.s 24
-					IL_02a2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_02a7: ldc.i4.0
-					IL_02a8: ceq
-					IL_02aa: stloc.s 25
-					IL_02ac: ldloc.s 25
-					IL_02ae: box [System.Runtime]System.Boolean
-					IL_02b3: stloc.s 29
-					IL_02b5: ldloc.s 29
-					IL_02b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02bc: stloc.s 25
-					IL_02be: ldloc.s 25
-					IL_02c0: brtrue IL_0317
+					IL_01d5: ldloc.s 24
+					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_01dc: stloc.s 24
+					IL_01de: ldloc.s 24
+					IL_01e0: stloc.s 12
+					IL_01e2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
+					IL_01e7: stloc.s 13
+					IL_01e9: ldarg.0
+					IL_01ea: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01f4: stloc.s 24
+					IL_01f6: ldc.i4.1
+					IL_01f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01fc: dup
+					IL_01fd: ldarg.2
+					IL_01fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_0203: stloc.s 26
+					IL_0205: ldarg.0
+					IL_0206: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+					IL_020b: ldnull
+					IL_020c: ldloc.s 12
+					IL_020e: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+					IL_0213: stloc.s 27
+					IL_0215: ldloc.s 27
+					IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_021c: stloc.s 27
+					IL_021e: ldloc.s 27
+					IL_0220: ldstr "split"
+					IL_0225: ldstr "/"
+					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_022f: stloc.s 27
+					IL_0231: ldloc.s 26
+					IL_0233: ldloc.s 27
+					IL_0235: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_023a: ldloc.s 26
+					IL_023c: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_0241: stloc.s 28
+					IL_0243: ldloc.s 24
+					IL_0245: ldstr "join"
+					IL_024a: ldloc.s 28
+					IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_0251: stloc.s 24
+					IL_0253: ldloc.s 24
+					IL_0255: stloc.s 14
+					IL_0257: ldarg.0
+					IL_0258: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0262: stloc.s 24
+					IL_0264: ldloc.s 24
+					IL_0266: ldstr "existsSync"
+					IL_026b: ldloc.s 14
+					IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0272: stloc.s 24
+					IL_0274: ldloc.s 24
+					IL_0276: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_027b: ldc.i4.0
+					IL_027c: ceq
+					IL_027e: stloc.s 25
+					IL_0280: ldloc.s 25
+					IL_0282: box [System.Runtime]System.Boolean
+					IL_0287: stloc.s 29
+					IL_0289: ldloc.s 29
+					IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0290: stloc.s 25
+					IL_0292: ldloc.s 25
+					IL_0294: brtrue IL_02eb
 
-					IL_02c5: ldarg.0
-					IL_02c6: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02d0: stloc.s 24
-					IL_02d2: ldloc.s 24
-					IL_02d4: ldstr "statSync"
-					IL_02d9: ldloc.s 14
-					IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_02e0: stloc.s 24
-					IL_02e2: ldloc.s 24
-					IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02e9: stloc.s 24
-					IL_02eb: ldloc.s 24
-					IL_02ed: ldstr "isDirectory"
-					IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02f7: stloc.s 24
-					IL_02f9: ldloc.s 24
-					IL_02fb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_0300: ldc.i4.0
-					IL_0301: ceq
-					IL_0303: stloc.s 25
-					IL_0305: ldloc.s 25
-					IL_0307: box [System.Runtime]System.Boolean
-					IL_030c: stloc.s 30
-					IL_030e: ldloc.s 30
-					IL_0310: stloc.s 33
-					IL_0312: br IL_031b
+					IL_0299: ldarg.0
+					IL_029a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02a4: stloc.s 24
+					IL_02a6: ldloc.s 24
+					IL_02a8: ldstr "statSync"
+					IL_02ad: ldloc.s 14
+					IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_02b4: stloc.s 24
+					IL_02b6: ldloc.s 24
+					IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02bd: stloc.s 24
+					IL_02bf: ldloc.s 24
+					IL_02c1: ldstr "isDirectory"
+					IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02cb: stloc.s 24
+					IL_02cd: ldloc.s 24
+					IL_02cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_02d4: ldc.i4.0
+					IL_02d5: ceq
+					IL_02d7: stloc.s 25
+					IL_02d9: ldloc.s 25
+					IL_02db: box [System.Runtime]System.Boolean
+					IL_02e0: stloc.s 30
+					IL_02e2: ldloc.s 30
+					IL_02e4: stloc.s 33
+					IL_02e6: br IL_02ef
 
-					IL_0317: ldloc.s 29
-					IL_0319: stloc.s 33
+					IL_02eb: ldloc.s 29
+					IL_02ed: stloc.s 33
 
-					IL_031b: ldloc.s 33
-					IL_031d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0322: stloc.s 25
-					IL_0324: ldloc.s 25
-					IL_0326: brfalse IL_033b
+					IL_02ef: ldloc.s 33
+					IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02f6: stloc.s 25
+					IL_02f8: ldloc.s 25
+					IL_02fa: brfalse IL_030f
 
-					IL_032b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
-					IL_0330: stloc.s 15
-					IL_0332: ldloc.1
-					IL_0333: ldloc.s 12
-					IL_0335: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_033a: pop
+					IL_02ff: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
+					IL_0304: stloc.s 15
+					IL_0306: ldloc.1
+					IL_0307: ldloc.s 12
+					IL_0309: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_030e: pop
 
-					IL_033b: br IL_01d2
+					IL_030f: br IL_01bc
 				// end loop
-				IL_0340: ldloc.s 9
-				IL_0342: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0347: ldc.i4.1
-				IL_0348: stloc.s 11
-				IL_034a: leave IL_036d
+				IL_0314: ldloc.s 9
+				IL_0316: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_031b: ldc.i4.1
+				IL_031c: stloc.s 11
+				IL_031e: leave IL_0341
 
-				IL_034f: ldc.i4.1
-				IL_0350: stloc.s 10
-				IL_0352: leave IL_036d
+				IL_0323: ldc.i4.1
+				IL_0324: stloc.s 10
+				IL_0326: leave IL_0341
 			} // end .try
 			finally
 			{
-				IL_0357: ldloc.s 10
-				IL_0359: brtrue IL_036c
+				IL_032b: ldloc.s 10
+				IL_032d: brtrue IL_0340
 
-				IL_035e: ldloc.s 11
-				IL_0360: brtrue IL_036c
+				IL_0332: ldloc.s 11
+				IL_0334: brtrue IL_0340
 
-				IL_0365: ldloc.s 9
-				IL_0367: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0339: ldloc.s 9
+				IL_033b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_036c: endfinally
+				IL_0340: endfinally
 			} // end handler
 
-			IL_036d: ldloc.0
-			IL_036e: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0373: conv.r8
-			IL_0374: ldc.r8 0.0
-			IL_037d: cgt
-			IL_037f: box [System.Runtime]System.Boolean
-			IL_0384: stloc.s 29
-			IL_0386: ldloc.s 29
-			IL_0388: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_038d: stloc.s 25
-			IL_038f: ldloc.s 25
-			IL_0391: brtrue IL_03b4
+			IL_0341: ldloc.0
+			IL_0342: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0347: conv.r8
+			IL_0348: ldc.r8 0.0
+			IL_0351: cgt
+			IL_0353: box [System.Runtime]System.Boolean
+			IL_0358: stloc.s 29
+			IL_035a: ldloc.s 29
+			IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0361: stloc.s 25
+			IL_0363: ldloc.s 25
+			IL_0365: brtrue IL_0388
 
-			IL_0396: ldloc.1
-			IL_0397: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_039c: conv.r8
-			IL_039d: ldc.r8 0.0
-			IL_03a6: cgt
-			IL_03a8: box [System.Runtime]System.Boolean
-			IL_03ad: stloc.s 34
-			IL_03af: br IL_03b8
+			IL_036a: ldloc.1
+			IL_036b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0370: conv.r8
+			IL_0371: ldc.r8 0.0
+			IL_037a: cgt
+			IL_037c: box [System.Runtime]System.Boolean
+			IL_0381: stloc.s 34
+			IL_0383: br IL_038c
 
-			IL_03b4: ldloc.s 29
-			IL_03b6: stloc.s 34
+			IL_0388: ldloc.s 29
+			IL_038a: stloc.s 34
 
-			IL_03b8: ldloc.s 34
-			IL_03ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03bf: stloc.s 25
-			IL_03c1: ldloc.s 25
-			IL_03c3: brfalse IL_04bb
+			IL_038c: ldloc.s 34
+			IL_038e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0393: stloc.s 25
+			IL_0395: ldloc.s 25
+			IL_0397: brfalse IL_048f
 
-			IL_03c8: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
-			IL_03cd: stloc.s 16
-			IL_03cf: ldc.i4.0
-			IL_03d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03d5: stloc.s 17
-			IL_03d7: ldloc.0
-			IL_03d8: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_03dd: conv.r8
-			IL_03de: ldc.r8 0.0
-			IL_03e7: cgt
-			IL_03e9: brfalse IL_042c
+			IL_039c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
+			IL_03a1: stloc.s 16
+			IL_03a3: ldc.i4.0
+			IL_03a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03a9: stloc.s 17
+			IL_03ab: ldloc.0
+			IL_03ac: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_03b1: conv.r8
+			IL_03b2: ldc.r8 0.0
+			IL_03bb: cgt
+			IL_03bd: brfalse IL_0400
 
-			IL_03ee: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
-			IL_03f3: stloc.s 18
-			IL_03f5: ldloc.0
-			IL_03f6: ldc.i4.1
-			IL_03f7: newarr [System.Runtime]System.Object
-			IL_03fc: dup
-			IL_03fd: ldc.i4.0
-			IL_03fe: ldstr ", "
-			IL_0403: stelem.ref
-			IL_0404: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0409: stloc.s 35
-			IL_040b: ldloc.s 35
-			IL_040d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0412: stloc.s 35
-			IL_0414: ldstr "missing files: "
-			IL_0419: ldloc.s 35
-			IL_041b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0420: stloc.s 35
-			IL_0422: ldloc.s 17
-			IL_0424: ldloc.s 35
-			IL_0426: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_042b: pop
+			IL_03c2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
+			IL_03c7: stloc.s 18
+			IL_03c9: ldloc.0
+			IL_03ca: ldc.i4.1
+			IL_03cb: newarr [System.Runtime]System.Object
+			IL_03d0: dup
+			IL_03d1: ldc.i4.0
+			IL_03d2: ldstr ", "
+			IL_03d7: stelem.ref
+			IL_03d8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03dd: stloc.s 35
+			IL_03df: ldloc.s 35
+			IL_03e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03e6: stloc.s 35
+			IL_03e8: ldstr "missing files: "
+			IL_03ed: ldloc.s 35
+			IL_03ef: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03f4: stloc.s 35
+			IL_03f6: ldloc.s 17
+			IL_03f8: ldloc.s 35
+			IL_03fa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03ff: pop
 
-			IL_042c: ldloc.1
-			IL_042d: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0432: conv.r8
-			IL_0433: ldc.r8 0.0
-			IL_043c: cgt
-			IL_043e: brfalse IL_0481
+			IL_0400: ldloc.1
+			IL_0401: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0406: conv.r8
+			IL_0407: ldc.r8 0.0
+			IL_0410: cgt
+			IL_0412: brfalse IL_0455
 
-			IL_0443: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
-			IL_0448: stloc.s 19
-			IL_044a: ldloc.1
-			IL_044b: ldc.i4.1
-			IL_044c: newarr [System.Runtime]System.Object
-			IL_0451: dup
-			IL_0452: ldc.i4.0
-			IL_0453: ldstr ", "
-			IL_0458: stelem.ref
-			IL_0459: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_045e: stloc.s 35
-			IL_0460: ldloc.s 35
-			IL_0462: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0467: stloc.s 35
-			IL_0469: ldstr "missing directories: "
-			IL_046e: ldloc.s 35
-			IL_0470: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0475: stloc.s 35
-			IL_0477: ldloc.s 17
-			IL_0479: ldloc.s 35
-			IL_047b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0480: pop
+			IL_0417: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
+			IL_041c: stloc.s 19
+			IL_041e: ldloc.1
+			IL_041f: ldc.i4.1
+			IL_0420: newarr [System.Runtime]System.Object
+			IL_0425: dup
+			IL_0426: ldc.i4.0
+			IL_0427: ldstr ", "
+			IL_042c: stelem.ref
+			IL_042d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0432: stloc.s 35
+			IL_0434: ldloc.s 35
+			IL_0436: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_043b: stloc.s 35
+			IL_043d: ldstr "missing directories: "
+			IL_0442: ldloc.s 35
+			IL_0444: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0449: stloc.s 35
+			IL_044b: ldloc.s 17
+			IL_044d: ldloc.s 35
+			IL_044f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0454: pop
 
-			IL_0481: ldloc.s 17
-			IL_0483: ldc.i4.1
-			IL_0484: newarr [System.Runtime]System.Object
-			IL_0489: dup
-			IL_048a: ldc.i4.0
-			IL_048b: ldstr "; "
-			IL_0490: stelem.ref
-			IL_0491: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0496: stloc.s 35
-			IL_0498: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_049d: dup
-			IL_049e: ldstr "ok"
-			IL_04a3: ldc.i4.0
-			IL_04a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04a9: dup
-			IL_04aa: ldstr "message"
-			IL_04af: ldloc.s 35
-			IL_04b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04b6: stloc.s 36
-			IL_04b8: ldloc.s 36
-			IL_04ba: ret
+			IL_0455: ldloc.s 17
+			IL_0457: ldc.i4.1
+			IL_0458: newarr [System.Runtime]System.Object
+			IL_045d: dup
+			IL_045e: ldc.i4.0
+			IL_045f: ldstr "; "
+			IL_0464: stelem.ref
+			IL_0465: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_046a: stloc.s 35
+			IL_046c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0471: dup
+			IL_0472: ldstr "ok"
+			IL_0477: ldc.i4.0
+			IL_0478: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_047d: dup
+			IL_047e: ldstr "message"
+			IL_0483: ldloc.s 35
+			IL_0485: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_048a: stloc.s 36
+			IL_048c: ldloc.s 36
+			IL_048e: ret
 
-			IL_04bb: ldarg.0
-			IL_04bc: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04c6: stloc.s 24
-			IL_04c8: ldloc.s 24
-			IL_04ca: ldstr "join"
-			IL_04cf: ldarg.2
-			IL_04d0: ldstr "package.json"
-			IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04da: stloc.s 24
-			IL_04dc: ldloc.s 24
-			IL_04de: stloc.s 20
-			IL_04e0: ldarg.0
-			IL_04e1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04eb: stloc.s 24
-			IL_04ed: ldloc.s 24
-			IL_04ef: ldstr "readFileSync"
-			IL_04f4: ldloc.s 20
-			IL_04f6: ldstr "utf8"
-			IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0500: stloc.s 24
-			IL_0502: ldloc.s 24
-			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_0509: stloc.s 24
-			IL_050b: ldloc.s 24
-			IL_050d: stloc.s 21
-			IL_050f: ldloc.s 21
-			IL_0511: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0516: ldc.i4.0
-			IL_0517: ceq
-			IL_0519: stloc.s 25
-			IL_051b: ldloc.s 25
-			IL_051d: box [System.Runtime]System.Boolean
-			IL_0522: stloc.s 29
-			IL_0524: ldloc.s 29
-			IL_0526: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_052b: stloc.s 25
-			IL_052d: ldloc.s 25
-			IL_052f: brtrue IL_0572
+			IL_048f: ldarg.0
+			IL_0490: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_049a: stloc.s 24
+			IL_049c: ldloc.s 24
+			IL_049e: ldstr "join"
+			IL_04a3: ldarg.2
+			IL_04a4: ldstr "package.json"
+			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04ae: stloc.s 24
+			IL_04b0: ldloc.s 24
+			IL_04b2: stloc.s 20
+			IL_04b4: ldarg.0
+			IL_04b5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04bf: stloc.s 24
+			IL_04c1: ldloc.s 24
+			IL_04c3: ldstr "readFileSync"
+			IL_04c8: ldloc.s 20
+			IL_04ca: ldstr "utf8"
+			IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04d4: stloc.s 24
+			IL_04d6: ldloc.s 24
+			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_04dd: stloc.s 24
+			IL_04df: ldloc.s 24
+			IL_04e1: stloc.s 21
+			IL_04e3: ldloc.s 21
+			IL_04e5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04ea: ldc.i4.0
+			IL_04eb: ceq
+			IL_04ed: stloc.s 25
+			IL_04ef: ldloc.s 25
+			IL_04f1: box [System.Runtime]System.Boolean
+			IL_04f6: stloc.s 29
+			IL_04f8: ldloc.s 29
+			IL_04fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04ff: stloc.s 25
+			IL_0501: ldloc.s 25
+			IL_0503: brtrue IL_0546
 
-			IL_0534: ldloc.s 21
-			IL_0536: ldstr "version"
-			IL_053b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0540: stloc.s 24
-			IL_0542: ldloc.s 24
-			IL_0544: ldarg.3
-			IL_0545: ldstr "upstream"
-			IL_054a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_054f: ldstr "packageVersion"
-			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0559: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_055e: stloc.s 25
-			IL_0560: ldloc.s 25
-			IL_0562: box [System.Runtime]System.Boolean
-			IL_0567: stloc.s 30
-			IL_0569: ldloc.s 30
-			IL_056b: stloc.s 37
-			IL_056d: br IL_0576
+			IL_0508: ldloc.s 21
+			IL_050a: ldstr "version"
+			IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0514: stloc.s 24
+			IL_0516: ldloc.s 24
+			IL_0518: ldarg.3
+			IL_0519: ldstr "upstream"
+			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0523: ldstr "packageVersion"
+			IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_052d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0532: stloc.s 25
+			IL_0534: ldloc.s 25
+			IL_0536: box [System.Runtime]System.Boolean
+			IL_053b: stloc.s 30
+			IL_053d: ldloc.s 30
+			IL_053f: stloc.s 37
+			IL_0541: br IL_054a
 
-			IL_0572: ldloc.s 29
-			IL_0574: stloc.s 37
+			IL_0546: ldloc.s 29
+			IL_0548: stloc.s 37
 
-			IL_0576: ldloc.s 37
-			IL_0578: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_057d: stloc.s 25
-			IL_057f: ldloc.s 25
-			IL_0581: brfalse IL_064d
+			IL_054a: ldloc.s 37
+			IL_054c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0551: stloc.s 25
+			IL_0553: ldloc.s 25
+			IL_0555: brfalse IL_0621
 
-			IL_0586: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
-			IL_058b: stloc.s 22
-			IL_058d: ldarg.3
-			IL_058e: ldstr "upstream"
-			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0598: ldstr "packageVersion"
-			IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05a7: stloc.s 35
-			IL_05a9: ldstr "package.json version mismatch: expected "
-			IL_05ae: ldloc.s 35
-			IL_05b0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05b5: stloc.s 35
-			IL_05b7: ldloc.s 35
-			IL_05b9: ldstr ", got "
-			IL_05be: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05c3: stloc.s 35
-			IL_05c5: ldloc.s 21
-			IL_05c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05cc: stloc.s 25
-			IL_05ce: ldloc.s 25
-			IL_05d0: brfalse IL_05e8
+			IL_055a: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
+			IL_055f: stloc.s 22
+			IL_0561: ldarg.3
+			IL_0562: ldstr "upstream"
+			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056c: ldstr "packageVersion"
+			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0576: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_057b: stloc.s 35
+			IL_057d: ldstr "package.json version mismatch: expected "
+			IL_0582: ldloc.s 35
+			IL_0584: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0589: stloc.s 35
+			IL_058b: ldloc.s 35
+			IL_058d: ldstr ", got "
+			IL_0592: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0597: stloc.s 35
+			IL_0599: ldloc.s 21
+			IL_059b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05a0: stloc.s 25
+			IL_05a2: ldloc.s 25
+			IL_05a4: brfalse IL_05bc
 
-			IL_05d5: ldloc.s 21
-			IL_05d7: ldstr "version"
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e1: stloc.s 38
-			IL_05e3: br IL_05ec
+			IL_05a9: ldloc.s 21
+			IL_05ab: ldstr "version"
+			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b5: stloc.s 38
+			IL_05b7: br IL_05c0
 
-			IL_05e8: ldloc.s 21
-			IL_05ea: stloc.s 38
+			IL_05bc: ldloc.s 21
+			IL_05be: stloc.s 38
 
-			IL_05ec: ldloc.s 38
-			IL_05ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05f3: stloc.s 25
-			IL_05f5: ldloc.s 25
-			IL_05f7: brfalse IL_060f
+			IL_05c0: ldloc.s 38
+			IL_05c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05c7: stloc.s 25
+			IL_05c9: ldloc.s 25
+			IL_05cb: brfalse IL_05e3
 
-			IL_05fc: ldloc.s 21
-			IL_05fe: ldstr "version"
-			IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0608: stloc.s 23
-			IL_060a: br IL_0616
+			IL_05d0: ldloc.s 21
+			IL_05d2: ldstr "version"
+			IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05dc: stloc.s 23
+			IL_05de: br IL_05ea
 
-			IL_060f: ldstr "<missing>"
-			IL_0614: stloc.s 23
+			IL_05e3: ldstr "<missing>"
+			IL_05e8: stloc.s 23
 
-			IL_0616: ldloc.s 23
-			IL_0618: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_061d: stloc.s 39
-			IL_061f: ldloc.s 35
-			IL_0621: ldloc.s 39
-			IL_0623: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0628: stloc.s 39
-			IL_062a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_062f: dup
-			IL_0630: ldstr "ok"
-			IL_0635: ldc.i4.0
-			IL_0636: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_063b: dup
-			IL_063c: ldstr "message"
-			IL_0641: ldloc.s 39
-			IL_0643: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0648: stloc.s 36
-			IL_064a: ldloc.s 36
-			IL_064c: ret
+			IL_05ea: ldloc.s 23
+			IL_05ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05f1: stloc.s 39
+			IL_05f3: ldloc.s 35
+			IL_05f5: ldloc.s 39
+			IL_05f7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05fc: stloc.s 39
+			IL_05fe: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0603: dup
+			IL_0604: ldstr "ok"
+			IL_0609: ldc.i4.0
+			IL_060a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_060f: dup
+			IL_0610: ldstr "message"
+			IL_0615: ldloc.s 39
+			IL_0617: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_061c: stloc.s 36
+			IL_061e: ldloc.s 36
+			IL_0620: ret
 
-			IL_064d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0652: dup
-			IL_0653: ldstr "ok"
-			IL_0658: ldc.i4.1
-			IL_0659: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_065e: dup
-			IL_065f: ldstr "message"
-			IL_0664: ldstr ""
-			IL_0669: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_066e: ret
+			IL_0621: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0626: dup
+			IL_0627: ldstr "ok"
+			IL_062c: ldc.i4.1
+			IL_062d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0632: dup
+			IL_0633: ldstr "message"
+			IL_0638: ldstr ""
+			IL_063d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0642: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -4787,7 +4706,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x525e
+						// Method begins at RVA 0x4f6e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4805,7 +4724,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5255
+					// Method begins at RVA 0x4f65
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4825,7 +4744,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5267
+					// Method begins at RVA 0x4f77
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4843,7 +4762,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x524c
+				// Method begins at RVA 0x4f5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4872,9 +4791,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4678
+			// Method begins at RVA 0x45a4
 			// Header size: 12
-			// Code size: 1142 (0x476)
+			// Code size: 856 (0x358)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14,
@@ -4895,413 +4814,296 @@
 			IL_0008: ceq
 			IL_000a: stloc.s 6
 			IL_000c: ldloc.s 6
-			IL_000e: brfalse IL_008f
+			IL_000e: brfalse IL_0079
 
 			IL_0013: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14::.ctor()
 			IL_0018: stloc.0
-			IL_0019: ldc.i4.1
-			IL_001a: newarr [System.Runtime]System.Object
-			IL_001f: dup
-			IL_0020: ldc.i4.0
-			IL_0021: ldarg.0
-			IL_0022: stelem.ref
-			IL_0023: ldc.i4.0
-			IL_0024: ldelem.ref
-			IL_0025: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_002a: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0035: ldnull
-			IL_0036: ldarg.2
-			IL_0037: ldarg.3
-			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_003d: stloc.s 7
-			IL_003f: ldloc.s 7
-			IL_0041: stloc.1
-			IL_0042: ldloc.1
-			IL_0043: ldstr "ok"
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0052: stloc.s 6
-			IL_0054: ldloc.s 6
-			IL_0056: brfalse IL_008f
+			IL_0019: ldarg.0
+			IL_001a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_001f: ldnull
+			IL_0020: ldarg.2
+			IL_0021: ldarg.3
+			IL_0022: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0027: stloc.s 7
+			IL_0029: ldloc.s 7
+			IL_002b: stloc.1
+			IL_002c: ldloc.1
+			IL_002d: ldstr "ok"
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_003c: stloc.s 6
+			IL_003e: ldloc.s 6
+			IL_0040: brfalse IL_0079
 
-			IL_005b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14/Block_L304C20::.ctor()
-			IL_0060: stloc.2
-			IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0066: dup
-			IL_0067: ldstr "source"
-			IL_006c: ldstr "managed-cache"
-			IL_0071: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0076: dup
-			IL_0077: ldstr "rootPath"
-			IL_007c: ldarg.2
-			IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0082: dup
-			IL_0083: ldstr "reused"
-			IL_0088: ldc.i4.1
-			IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_008e: ret
+			IL_0045: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14/Block_L304C20::.ctor()
+			IL_004a: stloc.2
+			IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0050: dup
+			IL_0051: ldstr "source"
+			IL_0056: ldstr "managed-cache"
+			IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0060: dup
+			IL_0061: ldstr "rootPath"
+			IL_0066: ldarg.2
+			IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_006c: dup
+			IL_006d: ldstr "reused"
+			IL_0072: ldc.i4.1
+			IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0078: ret
 
-			IL_008f: ldc.i4.1
-			IL_0090: newarr [System.Runtime]System.Object
-			IL_0095: dup
-			IL_0096: ldc.i4.0
-			IL_0097: ldarg.0
-			IL_0098: stelem.ref
-			IL_0099: ldc.i4.0
-			IL_009a: ldelem.ref
-			IL_009b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00a0: ldftn object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ab: ldnull
-			IL_00ac: ldarg.2
-			IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00b2: pop
-			IL_00b3: ldc.i4.1
-			IL_00b4: newarr [System.Runtime]System.Object
-			IL_00b9: dup
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldarg.0
-			IL_00bc: stelem.ref
-			IL_00bd: ldc.i4.0
-			IL_00be: ldelem.ref
-			IL_00bf: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00c4: ldftn object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00cf: ldnull
-			IL_00d0: ldarg.2
-			IL_00d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00d6: pop
-			IL_00d7: ldc.i4.1
-			IL_00d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00dd: dup
-			IL_00de: ldstr "init"
-			IL_00e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00e8: stloc.s 8
-			IL_00ea: ldc.i4.1
-			IL_00eb: newarr [System.Runtime]System.Object
-			IL_00f0: dup
-			IL_00f1: ldc.i4.0
-			IL_00f2: ldarg.0
-			IL_00f3: stelem.ref
-			IL_00f4: ldc.i4.0
-			IL_00f5: ldelem.ref
-			IL_00f6: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00fb: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0101: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0106: ldnull
-			IL_0107: ldloc.s 8
-			IL_0109: ldarg.2
-			IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_010f: pop
-			IL_0110: ldc.i4.3
-			IL_0111: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0116: dup
-			IL_0117: ldstr "config"
-			IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0121: dup
-			IL_0122: ldstr "core.autocrlf"
-			IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_012c: dup
-			IL_012d: ldstr "false"
-			IL_0132: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0137: stloc.s 8
-			IL_0139: ldc.i4.1
-			IL_013a: newarr [System.Runtime]System.Object
-			IL_013f: dup
-			IL_0140: ldc.i4.0
-			IL_0141: ldarg.0
-			IL_0142: stelem.ref
-			IL_0143: ldc.i4.0
-			IL_0144: ldelem.ref
-			IL_0145: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_014a: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0150: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0155: ldnull
-			IL_0156: ldloc.s 8
-			IL_0158: ldarg.2
-			IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_015e: pop
-			IL_015f: ldc.i4.3
-			IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0165: dup
-			IL_0166: ldstr "config"
-			IL_016b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0170: dup
-			IL_0171: ldstr "core.eol"
-			IL_0176: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_017b: dup
-			IL_017c: ldstr "lf"
-			IL_0181: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0186: stloc.s 8
-			IL_0188: ldc.i4.1
-			IL_0189: newarr [System.Runtime]System.Object
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldarg.0
-			IL_0191: stelem.ref
-			IL_0192: ldc.i4.0
-			IL_0193: ldelem.ref
-			IL_0194: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0199: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_019f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_01a4: ldnull
-			IL_01a5: ldloc.s 8
-			IL_01a7: ldarg.2
-			IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_01ad: pop
-			IL_01ae: ldc.i4.4
-			IL_01af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01b4: dup
-			IL_01b5: ldstr "remote"
-			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01bf: dup
-			IL_01c0: ldstr "add"
-			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01ca: dup
-			IL_01cb: ldstr "origin"
-			IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01d5: dup
-			IL_01d6: ldarg.3
-			IL_01d7: ldstr "upstream"
-			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e1: ldstr "cloneUrl"
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01f0: stloc.s 8
-			IL_01f2: ldc.i4.1
-			IL_01f3: newarr [System.Runtime]System.Object
-			IL_01f8: dup
-			IL_01f9: ldc.i4.0
-			IL_01fa: ldarg.0
+			IL_0079: ldarg.0
+			IL_007a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_007f: ldnull
+			IL_0080: ldarg.2
+			IL_0081: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0086: pop
+			IL_0087: ldarg.0
+			IL_0088: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_008d: ldnull
+			IL_008e: ldarg.2
+			IL_008f: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0094: pop
+			IL_0095: ldc.i4.1
+			IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_009b: dup
+			IL_009c: ldstr "init"
+			IL_00a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00a6: stloc.s 8
+			IL_00a8: ldarg.0
+			IL_00a9: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00ae: ldnull
+			IL_00af: ldloc.s 8
+			IL_00b1: ldarg.2
+			IL_00b2: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_00b7: pop
+			IL_00b8: ldc.i4.3
+			IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00be: dup
+			IL_00bf: ldstr "config"
+			IL_00c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00c9: dup
+			IL_00ca: ldstr "core.autocrlf"
+			IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00d4: dup
+			IL_00d5: ldstr "false"
+			IL_00da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00df: stloc.s 8
+			IL_00e1: ldarg.0
+			IL_00e2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00e7: ldnull
+			IL_00e8: ldloc.s 8
+			IL_00ea: ldarg.2
+			IL_00eb: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_00f0: pop
+			IL_00f1: ldc.i4.3
+			IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00f7: dup
+			IL_00f8: ldstr "config"
+			IL_00fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0102: dup
+			IL_0103: ldstr "core.eol"
+			IL_0108: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_010d: dup
+			IL_010e: ldstr "lf"
+			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0118: stloc.s 8
+			IL_011a: ldarg.0
+			IL_011b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0120: ldnull
+			IL_0121: ldloc.s 8
+			IL_0123: ldarg.2
+			IL_0124: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0129: pop
+			IL_012a: ldc.i4.4
+			IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0130: dup
+			IL_0131: ldstr "remote"
+			IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_013b: dup
+			IL_013c: ldstr "add"
+			IL_0141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0146: dup
+			IL_0147: ldstr "origin"
+			IL_014c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0151: dup
+			IL_0152: ldarg.3
+			IL_0153: ldstr "upstream"
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015d: ldstr "cloneUrl"
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0167: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_016c: stloc.s 8
+			IL_016e: ldarg.0
+			IL_016f: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0174: ldnull
+			IL_0175: ldloc.s 8
+			IL_0177: ldarg.2
+			IL_0178: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_017d: pop
+			IL_017e: ldc.i4.3
+			IL_017f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0184: dup
+			IL_0185: ldstr "sparse-checkout"
+			IL_018a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_018f: dup
+			IL_0190: ldstr "init"
+			IL_0195: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_019a: dup
+			IL_019b: ldstr "--no-cone"
+			IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a5: stloc.s 8
+			IL_01a7: ldarg.0
+			IL_01a8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01ad: ldnull
+			IL_01ae: ldloc.s 8
+			IL_01b0: ldarg.2
+			IL_01b1: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_01b6: pop
+			IL_01b7: ldc.i4.3
+			IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01bd: dup
+			IL_01be: ldstr "sparse-checkout"
+			IL_01c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01c8: dup
+			IL_01c9: ldstr "set"
+			IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01d3: dup
+			IL_01d4: ldstr "--no-cone"
+			IL_01d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01de: stloc.s 8
+			IL_01e0: ldarg.0
+			IL_01e1: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_01e6: ldnull
+			IL_01e7: ldarg.3
+			IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_01ed: stloc.s 7
+			IL_01ef: ldloc.s 8
+			IL_01f1: ldc.i4.1
+			IL_01f2: newarr [System.Runtime]System.Object
+			IL_01f7: dup
+			IL_01f8: ldc.i4.0
+			IL_01f9: ldloc.s 7
 			IL_01fb: stelem.ref
-			IL_01fc: ldc.i4.0
-			IL_01fd: ldelem.ref
-			IL_01fe: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0203: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0209: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_020e: ldnull
-			IL_020f: ldloc.s 8
-			IL_0211: ldarg.2
-			IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0217: pop
-			IL_0218: ldc.i4.3
-			IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_021e: dup
-			IL_021f: ldstr "sparse-checkout"
-			IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0229: dup
-			IL_022a: ldstr "init"
-			IL_022f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0234: dup
-			IL_0235: ldstr "--no-cone"
-			IL_023a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_023f: stloc.s 8
-			IL_0241: ldc.i4.1
-			IL_0242: newarr [System.Runtime]System.Object
-			IL_0247: dup
-			IL_0248: ldc.i4.0
-			IL_0249: ldarg.0
-			IL_024a: stelem.ref
-			IL_024b: ldc.i4.0
-			IL_024c: ldelem.ref
-			IL_024d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0252: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_025d: ldnull
-			IL_025e: ldloc.s 8
-			IL_0260: ldarg.2
-			IL_0261: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0266: pop
-			IL_0267: ldc.i4.3
-			IL_0268: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_026d: dup
-			IL_026e: ldstr "sparse-checkout"
-			IL_0273: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01fc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+			IL_0201: stloc.s 8
+			IL_0203: ldarg.0
+			IL_0204: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0209: ldnull
+			IL_020a: ldloc.s 8
+			IL_020c: ldarg.2
+			IL_020d: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0212: pop
+			IL_0213: ldc.i4.5
+			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0219: dup
+			IL_021a: ldstr "fetch"
+			IL_021f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0224: dup
+			IL_0225: ldstr "--depth"
+			IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_022f: dup
+			IL_0230: ldstr "1"
+			IL_0235: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_023a: dup
+			IL_023b: ldstr "origin"
+			IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0245: dup
+			IL_0246: ldarg.3
+			IL_0247: ldstr "upstream"
+			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0251: ldstr "commit"
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0260: stloc.s 8
+			IL_0262: ldarg.0
+			IL_0263: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0268: ldnull
+			IL_0269: ldloc.s 8
+			IL_026b: ldarg.2
+			IL_026c: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0271: pop
+			IL_0272: ldc.i4.3
+			IL_0273: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0278: dup
-			IL_0279: ldstr "set"
+			IL_0279: ldstr "checkout"
 			IL_027e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0283: dup
-			IL_0284: ldstr "--no-cone"
+			IL_0284: ldstr "--detach"
 			IL_0289: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_028e: stloc.s 8
-			IL_0290: ldc.i4.1
-			IL_0291: newarr [System.Runtime]System.Object
-			IL_0296: dup
-			IL_0297: ldc.i4.0
-			IL_0298: ldarg.0
-			IL_0299: stelem.ref
-			IL_029a: ldc.i4.0
-			IL_029b: ldelem.ref
+			IL_028e: dup
+			IL_028f: ldstr "FETCH_HEAD"
+			IL_0294: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0299: stloc.s 8
+			IL_029b: ldarg.0
 			IL_029c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_02a1: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_02a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_02ac: ldnull
-			IL_02ad: ldarg.3
-			IL_02ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_02b3: stloc.s 7
-			IL_02b5: ldloc.s 8
-			IL_02b7: ldc.i4.1
-			IL_02b8: newarr [System.Runtime]System.Object
-			IL_02bd: dup
-			IL_02be: ldc.i4.0
-			IL_02bf: ldloc.s 7
-			IL_02c1: stelem.ref
-			IL_02c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-			IL_02c7: stloc.s 8
-			IL_02c9: ldc.i4.1
-			IL_02ca: newarr [System.Runtime]System.Object
-			IL_02cf: dup
-			IL_02d0: ldc.i4.0
-			IL_02d1: ldarg.0
-			IL_02d2: stelem.ref
-			IL_02d3: ldc.i4.0
-			IL_02d4: ldelem.ref
-			IL_02d5: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_02da: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_02e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_02e5: ldnull
-			IL_02e6: ldloc.s 8
-			IL_02e8: ldarg.2
-			IL_02e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_02ee: pop
-			IL_02ef: ldc.i4.5
-			IL_02f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02f5: dup
-			IL_02f6: ldstr "fetch"
-			IL_02fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0300: dup
-			IL_0301: ldstr "--depth"
-			IL_0306: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_030b: dup
-			IL_030c: ldstr "1"
-			IL_0311: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0316: dup
-			IL_0317: ldstr "origin"
-			IL_031c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0321: dup
-			IL_0322: ldarg.3
-			IL_0323: ldstr "upstream"
-			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_032d: ldstr "commit"
-			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0337: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_033c: stloc.s 8
-			IL_033e: ldc.i4.1
-			IL_033f: newarr [System.Runtime]System.Object
-			IL_0344: dup
-			IL_0345: ldc.i4.0
-			IL_0346: ldarg.0
-			IL_0347: stelem.ref
-			IL_0348: ldc.i4.0
-			IL_0349: ldelem.ref
-			IL_034a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_034f: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0355: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_035a: ldnull
-			IL_035b: ldloc.s 8
-			IL_035d: ldarg.2
-			IL_035e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0363: pop
-			IL_0364: ldc.i4.3
-			IL_0365: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_036a: dup
-			IL_036b: ldstr "checkout"
-			IL_0370: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0375: dup
-			IL_0376: ldstr "--detach"
-			IL_037b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0380: dup
-			IL_0381: ldstr "FETCH_HEAD"
-			IL_0386: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_038b: stloc.s 8
-			IL_038d: ldc.i4.1
-			IL_038e: newarr [System.Runtime]System.Object
-			IL_0393: dup
-			IL_0394: ldc.i4.0
-			IL_0395: ldarg.0
-			IL_0396: stelem.ref
-			IL_0397: ldc.i4.0
-			IL_0398: ldelem.ref
-			IL_0399: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_039e: ldftn object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_03a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_03a9: ldnull
-			IL_03aa: ldloc.s 8
-			IL_03ac: ldarg.2
-			IL_03ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_03b2: pop
-			IL_03b3: ldc.i4.1
-			IL_03b4: newarr [System.Runtime]System.Object
-			IL_03b9: dup
-			IL_03ba: ldc.i4.0
-			IL_03bb: ldarg.0
-			IL_03bc: stelem.ref
-			IL_03bd: ldc.i4.0
-			IL_03be: ldelem.ref
-			IL_03bf: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_03c4: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_03ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_03cf: ldnull
-			IL_03d0: ldarg.2
-			IL_03d1: ldarg.3
-			IL_03d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_03d7: stloc.s 7
-			IL_03d9: ldloc.s 7
-			IL_03db: stloc.3
-			IL_03dc: ldloc.3
-			IL_03dd: ldstr "ok"
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03ec: ldc.i4.0
-			IL_03ed: ceq
-			IL_03ef: stloc.s 6
-			IL_03f1: ldloc.s 6
-			IL_03f3: brfalse IL_0448
+			IL_02a1: ldnull
+			IL_02a2: ldloc.s 8
+			IL_02a4: ldarg.2
+			IL_02a5: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_02aa: pop
+			IL_02ab: ldarg.0
+			IL_02ac: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_02b1: ldnull
+			IL_02b2: ldarg.2
+			IL_02b3: ldarg.3
+			IL_02b4: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_02b9: stloc.s 7
+			IL_02bb: ldloc.s 7
+			IL_02bd: stloc.3
+			IL_02be: ldloc.3
+			IL_02bf: ldstr "ok"
+			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02ce: ldc.i4.0
+			IL_02cf: ceq
+			IL_02d1: stloc.s 6
+			IL_02d3: ldloc.s 6
+			IL_02d5: brfalse IL_032a
 
-			IL_03f8: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22::.ctor()
-			IL_03fd: stloc.s 4
-			IL_03ff: ldloc.3
-			IL_0400: ldstr "message"
-			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_040f: stloc.s 9
-			IL_0411: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
-			IL_0416: ldloc.s 9
-			IL_0418: call string [System.Runtime]System.String::Concat(string, string)
-			IL_041d: stloc.s 9
-			IL_041f: ldloc.s 9
-			IL_0421: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0426: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_042b: stloc.s 7
-			IL_042d: ldloc.s 7
-			IL_042f: stloc.s 5
-			IL_0431: ldloc.s 5
-			IL_0433: isinst [System.Runtime]System.Exception
-			IL_0438: dup
-			IL_0439: brtrue IL_0447
+			IL_02da: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22::.ctor()
+			IL_02df: stloc.s 4
+			IL_02e1: ldloc.3
+			IL_02e2: ldstr "message"
+			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02f1: stloc.s 9
+			IL_02f3: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
+			IL_02f8: ldloc.s 9
+			IL_02fa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02ff: stloc.s 9
+			IL_0301: ldloc.s 9
+			IL_0303: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_030d: stloc.s 7
+			IL_030f: ldloc.s 7
+			IL_0311: stloc.s 5
+			IL_0313: ldloc.s 5
+			IL_0315: isinst [System.Runtime]System.Exception
+			IL_031a: dup
+			IL_031b: brtrue IL_0329
 
-			IL_043e: pop
-			IL_043f: ldloc.s 5
-			IL_0441: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0446: throw
+			IL_0320: pop
+			IL_0321: ldloc.s 5
+			IL_0323: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0328: throw
 
-			IL_0447: throw
+			IL_0329: throw
 
-			IL_0448: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_044d: dup
-			IL_044e: ldstr "source"
-			IL_0453: ldstr "managed-cache"
-			IL_0458: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_045d: dup
-			IL_045e: ldstr "rootPath"
-			IL_0463: ldarg.2
-			IL_0464: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0469: dup
-			IL_046a: ldstr "reused"
-			IL_046f: ldc.i4.0
-			IL_0470: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0475: ret
+			IL_032a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_032f: dup
+			IL_0330: ldstr "source"
+			IL_0335: ldstr "managed-cache"
+			IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_033f: dup
+			IL_0340: ldstr "rootPath"
+			IL_0345: ldarg.2
+			IL_0346: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_034b: dup
+			IL_034c: ldstr "reused"
+			IL_0351: ldc.i4.0
+			IL_0352: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0357: ret
 		} // end of method ensureManagedCheckout::__js_call__
 
 	} // end of class ensureManagedCheckout
@@ -5325,7 +5127,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5282
+						// Method begins at RVA 0x4f92
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5343,7 +5145,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5279
+					// Method begins at RVA 0x4f89
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5361,7 +5163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5270
+				// Method begins at RVA 0x4f80
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5390,9 +5192,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4afc
+			// Method begins at RVA 0x4908
 			// Header size: 12
-			// Code size: 423 (0x1a7)
+			// Code size: 346 (0x15a)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5407,168 +5209,134 @@
 				[9] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0011: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldarg.s args
-			IL_001f: ldarg.3
-			IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0025: stloc.s 5
-			IL_0027: ldloc.s 5
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0030: stloc.s 6
-			IL_0032: ldloc.s 6
-			IL_0034: brfalse IL_0152
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0006: ldnull
+			IL_0007: ldarg.s args
+			IL_0009: ldarg.3
+			IL_000a: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_000f: stloc.s 5
+			IL_0011: ldloc.s 5
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_001a: stloc.s 6
+			IL_001c: ldloc.s 6
+			IL_001e: brfalse IL_0126
 
-			IL_0039: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16::.ctor()
-			IL_003e: stloc.1
-			IL_003f: ldloc.0
-			IL_0040: ldstr "rootPath"
-			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004a: stloc.s 5
-			IL_004c: ldc.i4.1
-			IL_004d: newarr [System.Runtime]System.Object
-			IL_0052: dup
-			IL_0053: ldc.i4.0
-			IL_0054: ldarg.0
-			IL_0055: stelem.ref
-			IL_0056: ldc.i4.0
-			IL_0057: ldelem.ref
-			IL_0058: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_005d: ldftn object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0068: ldnull
-			IL_0069: ldloc.s 5
-			IL_006b: ldarg.3
-			IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0071: stloc.s 5
-			IL_0073: ldloc.s 5
-			IL_0075: stloc.2
-			IL_0076: ldloc.2
-			IL_0077: ldstr "ok"
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0086: ldc.i4.0
-			IL_0087: ceq
-			IL_0089: stloc.s 6
-			IL_008b: ldloc.s 6
-			IL_008d: brfalse IL_010c
+			IL_0023: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16::.ctor()
+			IL_0028: stloc.1
+			IL_0029: ldloc.0
+			IL_002a: ldstr "rootPath"
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0034: stloc.s 5
+			IL_0036: ldarg.0
+			IL_0037: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_003c: ldnull
+			IL_003d: ldloc.s 5
+			IL_003f: ldarg.3
+			IL_0040: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0045: stloc.s 5
+			IL_0047: ldloc.s 5
+			IL_0049: stloc.2
+			IL_004a: ldloc.2
+			IL_004b: ldstr "ok"
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_005a: ldc.i4.0
+			IL_005b: ceq
+			IL_005d: stloc.s 6
+			IL_005f: ldloc.s 6
+			IL_0061: brfalse IL_00e0
 
-			IL_0092: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24::.ctor()
-			IL_0097: stloc.3
-			IL_0098: ldloc.0
-			IL_0099: ldstr "rootPath"
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a8: stloc.s 7
-			IL_00aa: ldstr "Override test262 root '"
-			IL_00af: ldloc.s 7
-			IL_00b1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b6: stloc.s 7
-			IL_00b8: ldloc.s 7
-			IL_00ba: ldstr "' is invalid: "
-			IL_00bf: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c4: stloc.s 7
-			IL_00c6: ldloc.2
-			IL_00c7: ldstr "message"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00d6: stloc.s 8
-			IL_00d8: ldloc.s 7
-			IL_00da: ldloc.s 8
-			IL_00dc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e1: stloc.s 8
-			IL_00e3: ldloc.s 8
-			IL_00e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00ef: stloc.s 5
-			IL_00f1: ldloc.s 5
-			IL_00f3: stloc.s 4
-			IL_00f5: ldloc.s 4
-			IL_00f7: isinst [System.Runtime]System.Exception
-			IL_00fc: dup
-			IL_00fd: brtrue IL_010b
+			IL_0066: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24::.ctor()
+			IL_006b: stloc.3
+			IL_006c: ldloc.0
+			IL_006d: ldstr "rootPath"
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0077: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_007c: stloc.s 7
+			IL_007e: ldstr "Override test262 root '"
+			IL_0083: ldloc.s 7
+			IL_0085: call string [System.Runtime]System.String::Concat(string, string)
+			IL_008a: stloc.s 7
+			IL_008c: ldloc.s 7
+			IL_008e: ldstr "' is invalid: "
+			IL_0093: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0098: stloc.s 7
+			IL_009a: ldloc.2
+			IL_009b: ldstr "message"
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00aa: stloc.s 8
+			IL_00ac: ldloc.s 7
+			IL_00ae: ldloc.s 8
+			IL_00b0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b5: stloc.s 8
+			IL_00b7: ldloc.s 8
+			IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00c3: stloc.s 5
+			IL_00c5: ldloc.s 5
+			IL_00c7: stloc.s 4
+			IL_00c9: ldloc.s 4
+			IL_00cb: isinst [System.Runtime]System.Exception
+			IL_00d0: dup
+			IL_00d1: brtrue IL_00df
 
-			IL_0102: pop
-			IL_0103: ldloc.s 4
-			IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_010a: throw
+			IL_00d6: pop
+			IL_00d7: ldloc.s 4
+			IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00de: throw
 
-			IL_010b: throw
+			IL_00df: throw
 
-			IL_010c: ldloc.0
-			IL_010d: ldstr "source"
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0117: stloc.s 5
-			IL_0119: ldloc.0
-			IL_011a: ldstr "rootPath"
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0124: stloc.s 9
-			IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_012b: dup
-			IL_012c: ldstr "source"
-			IL_0131: ldloc.s 5
-			IL_0133: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0138: dup
-			IL_0139: ldstr "rootPath"
-			IL_013e: ldloc.s 9
-			IL_0140: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0145: dup
-			IL_0146: ldstr "reused"
-			IL_014b: ldc.i4.1
-			IL_014c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0151: ret
+			IL_00e0: ldloc.0
+			IL_00e1: ldstr "source"
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00eb: stloc.s 5
+			IL_00ed: ldloc.0
+			IL_00ee: ldstr "rootPath"
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f8: stloc.s 9
+			IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00ff: dup
+			IL_0100: ldstr "source"
+			IL_0105: ldloc.s 5
+			IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_010c: dup
+			IL_010d: ldstr "rootPath"
+			IL_0112: ldloc.s 9
+			IL_0114: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0119: dup
+			IL_011a: ldstr "reused"
+			IL_011f: ldc.i4.1
+			IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0125: ret
 
-			IL_0152: ldc.i4.1
-			IL_0153: newarr [System.Runtime]System.Object
-			IL_0158: dup
-			IL_0159: ldc.i4.0
-			IL_015a: ldarg.0
-			IL_015b: stelem.ref
-			IL_015c: ldc.i4.0
-			IL_015d: ldelem.ref
-			IL_015e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0163: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_016e: ldnull
-			IL_016f: ldarg.2
-			IL_0170: ldarg.3
-			IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0176: stloc.s 9
-			IL_0178: ldarg.s args
-			IL_017a: ldstr "force"
-			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0184: stloc.s 5
-			IL_0186: ldc.i4.1
-			IL_0187: newarr [System.Runtime]System.Object
-			IL_018c: dup
-			IL_018d: ldc.i4.0
-			IL_018e: ldarg.0
-			IL_018f: stelem.ref
-			IL_0190: ldc.i4.0
-			IL_0191: ldelem.ref
-			IL_0192: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0197: ldnull
-			IL_0198: ldloc.s 9
-			IL_019a: ldarg.3
-			IL_019b: ldloc.s 5
-			IL_019d: tail.
-			IL_019f: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_01a4: ret
+			IL_0126: ldarg.0
+			IL_0127: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_012c: ldnull
+			IL_012d: ldarg.2
+			IL_012e: ldarg.3
+			IL_012f: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_0134: stloc.s 9
+			IL_0136: ldarg.s args
+			IL_0138: ldstr "force"
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0142: stloc.s 5
+			IL_0144: ldarg.0
+			IL_0145: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_014a: ldnull
+			IL_014b: ldloc.s 9
+			IL_014d: ldarg.3
+			IL_014e: ldloc.s 5
+			IL_0150: tail.
+			IL_0152: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_0157: ret
 
-			IL_01a5: ldnull
-			IL_01a6: ret
+			IL_0158: ldnull
+			IL_0159: ret
 		} // end of method resolveBootstrapRoot::__js_call__
 
 	} // end of class resolveBootstrapRoot
@@ -5588,7 +5356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5294
+					// Method begins at RVA 0x4fa4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5606,7 +5374,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x528b
+				// Method begins at RVA 0x4f9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5635,7 +5403,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4cb0
+			// Method begins at RVA 0x4a70
 			// Header size: 12
 			// Code size: 356 (0x164)
 			.maxstack 8
@@ -5792,7 +5560,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52a6
+					// Method begins at RVA 0x4fb6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5812,7 +5580,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52af
+					// Method begins at RVA 0x4fbf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5830,7 +5598,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x529d
+				// Method begins at RVA 0x4fad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5856,9 +5624,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4e20
+			// Method begins at RVA 0x4be0
 			// Header size: 12
-			// Code size: 516 (0x204)
+			// Code size: 340 (0x154)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5886,197 +5654,125 @@
 			IL_0026: box [System.Runtime]System.Double
 			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_0030: stloc.s 7
-			IL_0032: ldc.i4.1
-			IL_0033: newarr [System.Runtime]System.Object
-			IL_0038: dup
-			IL_0039: ldc.i4.0
-			IL_003a: ldarg.0
-			IL_003b: stelem.ref
-			IL_003c: ldc.i4.0
-			IL_003d: ldelem.ref
-			IL_003e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0043: ldftn object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_004e: ldnull
-			IL_004f: ldloc.s 7
-			IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0056: stloc.s 7
-			IL_0058: ldloc.s 7
-			IL_005a: stloc.0
-			IL_005b: ldloc.0
-			IL_005c: ldstr "help"
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0066: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_006b: stloc.s 8
-			IL_006d: ldloc.s 8
-			IL_006f: brfalse IL_0083
+			IL_0032: ldarg.0
+			IL_0033: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0038: ldnull
+			IL_0039: ldloc.s 7
+			IL_003b: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_0040: stloc.s 7
+			IL_0042: ldloc.s 7
+			IL_0044: stloc.0
+			IL_0045: ldloc.0
+			IL_0046: ldstr "help"
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0055: stloc.s 8
+			IL_0057: ldloc.s 8
+			IL_0059: brfalse IL_006d
 
-			IL_0074: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L363C17::.ctor()
-			IL_0079: stloc.1
-			IL_007a: ldnull
-			IL_007b: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
-			IL_0080: pop
-			IL_0081: ldnull
-			IL_0082: ret
+			IL_005e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L363C17::.ctor()
+			IL_0063: stloc.1
+			IL_0064: ldnull
+			IL_0065: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
+			IL_006a: pop
+			IL_006b: ldnull
+			IL_006c: ret
 
-			IL_0083: ldloc.0
-			IL_0084: ldstr "pin"
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008e: stloc.s 7
-			IL_0090: ldloc.s 7
-			IL_0092: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0097: stloc.s 8
-			IL_0099: ldloc.s 8
-			IL_009b: brtrue IL_00cd
+			IL_006d: ldloc.0
+			IL_006e: ldstr "pin"
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0078: stloc.s 7
+			IL_007a: ldloc.s 7
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0081: stloc.s 8
+			IL_0083: ldloc.s 8
+			IL_0085: brtrue IL_00a1
 
-			IL_00a0: ldc.i4.1
-			IL_00a1: newarr [System.Runtime]System.Object
-			IL_00a6: dup
-			IL_00a7: ldc.i4.0
-			IL_00a8: ldarg.0
-			IL_00a9: stelem.ref
-			IL_00aa: ldc.i4.0
-			IL_00ab: ldelem.ref
-			IL_00ac: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00b1: ldftn object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-			IL_00b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00bc: ldnull
-			IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_00c2: stloc.s 9
-			IL_00c4: ldloc.s 9
-			IL_00c6: stloc.s 11
-			IL_00c8: br IL_00d1
+			IL_008a: ldarg.0
+			IL_008b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0090: ldnull
+			IL_0091: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+			IL_0096: stloc.s 9
+			IL_0098: ldloc.s 9
+			IL_009a: stloc.s 11
+			IL_009c: br IL_00a5
 
-			IL_00cd: ldloc.s 7
-			IL_00cf: stloc.s 11
+			IL_00a1: ldloc.s 7
+			IL_00a3: stloc.s 11
 
-			IL_00d1: ldc.i4.1
-			IL_00d2: newarr [System.Runtime]System.Object
-			IL_00d7: dup
-			IL_00d8: ldc.i4.0
-			IL_00d9: ldarg.0
-			IL_00da: stelem.ref
-			IL_00db: ldc.i4.0
-			IL_00dc: ldelem.ref
-			IL_00dd: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00e2: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ed: ldnull
-			IL_00ee: ldloc.s 11
-			IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00f5: stloc.s 7
-			IL_00f7: ldloc.s 7
-			IL_00f9: stloc.2
-			IL_00fa: ldc.i4.1
-			IL_00fb: newarr [System.Runtime]System.Object
-			IL_0100: dup
-			IL_0101: ldc.i4.0
-			IL_0102: ldarg.0
-			IL_0103: stelem.ref
-			IL_0104: ldc.i4.0
-			IL_0105: ldelem.ref
-			IL_0106: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_010b: ldftn object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0111: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0116: ldnull
-			IL_0117: ldloc.2
-			IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_011d: stloc.s 7
-			IL_011f: ldloc.s 7
-			IL_0121: stloc.3
-			IL_0122: ldc.i4.1
-			IL_0123: newarr [System.Runtime]System.Object
-			IL_0128: dup
-			IL_0129: ldc.i4.0
-			IL_012a: ldarg.0
-			IL_012b: stelem.ref
-			IL_012c: ldc.i4.0
-			IL_012d: ldelem.ref
-			IL_012e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0133: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0139: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_013e: ldnull
-			IL_013f: ldloc.0
-			IL_0140: ldloc.3
-			IL_0141: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0146: stloc.s 7
-			IL_0148: ldloc.s 7
-			IL_014a: stloc.s 4
-			IL_014c: ldloc.0
-			IL_014d: ldstr "describe"
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_015c: stloc.s 8
-			IL_015e: ldloc.s 8
-			IL_0160: brfalse IL_01a2
+			IL_00a5: ldarg.0
+			IL_00a6: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00ab: ldnull
+			IL_00ac: ldloc.s 11
+			IL_00ae: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00b3: stloc.s 7
+			IL_00b5: ldloc.s 7
+			IL_00b7: stloc.2
+			IL_00b8: ldarg.0
+			IL_00b9: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00be: ldnull
+			IL_00bf: ldloc.2
+			IL_00c0: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+			IL_00c5: stloc.s 7
+			IL_00c7: ldloc.s 7
+			IL_00c9: stloc.3
+			IL_00ca: ldarg.0
+			IL_00cb: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_00d0: ldnull
+			IL_00d1: ldloc.0
+			IL_00d2: ldloc.3
+			IL_00d3: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_00d8: stloc.s 7
+			IL_00da: ldloc.s 7
+			IL_00dc: stloc.s 4
+			IL_00de: ldloc.0
+			IL_00df: ldstr "describe"
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00ee: stloc.s 8
+			IL_00f0: ldloc.s 8
+			IL_00f2: brfalse IL_011e
 
-			IL_0165: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L372C21::.ctor()
-			IL_016a: stloc.s 5
-			IL_016c: ldc.i4.1
-			IL_016d: newarr [System.Runtime]System.Object
-			IL_0172: dup
-			IL_0173: ldc.i4.0
-			IL_0174: ldarg.0
-			IL_0175: stelem.ref
-			IL_0176: ldc.i4.0
-			IL_0177: ldelem.ref
-			IL_0178: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_017d: ldftn object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0188: ldnull
-			IL_0189: ldloc.3
-			IL_018a: ldloc.s 4
-			IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0191: stloc.s 7
-			IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0198: ldloc.s 7
-			IL_019a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_019f: pop
-			IL_01a0: ldnull
-			IL_01a1: ret
+			IL_00f7: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L372C21::.ctor()
+			IL_00fc: stloc.s 5
+			IL_00fe: ldarg.0
+			IL_00ff: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0104: ldnull
+			IL_0105: ldloc.3
+			IL_0106: ldloc.s 4
+			IL_0108: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+			IL_010d: stloc.s 7
+			IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0114: ldloc.s 7
+			IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_011b: pop
+			IL_011c: ldnull
+			IL_011d: ret
 
-			IL_01a2: ldc.i4.1
-			IL_01a3: newarr [System.Runtime]System.Object
-			IL_01a8: dup
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldarg.0
-			IL_01ab: stelem.ref
-			IL_01ac: ldc.i4.0
-			IL_01ad: ldelem.ref
-			IL_01ae: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_01b3: ldftn object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_01be: ldnull
-			IL_01bf: ldloc.2
-			IL_01c0: ldloc.3
-			IL_01c1: ldloc.0
-			IL_01c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_01c7: stloc.s 7
-			IL_01c9: ldloc.s 7
-			IL_01cb: stloc.s 6
-			IL_01cd: ldloc.0
-			IL_01ce: ldstr "printRoot"
-			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d8: stloc.s 7
-			IL_01da: ldc.i4.1
-			IL_01db: newarr [System.Runtime]System.Object
-			IL_01e0: dup
-			IL_01e1: ldc.i4.0
-			IL_01e2: ldarg.0
-			IL_01e3: stelem.ref
-			IL_01e4: ldc.i4.0
-			IL_01e5: ldelem.ref
-			IL_01e6: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_01eb: ldftn object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_01f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_01f6: ldnull
-			IL_01f7: ldloc.s 6
-			IL_01f9: ldloc.3
-			IL_01fa: ldloc.s 7
-			IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0201: pop
-			IL_0202: ldnull
-			IL_0203: ret
+			IL_011e: ldarg.0
+			IL_011f: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0124: ldnull
+			IL_0125: ldloc.2
+			IL_0126: ldloc.3
+			IL_0127: ldloc.0
+			IL_0128: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_012d: stloc.s 7
+			IL_012f: ldloc.s 7
+			IL_0131: stloc.s 6
+			IL_0133: ldloc.0
+			IL_0134: ldstr "printRoot"
+			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_013e: stloc.s 7
+			IL_0140: ldarg.0
+			IL_0141: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0146: ldnull
+			IL_0147: ldloc.s 6
+			IL_0149: ldloc.3
+			IL_014a: ldloc.s 7
+			IL_014c: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_0151: pop
+			IL_0152: ldnull
+			IL_0153: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -6112,7 +5808,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52c1
+					// Method begins at RVA 0x4fd1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6132,7 +5828,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x52ca
+					// Method begins at RVA 0x4fda
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6150,7 +5846,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x52b8
+				// Method begins at RVA 0x4fc8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6198,7 +5894,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5030
+			// Method begins at RVA 0x4d40
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -6224,7 +5920,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1758 (0x6de)
+		// Code size: 1736 (0x6c8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
@@ -6831,7 +6527,7 @@
 		IL_05d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_05d9: stloc.s 20
 		IL_05db: ldloc.s 20
-		IL_05dd: brfalse IL_06da
+		IL_05dd: brfalse IL_06c4
 
 		IL_05e2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29::.ctor()
 		IL_05e7: stloc.2
@@ -6839,102 +6535,93 @@
 		{
 			IL_05e8: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L395C6::.ctor()
 			IL_05ed: stloc.3
-			IL_05ee: ldc.i4.1
-			IL_05ef: newarr [System.Runtime]System.Object
-			IL_05f4: dup
-			IL_05f5: ldc.i4.0
-			IL_05f6: ldloc.0
-			IL_05f7: stelem.ref
-			IL_05f8: ldc.i4.0
-			IL_05f9: ldelem.ref
-			IL_05fa: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_05ff: ldftn object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-			IL_0605: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_060a: ldnull
-			IL_060b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0610: pop
-			IL_0611: leave IL_06da
+			IL_05ee: ldloc.0
+			IL_05ef: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_05f4: ldnull
+			IL_05f5: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+			IL_05fa: pop
+			IL_05fb: leave IL_06c4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0616: stloc.s 4
-			IL_0618: ldloc.s 4
-			IL_061a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_061f: dup
-			IL_0620: brtrue IL_0636
+			IL_0600: stloc.s 4
+			IL_0602: ldloc.s 4
+			IL_0604: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0609: dup
+			IL_060a: brtrue IL_0620
 
-			IL_0625: pop
-			IL_0626: ldloc.s 4
-			IL_0628: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_062d: dup
-			IL_062e: brtrue IL_0642
+			IL_060f: pop
+			IL_0610: ldloc.s 4
+			IL_0612: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0617: dup
+			IL_0618: brtrue IL_062c
 
-			IL_0633: pop
-			IL_0634: rethrow
+			IL_061d: pop
+			IL_061e: rethrow
 
-			IL_0636: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_063b: stloc.s 5
-			IL_063d: br IL_0644
+			IL_0620: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0625: stloc.s 5
+			IL_0627: br IL_062e
 
-			IL_0642: stloc.s 5
+			IL_062c: stloc.s 5
 
-			IL_0644: ldloc.s 5
-			IL_0646: stloc.s 18
-			IL_0648: ldloc.s 18
-			IL_064a: stloc.s 6
-			IL_064c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L397C18::.ctor()
-			IL_0651: stloc.s 7
-			IL_0653: ldloc.s 6
-			IL_0655: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_065a: stloc.s 20
-			IL_065c: ldloc.s 20
-			IL_065e: brfalse IL_0676
+			IL_062e: ldloc.s 5
+			IL_0630: stloc.s 18
+			IL_0632: ldloc.s 18
+			IL_0634: stloc.s 6
+			IL_0636: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L397C18::.ctor()
+			IL_063b: stloc.s 7
+			IL_063d: ldloc.s 6
+			IL_063f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0644: stloc.s 20
+			IL_0646: ldloc.s 20
+			IL_0648: brfalse IL_0660
 
-			IL_0663: ldloc.s 6
-			IL_0665: ldstr "message"
-			IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_066f: stloc.s 22
-			IL_0671: br IL_067a
+			IL_064d: ldloc.s 6
+			IL_064f: ldstr "message"
+			IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0659: stloc.s 22
+			IL_065b: br IL_0664
 
-			IL_0676: ldloc.s 6
-			IL_0678: stloc.s 22
+			IL_0660: ldloc.s 6
+			IL_0662: stloc.s 22
 
-			IL_067a: ldloc.s 22
-			IL_067c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0681: stloc.s 20
-			IL_0683: ldloc.s 20
-			IL_0685: brfalse IL_069d
+			IL_0664: ldloc.s 22
+			IL_0666: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_066b: stloc.s 20
+			IL_066d: ldloc.s 20
+			IL_066f: brfalse IL_0687
 
-			IL_068a: ldloc.s 6
-			IL_068c: ldstr "message"
-			IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0696: stloc.s 8
-			IL_0698: br IL_06aa
+			IL_0674: ldloc.s 6
+			IL_0676: ldstr "message"
+			IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0680: stloc.s 8
+			IL_0682: br IL_0694
 
-			IL_069d: ldloc.s 6
-			IL_069f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06a4: stloc.s 23
-			IL_06a6: ldloc.s 23
-			IL_06a8: stloc.s 8
+			IL_0687: ldloc.s 6
+			IL_0689: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_068e: stloc.s 23
+			IL_0690: ldloc.s 23
+			IL_0692: stloc.s 8
 
-			IL_06aa: ldloc.s 8
-			IL_06ac: stloc.s 9
-			IL_06ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06b3: ldloc.s 9
-			IL_06b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_06ba: pop
-			IL_06bb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_06c0: ldstr "exitCode"
-			IL_06c5: ldc.r8 1
-			IL_06ce: ldc.i4.1
-			IL_06cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_06d4: pop
-			IL_06d5: leave IL_06da
+			IL_0694: ldloc.s 8
+			IL_0696: stloc.s 9
+			IL_0698: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_069d: ldloc.s 9
+			IL_069f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_06a4: pop
+			IL_06a5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_06aa: ldstr "exitCode"
+			IL_06af: ldc.r8 1
+			IL_06b8: ldc.i4.1
+			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_06be: pop
+			IL_06bf: leave IL_06c4
 		} // end handler
 
-		IL_06da: ldnull
-		IL_06db: stloc.s 10
-		IL_06dd: ret
+		IL_06c4: ldnull
+		IL_06c5: stloc.s 10
+		IL_06c7: ret
 	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262Bootstrap
@@ -6946,7 +6633,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x52d3
+		// Method begins at RVA 0x4fe3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_Test262MetadataParser
+﻿// IL code: Compile_Scripts_Test262MetadataParser
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6489
+				// Method begins at RVA 0x5cb2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x292c
+			// Method begins at RVA 0x28c0
 			// Header size: 12
 			// Code size: 190 (0xbe)
 			.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x649b
+					// Method begins at RVA 0x5cc4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64a4
+					// Method begins at RVA 0x5ccd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64ad
+					// Method begins at RVA 0x5cd6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6492
+				// Method begins at RVA 0x5cbb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -218,7 +218,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x29f8
+			// Method begins at RVA 0x298c
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64bf
+					// Method begins at RVA 0x5ce8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64b6
+				// Method begins at RVA 0x5cdf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -348,9 +348,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2a7c
+			// Method begins at RVA 0x2a10
 			// Header size: 12
-			// Code size: 170 (0xaa)
+			// Code size: 126 (0x7e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/Scope/Block_L30C17,
@@ -376,58 +376,40 @@
 			IL_001d: ldstr "phase"
 			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0027: stloc.2
-			IL_0028: ldc.i4.1
-			IL_0029: newarr [System.Runtime]System.Object
-			IL_002e: dup
-			IL_002f: ldc.i4.0
-			IL_0030: ldarg.0
-			IL_0031: stelem.ref
-			IL_0032: ldc.i4.0
-			IL_0033: ldelem.ref
-			IL_0034: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0039: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0044: ldnull
-			IL_0045: ldloc.2
-			IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_004b: stloc.2
-			IL_004c: ldstr "{ phase: "
-			IL_0051: ldloc.2
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0057: stloc.3
-			IL_0058: ldloc.3
-			IL_0059: ldstr ", type: "
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0063: stloc.3
-			IL_0064: ldarg.2
-			IL_0065: ldstr "type"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006f: stloc.2
-			IL_0070: ldc.i4.1
-			IL_0071: newarr [System.Runtime]System.Object
-			IL_0076: dup
-			IL_0077: ldc.i4.0
-			IL_0078: ldarg.0
-			IL_0079: stelem.ref
-			IL_007a: ldc.i4.0
-			IL_007b: ldelem.ref
-			IL_007c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0081: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_008c: ldnull
-			IL_008d: ldloc.2
-			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0093: stloc.2
-			IL_0094: ldloc.3
-			IL_0095: ldloc.2
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_009b: stloc.3
-			IL_009c: ldloc.3
-			IL_009d: ldstr " }"
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a7: stloc.3
-			IL_00a8: ldloc.3
-			IL_00a9: ret
+			IL_0028: ldarg.0
+			IL_0029: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_002e: ldnull
+			IL_002f: ldloc.2
+			IL_0030: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0035: stloc.2
+			IL_0036: ldstr "{ phase: "
+			IL_003b: ldloc.2
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0041: stloc.3
+			IL_0042: ldloc.3
+			IL_0043: ldstr ", type: "
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004d: stloc.3
+			IL_004e: ldarg.2
+			IL_004f: ldstr "type"
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0059: stloc.2
+			IL_005a: ldarg.0
+			IL_005b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0060: ldnull
+			IL_0061: ldloc.2
+			IL_0062: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0067: stloc.2
+			IL_0068: ldloc.3
+			IL_0069: ldloc.2
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_006f: stloc.3
+			IL_0070: ldloc.3
+			IL_0071: ldstr " }"
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007b: stloc.3
+			IL_007c: ldloc.3
+			IL_007d: ret
 		} // end of method formatNegative::__js_call__
 
 	} // end of class formatNegative
@@ -447,7 +429,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64d1
+					// Method begins at RVA 0x5cfa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -465,7 +447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64c8
+				// Method begins at RVA 0x5cf1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -492,9 +474,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2b34
+			// Method begins at RVA 0x2a9c
 			// Header size: 12
-			// Code size: 238 (0xee)
+			// Code size: 172 (0xac)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/Scope/Block_L40C14,
@@ -520,85 +502,58 @@
 			IL_001d: ldstr "code"
 			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0027: stloc.2
-			IL_0028: ldc.i4.1
-			IL_0029: newarr [System.Runtime]System.Object
-			IL_002e: dup
-			IL_002f: ldc.i4.0
-			IL_0030: ldarg.0
-			IL_0031: stelem.ref
-			IL_0032: ldc.i4.0
-			IL_0033: ldelem.ref
-			IL_0034: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0039: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0044: ldnull
-			IL_0045: ldloc.2
-			IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_004b: stloc.2
-			IL_004c: ldstr "{ code: "
-			IL_0051: ldloc.2
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0057: stloc.3
-			IL_0058: ldloc.3
-			IL_0059: ldstr ", source: "
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0063: stloc.3
-			IL_0064: ldarg.2
-			IL_0065: ldstr "source"
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006f: stloc.2
-			IL_0070: ldc.i4.1
-			IL_0071: newarr [System.Runtime]System.Object
-			IL_0076: dup
-			IL_0077: ldc.i4.0
-			IL_0078: ldarg.0
-			IL_0079: stelem.ref
-			IL_007a: ldc.i4.0
-			IL_007b: ldelem.ref
-			IL_007c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0081: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_008c: ldnull
-			IL_008d: ldloc.2
-			IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0093: stloc.2
-			IL_0094: ldloc.3
-			IL_0095: ldloc.2
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_009b: stloc.3
-			IL_009c: ldloc.3
-			IL_009d: ldstr ", reason: "
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a7: stloc.3
-			IL_00a8: ldarg.2
-			IL_00a9: ldstr "reason"
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b3: stloc.2
-			IL_00b4: ldc.i4.1
-			IL_00b5: newarr [System.Runtime]System.Object
-			IL_00ba: dup
-			IL_00bb: ldc.i4.0
-			IL_00bc: ldarg.0
-			IL_00bd: stelem.ref
-			IL_00be: ldc.i4.0
-			IL_00bf: ldelem.ref
-			IL_00c0: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_00c5: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d0: ldnull
-			IL_00d1: ldloc.2
-			IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00d7: stloc.2
-			IL_00d8: ldloc.3
-			IL_00d9: ldloc.2
-			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00df: stloc.3
-			IL_00e0: ldloc.3
-			IL_00e1: ldstr " }"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00eb: stloc.3
-			IL_00ec: ldloc.3
-			IL_00ed: ret
+			IL_0028: ldarg.0
+			IL_0029: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_002e: ldnull
+			IL_002f: ldloc.2
+			IL_0030: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0035: stloc.2
+			IL_0036: ldstr "{ code: "
+			IL_003b: ldloc.2
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0041: stloc.3
+			IL_0042: ldloc.3
+			IL_0043: ldstr ", source: "
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004d: stloc.3
+			IL_004e: ldarg.2
+			IL_004f: ldstr "source"
+			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0059: stloc.2
+			IL_005a: ldarg.0
+			IL_005b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0060: ldnull
+			IL_0061: ldloc.2
+			IL_0062: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0067: stloc.2
+			IL_0068: ldloc.3
+			IL_0069: ldloc.2
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_006f: stloc.3
+			IL_0070: ldloc.3
+			IL_0071: ldstr ", reason: "
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007b: stloc.3
+			IL_007c: ldarg.2
+			IL_007d: ldstr "reason"
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0087: stloc.2
+			IL_0088: ldarg.0
+			IL_0089: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_008e: ldnull
+			IL_008f: ldloc.2
+			IL_0090: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0095: stloc.2
+			IL_0096: ldloc.3
+			IL_0097: ldloc.2
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_009d: stloc.3
+			IL_009e: ldloc.3
+			IL_009f: ldstr " }"
+			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00a9: stloc.3
+			IL_00aa: ldloc.3
+			IL_00ab: ret
 		} // end of method formatIssue::__js_call__
 
 	} // end of class formatIssue
@@ -614,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64da
+				// Method begins at RVA 0x5d03
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -642,1046 +597,982 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2c30
+			// Method begins at RVA 0x2b54
 			// Header size: 12
-			// Code size: 4414 (0x113e)
+			// Code size: 3248 (0xcb0)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0011: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldarg.2
-			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0023: stloc.0
-			IL_0024: ldstr "name: "
-			IL_0029: ldloc.0
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_002f: stloc.1
-			IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0035: ldloc.1
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_003b: pop
-			IL_003c: ldarg.3
-			IL_003d: ldstr "filePath"
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0047: stloc.0
-			IL_0048: ldc.i4.1
-			IL_0049: newarr [System.Runtime]System.Object
-			IL_004e: dup
-			IL_004f: ldc.i4.0
-			IL_0050: ldarg.0
-			IL_0051: stelem.ref
-			IL_0052: ldc.i4.0
-			IL_0053: ldelem.ref
-			IL_0054: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0059: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_005f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0064: ldnull
-			IL_0065: ldloc.0
-			IL_0066: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_006b: stloc.0
-			IL_006c: ldstr "filePath: "
-			IL_0071: ldloc.0
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0077: stloc.1
-			IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_007d: ldloc.1
-			IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0083: pop
-			IL_0084: ldarg.3
-			IL_0085: ldstr "fileName"
-			IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008f: stloc.0
-			IL_0090: ldc.i4.1
-			IL_0091: newarr [System.Runtime]System.Object
-			IL_0096: dup
-			IL_0097: ldc.i4.0
-			IL_0098: ldarg.0
-			IL_0099: stelem.ref
-			IL_009a: ldc.i4.0
-			IL_009b: ldelem.ref
-			IL_009c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_00a1: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00ac: ldnull
-			IL_00ad: ldloc.0
-			IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00b3: stloc.0
-			IL_00b4: ldstr "fileName: "
-			IL_00b9: ldloc.0
-			IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00bf: stloc.1
-			IL_00c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c5: ldloc.1
-			IL_00c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00cb: pop
-			IL_00cc: ldarg.3
-			IL_00cd: ldstr "hasFrontmatter"
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d7: stloc.0
-			IL_00d8: ldc.i4.1
-			IL_00d9: newarr [System.Runtime]System.Object
-			IL_00de: dup
-			IL_00df: ldc.i4.0
-			IL_00e0: ldarg.0
-			IL_00e1: stelem.ref
-			IL_00e2: ldc.i4.0
-			IL_00e3: ldelem.ref
-			IL_00e4: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_00e9: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00f4: ldnull
-			IL_00f5: ldloc.0
-			IL_00f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00fb: stloc.0
-			IL_00fc: ldstr "hasFrontmatter: "
-			IL_0101: ldloc.0
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0107: stloc.1
-			IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_010d: ldloc.1
-			IL_010e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0113: pop
-			IL_0114: ldarg.3
-			IL_0115: ldstr "unknownKeys"
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_011f: ldstr "length"
-			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0129: stloc.0
-			IL_012a: ldc.i4.1
-			IL_012b: newarr [System.Runtime]System.Object
-			IL_0130: dup
-			IL_0131: ldc.i4.0
-			IL_0132: ldarg.0
-			IL_0133: stelem.ref
-			IL_0134: ldc.i4.0
-			IL_0135: ldelem.ref
-			IL_0136: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_013b: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0141: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0146: ldnull
-			IL_0147: ldloc.0
-			IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_014d: stloc.0
-			IL_014e: ldstr "unknownKeys.length: "
-			IL_0153: ldloc.0
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0159: stloc.1
-			IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_015f: ldloc.1
-			IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0165: pop
-			IL_0166: ldarg.3
-			IL_0167: ldstr "unknownKeys"
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0171: ldc.r8 0.0
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_017f: stloc.0
-			IL_0180: ldc.i4.1
-			IL_0181: newarr [System.Runtime]System.Object
-			IL_0186: dup
-			IL_0187: ldc.i4.0
-			IL_0188: ldarg.0
-			IL_0189: stelem.ref
-			IL_018a: ldc.i4.0
-			IL_018b: ldelem.ref
-			IL_018c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0191: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0197: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_019c: ldnull
-			IL_019d: ldloc.0
-			IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_01a3: stloc.0
-			IL_01a4: ldstr "unknownKeys[0]: "
-			IL_01a9: ldloc.0
-			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01af: stloc.1
-			IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01b5: ldloc.1
-			IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01bb: pop
-			IL_01bc: ldarg.3
-			IL_01bd: ldstr "description"
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c7: stloc.0
-			IL_01c8: ldc.i4.1
-			IL_01c9: newarr [System.Runtime]System.Object
-			IL_01ce: dup
-			IL_01cf: ldc.i4.0
-			IL_01d0: ldarg.0
-			IL_01d1: stelem.ref
-			IL_01d2: ldc.i4.0
-			IL_01d3: ldelem.ref
-			IL_01d4: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_01d9: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_01df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_01e4: ldnull
-			IL_01e5: ldloc.0
-			IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_01eb: stloc.0
-			IL_01ec: ldstr "description: "
-			IL_01f1: ldloc.0
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01f7: stloc.1
-			IL_01f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01fd: ldloc.1
-			IL_01fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0203: pop
-			IL_0204: ldarg.3
-			IL_0205: ldstr "info"
-			IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_020f: stloc.0
-			IL_0210: ldc.i4.1
-			IL_0211: newarr [System.Runtime]System.Object
-			IL_0216: dup
-			IL_0217: ldc.i4.0
-			IL_0218: ldarg.0
-			IL_0219: stelem.ref
-			IL_021a: ldc.i4.0
-			IL_021b: ldelem.ref
-			IL_021c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0221: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0227: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_022c: ldnull
-			IL_022d: ldloc.0
-			IL_022e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0233: stloc.0
-			IL_0234: ldstr "info: "
-			IL_0239: ldloc.0
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_023f: stloc.1
-			IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0245: ldloc.1
-			IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_024b: pop
-			IL_024c: ldarg.3
-			IL_024d: ldstr "esid"
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0257: stloc.0
-			IL_0258: ldc.i4.1
-			IL_0259: newarr [System.Runtime]System.Object
-			IL_025e: dup
-			IL_025f: ldc.i4.0
-			IL_0260: ldarg.0
-			IL_0261: stelem.ref
-			IL_0262: ldc.i4.0
-			IL_0263: ldelem.ref
-			IL_0264: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0269: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_026f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0274: ldnull
-			IL_0275: ldloc.0
-			IL_0276: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_027b: stloc.0
-			IL_027c: ldstr "esid: "
-			IL_0281: ldloc.0
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0287: stloc.1
-			IL_0288: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_028d: ldloc.1
-			IL_028e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0293: pop
-			IL_0294: ldarg.3
-			IL_0295: ldstr "es5id"
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029f: stloc.0
-			IL_02a0: ldc.i4.1
-			IL_02a1: newarr [System.Runtime]System.Object
-			IL_02a6: dup
-			IL_02a7: ldc.i4.0
-			IL_02a8: ldarg.0
-			IL_02a9: stelem.ref
-			IL_02aa: ldc.i4.0
-			IL_02ab: ldelem.ref
-			IL_02ac: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_02b1: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_02b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_02bc: ldnull
-			IL_02bd: ldloc.0
-			IL_02be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_02c3: stloc.0
-			IL_02c4: ldstr "es5id: "
-			IL_02c9: ldloc.0
-			IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02cf: stloc.1
-			IL_02d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02d5: ldloc.1
-			IL_02d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02db: pop
-			IL_02dc: ldarg.3
-			IL_02dd: ldstr "includes"
-			IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e7: ldstr "length"
-			IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02f1: stloc.0
-			IL_02f2: ldc.i4.1
-			IL_02f3: newarr [System.Runtime]System.Object
-			IL_02f8: dup
-			IL_02f9: ldc.i4.0
-			IL_02fa: ldarg.0
-			IL_02fb: stelem.ref
-			IL_02fc: ldc.i4.0
-			IL_02fd: ldelem.ref
-			IL_02fe: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0303: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0309: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_030e: ldnull
-			IL_030f: ldloc.0
-			IL_0310: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0315: stloc.0
-			IL_0316: ldstr "includes.length: "
-			IL_031b: ldloc.0
-			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0321: stloc.1
-			IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0327: ldloc.1
-			IL_0328: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_032d: pop
-			IL_032e: ldarg.3
-			IL_032f: ldstr "includes"
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0339: ldc.r8 0.0
-			IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0347: stloc.0
-			IL_0348: ldc.i4.1
-			IL_0349: newarr [System.Runtime]System.Object
-			IL_034e: dup
-			IL_034f: ldc.i4.0
-			IL_0350: ldarg.0
-			IL_0351: stelem.ref
-			IL_0352: ldc.i4.0
-			IL_0353: ldelem.ref
-			IL_0354: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0359: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_035f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0364: ldnull
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0006: ldnull
+			IL_0007: ldarg.2
+			IL_0008: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_000d: stloc.0
+			IL_000e: ldstr "name: "
+			IL_0013: ldloc.0
+			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0019: stloc.1
+			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_001f: ldloc.1
+			IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0025: pop
+			IL_0026: ldarg.3
+			IL_0027: ldstr "filePath"
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0031: stloc.0
+			IL_0032: ldarg.0
+			IL_0033: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0038: ldnull
+			IL_0039: ldloc.0
+			IL_003a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_003f: stloc.0
+			IL_0040: ldstr "filePath: "
+			IL_0045: ldloc.0
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004b: stloc.1
+			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0051: ldloc.1
+			IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0057: pop
+			IL_0058: ldarg.3
+			IL_0059: ldstr "fileName"
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0063: stloc.0
+			IL_0064: ldarg.0
+			IL_0065: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_006a: ldnull
+			IL_006b: ldloc.0
+			IL_006c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0071: stloc.0
+			IL_0072: ldstr "fileName: "
+			IL_0077: ldloc.0
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007d: stloc.1
+			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0083: ldloc.1
+			IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0089: pop
+			IL_008a: ldarg.3
+			IL_008b: ldstr "hasFrontmatter"
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0095: stloc.0
+			IL_0096: ldarg.0
+			IL_0097: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_009c: ldnull
+			IL_009d: ldloc.0
+			IL_009e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_00a3: stloc.0
+			IL_00a4: ldstr "hasFrontmatter: "
+			IL_00a9: ldloc.0
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00af: stloc.1
+			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00b5: ldloc.1
+			IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00bb: pop
+			IL_00bc: ldarg.3
+			IL_00bd: ldstr "unknownKeys"
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c7: ldstr "length"
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d1: stloc.0
+			IL_00d2: ldarg.0
+			IL_00d3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_00d8: ldnull
+			IL_00d9: ldloc.0
+			IL_00da: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_00df: stloc.0
+			IL_00e0: ldstr "unknownKeys.length: "
+			IL_00e5: ldloc.0
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00eb: stloc.1
+			IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00f1: ldloc.1
+			IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00f7: pop
+			IL_00f8: ldarg.3
+			IL_00f9: ldstr "unknownKeys"
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0103: ldc.r8 0.0
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0111: stloc.0
+			IL_0112: ldarg.0
+			IL_0113: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0118: ldnull
+			IL_0119: ldloc.0
+			IL_011a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_011f: stloc.0
+			IL_0120: ldstr "unknownKeys[0]: "
+			IL_0125: ldloc.0
+			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_012b: stloc.1
+			IL_012c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0131: ldloc.1
+			IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0137: pop
+			IL_0138: ldarg.3
+			IL_0139: ldstr "description"
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0143: stloc.0
+			IL_0144: ldarg.0
+			IL_0145: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_014a: ldnull
+			IL_014b: ldloc.0
+			IL_014c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0151: stloc.0
+			IL_0152: ldstr "description: "
+			IL_0157: ldloc.0
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_015d: stloc.1
+			IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0163: ldloc.1
+			IL_0164: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0169: pop
+			IL_016a: ldarg.3
+			IL_016b: ldstr "info"
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0175: stloc.0
+			IL_0176: ldarg.0
+			IL_0177: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_017c: ldnull
+			IL_017d: ldloc.0
+			IL_017e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0183: stloc.0
+			IL_0184: ldstr "info: "
+			IL_0189: ldloc.0
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_018f: stloc.1
+			IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0195: ldloc.1
+			IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_019b: pop
+			IL_019c: ldarg.3
+			IL_019d: ldstr "esid"
+			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a7: stloc.0
+			IL_01a8: ldarg.0
+			IL_01a9: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_01ae: ldnull
+			IL_01af: ldloc.0
+			IL_01b0: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_01b5: stloc.0
+			IL_01b6: ldstr "esid: "
+			IL_01bb: ldloc.0
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01c1: stloc.1
+			IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01c7: ldloc.1
+			IL_01c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01cd: pop
+			IL_01ce: ldarg.3
+			IL_01cf: ldstr "es5id"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d9: stloc.0
+			IL_01da: ldarg.0
+			IL_01db: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_01e0: ldnull
+			IL_01e1: ldloc.0
+			IL_01e2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_01e7: stloc.0
+			IL_01e8: ldstr "es5id: "
+			IL_01ed: ldloc.0
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01f3: stloc.1
+			IL_01f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01f9: ldloc.1
+			IL_01fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ff: pop
+			IL_0200: ldarg.3
+			IL_0201: ldstr "includes"
+			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_020b: ldstr "length"
+			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0215: stloc.0
+			IL_0216: ldarg.0
+			IL_0217: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_021c: ldnull
+			IL_021d: ldloc.0
+			IL_021e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0223: stloc.0
+			IL_0224: ldstr "includes.length: "
+			IL_0229: ldloc.0
+			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_022f: stloc.1
+			IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0235: ldloc.1
+			IL_0236: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_023b: pop
+			IL_023c: ldarg.3
+			IL_023d: ldstr "includes"
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0247: ldc.r8 0.0
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0255: stloc.0
+			IL_0256: ldarg.0
+			IL_0257: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_025c: ldnull
+			IL_025d: ldloc.0
+			IL_025e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0263: stloc.0
+			IL_0264: ldstr "includes[0]: "
+			IL_0269: ldloc.0
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_026f: stloc.1
+			IL_0270: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0275: ldloc.1
+			IL_0276: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_027b: pop
+			IL_027c: ldarg.3
+			IL_027d: ldstr "includes"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0287: ldc.r8 1
+			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0295: stloc.0
+			IL_0296: ldarg.0
+			IL_0297: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_029c: ldnull
+			IL_029d: ldloc.0
+			IL_029e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_02a3: stloc.0
+			IL_02a4: ldstr "includes[1]: "
+			IL_02a9: ldloc.0
+			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02af: stloc.1
+			IL_02b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02b5: ldloc.1
+			IL_02b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02bb: pop
+			IL_02bc: ldarg.3
+			IL_02bd: ldstr "flags"
+			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c7: ldstr "length"
+			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d1: stloc.0
+			IL_02d2: ldarg.0
+			IL_02d3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_02d8: ldnull
+			IL_02d9: ldloc.0
+			IL_02da: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_02df: stloc.0
+			IL_02e0: ldstr "flags.length: "
+			IL_02e5: ldloc.0
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02eb: stloc.1
+			IL_02ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f1: ldloc.1
+			IL_02f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02f7: pop
+			IL_02f8: ldarg.3
+			IL_02f9: ldstr "flags"
+			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0303: ldc.r8 0.0
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0311: stloc.0
+			IL_0312: ldarg.0
+			IL_0313: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0318: ldnull
+			IL_0319: ldloc.0
+			IL_031a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_031f: stloc.0
+			IL_0320: ldstr "flags[0]: "
+			IL_0325: ldloc.0
+			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_032b: stloc.1
+			IL_032c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0331: ldloc.1
+			IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0337: pop
+			IL_0338: ldarg.3
+			IL_0339: ldstr "flags"
+			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0343: ldc.r8 1
+			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0351: stloc.0
+			IL_0352: ldarg.0
+			IL_0353: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0358: ldnull
+			IL_0359: ldloc.0
+			IL_035a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_035f: stloc.0
+			IL_0360: ldstr "flags[1]: "
 			IL_0365: ldloc.0
-			IL_0366: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_036b: stloc.0
-			IL_036c: ldstr "includes[0]: "
-			IL_0371: ldloc.0
-			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0377: stloc.1
-			IL_0378: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_037d: ldloc.1
-			IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0383: pop
-			IL_0384: ldarg.3
-			IL_0385: ldstr "includes"
-			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_038f: ldc.r8 1
-			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_039d: stloc.0
-			IL_039e: ldc.i4.1
-			IL_039f: newarr [System.Runtime]System.Object
-			IL_03a4: dup
-			IL_03a5: ldc.i4.0
-			IL_03a6: ldarg.0
-			IL_03a7: stelem.ref
-			IL_03a8: ldc.i4.0
-			IL_03a9: ldelem.ref
-			IL_03aa: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_03af: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_03b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_03ba: ldnull
-			IL_03bb: ldloc.0
-			IL_03bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_03c1: stloc.0
-			IL_03c2: ldstr "includes[1]: "
-			IL_03c7: ldloc.0
-			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03cd: stloc.1
-			IL_03ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03d3: ldloc.1
-			IL_03d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03d9: pop
-			IL_03da: ldarg.3
-			IL_03db: ldstr "flags"
-			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e5: ldstr "length"
-			IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ef: stloc.0
-			IL_03f0: ldc.i4.1
-			IL_03f1: newarr [System.Runtime]System.Object
-			IL_03f6: dup
-			IL_03f7: ldc.i4.0
-			IL_03f8: ldarg.0
-			IL_03f9: stelem.ref
-			IL_03fa: ldc.i4.0
-			IL_03fb: ldelem.ref
-			IL_03fc: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0401: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0407: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_040c: ldnull
-			IL_040d: ldloc.0
-			IL_040e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0413: stloc.0
-			IL_0414: ldstr "flags.length: "
-			IL_0419: ldloc.0
-			IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_041f: stloc.1
-			IL_0420: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0425: ldloc.1
-			IL_0426: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_042b: pop
-			IL_042c: ldarg.3
-			IL_042d: ldstr "flags"
-			IL_0432: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0437: ldc.r8 0.0
-			IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0445: stloc.0
-			IL_0446: ldc.i4.1
-			IL_0447: newarr [System.Runtime]System.Object
-			IL_044c: dup
-			IL_044d: ldc.i4.0
+			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_036b: stloc.1
+			IL_036c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0371: ldloc.1
+			IL_0372: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0377: pop
+			IL_0378: ldarg.3
+			IL_0379: ldstr "flags"
+			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0383: ldc.r8 2
+			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0391: stloc.0
+			IL_0392: ldarg.0
+			IL_0393: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0398: ldnull
+			IL_0399: ldloc.0
+			IL_039a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_039f: stloc.0
+			IL_03a0: ldstr "flags[2]: "
+			IL_03a5: ldloc.0
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03ab: stloc.1
+			IL_03ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03b1: ldloc.1
+			IL_03b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03b7: pop
+			IL_03b8: ldarg.3
+			IL_03b9: ldstr "features"
+			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c3: ldstr "length"
+			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03cd: stloc.0
+			IL_03ce: ldarg.0
+			IL_03cf: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_03d4: ldnull
+			IL_03d5: ldloc.0
+			IL_03d6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_03db: stloc.0
+			IL_03dc: ldstr "features.length: "
+			IL_03e1: ldloc.0
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03e7: stloc.1
+			IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ed: ldloc.1
+			IL_03ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03f3: pop
+			IL_03f4: ldarg.3
+			IL_03f5: ldstr "features"
+			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03ff: ldc.r8 0.0
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_040d: stloc.0
+			IL_040e: ldarg.0
+			IL_040f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0414: ldnull
+			IL_0415: ldloc.0
+			IL_0416: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_041b: stloc.0
+			IL_041c: ldstr "features[0]: "
+			IL_0421: ldloc.0
+			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0427: stloc.1
+			IL_0428: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_042d: ldloc.1
+			IL_042e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0433: pop
+			IL_0434: ldarg.3
+			IL_0435: ldstr "features"
+			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_043f: ldc.r8 1
+			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_044d: stloc.0
 			IL_044e: ldarg.0
-			IL_044f: stelem.ref
-			IL_0450: ldc.i4.0
-			IL_0451: ldelem.ref
-			IL_0452: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0457: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_045d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0462: ldnull
-			IL_0463: ldloc.0
-			IL_0464: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0469: stloc.0
-			IL_046a: ldstr "flags[0]: "
-			IL_046f: ldloc.0
-			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0475: stloc.1
-			IL_0476: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_047b: ldloc.1
-			IL_047c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0481: pop
-			IL_0482: ldarg.3
-			IL_0483: ldstr "flags"
-			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_048d: ldc.r8 1
-			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_049b: stloc.0
-			IL_049c: ldc.i4.1
-			IL_049d: newarr [System.Runtime]System.Object
-			IL_04a2: dup
-			IL_04a3: ldc.i4.0
-			IL_04a4: ldarg.0
-			IL_04a5: stelem.ref
-			IL_04a6: ldc.i4.0
-			IL_04a7: ldelem.ref
-			IL_04a8: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_04ad: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_04b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_04b8: ldnull
-			IL_04b9: ldloc.0
-			IL_04ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_04bf: stloc.0
-			IL_04c0: ldstr "flags[1]: "
-			IL_04c5: ldloc.0
-			IL_04c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04cb: stloc.1
-			IL_04cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04d1: ldloc.1
-			IL_04d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04d7: pop
-			IL_04d8: ldarg.3
-			IL_04d9: ldstr "flags"
-			IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04e3: ldc.r8 2
-			IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_04f1: stloc.0
-			IL_04f2: ldc.i4.1
-			IL_04f3: newarr [System.Runtime]System.Object
-			IL_04f8: dup
-			IL_04f9: ldc.i4.0
-			IL_04fa: ldarg.0
-			IL_04fb: stelem.ref
-			IL_04fc: ldc.i4.0
-			IL_04fd: ldelem.ref
-			IL_04fe: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0503: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0509: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_050e: ldnull
-			IL_050f: ldloc.0
-			IL_0510: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0515: stloc.0
-			IL_0516: ldstr "flags[2]: "
-			IL_051b: ldloc.0
-			IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0521: stloc.1
-			IL_0522: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0527: ldloc.1
-			IL_0528: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_052d: pop
-			IL_052e: ldarg.3
-			IL_052f: ldstr "features"
-			IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0539: ldstr "length"
-			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0543: stloc.0
-			IL_0544: ldc.i4.1
-			IL_0545: newarr [System.Runtime]System.Object
-			IL_054a: dup
-			IL_054b: ldc.i4.0
-			IL_054c: ldarg.0
-			IL_054d: stelem.ref
-			IL_054e: ldc.i4.0
-			IL_054f: ldelem.ref
-			IL_0550: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0555: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_055b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0560: ldnull
-			IL_0561: ldloc.0
-			IL_0562: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0567: stloc.0
-			IL_0568: ldstr "features.length: "
-			IL_056d: ldloc.0
-			IL_056e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0573: stloc.1
-			IL_0574: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0579: ldloc.1
-			IL_057a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_057f: pop
-			IL_0580: ldarg.3
-			IL_0581: ldstr "features"
-			IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_058b: ldc.r8 0.0
-			IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0599: stloc.0
-			IL_059a: ldc.i4.1
-			IL_059b: newarr [System.Runtime]System.Object
-			IL_05a0: dup
-			IL_05a1: ldc.i4.0
-			IL_05a2: ldarg.0
-			IL_05a3: stelem.ref
-			IL_05a4: ldc.i4.0
-			IL_05a5: ldelem.ref
-			IL_05a6: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_05ab: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_05b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_05b6: ldnull
-			IL_05b7: ldloc.0
-			IL_05b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_05bd: stloc.0
-			IL_05be: ldstr "features[0]: "
-			IL_05c3: ldloc.0
-			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05c9: stloc.1
-			IL_05ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05cf: ldloc.1
-			IL_05d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05d5: pop
-			IL_05d6: ldarg.3
-			IL_05d7: ldstr "features"
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e1: ldc.r8 1
-			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_044f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0454: ldnull
+			IL_0455: ldloc.0
+			IL_0456: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_045b: stloc.0
+			IL_045c: ldstr "features[1]: "
+			IL_0461: ldloc.0
+			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0467: stloc.1
+			IL_0468: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_046d: ldloc.1
+			IL_046e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0473: pop
+			IL_0474: ldarg.3
+			IL_0475: ldstr "locale"
+			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_047f: ldstr "length"
+			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0489: stloc.0
+			IL_048a: ldarg.0
+			IL_048b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0490: ldnull
+			IL_0491: ldloc.0
+			IL_0492: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0497: stloc.0
+			IL_0498: ldstr "locale.length: "
+			IL_049d: ldloc.0
+			IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04a3: stloc.1
+			IL_04a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04a9: ldloc.1
+			IL_04aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04af: pop
+			IL_04b0: ldarg.3
+			IL_04b1: ldstr "locale"
+			IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04bb: ldc.r8 0.0
+			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_04c9: stloc.0
+			IL_04ca: ldarg.0
+			IL_04cb: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_04d0: ldnull
+			IL_04d1: ldloc.0
+			IL_04d2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_04d7: stloc.0
+			IL_04d8: ldstr "locale[0]: "
+			IL_04dd: ldloc.0
+			IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04e3: stloc.1
+			IL_04e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04e9: ldloc.1
+			IL_04ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04ef: pop
+			IL_04f0: ldarg.3
+			IL_04f1: ldstr "defines"
+			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fb: ldstr "length"
+			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0505: stloc.0
+			IL_0506: ldarg.0
+			IL_0507: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_050c: ldnull
+			IL_050d: ldloc.0
+			IL_050e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0513: stloc.0
+			IL_0514: ldstr "defines.length: "
+			IL_0519: ldloc.0
+			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_051f: stloc.1
+			IL_0520: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0525: ldloc.1
+			IL_0526: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_052b: pop
+			IL_052c: ldarg.3
+			IL_052d: ldstr "defines"
+			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0537: ldc.r8 0.0
+			IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0545: stloc.0
+			IL_0546: ldarg.0
+			IL_0547: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_054c: ldnull
+			IL_054d: ldloc.0
+			IL_054e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0553: stloc.0
+			IL_0554: ldstr "defines[0]: "
+			IL_0559: ldloc.0
+			IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_055f: stloc.1
+			IL_0560: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0565: ldloc.1
+			IL_0566: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_056b: pop
+			IL_056c: ldarg.3
+			IL_056d: ldstr "negative"
+			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0577: stloc.0
+			IL_0578: ldarg.0
+			IL_0579: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_057e: ldnull
+			IL_057f: ldloc.0
+			IL_0580: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0585: stloc.0
+			IL_0586: ldstr "negative: "
+			IL_058b: ldloc.0
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0591: stloc.1
+			IL_0592: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0597: ldloc.1
+			IL_0598: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_059d: pop
+			IL_059e: ldarg.3
+			IL_059f: ldstr "execution"
+			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05a9: ldstr "sourceType"
+			IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b3: stloc.0
+			IL_05b4: ldarg.0
+			IL_05b5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_05ba: ldnull
+			IL_05bb: ldloc.0
+			IL_05bc: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_05c1: stloc.0
+			IL_05c2: ldstr "execution.sourceType: "
+			IL_05c7: ldloc.0
+			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05cd: stloc.1
+			IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05d3: ldloc.1
+			IL_05d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05d9: pop
+			IL_05da: ldarg.3
+			IL_05db: ldstr "execution"
+			IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e5: ldstr "strictMode"
+			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_05ef: stloc.0
-			IL_05f0: ldc.i4.1
-			IL_05f1: newarr [System.Runtime]System.Object
-			IL_05f6: dup
-			IL_05f7: ldc.i4.0
-			IL_05f8: ldarg.0
-			IL_05f9: stelem.ref
-			IL_05fa: ldc.i4.0
-			IL_05fb: ldelem.ref
-			IL_05fc: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0601: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0607: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_060c: ldnull
-			IL_060d: ldloc.0
-			IL_060e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0613: stloc.0
-			IL_0614: ldstr "features[1]: "
-			IL_0619: ldloc.0
-			IL_061a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_061f: stloc.1
-			IL_0620: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0625: ldloc.1
-			IL_0626: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_062b: pop
-			IL_062c: ldarg.3
-			IL_062d: ldstr "locale"
-			IL_0632: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0637: ldstr "length"
-			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0641: stloc.0
-			IL_0642: ldc.i4.1
-			IL_0643: newarr [System.Runtime]System.Object
-			IL_0648: dup
-			IL_0649: ldc.i4.0
-			IL_064a: ldarg.0
-			IL_064b: stelem.ref
-			IL_064c: ldc.i4.0
-			IL_064d: ldelem.ref
-			IL_064e: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0653: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0659: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_065e: ldnull
-			IL_065f: ldloc.0
-			IL_0660: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0665: stloc.0
-			IL_0666: ldstr "locale.length: "
-			IL_066b: ldloc.0
-			IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0671: stloc.1
-			IL_0672: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0677: ldloc.1
-			IL_0678: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_067d: pop
-			IL_067e: ldarg.3
-			IL_067f: ldstr "locale"
-			IL_0684: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0689: ldc.r8 0.0
-			IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0697: stloc.0
-			IL_0698: ldc.i4.1
-			IL_0699: newarr [System.Runtime]System.Object
-			IL_069e: dup
-			IL_069f: ldc.i4.0
-			IL_06a0: ldarg.0
-			IL_06a1: stelem.ref
-			IL_06a2: ldc.i4.0
-			IL_06a3: ldelem.ref
-			IL_06a4: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_06a9: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_06af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_06b4: ldnull
-			IL_06b5: ldloc.0
-			IL_06b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_06bb: stloc.0
-			IL_06bc: ldstr "locale[0]: "
-			IL_06c1: ldloc.0
-			IL_06c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06c7: stloc.1
-			IL_06c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06cd: ldloc.1
-			IL_06ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06d3: pop
-			IL_06d4: ldarg.3
-			IL_06d5: ldstr "defines"
-			IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06df: ldstr "length"
-			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06e9: stloc.0
-			IL_06ea: ldc.i4.1
-			IL_06eb: newarr [System.Runtime]System.Object
-			IL_06f0: dup
-			IL_06f1: ldc.i4.0
-			IL_06f2: ldarg.0
-			IL_06f3: stelem.ref
-			IL_06f4: ldc.i4.0
-			IL_06f5: ldelem.ref
-			IL_06f6: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_06fb: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0701: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0706: ldnull
-			IL_0707: ldloc.0
-			IL_0708: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_070d: stloc.0
-			IL_070e: ldstr "defines.length: "
-			IL_0713: ldloc.0
-			IL_0714: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0719: stloc.1
-			IL_071a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_071f: ldloc.1
-			IL_0720: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0725: pop
-			IL_0726: ldarg.3
-			IL_0727: ldstr "defines"
-			IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0731: ldc.r8 0.0
-			IL_073a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_073f: stloc.0
-			IL_0740: ldc.i4.1
-			IL_0741: newarr [System.Runtime]System.Object
-			IL_0746: dup
-			IL_0747: ldc.i4.0
-			IL_0748: ldarg.0
-			IL_0749: stelem.ref
-			IL_074a: ldc.i4.0
-			IL_074b: ldelem.ref
-			IL_074c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0751: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0757: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_075c: ldnull
-			IL_075d: ldloc.0
-			IL_075e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0763: stloc.0
-			IL_0764: ldstr "defines[0]: "
-			IL_0769: ldloc.0
-			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_076f: stloc.1
-			IL_0770: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0775: ldloc.1
-			IL_0776: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_077b: pop
-			IL_077c: ldarg.3
-			IL_077d: ldstr "negative"
-			IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0787: stloc.0
-			IL_0788: ldc.i4.1
-			IL_0789: newarr [System.Runtime]System.Object
-			IL_078e: dup
-			IL_078f: ldc.i4.0
-			IL_0790: ldarg.0
-			IL_0791: stelem.ref
-			IL_0792: ldc.i4.0
-			IL_0793: ldelem.ref
-			IL_0794: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0799: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_079f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_07a4: ldnull
-			IL_07a5: ldloc.0
-			IL_07a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_07ab: stloc.0
-			IL_07ac: ldstr "negative: "
-			IL_07b1: ldloc.0
-			IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_07b7: stloc.1
-			IL_07b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07bd: ldloc.1
-			IL_07be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07c3: pop
-			IL_07c4: ldarg.3
-			IL_07c5: ldstr "execution"
-			IL_07ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07cf: ldstr "sourceType"
-			IL_07d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07d9: stloc.0
-			IL_07da: ldc.i4.1
-			IL_07db: newarr [System.Runtime]System.Object
-			IL_07e0: dup
-			IL_07e1: ldc.i4.0
-			IL_07e2: ldarg.0
-			IL_07e3: stelem.ref
-			IL_07e4: ldc.i4.0
-			IL_07e5: ldelem.ref
-			IL_07e6: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_07eb: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_07f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_07f6: ldnull
-			IL_07f7: ldloc.0
-			IL_07f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_07fd: stloc.0
-			IL_07fe: ldstr "execution.sourceType: "
-			IL_0803: ldloc.0
-			IL_0804: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0809: stloc.1
-			IL_080a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_080f: ldloc.1
-			IL_0810: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0815: pop
-			IL_0816: ldarg.3
-			IL_0817: ldstr "execution"
-			IL_081c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0821: ldstr "strictMode"
-			IL_0826: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_082b: stloc.0
-			IL_082c: ldc.i4.1
-			IL_082d: newarr [System.Runtime]System.Object
-			IL_0832: dup
-			IL_0833: ldc.i4.0
-			IL_0834: ldarg.0
-			IL_0835: stelem.ref
-			IL_0836: ldc.i4.0
-			IL_0837: ldelem.ref
-			IL_0838: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_083d: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0843: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0848: ldnull
-			IL_0849: ldloc.0
-			IL_084a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_084f: stloc.0
-			IL_0850: ldstr "execution.strictMode: "
-			IL_0855: ldloc.0
-			IL_0856: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_085b: stloc.1
-			IL_085c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0861: ldloc.1
-			IL_0862: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0867: pop
-			IL_0868: ldarg.3
-			IL_0869: ldstr "execution"
+			IL_05f0: ldarg.0
+			IL_05f1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_05f6: ldnull
+			IL_05f7: ldloc.0
+			IL_05f8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_05fd: stloc.0
+			IL_05fe: ldstr "execution.strictMode: "
+			IL_0603: ldloc.0
+			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0609: stloc.1
+			IL_060a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_060f: ldloc.1
+			IL_0610: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0615: pop
+			IL_0616: ldarg.3
+			IL_0617: ldstr "execution"
+			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0621: ldstr "defaultHarnessIncludes"
+			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_062b: ldstr "length"
+			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0635: stloc.0
+			IL_0636: ldarg.0
+			IL_0637: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_063c: ldnull
+			IL_063d: ldloc.0
+			IL_063e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0643: stloc.0
+			IL_0644: ldstr "execution.defaultHarnessIncludes.length: "
+			IL_0649: ldloc.0
+			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_064f: stloc.1
+			IL_0650: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0655: ldloc.1
+			IL_0656: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_065b: pop
+			IL_065c: ldarg.3
+			IL_065d: ldstr "execution"
+			IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0667: ldstr "defaultHarnessIncludes"
+			IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0671: ldc.r8 0.0
+			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_067f: stloc.0
+			IL_0680: ldarg.0
+			IL_0681: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0686: ldnull
+			IL_0687: ldloc.0
+			IL_0688: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_068d: stloc.0
+			IL_068e: ldstr "execution.defaultHarnessIncludes[0]: "
+			IL_0693: ldloc.0
+			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0699: stloc.1
+			IL_069a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_069f: ldloc.1
+			IL_06a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06a5: pop
+			IL_06a6: ldarg.3
+			IL_06a7: ldstr "execution"
+			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b1: ldstr "defaultHarnessIncludes"
+			IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06bb: ldc.r8 1
+			IL_06c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_06c9: stloc.0
+			IL_06ca: ldarg.0
+			IL_06cb: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_06d0: ldnull
+			IL_06d1: ldloc.0
+			IL_06d2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_06d7: stloc.0
+			IL_06d8: ldstr "execution.defaultHarnessIncludes[1]: "
+			IL_06dd: ldloc.0
+			IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06e3: stloc.1
+			IL_06e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06e9: ldloc.1
+			IL_06ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06ef: pop
+			IL_06f0: ldarg.3
+			IL_06f1: ldstr "execution"
+			IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06fb: ldstr "harnessIncludes"
+			IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0705: ldstr "length"
+			IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070f: stloc.0
+			IL_0710: ldarg.0
+			IL_0711: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0716: ldnull
+			IL_0717: ldloc.0
+			IL_0718: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_071d: stloc.0
+			IL_071e: ldstr "execution.harnessIncludes.length: "
+			IL_0723: ldloc.0
+			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0729: stloc.1
+			IL_072a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_072f: ldloc.1
+			IL_0730: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0735: pop
+			IL_0736: ldarg.3
+			IL_0737: ldstr "execution"
+			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0741: ldstr "harnessIncludes"
+			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_074b: ldc.r8 0.0
+			IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0759: stloc.0
+			IL_075a: ldarg.0
+			IL_075b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0760: ldnull
+			IL_0761: ldloc.0
+			IL_0762: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0767: stloc.0
+			IL_0768: ldstr "execution.harnessIncludes[0]: "
+			IL_076d: ldloc.0
+			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0773: stloc.1
+			IL_0774: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0779: ldloc.1
+			IL_077a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_077f: pop
+			IL_0780: ldarg.3
+			IL_0781: ldstr "execution"
+			IL_0786: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_078b: ldstr "harnessIncludes"
+			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0795: ldc.r8 1
+			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_07a3: stloc.0
+			IL_07a4: ldarg.0
+			IL_07a5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_07aa: ldnull
+			IL_07ab: ldloc.0
+			IL_07ac: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_07b1: stloc.0
+			IL_07b2: ldstr "execution.harnessIncludes[1]: "
+			IL_07b7: ldloc.0
+			IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_07bd: stloc.1
+			IL_07be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07c3: ldloc.1
+			IL_07c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07c9: pop
+			IL_07ca: ldarg.3
+			IL_07cb: ldstr "execution"
+			IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07d5: ldstr "harnessIncludes"
+			IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07df: ldc.r8 2
+			IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_07ed: stloc.0
+			IL_07ee: ldarg.0
+			IL_07ef: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_07f4: ldnull
+			IL_07f5: ldloc.0
+			IL_07f6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_07fb: stloc.0
+			IL_07fc: ldstr "execution.harnessIncludes[2]: "
+			IL_0801: ldloc.0
+			IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0807: stloc.1
+			IL_0808: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_080d: ldloc.1
+			IL_080e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0813: pop
+			IL_0814: ldarg.3
+			IL_0815: ldstr "execution"
+			IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_081f: ldstr "harnessIncludes"
+			IL_0824: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0829: ldc.r8 3
+			IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0837: stloc.0
+			IL_0838: ldarg.0
+			IL_0839: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_083e: ldnull
+			IL_083f: ldloc.0
+			IL_0840: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0845: stloc.0
+			IL_0846: ldstr "execution.harnessIncludes[3]: "
+			IL_084b: ldloc.0
+			IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0851: stloc.1
+			IL_0852: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0857: ldloc.1
+			IL_0858: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_085d: pop
+			IL_085e: ldarg.3
+			IL_085f: ldstr "execution"
+			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0869: ldstr "requiresDefaultHarness"
 			IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0873: ldstr "defaultHarnessIncludes"
-			IL_0878: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_087d: ldstr "length"
-			IL_0882: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0887: stloc.0
-			IL_0888: ldc.i4.1
-			IL_0889: newarr [System.Runtime]System.Object
-			IL_088e: dup
-			IL_088f: ldc.i4.0
-			IL_0890: ldarg.0
-			IL_0891: stelem.ref
-			IL_0892: ldc.i4.0
-			IL_0893: ldelem.ref
-			IL_0894: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0899: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_089f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_08a4: ldnull
-			IL_08a5: ldloc.0
-			IL_08a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_08ab: stloc.0
-			IL_08ac: ldstr "execution.defaultHarnessIncludes.length: "
-			IL_08b1: ldloc.0
-			IL_08b2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_08b7: stloc.1
-			IL_08b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08bd: ldloc.1
-			IL_08be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08c3: pop
-			IL_08c4: ldarg.3
-			IL_08c5: ldstr "execution"
-			IL_08ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08cf: ldstr "defaultHarnessIncludes"
-			IL_08d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08d9: ldc.r8 0.0
-			IL_08e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_08e7: stloc.0
-			IL_08e8: ldc.i4.1
-			IL_08e9: newarr [System.Runtime]System.Object
-			IL_08ee: dup
-			IL_08ef: ldc.i4.0
-			IL_08f0: ldarg.0
-			IL_08f1: stelem.ref
-			IL_08f2: ldc.i4.0
-			IL_08f3: ldelem.ref
-			IL_08f4: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_08f9: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_08ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0904: ldnull
-			IL_0905: ldloc.0
-			IL_0906: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_090b: stloc.0
-			IL_090c: ldstr "execution.defaultHarnessIncludes[0]: "
-			IL_0911: ldloc.0
-			IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0917: stloc.1
-			IL_0918: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_091d: ldloc.1
-			IL_091e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0923: pop
-			IL_0924: ldarg.3
-			IL_0925: ldstr "execution"
-			IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_092f: ldstr "defaultHarnessIncludes"
-			IL_0934: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0939: ldc.r8 1
-			IL_0942: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0947: stloc.0
-			IL_0948: ldc.i4.1
-			IL_0949: newarr [System.Runtime]System.Object
-			IL_094e: dup
-			IL_094f: ldc.i4.0
-			IL_0950: ldarg.0
-			IL_0951: stelem.ref
-			IL_0952: ldc.i4.0
-			IL_0953: ldelem.ref
-			IL_0954: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0959: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_095f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0964: ldnull
-			IL_0965: ldloc.0
-			IL_0966: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_096b: stloc.0
-			IL_096c: ldstr "execution.defaultHarnessIncludes[1]: "
-			IL_0971: ldloc.0
-			IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0977: stloc.1
-			IL_0978: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_097d: ldloc.1
-			IL_097e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0983: pop
-			IL_0984: ldarg.3
-			IL_0985: ldstr "execution"
-			IL_098a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_098f: ldstr "harnessIncludes"
-			IL_0994: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0999: ldstr "length"
-			IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09a3: stloc.0
-			IL_09a4: ldc.i4.1
-			IL_09a5: newarr [System.Runtime]System.Object
-			IL_09aa: dup
-			IL_09ab: ldc.i4.0
-			IL_09ac: ldarg.0
-			IL_09ad: stelem.ref
-			IL_09ae: ldc.i4.0
-			IL_09af: ldelem.ref
-			IL_09b0: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_09b5: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_09bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_09c0: ldnull
-			IL_09c1: ldloc.0
-			IL_09c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_09c7: stloc.0
-			IL_09c8: ldstr "execution.harnessIncludes.length: "
-			IL_09cd: ldloc.0
-			IL_09ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_09d3: stloc.1
-			IL_09d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09d9: ldloc.1
-			IL_09da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09df: pop
-			IL_09e0: ldarg.3
-			IL_09e1: ldstr "execution"
-			IL_09e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09eb: ldstr "harnessIncludes"
-			IL_09f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09f5: ldc.r8 0.0
-			IL_09fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a03: stloc.0
-			IL_0a04: ldc.i4.1
-			IL_0a05: newarr [System.Runtime]System.Object
-			IL_0a0a: dup
-			IL_0a0b: ldc.i4.0
-			IL_0a0c: ldarg.0
-			IL_0a0d: stelem.ref
-			IL_0a0e: ldc.i4.0
-			IL_0a0f: ldelem.ref
-			IL_0a10: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0a15: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0a1b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0a20: ldnull
-			IL_0a21: ldloc.0
-			IL_0a22: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0a27: stloc.0
-			IL_0a28: ldstr "execution.harnessIncludes[0]: "
-			IL_0a2d: ldloc.0
-			IL_0a2e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a33: stloc.1
-			IL_0a34: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a39: ldloc.1
-			IL_0a3a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a3f: pop
-			IL_0a40: ldarg.3
-			IL_0a41: ldstr "execution"
-			IL_0a46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a4b: ldstr "harnessIncludes"
-			IL_0a50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a55: ldc.r8 1
-			IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a63: stloc.0
-			IL_0a64: ldc.i4.1
-			IL_0a65: newarr [System.Runtime]System.Object
-			IL_0a6a: dup
-			IL_0a6b: ldc.i4.0
-			IL_0a6c: ldarg.0
-			IL_0a6d: stelem.ref
-			IL_0a6e: ldc.i4.0
-			IL_0a6f: ldelem.ref
-			IL_0a70: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0a75: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0a7b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0a80: ldnull
-			IL_0a81: ldloc.0
-			IL_0a82: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0a87: stloc.0
-			IL_0a88: ldstr "execution.harnessIncludes[1]: "
-			IL_0a8d: ldloc.0
-			IL_0a8e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a93: stloc.1
-			IL_0a94: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a99: ldloc.1
-			IL_0a9a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a9f: pop
-			IL_0aa0: ldarg.3
-			IL_0aa1: ldstr "execution"
-			IL_0aa6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aab: ldstr "harnessIncludes"
-			IL_0ab0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ab5: ldc.r8 2
-			IL_0abe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ac3: stloc.0
-			IL_0ac4: ldc.i4.1
-			IL_0ac5: newarr [System.Runtime]System.Object
-			IL_0aca: dup
-			IL_0acb: ldc.i4.0
+			IL_0873: stloc.0
+			IL_0874: ldarg.0
+			IL_0875: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_087a: ldnull
+			IL_087b: ldloc.0
+			IL_087c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0881: stloc.0
+			IL_0882: ldstr "execution.requiresDefaultHarness: "
+			IL_0887: ldloc.0
+			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_088d: stloc.1
+			IL_088e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0893: ldloc.1
+			IL_0894: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0899: pop
+			IL_089a: ldarg.3
+			IL_089b: ldstr "execution"
+			IL_08a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08a5: ldstr "requiresAsyncHarness"
+			IL_08aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08af: stloc.0
+			IL_08b0: ldarg.0
+			IL_08b1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_08b6: ldnull
+			IL_08b7: ldloc.0
+			IL_08b8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_08bd: stloc.0
+			IL_08be: ldstr "execution.requiresAsyncHarness: "
+			IL_08c3: ldloc.0
+			IL_08c4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_08c9: stloc.1
+			IL_08ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08cf: ldloc.1
+			IL_08d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08d5: pop
+			IL_08d6: ldarg.3
+			IL_08d7: ldstr "execution"
+			IL_08dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08e1: ldstr "requiresAgent"
+			IL_08e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08eb: stloc.0
+			IL_08ec: ldarg.0
+			IL_08ed: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_08f2: ldnull
+			IL_08f3: ldloc.0
+			IL_08f4: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_08f9: stloc.0
+			IL_08fa: ldstr "execution.requiresAgent: "
+			IL_08ff: ldloc.0
+			IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0905: stloc.1
+			IL_0906: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_090b: ldloc.1
+			IL_090c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0911: pop
+			IL_0912: ldarg.3
+			IL_0913: ldstr "execution"
+			IL_0918: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_091d: ldstr "canBlock"
+			IL_0922: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0927: stloc.0
+			IL_0928: ldarg.0
+			IL_0929: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_092e: ldnull
+			IL_092f: ldloc.0
+			IL_0930: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0935: stloc.0
+			IL_0936: ldstr "execution.canBlock: "
+			IL_093b: ldloc.0
+			IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0941: stloc.1
+			IL_0942: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0947: ldloc.1
+			IL_0948: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_094d: pop
+			IL_094e: ldarg.3
+			IL_094f: ldstr "execution"
+			IL_0954: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0959: ldstr "isModule"
+			IL_095e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0963: stloc.0
+			IL_0964: ldarg.0
+			IL_0965: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_096a: ldnull
+			IL_096b: ldloc.0
+			IL_096c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0971: stloc.0
+			IL_0972: ldstr "execution.isModule: "
+			IL_0977: ldloc.0
+			IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_097d: stloc.1
+			IL_097e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0983: ldloc.1
+			IL_0984: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0989: pop
+			IL_098a: ldarg.3
+			IL_098b: ldstr "execution"
+			IL_0990: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0995: ldstr "isRaw"
+			IL_099a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_099f: stloc.0
+			IL_09a0: ldarg.0
+			IL_09a1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_09a6: ldnull
+			IL_09a7: ldloc.0
+			IL_09a8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_09ad: stloc.0
+			IL_09ae: ldstr "execution.isRaw: "
+			IL_09b3: ldloc.0
+			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09b9: stloc.1
+			IL_09ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09bf: ldloc.1
+			IL_09c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09c5: pop
+			IL_09c6: ldarg.3
+			IL_09c7: ldstr "execution"
+			IL_09cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d1: ldstr "isAsync"
+			IL_09d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09db: stloc.0
+			IL_09dc: ldarg.0
+			IL_09dd: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_09e2: ldnull
+			IL_09e3: ldloc.0
+			IL_09e4: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_09e9: stloc.0
+			IL_09ea: ldstr "execution.isAsync: "
+			IL_09ef: ldloc.0
+			IL_09f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09f5: stloc.1
+			IL_09f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09fb: ldloc.1
+			IL_09fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a01: pop
+			IL_0a02: ldarg.3
+			IL_0a03: ldstr "execution"
+			IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0d: ldstr "isGenerated"
+			IL_0a12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a17: stloc.0
+			IL_0a18: ldarg.0
+			IL_0a19: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0a1e: ldnull
+			IL_0a1f: ldloc.0
+			IL_0a20: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0a25: stloc.0
+			IL_0a26: ldstr "execution.isGenerated: "
+			IL_0a2b: ldloc.0
+			IL_0a2c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a31: stloc.1
+			IL_0a32: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a37: ldloc.1
+			IL_0a38: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a3d: pop
+			IL_0a3e: ldarg.3
+			IL_0a3f: ldstr "execution"
+			IL_0a44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a49: ldstr "isNonDeterministic"
+			IL_0a4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a53: stloc.0
+			IL_0a54: ldarg.0
+			IL_0a55: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0a5a: ldnull
+			IL_0a5b: ldloc.0
+			IL_0a5c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0a61: stloc.0
+			IL_0a62: ldstr "execution.isNonDeterministic: "
+			IL_0a67: ldloc.0
+			IL_0a68: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a6d: stloc.1
+			IL_0a6e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a73: ldloc.1
+			IL_0a74: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a79: pop
+			IL_0a7a: ldarg.3
+			IL_0a7b: ldstr "execution"
+			IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a85: ldstr "isFixture"
+			IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a8f: stloc.0
+			IL_0a90: ldarg.0
+			IL_0a91: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0a96: ldnull
+			IL_0a97: ldloc.0
+			IL_0a98: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0a9d: stloc.0
+			IL_0a9e: ldstr "execution.isFixture: "
+			IL_0aa3: ldloc.0
+			IL_0aa4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0aa9: stloc.1
+			IL_0aaa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0aaf: ldloc.1
+			IL_0ab0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ab5: pop
+			IL_0ab6: ldarg.3
+			IL_0ab7: ldstr "mvpBlockers"
+			IL_0abc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ac1: ldstr "length"
+			IL_0ac6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0acb: stloc.0
 			IL_0acc: ldarg.0
-			IL_0acd: stelem.ref
-			IL_0ace: ldc.i4.0
-			IL_0acf: ldelem.ref
-			IL_0ad0: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0ad5: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0adb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0ae0: ldnull
-			IL_0ae1: ldloc.0
-			IL_0ae2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0ae7: stloc.0
-			IL_0ae8: ldstr "execution.harnessIncludes[2]: "
-			IL_0aed: ldloc.0
-			IL_0aee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0af3: stloc.1
-			IL_0af4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0af9: ldloc.1
-			IL_0afa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0aff: pop
-			IL_0b00: ldarg.3
-			IL_0b01: ldstr "execution"
-			IL_0b06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b0b: ldstr "harnessIncludes"
-			IL_0b10: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b15: ldc.r8 3
-			IL_0b1e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b23: stloc.0
-			IL_0b24: ldc.i4.1
-			IL_0b25: newarr [System.Runtime]System.Object
-			IL_0b2a: dup
-			IL_0b2b: ldc.i4.0
-			IL_0b2c: ldarg.0
-			IL_0b2d: stelem.ref
-			IL_0b2e: ldc.i4.0
-			IL_0b2f: ldelem.ref
-			IL_0b30: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0b35: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0b3b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0b40: ldnull
-			IL_0b41: ldloc.0
-			IL_0b42: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0b47: stloc.0
-			IL_0b48: ldstr "execution.harnessIncludes[3]: "
-			IL_0b4d: ldloc.0
-			IL_0b4e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b53: stloc.1
-			IL_0b54: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b59: ldloc.1
-			IL_0b5a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b5f: pop
-			IL_0b60: ldarg.3
-			IL_0b61: ldstr "execution"
-			IL_0b66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b6b: ldstr "requiresDefaultHarness"
-			IL_0b70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b75: stloc.0
-			IL_0b76: ldc.i4.1
-			IL_0b77: newarr [System.Runtime]System.Object
-			IL_0b7c: dup
-			IL_0b7d: ldc.i4.0
-			IL_0b7e: ldarg.0
-			IL_0b7f: stelem.ref
-			IL_0b80: ldc.i4.0
-			IL_0b81: ldelem.ref
-			IL_0b82: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0b87: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0b8d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0acd: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0ad2: ldnull
+			IL_0ad3: ldloc.0
+			IL_0ad4: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0ad9: stloc.0
+			IL_0ada: ldstr "mvpBlockers.length: "
+			IL_0adf: ldloc.0
+			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ae5: stloc.1
+			IL_0ae6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0aeb: ldloc.1
+			IL_0aec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0af1: pop
+			IL_0af2: ldarg.3
+			IL_0af3: ldstr "mvpBlockers"
+			IL_0af8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0afd: ldc.r8 0.0
+			IL_0b06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b0b: stloc.0
+			IL_0b0c: ldarg.0
+			IL_0b0d: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0b12: ldnull
+			IL_0b13: ldloc.0
+			IL_0b14: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0b19: stloc.0
+			IL_0b1a: ldstr "mvpBlockers[0]: "
+			IL_0b1f: ldloc.0
+			IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b25: stloc.1
+			IL_0b26: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b2b: ldloc.1
+			IL_0b2c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b31: pop
+			IL_0b32: ldarg.3
+			IL_0b33: ldstr "mvpBlockers"
+			IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b3d: ldc.r8 1
+			IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b4b: stloc.0
+			IL_0b4c: ldarg.0
+			IL_0b4d: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0b52: ldnull
+			IL_0b53: ldloc.0
+			IL_0b54: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0b59: stloc.0
+			IL_0b5a: ldstr "mvpBlockers[1]: "
+			IL_0b5f: ldloc.0
+			IL_0b60: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b65: stloc.1
+			IL_0b66: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b6b: ldloc.1
+			IL_0b6c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b71: pop
+			IL_0b72: ldarg.3
+			IL_0b73: ldstr "mvpBlockers"
+			IL_0b78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b7d: ldc.r8 2
+			IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b8b: stloc.0
+			IL_0b8c: ldarg.0
+			IL_0b8d: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
 			IL_0b92: ldnull
 			IL_0b93: ldloc.0
-			IL_0b94: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
+			IL_0b94: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
 			IL_0b99: stloc.0
-			IL_0b9a: ldstr "execution.requiresDefaultHarness: "
+			IL_0b9a: ldstr "mvpBlockers[2]: "
 			IL_0b9f: ldloc.0
 			IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 			IL_0ba5: stloc.1
@@ -1690,500 +1581,87 @@
 			IL_0bac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0bb1: pop
 			IL_0bb2: ldarg.3
-			IL_0bb3: ldstr "execution"
+			IL_0bb3: ldstr "mvpBlockers"
 			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bbd: ldstr "requiresAsyncHarness"
-			IL_0bc2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bc7: stloc.0
-			IL_0bc8: ldc.i4.1
-			IL_0bc9: newarr [System.Runtime]System.Object
-			IL_0bce: dup
-			IL_0bcf: ldc.i4.0
-			IL_0bd0: ldarg.0
-			IL_0bd1: stelem.ref
-			IL_0bd2: ldc.i4.0
-			IL_0bd3: ldelem.ref
-			IL_0bd4: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0bd9: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0bdf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0be4: ldnull
-			IL_0be5: ldloc.0
-			IL_0be6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0beb: stloc.0
-			IL_0bec: ldstr "execution.requiresAsyncHarness: "
-			IL_0bf1: ldloc.0
-			IL_0bf2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0bf7: stloc.1
-			IL_0bf8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0bfd: ldloc.1
-			IL_0bfe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c03: pop
-			IL_0c04: ldarg.3
-			IL_0c05: ldstr "execution"
-			IL_0c0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c0f: ldstr "requiresAgent"
-			IL_0c14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c19: stloc.0
-			IL_0c1a: ldc.i4.1
-			IL_0c1b: newarr [System.Runtime]System.Object
-			IL_0c20: dup
-			IL_0c21: ldc.i4.0
-			IL_0c22: ldarg.0
-			IL_0c23: stelem.ref
-			IL_0c24: ldc.i4.0
-			IL_0c25: ldelem.ref
-			IL_0c26: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0c2b: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0c31: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0c36: ldnull
-			IL_0c37: ldloc.0
-			IL_0c38: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0c3d: stloc.0
-			IL_0c3e: ldstr "execution.requiresAgent: "
-			IL_0c43: ldloc.0
-			IL_0c44: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0c49: stloc.1
-			IL_0c4a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0c4f: ldloc.1
-			IL_0c50: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c55: pop
-			IL_0c56: ldarg.3
-			IL_0c57: ldstr "execution"
-			IL_0c5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c61: ldstr "canBlock"
-			IL_0c66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c6b: stloc.0
-			IL_0c6c: ldc.i4.1
-			IL_0c6d: newarr [System.Runtime]System.Object
-			IL_0c72: dup
-			IL_0c73: ldc.i4.0
-			IL_0c74: ldarg.0
-			IL_0c75: stelem.ref
-			IL_0c76: ldc.i4.0
-			IL_0c77: ldelem.ref
-			IL_0c78: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0c7d: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0c83: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0c88: ldnull
-			IL_0c89: ldloc.0
-			IL_0c8a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0c8f: stloc.0
-			IL_0c90: ldstr "execution.canBlock: "
-			IL_0c95: ldloc.0
-			IL_0c96: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0c9b: stloc.1
-			IL_0c9c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ca1: ldloc.1
-			IL_0ca2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0ca7: pop
-			IL_0ca8: ldarg.3
-			IL_0ca9: ldstr "execution"
-			IL_0cae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cb3: ldstr "isModule"
-			IL_0cb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cbd: stloc.0
-			IL_0cbe: ldc.i4.1
-			IL_0cbf: newarr [System.Runtime]System.Object
-			IL_0cc4: dup
-			IL_0cc5: ldc.i4.0
-			IL_0cc6: ldarg.0
-			IL_0cc7: stelem.ref
-			IL_0cc8: ldc.i4.0
-			IL_0cc9: ldelem.ref
-			IL_0cca: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0ccf: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0cd5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0cda: ldnull
-			IL_0cdb: ldloc.0
-			IL_0cdc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0ce1: stloc.0
-			IL_0ce2: ldstr "execution.isModule: "
-			IL_0ce7: ldloc.0
-			IL_0ce8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0ced: stloc.1
-			IL_0cee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0cf3: ldloc.1
-			IL_0cf4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0cf9: pop
-			IL_0cfa: ldarg.3
-			IL_0cfb: ldstr "execution"
-			IL_0d00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d05: ldstr "isRaw"
-			IL_0d0a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d0f: stloc.0
-			IL_0d10: ldc.i4.1
-			IL_0d11: newarr [System.Runtime]System.Object
-			IL_0d16: dup
-			IL_0d17: ldc.i4.0
-			IL_0d18: ldarg.0
-			IL_0d19: stelem.ref
-			IL_0d1a: ldc.i4.0
-			IL_0d1b: ldelem.ref
-			IL_0d1c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0d21: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0d27: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0d2c: ldnull
-			IL_0d2d: ldloc.0
-			IL_0d2e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0d33: stloc.0
-			IL_0d34: ldstr "execution.isRaw: "
-			IL_0d39: ldloc.0
-			IL_0d3a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0d3f: stloc.1
-			IL_0d40: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0d45: ldloc.1
-			IL_0d46: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0d4b: pop
-			IL_0d4c: ldarg.3
-			IL_0d4d: ldstr "execution"
-			IL_0d52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d57: ldstr "isAsync"
-			IL_0d5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d61: stloc.0
-			IL_0d62: ldc.i4.1
-			IL_0d63: newarr [System.Runtime]System.Object
-			IL_0d68: dup
-			IL_0d69: ldc.i4.0
-			IL_0d6a: ldarg.0
-			IL_0d6b: stelem.ref
-			IL_0d6c: ldc.i4.0
-			IL_0d6d: ldelem.ref
-			IL_0d6e: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0d73: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0d79: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0d7e: ldnull
-			IL_0d7f: ldloc.0
-			IL_0d80: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0d85: stloc.0
-			IL_0d86: ldstr "execution.isAsync: "
-			IL_0d8b: ldloc.0
-			IL_0d8c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0d91: stloc.1
-			IL_0d92: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0d97: ldloc.1
-			IL_0d98: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0d9d: pop
-			IL_0d9e: ldarg.3
-			IL_0d9f: ldstr "execution"
-			IL_0da4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0da9: ldstr "isGenerated"
-			IL_0dae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0db3: stloc.0
-			IL_0db4: ldc.i4.1
-			IL_0db5: newarr [System.Runtime]System.Object
-			IL_0dba: dup
-			IL_0dbb: ldc.i4.0
-			IL_0dbc: ldarg.0
-			IL_0dbd: stelem.ref
-			IL_0dbe: ldc.i4.0
-			IL_0dbf: ldelem.ref
-			IL_0dc0: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0dc5: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0dcb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0dd0: ldnull
-			IL_0dd1: ldloc.0
-			IL_0dd2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0dd7: stloc.0
-			IL_0dd8: ldstr "execution.isGenerated: "
-			IL_0ddd: ldloc.0
-			IL_0dde: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0de3: stloc.1
-			IL_0de4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0de9: ldloc.1
-			IL_0dea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0def: pop
-			IL_0df0: ldarg.3
-			IL_0df1: ldstr "execution"
-			IL_0df6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0dfb: ldstr "isNonDeterministic"
-			IL_0e00: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e05: stloc.0
-			IL_0e06: ldc.i4.1
-			IL_0e07: newarr [System.Runtime]System.Object
-			IL_0e0c: dup
-			IL_0e0d: ldc.i4.0
-			IL_0e0e: ldarg.0
-			IL_0e0f: stelem.ref
-			IL_0e10: ldc.i4.0
-			IL_0e11: ldelem.ref
-			IL_0e12: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0e17: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0e1d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0e22: ldnull
-			IL_0e23: ldloc.0
-			IL_0e24: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0e29: stloc.0
-			IL_0e2a: ldstr "execution.isNonDeterministic: "
-			IL_0e2f: ldloc.0
-			IL_0e30: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0e35: stloc.1
-			IL_0e36: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0e3b: ldloc.1
-			IL_0e3c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0e41: pop
-			IL_0e42: ldarg.3
-			IL_0e43: ldstr "execution"
-			IL_0e48: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e4d: ldstr "isFixture"
-			IL_0e52: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e57: stloc.0
-			IL_0e58: ldc.i4.1
-			IL_0e59: newarr [System.Runtime]System.Object
-			IL_0e5e: dup
-			IL_0e5f: ldc.i4.0
-			IL_0e60: ldarg.0
-			IL_0e61: stelem.ref
-			IL_0e62: ldc.i4.0
-			IL_0e63: ldelem.ref
-			IL_0e64: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0e69: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0e6f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0e74: ldnull
-			IL_0e75: ldloc.0
-			IL_0e76: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0e7b: stloc.0
-			IL_0e7c: ldstr "execution.isFixture: "
-			IL_0e81: ldloc.0
-			IL_0e82: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0e87: stloc.1
-			IL_0e88: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0e8d: ldloc.1
-			IL_0e8e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0e93: pop
-			IL_0e94: ldarg.3
-			IL_0e95: ldstr "mvpBlockers"
-			IL_0e9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e9f: ldstr "length"
-			IL_0ea4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ea9: stloc.0
-			IL_0eaa: ldc.i4.1
-			IL_0eab: newarr [System.Runtime]System.Object
-			IL_0eb0: dup
-			IL_0eb1: ldc.i4.0
-			IL_0eb2: ldarg.0
-			IL_0eb3: stelem.ref
-			IL_0eb4: ldc.i4.0
-			IL_0eb5: ldelem.ref
-			IL_0eb6: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0ebb: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0ec1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0ec6: ldnull
-			IL_0ec7: ldloc.0
-			IL_0ec8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0ecd: stloc.0
-			IL_0ece: ldstr "mvpBlockers.length: "
-			IL_0ed3: ldloc.0
-			IL_0ed4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0ed9: stloc.1
-			IL_0eda: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0edf: ldloc.1
-			IL_0ee0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0ee5: pop
-			IL_0ee6: ldarg.3
-			IL_0ee7: ldstr "mvpBlockers"
-			IL_0eec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ef1: ldc.r8 0.0
-			IL_0efa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0eff: stloc.0
-			IL_0f00: ldc.i4.1
-			IL_0f01: newarr [System.Runtime]System.Object
-			IL_0f06: dup
-			IL_0f07: ldc.i4.0
-			IL_0f08: ldarg.0
-			IL_0f09: stelem.ref
-			IL_0f0a: ldc.i4.0
-			IL_0f0b: ldelem.ref
-			IL_0f0c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0f11: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0f17: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0f1c: ldnull
-			IL_0f1d: ldloc.0
-			IL_0f1e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0f23: stloc.0
-			IL_0f24: ldstr "mvpBlockers[0]: "
-			IL_0f29: ldloc.0
-			IL_0f2a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0f2f: stloc.1
-			IL_0f30: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0f35: ldloc.1
-			IL_0f36: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0f3b: pop
-			IL_0f3c: ldarg.3
-			IL_0f3d: ldstr "mvpBlockers"
-			IL_0f42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f47: ldc.r8 1
-			IL_0f50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f55: stloc.0
-			IL_0f56: ldc.i4.1
-			IL_0f57: newarr [System.Runtime]System.Object
-			IL_0f5c: dup
-			IL_0f5d: ldc.i4.0
-			IL_0f5e: ldarg.0
-			IL_0f5f: stelem.ref
-			IL_0f60: ldc.i4.0
-			IL_0f61: ldelem.ref
-			IL_0f62: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0f67: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0f6d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0f72: ldnull
-			IL_0f73: ldloc.0
-			IL_0f74: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0f79: stloc.0
-			IL_0f7a: ldstr "mvpBlockers[1]: "
-			IL_0f7f: ldloc.0
-			IL_0f80: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0f85: stloc.1
-			IL_0f86: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0f8b: ldloc.1
-			IL_0f8c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0f91: pop
-			IL_0f92: ldarg.3
-			IL_0f93: ldstr "mvpBlockers"
-			IL_0f98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f9d: ldc.r8 2
-			IL_0fa6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0fab: stloc.0
-			IL_0fac: ldc.i4.1
-			IL_0fad: newarr [System.Runtime]System.Object
-			IL_0fb2: dup
-			IL_0fb3: ldc.i4.0
-			IL_0fb4: ldarg.0
-			IL_0fb5: stelem.ref
-			IL_0fb6: ldc.i4.0
-			IL_0fb7: ldelem.ref
-			IL_0fb8: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0fbd: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0fc3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0fc8: ldnull
-			IL_0fc9: ldloc.0
-			IL_0fca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0fcf: stloc.0
-			IL_0fd0: ldstr "mvpBlockers[2]: "
-			IL_0fd5: ldloc.0
-			IL_0fd6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0fdb: stloc.1
-			IL_0fdc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0fe1: ldloc.1
-			IL_0fe2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0fe7: pop
-			IL_0fe8: ldarg.3
-			IL_0fe9: ldstr "mvpBlockers"
-			IL_0fee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ff3: ldc.r8 3
-			IL_0ffc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1001: stloc.0
-			IL_1002: ldc.i4.1
-			IL_1003: newarr [System.Runtime]System.Object
-			IL_1008: dup
-			IL_1009: ldc.i4.0
-			IL_100a: ldarg.0
-			IL_100b: stelem.ref
-			IL_100c: ldc.i4.0
-			IL_100d: ldelem.ref
-			IL_100e: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_1013: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_1019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_101e: ldnull
-			IL_101f: ldloc.0
-			IL_1020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_1025: stloc.0
-			IL_1026: ldstr "mvpBlockers[3]: "
-			IL_102b: ldloc.0
-			IL_102c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1031: stloc.1
-			IL_1032: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1037: ldloc.1
-			IL_1038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_103d: pop
-			IL_103e: ldarg.3
-			IL_103f: ldstr "unsupported"
-			IL_1044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1049: ldstr "length"
-			IL_104e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_1053: stloc.0
-			IL_1054: ldc.i4.1
-			IL_1055: newarr [System.Runtime]System.Object
-			IL_105a: dup
-			IL_105b: ldc.i4.0
-			IL_105c: ldarg.0
-			IL_105d: stelem.ref
-			IL_105e: ldc.i4.0
-			IL_105f: ldelem.ref
-			IL_1060: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_1065: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_106b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_1070: ldnull
-			IL_1071: ldloc.0
-			IL_1072: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_1077: stloc.0
-			IL_1078: ldstr "unsupported.length: "
-			IL_107d: ldloc.0
-			IL_107e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_1083: stloc.1
-			IL_1084: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1089: ldloc.1
-			IL_108a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_108f: pop
-			IL_1090: ldarg.3
-			IL_1091: ldstr "unsupported"
-			IL_1096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_109b: ldc.r8 0.0
-			IL_10a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_10a9: stloc.0
-			IL_10aa: ldc.i4.1
-			IL_10ab: newarr [System.Runtime]System.Object
-			IL_10b0: dup
-			IL_10b1: ldc.i4.0
-			IL_10b2: ldarg.0
-			IL_10b3: stelem.ref
-			IL_10b4: ldc.i4.0
-			IL_10b5: ldelem.ref
-			IL_10b6: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_10bb: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_10c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_10c6: ldnull
-			IL_10c7: ldloc.0
-			IL_10c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_10cd: stloc.0
-			IL_10ce: ldstr "unsupported[0]: "
-			IL_10d3: ldloc.0
-			IL_10d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_10d9: stloc.1
-			IL_10da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_10df: ldloc.1
-			IL_10e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_10e5: pop
-			IL_10e6: ldarg.3
-			IL_10e7: ldstr "unsupported"
-			IL_10ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_10f1: ldc.r8 1
-			IL_10fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_10ff: stloc.0
-			IL_1100: ldc.i4.1
-			IL_1101: newarr [System.Runtime]System.Object
-			IL_1106: dup
-			IL_1107: ldc.i4.0
-			IL_1108: ldarg.0
-			IL_1109: stelem.ref
-			IL_110a: ldc.i4.0
-			IL_110b: ldelem.ref
-			IL_110c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_1111: ldftn object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_1117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_111c: ldnull
-			IL_111d: ldloc.0
-			IL_111e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_1123: stloc.0
-			IL_1124: ldstr "unsupported[1]: "
-			IL_1129: ldloc.0
-			IL_112a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_112f: stloc.1
-			IL_1130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_1135: ldloc.1
-			IL_1136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_113b: pop
-			IL_113c: ldnull
-			IL_113d: ret
+			IL_0bbd: ldc.r8 3
+			IL_0bc6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0bcb: stloc.0
+			IL_0bcc: ldarg.0
+			IL_0bcd: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0bd2: ldnull
+			IL_0bd3: ldloc.0
+			IL_0bd4: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0bd9: stloc.0
+			IL_0bda: ldstr "mvpBlockers[3]: "
+			IL_0bdf: ldloc.0
+			IL_0be0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0be5: stloc.1
+			IL_0be6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0beb: ldloc.1
+			IL_0bec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0bf1: pop
+			IL_0bf2: ldarg.3
+			IL_0bf3: ldstr "unsupported"
+			IL_0bf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bfd: ldstr "length"
+			IL_0c02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c07: stloc.0
+			IL_0c08: ldarg.0
+			IL_0c09: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0c0e: ldnull
+			IL_0c0f: ldloc.0
+			IL_0c10: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0c15: stloc.0
+			IL_0c16: ldstr "unsupported.length: "
+			IL_0c1b: ldloc.0
+			IL_0c1c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c21: stloc.1
+			IL_0c22: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c27: ldloc.1
+			IL_0c28: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c2d: pop
+			IL_0c2e: ldarg.3
+			IL_0c2f: ldstr "unsupported"
+			IL_0c34: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c39: ldc.r8 0.0
+			IL_0c42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c47: stloc.0
+			IL_0c48: ldarg.0
+			IL_0c49: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0c4e: ldnull
+			IL_0c4f: ldloc.0
+			IL_0c50: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0c55: stloc.0
+			IL_0c56: ldstr "unsupported[0]: "
+			IL_0c5b: ldloc.0
+			IL_0c5c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c61: stloc.1
+			IL_0c62: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c67: ldloc.1
+			IL_0c68: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c6d: pop
+			IL_0c6e: ldarg.3
+			IL_0c6f: ldstr "unsupported"
+			IL_0c74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c79: ldc.r8 1
+			IL_0c82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c87: stloc.0
+			IL_0c88: ldarg.0
+			IL_0c89: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+			IL_0c8e: ldnull
+			IL_0c8f: ldloc.0
+			IL_0c90: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+			IL_0c95: stloc.0
+			IL_0c96: ldstr "unsupported[1]: "
+			IL_0c9b: ldloc.0
+			IL_0c9c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ca1: stloc.1
+			IL_0ca2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0ca7: ldloc.1
+			IL_0ca8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0cad: pop
+			IL_0cae: ldnull
+			IL_0caf: ret
 		} // end of method writeParsedResult::__js_call__
 
 	} // end of class writeParsedResult
@@ -2215,7 +1693,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x6480
+			// Method begins at RVA 0x5ca9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2241,7 +1719,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 815 (0x32f)
+		// Code size: 705 (0x2c1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262MetadataParser/Scope,
@@ -2444,103 +1922,58 @@
 		IL_0217: stloc.s 8
 		IL_0219: ldloc.s 8
 		IL_021b: stloc.s 7
-		IL_021d: ldc.i4.1
-		IL_021e: newarr [System.Runtime]System.Object
-		IL_0223: dup
-		IL_0224: ldc.i4.0
-		IL_0225: ldloc.0
-		IL_0226: stelem.ref
-		IL_0227: ldc.i4.0
-		IL_0228: ldelem.ref
-		IL_0229: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_022e: ldftn object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_0234: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0239: ldnull
-		IL_023a: ldstr "basic-strict"
-		IL_023f: ldloc.3
-		IL_0240: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0245: pop
-		IL_0246: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_024b: ldstr "---"
-		IL_0250: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0255: pop
-		IL_0256: ldc.i4.1
-		IL_0257: newarr [System.Runtime]System.Object
-		IL_025c: dup
-		IL_025d: ldc.i4.0
-		IL_025e: ldloc.0
-		IL_025f: stelem.ref
-		IL_0260: ldc.i4.0
-		IL_0261: ldelem.ref
-		IL_0262: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0267: ldftn object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_026d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0272: ldnull
-		IL_0273: ldstr "negative-parse"
-		IL_0278: ldloc.s 4
-		IL_027a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_027f: pop
-		IL_0280: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0285: ldstr "---"
-		IL_028a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_028f: pop
-		IL_0290: ldc.i4.1
-		IL_0291: newarr [System.Runtime]System.Object
-		IL_0296: dup
-		IL_0297: ldc.i4.0
-		IL_0298: ldloc.0
-		IL_0299: stelem.ref
-		IL_029a: ldc.i4.0
-		IL_029b: ldelem.ref
-		IL_029c: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_02a1: ldftn object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_02a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_02ac: ldnull
-		IL_02ad: ldstr "async-generated"
-		IL_02b2: ldloc.s 5
-		IL_02b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_02b9: pop
-		IL_02ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02bf: ldstr "---"
-		IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c9: pop
-		IL_02ca: ldc.i4.1
-		IL_02cb: newarr [System.Runtime]System.Object
-		IL_02d0: dup
-		IL_02d1: ldc.i4.0
-		IL_02d2: ldloc.0
-		IL_02d3: stelem.ref
-		IL_02d4: ldc.i4.0
-		IL_02d5: ldelem.ref
-		IL_02d6: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_02db: ldftn object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_02e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_02e6: ldnull
-		IL_02e7: ldstr "module-resolution"
-		IL_02ec: ldloc.s 6
-		IL_02ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_02f3: pop
-		IL_02f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f9: ldstr "---"
-		IL_02fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0303: pop
-		IL_0304: ldc.i4.1
-		IL_0305: newarr [System.Runtime]System.Object
-		IL_030a: dup
-		IL_030b: ldc.i4.0
-		IL_030c: ldloc.0
-		IL_030d: stelem.ref
-		IL_030e: ldc.i4.0
-		IL_030f: ldelem.ref
-		IL_0310: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0315: ldftn object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_031b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0320: ldnull
-		IL_0321: ldstr "fixture-unsupported"
-		IL_0326: ldloc.s 7
-		IL_0328: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_032d: pop
-		IL_032e: ret
+		IL_021d: ldloc.0
+		IL_021e: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_0223: ldnull
+		IL_0224: ldstr "basic-strict"
+		IL_0229: ldloc.3
+		IL_022a: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
+		IL_022f: pop
+		IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0235: ldstr "---"
+		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023f: pop
+		IL_0240: ldloc.0
+		IL_0241: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_0246: ldnull
+		IL_0247: ldstr "negative-parse"
+		IL_024c: ldloc.s 4
+		IL_024e: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
+		IL_0253: pop
+		IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0259: ldstr "---"
+		IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0263: pop
+		IL_0264: ldloc.0
+		IL_0265: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_026a: ldnull
+		IL_026b: ldstr "async-generated"
+		IL_0270: ldloc.s 5
+		IL_0272: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
+		IL_0277: pop
+		IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027d: ldstr "---"
+		IL_0282: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0287: pop
+		IL_0288: ldloc.0
+		IL_0289: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_028e: ldnull
+		IL_028f: ldstr "module-resolution"
+		IL_0294: ldloc.s 6
+		IL_0296: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
+		IL_029b: pop
+		IL_029c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a1: ldstr "---"
+		IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ab: pop
+		IL_02ac: ldloc.0
+		IL_02ad: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
+		IL_02b2: ldnull
+		IL_02b3: ldstr "fixture-unsupported"
+		IL_02b8: ldloc.s 7
+		IL_02ba: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
+		IL_02bf: pop
+		IL_02c0: ret
 	} // end of method Compile_Scripts_Test262MetadataParser::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262MetadataParser
@@ -2560,7 +1993,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64ec
+				// Method begins at RVA 0x5d15
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2584,7 +2017,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3d7c
+			// Method begins at RVA 0x3810
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -2648,7 +2081,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6507
+						// Method begins at RVA 0x5d30
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2666,7 +2099,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x64fe
+					// Method begins at RVA 0x5d27
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2684,7 +2117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x64f5
+				// Method begins at RVA 0x5d1e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2711,7 +2144,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3de4
+			// Method begins at RVA 0x3878
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -2816,7 +2249,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6522
+						// Method begins at RVA 0x5d4b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2834,7 +2267,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6519
+					// Method begins at RVA 0x5d42
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2852,7 +2285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6510
+				// Method begins at RVA 0x5d39
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2879,7 +2312,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3e9c
+			// Method begins at RVA 0x3930
 			// Header size: 12
 			// Code size: 355 (0x163)
 			.maxstack 8
@@ -3035,7 +2468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6534
+					// Method begins at RVA 0x5d5d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3053,7 +2486,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x652b
+				// Method begins at RVA 0x5d54
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3081,7 +2514,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x654f
+						// Method begins at RVA 0x5d78
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3099,7 +2532,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6546
+					// Method begins at RVA 0x5d6f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3117,7 +2550,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x653d
+				// Method begins at RVA 0x5d66
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3144,9 +2577,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x400c
+			// Method begins at RVA 0x3aa0
 			// Header size: 12
-			// Code size: 330 (0x14a)
+			// Code size: 308 (0x134)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3220,7 +2653,7 @@
 				IL_00b1: ldstr "length"
 				IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_00bb: clt
-				IL_00bd: brfalse IL_0148
+				IL_00bd: brfalse IL_0132
 
 				IL_00c2: newobj instance void Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41::.ctor()
 				IL_00c7: stloc.s 5
@@ -3240,39 +2673,30 @@
 				IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 				IL_00f6: stloc.s 9
 				IL_00f8: ldloc.s 9
-				IL_00fa: brfalse IL_0135
+				IL_00fa: brfalse IL_011f
 
 				IL_00ff: newobj instance void Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41/Block_L71C21::.ctor()
 				IL_0104: stloc.s 7
-				IL_0106: ldc.i4.1
-				IL_0107: newarr [System.Runtime]System.Object
-				IL_010c: dup
-				IL_010d: ldc.i4.0
-				IL_010e: ldarg.0
-				IL_010f: stelem.ref
-				IL_0110: ldc.i4.0
-				IL_0111: ldelem.ref
-				IL_0112: castclass Modules.test262_metadataParser/Scope
-				IL_0117: ldftn object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_011d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_0122: ldnull
-				IL_0123: ldloc.s 6
-				IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-				IL_012a: stloc.s 8
-				IL_012c: ldloc.3
-				IL_012d: ldloc.s 8
-				IL_012f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0134: pop
+				IL_0106: ldarg.0
+				IL_0107: castclass Modules.test262_metadataParser/Scope
+				IL_010c: ldnull
+				IL_010d: ldloc.s 6
+				IL_010f: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0114: stloc.s 8
+				IL_0116: ldloc.3
+				IL_0117: ldloc.s 8
+				IL_0119: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_011e: pop
 
-				IL_0135: ldloc.s 4
-				IL_0137: ldc.r8 1
-				IL_0140: add
-				IL_0141: stloc.s 4
-				IL_0143: br IL_00ae
+				IL_011f: ldloc.s 4
+				IL_0121: ldc.r8 1
+				IL_012a: add
+				IL_012b: stloc.s 4
+				IL_012d: br IL_00ae
 			// end loop
 
-			IL_0148: ldloc.3
-			IL_0149: ret
+			IL_0132: ldloc.3
+			IL_0133: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -3292,7 +2716,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6561
+					// Method begins at RVA 0x5d8a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3310,7 +2734,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6558
+				// Method begins at RVA 0x5d81
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3337,9 +2761,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4164
+			// Method begins at RVA 0x3be0
 			// Header size: 12
-			// Code size: 173 (0xad)
+			// Code size: 151 (0x97)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3393,42 +2817,28 @@
 			IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0068: stloc.3
 			IL_0069: ldloc.3
-			IL_006a: brfalse IL_0090
+			IL_006a: brfalse IL_0085
 
 			IL_006f: newobj instance void Modules.test262_metadataParser/parseInlineValue/Scope/Block_L81C56::.ctor()
 			IL_0074: stloc.1
-			IL_0075: ldc.i4.1
-			IL_0076: newarr [System.Runtime]System.Object
-			IL_007b: dup
-			IL_007c: ldc.i4.0
-			IL_007d: ldarg.0
-			IL_007e: stelem.ref
-			IL_007f: ldc.i4.0
-			IL_0080: ldelem.ref
-			IL_0081: castclass Modules.test262_metadataParser/Scope
-			IL_0086: ldnull
-			IL_0087: ldloc.0
-			IL_0088: tail.
-			IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_008f: ret
+			IL_0075: ldarg.0
+			IL_0076: castclass Modules.test262_metadataParser/Scope
+			IL_007b: ldnull
+			IL_007c: ldloc.0
+			IL_007d: tail.
+			IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0084: ret
 
-			IL_0090: ldc.i4.1
-			IL_0091: newarr [System.Runtime]System.Object
-			IL_0096: dup
-			IL_0097: ldc.i4.0
-			IL_0098: ldarg.0
-			IL_0099: stelem.ref
-			IL_009a: ldc.i4.0
-			IL_009b: ldelem.ref
-			IL_009c: castclass Modules.test262_metadataParser/Scope
-			IL_00a1: ldnull
-			IL_00a2: ldloc.0
-			IL_00a3: tail.
-			IL_00a5: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_00aa: ret
+			IL_0085: ldarg.0
+			IL_0086: castclass Modules.test262_metadataParser/Scope
+			IL_008b: ldnull
+			IL_008c: ldloc.0
+			IL_008d: tail.
+			IL_008f: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0094: ret
 
-			IL_00ab: ldnull
-			IL_00ac: ret
+			IL_0095: ldnull
+			IL_0096: ret
 		} // end of method parseInlineValue::__js_call__
 
 	} // end of class parseInlineValue
@@ -3444,7 +2854,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x656a
+				// Method begins at RVA 0x5d93
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3472,7 +2882,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6585
+						// Method begins at RVA 0x5dae
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3492,7 +2902,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x658e
+						// Method begins at RVA 0x5db7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3512,7 +2922,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6597
+						// Method begins at RVA 0x5dc0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3532,7 +2942,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65a0
+						// Method begins at RVA 0x5dc9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3550,7 +2960,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x657c
+					// Method begins at RVA 0x5da5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3568,7 +2978,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6573
+				// Method begins at RVA 0x5d9c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3595,7 +3005,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4220
+			// Method begins at RVA 0x3c84
 			// Header size: 12
 			// Code size: 327 (0x147)
 			.maxstack 8
@@ -3752,7 +3162,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65bb
+						// Method begins at RVA 0x5de4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3772,7 +3182,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65c4
+						// Method begins at RVA 0x5ded
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3792,7 +3202,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x65cd
+						// Method begins at RVA 0x5df6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3810,7 +3220,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65b2
+					// Method begins at RVA 0x5ddb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3828,7 +3238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65a9
+				// Method begins at RVA 0x5dd2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3858,9 +3268,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4374
+			// Method begins at RVA 0x3dd8
 			// Header size: 12
-			// Code size: 477 (0x1dd)
+			// Code size: 444 (0x1bc)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3902,7 +3312,7 @@
 				IL_003c: ldloc.s 9
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_0194
+				IL_0045: brfalse IL_017e
 
 				IL_004a: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37::.ctor()
 				IL_004f: stloc.2
@@ -3946,114 +3356,98 @@
 				IL_00c5: pop
 				IL_00c6: br IL_0017
 
-				IL_00cb: ldc.i4.1
-				IL_00cc: newarr [System.Runtime]System.Object
-				IL_00d1: dup
-				IL_00d2: ldc.i4.0
-				IL_00d3: ldarg.0
-				IL_00d4: stelem.ref
-				IL_00d5: ldc.i4.0
-				IL_00d6: ldelem.ref
-				IL_00d7: castclass Modules.test262_metadataParser/Scope
-				IL_00dc: ldftn object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_00e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_00e7: ldnull
-				IL_00e8: ldloc.3
-				IL_00e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-				IL_00ee: stloc.s 9
-				IL_00f0: ldloc.s 9
-				IL_00f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f7: stloc.s 10
-				IL_00f9: ldloc.s 10
-				IL_00fb: stloc.s 5
-				IL_00fd: ldloc.s 5
-				IL_00ff: ldarg.s parentIndent
-				IL_0101: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0106: cgt
-				IL_0108: ldc.i4.0
-				IL_0109: ceq
-				IL_010b: brfalse IL_011c
+				IL_00cb: ldarg.0
+				IL_00cc: castclass Modules.test262_metadataParser/Scope
+				IL_00d1: ldnull
+				IL_00d2: ldloc.3
+				IL_00d3: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_00d8: stloc.s 9
+				IL_00da: ldloc.s 9
+				IL_00dc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00e1: stloc.s 10
+				IL_00e3: ldloc.s 10
+				IL_00e5: stloc.s 5
+				IL_00e7: ldloc.s 5
+				IL_00e9: ldarg.s parentIndent
+				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00f0: cgt
+				IL_00f2: ldc.i4.0
+				IL_00f3: ceq
+				IL_00f5: brfalse IL_0106
 
-				IL_0110: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
-				IL_0115: stloc.s 6
-				IL_0117: br IL_0194
+				IL_00fa: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
+				IL_00ff: stloc.s 6
+				IL_0101: br IL_017e
 
-				IL_011c: ldloc.1
-				IL_011d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0122: stloc.s 10
-				IL_0124: ldloc.s 10
-				IL_0126: ldc.r8 0.0
-				IL_012f: clt
-				IL_0131: brfalse IL_0149
+				IL_0106: ldloc.1
+				IL_0107: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_010c: stloc.s 10
+				IL_010e: ldloc.s 10
+				IL_0110: ldc.r8 0.0
+				IL_0119: clt
+				IL_011b: brfalse IL_0133
 
-				IL_0136: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
-				IL_013b: stloc.s 7
-				IL_013d: ldloc.s 5
-				IL_013f: box [System.Runtime]System.Double
-				IL_0144: stloc.s 12
-				IL_0146: ldloc.s 12
-				IL_0148: stloc.1
+				IL_0120: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
+				IL_0125: stloc.s 7
+				IL_0127: ldloc.s 5
+				IL_0129: box [System.Runtime]System.Double
+				IL_012e: stloc.s 12
+				IL_0130: ldloc.s 12
+				IL_0132: stloc.1
 
-				IL_0149: ldloc.3
-				IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_014f: stloc.s 9
-				IL_0151: ldloc.s 9
-				IL_0153: ldstr "substring"
-				IL_0158: ldloc.1
-				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_015e: stloc.s 9
-				IL_0160: ldloc.0
-				IL_0161: ldloc.s 9
-				IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0168: pop
-				IL_0169: ldarg.3
-				IL_016a: ldstr "index"
-				IL_016f: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0174: ldc.r8 1
-				IL_017d: add
-				IL_017e: stloc.s 10
-				IL_0180: ldarg.3
-				IL_0181: ldstr "index"
-				IL_0186: ldloc.s 10
-				IL_0188: ldc.i4.1
-				IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_018e: pop
-				IL_018f: br IL_0017
+				IL_0133: ldloc.3
+				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0139: stloc.s 9
+				IL_013b: ldloc.s 9
+				IL_013d: ldstr "substring"
+				IL_0142: ldloc.1
+				IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0148: stloc.s 9
+				IL_014a: ldloc.0
+				IL_014b: ldloc.s 9
+				IL_014d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0152: pop
+				IL_0153: ldarg.3
+				IL_0154: ldstr "index"
+				IL_0159: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_015e: ldc.r8 1
+				IL_0167: add
+				IL_0168: stloc.s 10
+				IL_016a: ldarg.3
+				IL_016b: ldstr "index"
+				IL_0170: ldloc.s 10
+				IL_0172: ldc.i4.1
+				IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0178: pop
+				IL_0179: br IL_0017
 			// end loop
 
-			IL_0194: ldarg.s style
-			IL_0196: ldstr ">"
-			IL_019b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01a0: stloc.s 11
-			IL_01a2: ldloc.s 11
-			IL_01a4: brfalse IL_01c4
+			IL_017e: ldarg.s style
+			IL_0180: ldstr ">"
+			IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_018a: stloc.s 11
+			IL_018c: ldloc.s 11
+			IL_018e: brfalse IL_01a3
 
-			IL_01a9: ldc.i4.1
-			IL_01aa: newarr [System.Runtime]System.Object
-			IL_01af: dup
-			IL_01b0: ldc.i4.0
-			IL_01b1: ldarg.0
-			IL_01b2: stelem.ref
-			IL_01b3: ldc.i4.0
-			IL_01b4: ldelem.ref
-			IL_01b5: castclass Modules.test262_metadataParser/Scope
-			IL_01ba: ldnull
-			IL_01bb: ldloc.0
-			IL_01bc: tail.
-			IL_01be: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_01c3: ret
+			IL_0193: ldarg.0
+			IL_0194: castclass Modules.test262_metadataParser/Scope
+			IL_0199: ldnull
+			IL_019a: ldloc.0
+			IL_019b: tail.
+			IL_019d: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_01a2: ret
 
-			IL_01c4: ldloc.0
-			IL_01c5: ldc.i4.1
-			IL_01c6: newarr [System.Runtime]System.Object
-			IL_01cb: dup
-			IL_01cc: ldc.i4.0
-			IL_01cd: ldstr "\n"
-			IL_01d2: stelem.ref
-			IL_01d3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01d8: stloc.s 13
-			IL_01da: ldloc.s 13
-			IL_01dc: ret
+			IL_01a3: ldloc.0
+			IL_01a4: ldc.i4.1
+			IL_01a5: newarr [System.Runtime]System.Object
+			IL_01aa: dup
+			IL_01ab: ldc.i4.0
+			IL_01ac: ldstr "\n"
+			IL_01b1: stelem.ref
+			IL_01b2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01b7: stloc.s 13
+			IL_01b9: ldloc.s 13
+			IL_01bb: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -4073,7 +3467,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65df
+					// Method begins at RVA 0x5e08
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4093,7 +3487,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65e8
+					// Method begins at RVA 0x5e11
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4113,7 +3507,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x65f1
+					// Method begins at RVA 0x5e1a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4131,7 +3525,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65d6
+				// Method begins at RVA 0x5dff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4160,9 +3554,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4560
+			// Method begins at RVA 0x3fa0
 			// Header size: 12
-			// Code size: 420 (0x1a4)
+			// Code size: 387 (0x183)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4282,73 +3676,57 @@
 			IL_0107: ldloc.0
 			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
 			IL_010d: stloc.s 5
-			IL_010f: ldc.i4.1
-			IL_0110: newarr [System.Runtime]System.Object
-			IL_0115: dup
-			IL_0116: ldc.i4.0
-			IL_0117: ldarg.0
-			IL_0118: stelem.ref
-			IL_0119: ldc.i4.0
-			IL_011a: ldelem.ref
-			IL_011b: castclass Modules.test262_metadataParser/Scope
-			IL_0120: ldftn object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_012b: ldnull
-			IL_012c: ldloc.s 5
-			IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0133: stloc.s 5
-			IL_0135: ldloc.s 5
-			IL_0137: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_013c: stloc.s 6
-			IL_013e: ldloc.s 6
-			IL_0140: stloc.3
-			IL_0141: ldloc.3
-			IL_0142: ldarg.s parentIndent
-			IL_0144: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0149: cgt
-			IL_014b: ldc.i4.0
-			IL_014c: ceq
-			IL_014e: brfalse IL_016e
+			IL_010f: ldarg.0
+			IL_0110: castclass Modules.test262_metadataParser/Scope
+			IL_0115: ldnull
+			IL_0116: ldloc.s 5
+			IL_0118: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_011d: stloc.s 5
+			IL_011f: ldloc.s 5
+			IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0126: stloc.s 6
+			IL_0128: ldloc.s 6
+			IL_012a: stloc.3
+			IL_012b: ldloc.3
+			IL_012c: ldarg.s parentIndent
+			IL_012e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0133: cgt
+			IL_0135: ldc.i4.0
+			IL_0136: ceq
+			IL_0138: brfalse IL_0158
 
-			IL_0153: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
-			IL_0158: stloc.s 4
-			IL_015a: ldarg.3
-			IL_015b: ldstr "index"
-			IL_0160: ldloc.0
-			IL_0161: ldc.i4.1
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0167: pop
-			IL_0168: ldstr ""
-			IL_016d: ret
+			IL_013d: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
+			IL_0142: stloc.s 4
+			IL_0144: ldarg.3
+			IL_0145: ldstr "index"
+			IL_014a: ldloc.0
+			IL_014b: ldc.i4.1
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0151: pop
+			IL_0152: ldstr ""
+			IL_0157: ret
 
-			IL_016e: ldarg.3
-			IL_016f: ldstr "index"
-			IL_0174: ldloc.0
-			IL_0175: ldc.i4.1
-			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_017b: pop
-			IL_017c: ldloc.3
-			IL_017d: box [System.Runtime]System.Double
-			IL_0182: stloc.s 12
-			IL_0184: ldc.i4.1
-			IL_0185: newarr [System.Runtime]System.Object
-			IL_018a: dup
-			IL_018b: ldc.i4.0
-			IL_018c: ldarg.0
-			IL_018d: stelem.ref
-			IL_018e: ldc.i4.0
-			IL_018f: ldelem.ref
-			IL_0190: castclass Modules.test262_metadataParser/Scope
-			IL_0195: ldnull
-			IL_0196: ldarg.2
-			IL_0197: ldarg.3
-			IL_0198: ldloc.s 12
-			IL_019a: tail.
-			IL_019c: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01a1: ret
+			IL_0158: ldarg.3
+			IL_0159: ldstr "index"
+			IL_015e: ldloc.0
+			IL_015f: ldc.i4.1
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0165: pop
+			IL_0166: ldloc.3
+			IL_0167: box [System.Runtime]System.Double
+			IL_016c: stloc.s 12
+			IL_016e: ldarg.0
+			IL_016f: castclass Modules.test262_metadataParser/Scope
+			IL_0174: ldnull
+			IL_0175: ldarg.2
+			IL_0176: ldarg.3
+			IL_0177: ldloc.s 12
+			IL_0179: tail.
+			IL_017b: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0180: ret
 
-			IL_01a2: ldnull
-			IL_01a3: ret
+			IL_0181: ldnull
+			IL_0182: ret
 		} // end of method parseIndentedValue::__js_call__
 
 	} // end of class parseIndentedValue
@@ -4372,7 +3750,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x660c
+						// Method begins at RVA 0x5e35
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4392,7 +3770,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6615
+						// Method begins at RVA 0x5e3e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4412,7 +3790,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x661e
+						// Method begins at RVA 0x5e47
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4432,7 +3810,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6627
+						// Method begins at RVA 0x5e50
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4452,7 +3830,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6630
+						// Method begins at RVA 0x5e59
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4472,7 +3850,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6639
+						// Method begins at RVA 0x5e62
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4492,7 +3870,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6642
+						// Method begins at RVA 0x5e6b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4510,7 +3888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6603
+					// Method begins at RVA 0x5e2c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4528,7 +3906,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x65fa
+				// Method begins at RVA 0x5e23
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4557,9 +3935,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4710
+			// Method begins at RVA 0x4130
 			// Header size: 12
-			// Code size: 1007 (0x3ef)
+			// Code size: 919 (0x397)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -4612,7 +3990,7 @@
 				IL_002b: ldloc.s 19
 				IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0032: clt
-				IL_0034: brfalse IL_03ed
+				IL_0034: brfalse IL_0395
 
 				IL_0039: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37::.ctor()
 				IL_003e: stloc.1
@@ -4652,305 +4030,269 @@
 				IL_00a7: pop
 				IL_00a8: br IL_0006
 
-				IL_00ad: ldc.i4.1
-				IL_00ae: newarr [System.Runtime]System.Object
-				IL_00b3: dup
-				IL_00b4: ldc.i4.0
-				IL_00b5: ldarg.0
-				IL_00b6: stelem.ref
-				IL_00b7: ldc.i4.0
-				IL_00b8: ldelem.ref
-				IL_00b9: castclass Modules.test262_metadataParser/Scope
-				IL_00be: ldftn object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_00c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_00c9: ldnull
-				IL_00ca: ldloc.2
-				IL_00cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-				IL_00d0: stloc.s 19
-				IL_00d2: ldloc.s 19
-				IL_00d4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00d9: stloc.s 20
-				IL_00db: ldloc.s 20
-				IL_00dd: stloc.s 4
-				IL_00df: ldloc.s 4
-				IL_00e1: ldarg.s baseIndent
-				IL_00e3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00e8: clt
-				IL_00ea: brfalse IL_00fb
+				IL_00ad: ldarg.0
+				IL_00ae: castclass Modules.test262_metadataParser/Scope
+				IL_00b3: ldnull
+				IL_00b4: ldloc.2
+				IL_00b5: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_00ba: stloc.s 19
+				IL_00bc: ldloc.s 19
+				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00c3: stloc.s 20
+				IL_00c5: ldloc.s 20
+				IL_00c7: stloc.s 4
+				IL_00c9: ldloc.s 4
+				IL_00cb: ldarg.s baseIndent
+				IL_00cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d2: clt
+				IL_00d4: brfalse IL_00e5
 
-				IL_00ef: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
-				IL_00f4: stloc.s 5
-				IL_00f6: br IL_03ed
+				IL_00d9: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
+				IL_00de: stloc.s 5
+				IL_00e0: br IL_0395
 
-				IL_00fb: ldloc.s 4
-				IL_00fd: ldarg.s baseIndent
-				IL_00ff: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0104: cgt
-				IL_0106: brfalse IL_017b
+				IL_00e5: ldloc.s 4
+				IL_00e7: ldarg.s baseIndent
+				IL_00e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ee: cgt
+				IL_00f0: brfalse IL_0165
 
-				IL_010b: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
-				IL_0110: stloc.s 6
-				IL_0112: ldarg.3
-				IL_0113: ldstr "index"
-				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_011d: ldc.r8 1
-				IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_012b: stloc.s 22
-				IL_012d: ldloc.s 22
-				IL_012f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0134: stloc.s 23
-				IL_0136: ldstr "Unexpected indentation at frontmatter line "
-				IL_013b: ldloc.s 23
-				IL_013d: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0142: stloc.s 23
-				IL_0144: ldloc.s 23
-				IL_0146: ldstr "."
-				IL_014b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0150: stloc.s 23
-				IL_0152: ldloc.s 23
-				IL_0154: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0159: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_015e: stloc.s 19
-				IL_0160: ldloc.s 19
-				IL_0162: stloc.s 7
-				IL_0164: ldloc.s 7
-				IL_0166: isinst [System.Runtime]System.Exception
-				IL_016b: dup
-				IL_016c: brtrue IL_017a
+				IL_00f5: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
+				IL_00fa: stloc.s 6
+				IL_00fc: ldarg.3
+				IL_00fd: ldstr "index"
+				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0107: ldc.r8 1
+				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0115: stloc.s 22
+				IL_0117: ldloc.s 22
+				IL_0119: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_011e: stloc.s 23
+				IL_0120: ldstr "Unexpected indentation at frontmatter line "
+				IL_0125: ldloc.s 23
+				IL_0127: call string [System.Runtime]System.String::Concat(string, string)
+				IL_012c: stloc.s 23
+				IL_012e: ldloc.s 23
+				IL_0130: ldstr "."
+				IL_0135: call string [System.Runtime]System.String::Concat(string, string)
+				IL_013a: stloc.s 23
+				IL_013c: ldloc.s 23
+				IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0143: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0148: stloc.s 19
+				IL_014a: ldloc.s 19
+				IL_014c: stloc.s 7
+				IL_014e: ldloc.s 7
+				IL_0150: isinst [System.Runtime]System.Exception
+				IL_0155: dup
+				IL_0156: brtrue IL_0164
 
-				IL_0171: pop
-				IL_0172: ldloc.s 7
-				IL_0174: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0179: throw
+				IL_015b: pop
+				IL_015c: ldloc.s 7
+				IL_015e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0163: throw
 
-				IL_017a: throw
+				IL_0164: throw
 
-				IL_017b: ldloc.2
-				IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0181: stloc.s 19
-				IL_0183: ldloc.s 4
-				IL_0185: box [System.Runtime]System.Double
-				IL_018a: stloc.s 24
-				IL_018c: ldloc.s 19
-				IL_018e: ldstr "substring"
-				IL_0193: ldloc.s 24
-				IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_019a: stloc.s 19
-				IL_019c: ldloc.s 19
-				IL_019e: stloc.s 8
-				IL_01a0: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_01a5: ldstr ""
-				IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_01af: stloc.s 25
-				IL_01b1: ldloc.s 25
-				IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01b8: stloc.s 19
-				IL_01ba: ldloc.s 19
-				IL_01bc: ldstr "exec"
-				IL_01c1: ldloc.s 8
-				IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01c8: stloc.s 19
-				IL_01ca: ldloc.s 19
-				IL_01cc: stloc.s 9
-				IL_01ce: ldloc.s 9
-				IL_01d0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_01d5: ldc.i4.0
-				IL_01d6: ceq
-				IL_01d8: stloc.s 21
-				IL_01da: ldloc.s 21
-				IL_01dc: brfalse IL_0265
+				IL_0165: ldloc.2
+				IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_016b: stloc.s 19
+				IL_016d: ldloc.s 4
+				IL_016f: box [System.Runtime]System.Double
+				IL_0174: stloc.s 24
+				IL_0176: ldloc.s 19
+				IL_0178: ldstr "substring"
+				IL_017d: ldloc.s 24
+				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0184: stloc.s 19
+				IL_0186: ldloc.s 19
+				IL_0188: stloc.s 8
+				IL_018a: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_018f: ldstr ""
+				IL_0194: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0199: stloc.s 25
+				IL_019b: ldloc.s 25
+				IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a2: stloc.s 19
+				IL_01a4: ldloc.s 19
+				IL_01a6: ldstr "exec"
+				IL_01ab: ldloc.s 8
+				IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01b2: stloc.s 19
+				IL_01b4: ldloc.s 19
+				IL_01b6: stloc.s 9
+				IL_01b8: ldloc.s 9
+				IL_01ba: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01bf: ldc.i4.0
+				IL_01c0: ceq
+				IL_01c2: stloc.s 21
+				IL_01c4: ldloc.s 21
+				IL_01c6: brfalse IL_024f
 
-				IL_01e1: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
-				IL_01e6: stloc.s 10
-				IL_01e8: ldarg.3
-				IL_01e9: ldstr "index"
-				IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01f3: ldc.r8 1
-				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0201: stloc.s 22
-				IL_0203: ldloc.s 22
-				IL_0205: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_020a: stloc.s 23
-				IL_020c: ldstr "Invalid frontmatter line "
-				IL_0211: ldloc.s 23
-				IL_0213: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0218: stloc.s 23
-				IL_021a: ldloc.s 23
-				IL_021c: ldstr ": "
-				IL_0221: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0226: stloc.s 23
-				IL_0228: ldloc.s 8
-				IL_022a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_022f: stloc.s 26
-				IL_0231: ldloc.s 23
-				IL_0233: ldloc.s 26
-				IL_0235: call string [System.Runtime]System.String::Concat(string, string)
-				IL_023a: stloc.s 26
-				IL_023c: ldloc.s 26
-				IL_023e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0243: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0248: stloc.s 19
-				IL_024a: ldloc.s 19
-				IL_024c: stloc.s 11
-				IL_024e: ldloc.s 11
-				IL_0250: isinst [System.Runtime]System.Exception
-				IL_0255: dup
-				IL_0256: brtrue IL_0264
+				IL_01cb: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
+				IL_01d0: stloc.s 10
+				IL_01d2: ldarg.3
+				IL_01d3: ldstr "index"
+				IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01dd: ldc.r8 1
+				IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01eb: stloc.s 22
+				IL_01ed: ldloc.s 22
+				IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01f4: stloc.s 23
+				IL_01f6: ldstr "Invalid frontmatter line "
+				IL_01fb: ldloc.s 23
+				IL_01fd: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0202: stloc.s 23
+				IL_0204: ldloc.s 23
+				IL_0206: ldstr ": "
+				IL_020b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0210: stloc.s 23
+				IL_0212: ldloc.s 8
+				IL_0214: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0219: stloc.s 26
+				IL_021b: ldloc.s 23
+				IL_021d: ldloc.s 26
+				IL_021f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0224: stloc.s 26
+				IL_0226: ldloc.s 26
+				IL_0228: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0232: stloc.s 19
+				IL_0234: ldloc.s 19
+				IL_0236: stloc.s 11
+				IL_0238: ldloc.s 11
+				IL_023a: isinst [System.Runtime]System.Exception
+				IL_023f: dup
+				IL_0240: brtrue IL_024e
 
-				IL_025b: pop
-				IL_025c: ldloc.s 11
-				IL_025e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0263: throw
+				IL_0245: pop
+				IL_0246: ldloc.s 11
+				IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_024d: throw
 
-				IL_0264: throw
+				IL_024e: throw
 
-				IL_0265: ldloc.s 9
-				IL_0267: ldc.r8 1
-				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0275: stloc.s 12
-				IL_0277: ldloc.s 9
-				IL_0279: ldc.r8 2
-				IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_028c: stloc.s 19
-				IL_028e: ldloc.s 19
-				IL_0290: ldstr "trim"
-				IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_029a: stloc.s 19
-				IL_029c: ldloc.s 19
-				IL_029e: stloc.s 13
-				IL_02a0: ldarg.3
-				IL_02a1: ldstr "index"
-				IL_02a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_02ab: ldc.r8 1
-				IL_02b4: add
-				IL_02b5: stloc.s 20
-				IL_02b7: ldarg.3
-				IL_02b8: ldstr "index"
-				IL_02bd: ldloc.s 20
-				IL_02bf: ldc.i4.1
-				IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_02c5: pop
-				IL_02c6: ldnull
-				IL_02c7: stloc.s 14
-				IL_02c9: ldloc.s 13
-				IL_02cb: ldstr "|"
-				IL_02d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02d5: stloc.s 21
-				IL_02d7: ldloc.s 21
-				IL_02d9: box [System.Runtime]System.Boolean
-				IL_02de: stloc.s 27
-				IL_02e0: ldloc.s 27
-				IL_02e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02e7: stloc.s 21
-				IL_02e9: ldloc.s 21
-				IL_02eb: brtrue IL_0310
+				IL_024f: ldloc.s 9
+				IL_0251: ldc.r8 1
+				IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_025f: stloc.s 12
+				IL_0261: ldloc.s 9
+				IL_0263: ldc.r8 2
+				IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0276: stloc.s 19
+				IL_0278: ldloc.s 19
+				IL_027a: ldstr "trim"
+				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0284: stloc.s 19
+				IL_0286: ldloc.s 19
+				IL_0288: stloc.s 13
+				IL_028a: ldarg.3
+				IL_028b: ldstr "index"
+				IL_0290: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0295: ldc.r8 1
+				IL_029e: add
+				IL_029f: stloc.s 20
+				IL_02a1: ldarg.3
+				IL_02a2: ldstr "index"
+				IL_02a7: ldloc.s 20
+				IL_02a9: ldc.i4.1
+				IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_02af: pop
+				IL_02b0: ldnull
+				IL_02b1: stloc.s 14
+				IL_02b3: ldloc.s 13
+				IL_02b5: ldstr "|"
+				IL_02ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02bf: stloc.s 21
+				IL_02c1: ldloc.s 21
+				IL_02c3: box [System.Runtime]System.Boolean
+				IL_02c8: stloc.s 27
+				IL_02ca: ldloc.s 27
+				IL_02cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d1: stloc.s 21
+				IL_02d3: ldloc.s 21
+				IL_02d5: brtrue IL_02fa
 
-				IL_02f0: ldloc.s 13
-				IL_02f2: ldstr ">"
-				IL_02f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02fc: stloc.s 21
-				IL_02fe: ldloc.s 21
-				IL_0300: box [System.Runtime]System.Boolean
-				IL_0305: stloc.s 28
-				IL_0307: ldloc.s 28
-				IL_0309: stloc.s 29
-				IL_030b: br IL_0314
+				IL_02da: ldloc.s 13
+				IL_02dc: ldstr ">"
+				IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02e6: stloc.s 21
+				IL_02e8: ldloc.s 21
+				IL_02ea: box [System.Runtime]System.Boolean
+				IL_02ef: stloc.s 28
+				IL_02f1: ldloc.s 28
+				IL_02f3: stloc.s 29
+				IL_02f5: br IL_02fe
 
-				IL_0310: ldloc.s 27
-				IL_0312: stloc.s 29
+				IL_02fa: ldloc.s 27
+				IL_02fc: stloc.s 29
 
-				IL_0314: ldloc.s 29
-				IL_0316: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_031b: stloc.s 21
-				IL_031d: ldloc.s 21
-				IL_031f: brfalse IL_035e
+				IL_02fe: ldloc.s 29
+				IL_0300: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0305: stloc.s 21
+				IL_0307: ldloc.s 21
+				IL_0309: brfalse IL_0332
 
-				IL_0324: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
-				IL_0329: stloc.s 15
-				IL_032b: ldc.i4.1
-				IL_032c: newarr [System.Runtime]System.Object
-				IL_0331: dup
-				IL_0332: ldc.i4.0
-				IL_0333: ldarg.0
-				IL_0334: stelem.ref
-				IL_0335: ldc.i4.0
-				IL_0336: ldelem.ref
-				IL_0337: castclass Modules.test262_metadataParser/Scope
-				IL_033c: ldftn object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object, object)
-				IL_0342: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::.ctor(object, native int)
-				IL_0347: ldnull
-				IL_0348: ldarg.2
-				IL_0349: ldarg.3
-				IL_034a: ldarg.s baseIndent
-				IL_034c: ldloc.s 13
-				IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes4::Invoke(object, object, object, object, object)
-				IL_0353: stloc.s 19
-				IL_0355: ldloc.s 19
-				IL_0357: stloc.s 14
-				IL_0359: br IL_03dc
+				IL_030e: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
+				IL_0313: stloc.s 15
+				IL_0315: ldarg.0
+				IL_0316: castclass Modules.test262_metadataParser/Scope
+				IL_031b: ldnull
+				IL_031c: ldarg.2
+				IL_031d: ldarg.3
+				IL_031e: ldarg.s baseIndent
+				IL_0320: ldloc.s 13
+				IL_0322: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object, object)
+				IL_0327: stloc.s 19
+				IL_0329: ldloc.s 19
+				IL_032b: stloc.s 14
+				IL_032d: br IL_0384
 
-				IL_035e: ldloc.s 13
-				IL_0360: ldstr ""
-				IL_0365: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_036a: stloc.s 21
-				IL_036c: ldloc.s 21
-				IL_036e: brfalse IL_03ab
+				IL_0332: ldloc.s 13
+				IL_0334: ldstr ""
+				IL_0339: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_033e: stloc.s 21
+				IL_0340: ldloc.s 21
+				IL_0342: brfalse IL_0369
 
-				IL_0373: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
-				IL_0378: stloc.s 16
-				IL_037a: ldc.i4.1
-				IL_037b: newarr [System.Runtime]System.Object
-				IL_0380: dup
-				IL_0381: ldc.i4.0
-				IL_0382: ldarg.0
-				IL_0383: stelem.ref
-				IL_0384: ldc.i4.0
-				IL_0385: ldelem.ref
-				IL_0386: castclass Modules.test262_metadataParser/Scope
-				IL_038b: ldftn object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-				IL_0391: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-				IL_0396: ldnull
-				IL_0397: ldarg.2
-				IL_0398: ldarg.3
-				IL_0399: ldarg.s baseIndent
-				IL_039b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-				IL_03a0: stloc.s 19
-				IL_03a2: ldloc.s 19
-				IL_03a4: stloc.s 14
-				IL_03a6: br IL_03dc
+				IL_0347: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
+				IL_034c: stloc.s 16
+				IL_034e: ldarg.0
+				IL_034f: castclass Modules.test262_metadataParser/Scope
+				IL_0354: ldnull
+				IL_0355: ldarg.2
+				IL_0356: ldarg.3
+				IL_0357: ldarg.s baseIndent
+				IL_0359: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+				IL_035e: stloc.s 19
+				IL_0360: ldloc.s 19
+				IL_0362: stloc.s 14
+				IL_0364: br IL_0384
 
-				IL_03ab: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
-				IL_03b0: stloc.s 17
-				IL_03b2: ldc.i4.1
-				IL_03b3: newarr [System.Runtime]System.Object
-				IL_03b8: dup
-				IL_03b9: ldc.i4.0
-				IL_03ba: ldarg.0
-				IL_03bb: stelem.ref
-				IL_03bc: ldc.i4.0
-				IL_03bd: ldelem.ref
-				IL_03be: castclass Modules.test262_metadataParser/Scope
-				IL_03c3: ldftn object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_03c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_03ce: ldnull
-				IL_03cf: ldloc.s 13
-				IL_03d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-				IL_03d6: stloc.s 19
-				IL_03d8: ldloc.s 19
-				IL_03da: stloc.s 14
+				IL_0369: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
+				IL_036e: stloc.s 17
+				IL_0370: ldarg.0
+				IL_0371: castclass Modules.test262_metadataParser/Scope
+				IL_0376: ldnull
+				IL_0377: ldloc.s 13
+				IL_0379: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_037e: stloc.s 19
+				IL_0380: ldloc.s 19
+				IL_0382: stloc.s 14
 
-				IL_03dc: ldloc.0
-				IL_03dd: ldloc.s 12
-				IL_03df: ldloc.s 14
-				IL_03e1: ldc.i4.1
-				IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_03e7: pop
-				IL_03e8: br IL_0006
+				IL_0384: ldloc.0
+				IL_0385: ldloc.s 12
+				IL_0387: ldloc.s 14
+				IL_0389: ldc.i4.1
+				IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_038f: pop
+				IL_0390: br IL_0006
 			// end loop
 
-			IL_03ed: ldloc.0
-			IL_03ee: ret
+			IL_0395: ldloc.0
+			IL_0396: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -4966,7 +4308,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x664b
+				// Method begins at RVA 0x5e74
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4993,9 +4335,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4b0c
+			// Method begins at RVA 0x44d4
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5023,26 +4365,19 @@
 			IL_002d: ldc.r8 0.0
 			IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 			IL_003b: stloc.2
-			IL_003c: ldc.i4.1
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldarg.0
-			IL_0045: stelem.ref
-			IL_0046: ldc.i4.0
-			IL_0047: ldelem.ref
-			IL_0048: castclass Modules.test262_metadataParser/Scope
-			IL_004d: ldnull
-			IL_004e: ldloc.0
-			IL_004f: ldloc.2
-			IL_0050: ldc.r8 0.0
-			IL_0059: box [System.Runtime]System.Double
-			IL_005e: tail.
-			IL_0060: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0065: ret
+			IL_003c: ldarg.0
+			IL_003d: castclass Modules.test262_metadataParser/Scope
+			IL_0042: ldnull
+			IL_0043: ldloc.0
+			IL_0044: ldloc.2
+			IL_0045: ldc.r8 0.0
+			IL_004e: box [System.Runtime]System.Double
+			IL_0053: tail.
+			IL_0055: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_005a: ret
 
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method parseTest262Frontmatter::__js_call__
 
 	} // end of class parseTest262Frontmatter
@@ -5062,7 +4397,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x665d
+					// Method begins at RVA 0x5e86
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5082,7 +4417,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6666
+					// Method begins at RVA 0x5e8f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5102,7 +4437,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x666f
+					// Method begins at RVA 0x5e98
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5120,7 +4455,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6654
+				// Method begins at RVA 0x5e7d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5147,7 +4482,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4b80
+			// Method begins at RVA 0x4540
 			// Header size: 12
 			// Code size: 348 (0x15c)
 			.maxstack 8
@@ -5299,7 +4634,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6678
+				// Method begins at RVA 0x5ea1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5323,7 +4658,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4ce8
+			// Method begins at RVA 0x46a8
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -5382,7 +4717,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x668a
+					// Method begins at RVA 0x5eb3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5400,7 +4735,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6681
+				// Method begins at RVA 0x5eaa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5424,7 +4759,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4d3c
+			// Method begins at RVA 0x46fc
 			// Header size: 12
 			// Code size: 125 (0x7d)
 			.maxstack 8
@@ -5502,7 +4837,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6693
+				// Method begins at RVA 0x5ebc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5527,7 +4862,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4dc8
+			// Method begins at RVA 0x4788
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -5575,7 +4910,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x669c
+				// Method begins at RVA 0x5ec5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5602,7 +4937,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4e08
+			// Method begins at RVA 0x47c8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -5651,7 +4986,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66ae
+					// Method begins at RVA 0x5ed7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5671,7 +5006,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66b7
+					// Method begins at RVA 0x5ee0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5689,7 +5024,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66a5
+				// Method begins at RVA 0x5ece
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5717,7 +5052,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x66d2
+						// Method begins at RVA 0x5efb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5735,7 +5070,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66c9
+					// Method begins at RVA 0x5ef2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5753,7 +5088,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66c0
+				// Method begins at RVA 0x5ee9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5782,7 +5117,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4e54
+			// Method begins at RVA 0x4814
 			// Header size: 12
 			// Code size: 405 (0x195)
 			.maxstack 8
@@ -5976,7 +5311,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66e4
+					// Method begins at RVA 0x5f0d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5996,7 +5331,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66ed
+					// Method begins at RVA 0x5f16
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6014,7 +5349,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66db
+				// Method begins at RVA 0x5f04
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6043,7 +5378,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4ff8
+			// Method begins at RVA 0x49b8
 			// Header size: 12
 			// Code size: 220 (0xdc)
 			.maxstack 8
@@ -6169,7 +5504,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x66ff
+					// Method begins at RVA 0x5f28
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6189,7 +5524,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6708
+					// Method begins at RVA 0x5f31
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6209,7 +5544,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6711
+					// Method begins at RVA 0x5f3a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6229,7 +5564,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6735
+					// Method begins at RVA 0x5f5e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6247,7 +5582,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x66f6
+				// Method begins at RVA 0x5f1f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6275,7 +5610,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x672c
+						// Method begins at RVA 0x5f55
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6293,7 +5628,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6723
+					// Method begins at RVA 0x5f4c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6311,7 +5646,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x671a
+				// Method begins at RVA 0x5f43
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6339,9 +5674,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x50e0
+			// Method begins at RVA 0x4aa0
 			// Header size: 12
-			// Code size: 1015 (0x3f7)
+			// Code size: 971 (0x3cb)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.test262_metadataParser/normalizeNegative/Scope/Block_L294C79,
@@ -6499,258 +5834,240 @@
 			IL_013d: ldstr "phase"
 			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0147: stloc.s 20
-			IL_0149: ldc.i4.1
-			IL_014a: newarr [System.Runtime]System.Object
-			IL_014f: dup
-			IL_0150: ldc.i4.0
-			IL_0151: ldarg.0
-			IL_0152: stelem.ref
-			IL_0153: ldc.i4.0
-			IL_0154: ldelem.ref
-			IL_0155: castclass Modules.test262_metadataParser/Scope
-			IL_015a: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0165: ldnull
-			IL_0166: ldloc.s 20
-			IL_0168: ldstr "negative.phase"
-			IL_016d: ldarg.3
-			IL_016e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0173: stloc.s 20
-			IL_0175: ldloc.s 20
-			IL_0177: stloc.2
-			IL_0178: ldarg.2
-			IL_0179: ldstr "type"
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0149: ldarg.0
+			IL_014a: castclass Modules.test262_metadataParser/Scope
+			IL_014f: ldnull
+			IL_0150: ldloc.s 20
+			IL_0152: ldstr "negative.phase"
+			IL_0157: ldarg.3
+			IL_0158: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_015d: stloc.s 20
+			IL_015f: ldloc.s 20
+			IL_0161: stloc.2
+			IL_0162: ldarg.2
+			IL_0163: ldstr "type"
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016d: stloc.s 20
+			IL_016f: ldarg.0
+			IL_0170: castclass Modules.test262_metadataParser/Scope
+			IL_0175: ldnull
+			IL_0176: ldloc.s 20
+			IL_0178: ldstr "negative.type"
+			IL_017d: ldarg.3
+			IL_017e: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
 			IL_0183: stloc.s 20
-			IL_0185: ldc.i4.1
-			IL_0186: newarr [System.Runtime]System.Object
-			IL_018b: dup
-			IL_018c: ldc.i4.0
-			IL_018d: ldarg.0
-			IL_018e: stelem.ref
-			IL_018f: ldc.i4.0
-			IL_0190: ldelem.ref
-			IL_0191: castclass Modules.test262_metadataParser/Scope
-			IL_0196: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_019c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_01a1: ldnull
-			IL_01a2: ldloc.s 20
-			IL_01a4: ldstr "negative.type"
-			IL_01a9: ldarg.3
-			IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_01af: stloc.s 20
-			IL_01b1: ldloc.s 20
-			IL_01b3: stloc.3
-			IL_01b4: ldc.i4.3
-			IL_01b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01ba: dup
-			IL_01bb: ldstr "parse"
-			IL_01c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01c5: dup
-			IL_01c6: ldstr "resolution"
-			IL_01cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01d0: dup
-			IL_01d1: ldstr "runtime"
-			IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01db: stloc.s 4
-			IL_01dd: ldloc.2
-			IL_01de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01e3: stloc.s 12
-			IL_01e5: ldloc.s 12
-			IL_01e7: brfalse IL_0220
+			IL_0185: ldloc.s 20
+			IL_0187: stloc.3
+			IL_0188: ldc.i4.3
+			IL_0189: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_018e: dup
+			IL_018f: ldstr "parse"
+			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0199: dup
+			IL_019a: ldstr "resolution"
+			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a4: dup
+			IL_01a5: ldstr "runtime"
+			IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01af: stloc.s 4
+			IL_01b1: ldloc.2
+			IL_01b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01b7: stloc.s 12
+			IL_01b9: ldloc.s 12
+			IL_01bb: brfalse IL_01f4
 
-			IL_01ec: ldloc.s 4
-			IL_01ee: ldc.i4.1
-			IL_01ef: newarr [System.Runtime]System.Object
-			IL_01f4: dup
-			IL_01f5: ldc.i4.0
-			IL_01f6: ldloc.2
-			IL_01f7: stelem.ref
-			IL_01f8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-			IL_01fd: stloc.s 21
-			IL_01ff: ldloc.s 21
-			IL_0201: ldc.r8 0.0
-			IL_020a: clt
-			IL_020c: stloc.s 12
-			IL_020e: ldloc.s 12
-			IL_0210: box [System.Runtime]System.Boolean
-			IL_0215: stloc.s 13
-			IL_0217: ldloc.s 13
-			IL_0219: stloc.s 22
-			IL_021b: br IL_0223
+			IL_01c0: ldloc.s 4
+			IL_01c2: ldc.i4.1
+			IL_01c3: newarr [System.Runtime]System.Object
+			IL_01c8: dup
+			IL_01c9: ldc.i4.0
+			IL_01ca: ldloc.2
+			IL_01cb: stelem.ref
+			IL_01cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+			IL_01d1: stloc.s 21
+			IL_01d3: ldloc.s 21
+			IL_01d5: ldc.r8 0.0
+			IL_01de: clt
+			IL_01e0: stloc.s 12
+			IL_01e2: ldloc.s 12
+			IL_01e4: box [System.Runtime]System.Boolean
+			IL_01e9: stloc.s 13
+			IL_01eb: ldloc.s 13
+			IL_01ed: stloc.s 22
+			IL_01ef: br IL_01f7
 
-			IL_0220: ldloc.2
-			IL_0221: stloc.s 22
+			IL_01f4: ldloc.2
+			IL_01f5: stloc.s 22
 
-			IL_0223: ldloc.s 22
-			IL_0225: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022a: stloc.s 12
-			IL_022c: ldloc.s 12
-			IL_022e: brfalse IL_0272
+			IL_01f7: ldloc.s 22
+			IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01fe: stloc.s 12
+			IL_0200: ldloc.s 12
+			IL_0202: brfalse IL_0246
 
-			IL_0233: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L307C49::.ctor()
-			IL_0238: stloc.s 5
-			IL_023a: ldloc.2
-			IL_023b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0240: stloc.s 23
-			IL_0242: ldstr "Unsupported negative phase '"
-			IL_0247: ldloc.s 23
-			IL_0249: call string [System.Runtime]System.String::Concat(string, string)
-			IL_024e: stloc.s 23
-			IL_0250: ldloc.s 23
-			IL_0252: ldstr "'."
-			IL_0257: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025c: stloc.s 23
-			IL_025e: ldnull
-			IL_025f: ldarg.3
-			IL_0260: ldstr "unknown-negative-phase"
-			IL_0265: ldstr "negative.phase"
-			IL_026a: ldloc.s 23
-			IL_026c: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0271: pop
+			IL_0207: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L307C49::.ctor()
+			IL_020c: stloc.s 5
+			IL_020e: ldloc.2
+			IL_020f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0214: stloc.s 23
+			IL_0216: ldstr "Unsupported negative phase '"
+			IL_021b: ldloc.s 23
+			IL_021d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0222: stloc.s 23
+			IL_0224: ldloc.s 23
+			IL_0226: ldstr "'."
+			IL_022b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0230: stloc.s 23
+			IL_0232: ldnull
+			IL_0233: ldarg.3
+			IL_0234: ldstr "unknown-negative-phase"
+			IL_0239: ldstr "negative.phase"
+			IL_023e: ldloc.s 23
+			IL_0240: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+			IL_0245: pop
 
-			IL_0272: ldarg.2
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_0278: stloc.s 20
-			IL_027a: ldloc.s 20
-			IL_027c: stloc.s 6
-			IL_027e: ldc.r8 0.0
-			IL_0287: stloc.s 7
-			// loop start (head: IL_0289)
-				IL_0289: ldloc.s 7
-				IL_028b: ldloc.s 6
-				IL_028d: ldstr "length"
-				IL_0292: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0297: clt
-				IL_0299: brfalse IL_0372
+			IL_0246: ldarg.2
+			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_024c: stloc.s 20
+			IL_024e: ldloc.s 20
+			IL_0250: stloc.s 6
+			IL_0252: ldc.r8 0.0
+			IL_025b: stloc.s 7
+			// loop start (head: IL_025d)
+				IL_025d: ldloc.s 7
+				IL_025f: ldloc.s 6
+				IL_0261: ldstr "length"
+				IL_0266: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_026b: clt
+				IL_026d: brfalse IL_0346
 
-				IL_029e: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40::.ctor()
-				IL_02a3: stloc.s 8
-				IL_02a5: ldloc.s 6
-				IL_02a7: ldloc.s 7
-				IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02ae: stloc.s 9
-				IL_02b0: ldloc.s 9
-				IL_02b2: ldstr "phase"
-				IL_02b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_02bc: stloc.s 12
-				IL_02be: ldloc.s 12
-				IL_02c0: box [System.Runtime]System.Boolean
-				IL_02c5: stloc.s 13
-				IL_02c7: ldloc.s 13
-				IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02ce: stloc.s 12
-				IL_02d0: ldloc.s 12
-				IL_02d2: brfalse IL_02f7
+				IL_0272: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40::.ctor()
+				IL_0277: stloc.s 8
+				IL_0279: ldloc.s 6
+				IL_027b: ldloc.s 7
+				IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0282: stloc.s 9
+				IL_0284: ldloc.s 9
+				IL_0286: ldstr "phase"
+				IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0290: stloc.s 12
+				IL_0292: ldloc.s 12
+				IL_0294: box [System.Runtime]System.Boolean
+				IL_0299: stloc.s 13
+				IL_029b: ldloc.s 13
+				IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02a2: stloc.s 12
+				IL_02a4: ldloc.s 12
+				IL_02a6: brfalse IL_02cb
 
-				IL_02d7: ldloc.s 9
-				IL_02d9: ldstr "type"
-				IL_02de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_02e3: stloc.s 12
-				IL_02e5: ldloc.s 12
-				IL_02e7: box [System.Runtime]System.Boolean
-				IL_02ec: stloc.s 14
-				IL_02ee: ldloc.s 14
-				IL_02f0: stloc.s 24
-				IL_02f2: br IL_02fb
+				IL_02ab: ldloc.s 9
+				IL_02ad: ldstr "type"
+				IL_02b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_02b7: stloc.s 12
+				IL_02b9: ldloc.s 12
+				IL_02bb: box [System.Runtime]System.Boolean
+				IL_02c0: stloc.s 14
+				IL_02c2: ldloc.s 14
+				IL_02c4: stloc.s 24
+				IL_02c6: br IL_02cf
 
-				IL_02f7: ldloc.s 13
-				IL_02f9: stloc.s 24
+				IL_02cb: ldloc.s 13
+				IL_02cd: stloc.s 24
 
-				IL_02fb: ldloc.s 24
-				IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0302: stloc.s 12
-				IL_0304: ldloc.s 12
-				IL_0306: brfalse IL_035f
+				IL_02cf: ldloc.s 24
+				IL_02d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d6: stloc.s 12
+				IL_02d8: ldloc.s 12
+				IL_02da: brfalse IL_0333
 
-				IL_030b: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40/Block_L314C43::.ctor()
-				IL_0310: stloc.s 10
-				IL_0312: ldloc.s 9
-				IL_0314: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0319: stloc.s 23
-				IL_031b: ldstr "negative."
-				IL_0320: ldloc.s 23
-				IL_0322: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0327: stloc.s 23
-				IL_0329: ldloc.s 9
-				IL_032b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0330: stloc.s 25
-				IL_0332: ldstr "Unsupported negative metadata key '"
-				IL_0337: ldloc.s 25
-				IL_0339: call string [System.Runtime]System.String::Concat(string, string)
-				IL_033e: stloc.s 25
-				IL_0340: ldloc.s 25
-				IL_0342: ldstr "'."
-				IL_0347: call string [System.Runtime]System.String::Concat(string, string)
-				IL_034c: stloc.s 25
-				IL_034e: ldnull
-				IL_034f: ldarg.3
-				IL_0350: ldstr "unknown-negative-key"
-				IL_0355: ldloc.s 23
-				IL_0357: ldloc.s 25
-				IL_0359: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_035e: pop
+				IL_02df: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40/Block_L314C43::.ctor()
+				IL_02e4: stloc.s 10
+				IL_02e6: ldloc.s 9
+				IL_02e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_02ed: stloc.s 23
+				IL_02ef: ldstr "negative."
+				IL_02f4: ldloc.s 23
+				IL_02f6: call string [System.Runtime]System.String::Concat(string, string)
+				IL_02fb: stloc.s 23
+				IL_02fd: ldloc.s 9
+				IL_02ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0304: stloc.s 25
+				IL_0306: ldstr "Unsupported negative metadata key '"
+				IL_030b: ldloc.s 25
+				IL_030d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0312: stloc.s 25
+				IL_0314: ldloc.s 25
+				IL_0316: ldstr "'."
+				IL_031b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0320: stloc.s 25
+				IL_0322: ldnull
+				IL_0323: ldarg.3
+				IL_0324: ldstr "unknown-negative-key"
+				IL_0329: ldloc.s 23
+				IL_032b: ldloc.s 25
+				IL_032d: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+				IL_0332: pop
 
-				IL_035f: ldloc.s 7
-				IL_0361: ldc.r8 1
-				IL_036a: add
-				IL_036b: stloc.s 7
-				IL_036d: br IL_0289
+				IL_0333: ldloc.s 7
+				IL_0335: ldc.r8 1
+				IL_033e: add
+				IL_033f: stloc.s 7
+				IL_0341: br IL_025d
 			// end loop
 
-			IL_0372: ldloc.2
-			IL_0373: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0378: ldc.i4.0
-			IL_0379: ceq
-			IL_037b: stloc.s 12
-			IL_037d: ldloc.s 12
-			IL_037f: box [System.Runtime]System.Boolean
-			IL_0384: stloc.s 13
-			IL_0386: ldloc.s 13
-			IL_0388: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_038d: stloc.s 12
-			IL_038f: ldloc.s 12
-			IL_0391: brtrue IL_03b3
+			IL_0346: ldloc.2
+			IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_034c: ldc.i4.0
+			IL_034d: ceq
+			IL_034f: stloc.s 12
+			IL_0351: ldloc.s 12
+			IL_0353: box [System.Runtime]System.Boolean
+			IL_0358: stloc.s 13
+			IL_035a: ldloc.s 13
+			IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0361: stloc.s 12
+			IL_0363: ldloc.s 12
+			IL_0365: brtrue IL_0387
 
-			IL_0396: ldloc.3
-			IL_0397: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_039c: ldc.i4.0
-			IL_039d: ceq
-			IL_039f: stloc.s 12
-			IL_03a1: ldloc.s 12
-			IL_03a3: box [System.Runtime]System.Boolean
-			IL_03a8: stloc.s 14
-			IL_03aa: ldloc.s 14
-			IL_03ac: stloc.s 26
-			IL_03ae: br IL_03b7
+			IL_036a: ldloc.3
+			IL_036b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0370: ldc.i4.0
+			IL_0371: ceq
+			IL_0373: stloc.s 12
+			IL_0375: ldloc.s 12
+			IL_0377: box [System.Runtime]System.Boolean
+			IL_037c: stloc.s 14
+			IL_037e: ldloc.s 14
+			IL_0380: stloc.s 26
+			IL_0382: br IL_038b
 
-			IL_03b3: ldloc.s 13
-			IL_03b5: stloc.s 26
+			IL_0387: ldloc.s 13
+			IL_0389: stloc.s 26
 
-			IL_03b7: ldloc.s 26
-			IL_03b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03be: stloc.s 12
-			IL_03c0: ldloc.s 12
-			IL_03c2: brfalse IL_03d5
+			IL_038b: ldloc.s 26
+			IL_038d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0392: stloc.s 12
+			IL_0394: ldloc.s 12
+			IL_0396: brfalse IL_03a9
 
-			IL_03c7: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L319C23::.ctor()
-			IL_03cc: stloc.s 11
-			IL_03ce: ldc.i4.0
-			IL_03cf: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03d4: ret
+			IL_039b: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L319C23::.ctor()
+			IL_03a0: stloc.s 11
+			IL_03a2: ldc.i4.0
+			IL_03a3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03a8: ret
 
-			IL_03d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03da: dup
-			IL_03db: ldstr "phase"
-			IL_03e0: ldloc.2
-			IL_03e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03e6: dup
-			IL_03e7: ldstr "type"
-			IL_03ec: ldloc.3
-			IL_03ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03f2: stloc.s 27
-			IL_03f4: ldloc.s 27
-			IL_03f6: ret
+			IL_03a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03ae: dup
+			IL_03af: ldstr "phase"
+			IL_03b4: ldloc.2
+			IL_03b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03ba: dup
+			IL_03bb: ldstr "type"
+			IL_03c0: ldloc.3
+			IL_03c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03c6: stloc.s 27
+			IL_03c8: ldloc.s 27
+			IL_03ca: ret
 		} // end of method normalizeNegative::__js_call__
 
 	} // end of class normalizeNegative
@@ -6774,7 +6091,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x676b
+						// Method begins at RVA 0x5f94
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6794,7 +6111,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6774
+						// Method begins at RVA 0x5f9d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6814,7 +6131,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x677d
+						// Method begins at RVA 0x5fa6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6832,7 +6149,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6762
+					// Method begins at RVA 0x5f8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6852,7 +6169,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6786
+					// Method begins at RVA 0x5faf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6872,7 +6189,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x678f
+					// Method begins at RVA 0x5fb8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6890,7 +6207,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x673e
+				// Method begins at RVA 0x5f67
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6918,7 +6235,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6759
+						// Method begins at RVA 0x5f82
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6936,7 +6253,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6750
+					// Method begins at RVA 0x5f79
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6954,7 +6271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6747
+				// Method begins at RVA 0x5f70
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6982,7 +6299,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x67aa
+						// Method begins at RVA 0x5fd3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7000,7 +6317,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67a1
+					// Method begins at RVA 0x5fca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7018,7 +6335,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6798
+				// Method begins at RVA 0x5fc1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7047,7 +6364,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x54e4
+			// Method begins at RVA 0x4e78
 			// Header size: 12
 			// Code size: 1461 (0x5b5)
 			.maxstack 8
@@ -7644,7 +6961,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67bc
+					// Method begins at RVA 0x5fe5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7664,7 +6981,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67c5
+					// Method begins at RVA 0x5fee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7684,7 +7001,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67ce
+					// Method begins at RVA 0x5ff7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7704,7 +7021,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67d7
+					// Method begins at RVA 0x6000
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7724,7 +7041,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67e0
+					// Method begins at RVA 0x6009
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7744,7 +7061,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67e9
+					// Method begins at RVA 0x6012
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7764,7 +7081,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x67f2
+					// Method begins at RVA 0x601b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7782,7 +7099,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67b3
+				// Method begins at RVA 0x5fdc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7811,7 +7128,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5aa8
+			// Method begins at RVA 0x543c
 			// Header size: 12
 			// Code size: 549 (0x225)
 			.maxstack 8
@@ -8040,7 +7357,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x683a
+					// Method begins at RVA 0x6063
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8058,7 +7375,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x67fb
+				// Method begins at RVA 0x6024
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8086,7 +7403,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6816
+						// Method begins at RVA 0x603f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8104,7 +7421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x680d
+					// Method begins at RVA 0x6036
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8122,7 +7439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6804
+				// Method begins at RVA 0x602d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8150,7 +7467,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6831
+						// Method begins at RVA 0x605a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -8168,7 +7485,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6828
+					// Method begins at RVA 0x6051
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -8186,7 +7503,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x681f
+				// Method begins at RVA 0x6048
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8214,9 +7531,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5cdc
+			// Method begins at RVA 0x5670
 			// Header size: 12
-			// Code size: 1849 (0x739)
+			// Code size: 1497 (0x5d9)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8309,630 +7626,486 @@
 			IL_0062: stloc.s 28
 			IL_0064: ldloc.s 28
 			IL_0066: stloc.2
-			IL_0067: ldc.i4.1
-			IL_0068: newarr [System.Runtime]System.Object
-			IL_006d: dup
-			IL_006e: ldc.i4.0
-			IL_006f: ldarg.0
-			IL_0070: stelem.ref
-			IL_0071: ldc.i4.0
-			IL_0072: ldelem.ref
-			IL_0073: castclass Modules.test262_metadataParser/Scope
-			IL_0078: ldftn object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_007e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0083: ldnull
-			IL_0084: ldarg.2
-			IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_008a: stloc.s 28
-			IL_008c: ldloc.s 28
-			IL_008e: stloc.3
-			IL_008f: ldc.i4.0
-			IL_0090: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0095: stloc.s 4
-			IL_0097: ldloc.3
-			IL_0098: ldc.i4.0
-			IL_0099: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_00a3: stloc.s 25
-			IL_00a5: ldloc.s 25
-			IL_00a7: stloc.s 5
-			IL_00a9: ldloc.s 5
-			IL_00ab: brfalse IL_00de
+			IL_0067: ldarg.0
+			IL_0068: castclass Modules.test262_metadataParser/Scope
+			IL_006d: ldnull
+			IL_006e: ldarg.2
+			IL_006f: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0074: stloc.s 28
+			IL_0076: ldloc.s 28
+			IL_0078: stloc.3
+			IL_0079: ldc.i4.0
+			IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_007f: stloc.s 4
+			IL_0081: ldloc.3
+			IL_0082: ldc.i4.0
+			IL_0083: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0088: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_008d: stloc.s 25
+			IL_008f: ldloc.s 25
+			IL_0091: stloc.s 5
+			IL_0093: ldloc.s 5
+			IL_0095: brfalse IL_00b2
 
-			IL_00b0: ldc.i4.1
-			IL_00b1: newarr [System.Runtime]System.Object
-			IL_00b6: dup
-			IL_00b7: ldc.i4.0
-			IL_00b8: ldarg.0
-			IL_00b9: stelem.ref
-			IL_00ba: ldc.i4.0
-			IL_00bb: ldelem.ref
-			IL_00bc: castclass Modules.test262_metadataParser/Scope
-			IL_00c1: ldftn object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_00c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00cc: ldnull
-			IL_00cd: ldloc.3
-			IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00d3: stloc.s 28
-			IL_00d5: ldloc.s 28
-			IL_00d7: stloc.s 6
-			IL_00d9: br IL_00e5
+			IL_009a: ldarg.0
+			IL_009b: castclass Modules.test262_metadataParser/Scope
+			IL_00a0: ldnull
+			IL_00a1: ldloc.3
+			IL_00a2: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_00a7: stloc.s 28
+			IL_00a9: ldloc.s 28
+			IL_00ab: stloc.s 6
+			IL_00ad: br IL_00b9
 
-			IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00e3: stloc.s 6
+			IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00b7: stloc.s 6
 
-			IL_00e5: ldloc.s 6
-			IL_00e7: stloc.s 7
-			IL_00e9: ldloc.s 7
-			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_00f0: stloc.s 28
-			IL_00f2: ldloc.s 28
-			IL_00f4: stloc.s 8
-			IL_00f6: ldc.i4.0
-			IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00fc: stloc.s 9
-			IL_00fe: ldc.r8 0.0
-			IL_0107: stloc.s 10
-			// loop start (head: IL_0109)
-				IL_0109: ldloc.s 10
-				IL_010b: ldloc.s 8
-				IL_010d: ldstr "length"
-				IL_0112: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0117: clt
-				IL_0119: brfalse IL_01b5
+			IL_00b9: ldloc.s 6
+			IL_00bb: stloc.s 7
+			IL_00bd: ldloc.s 7
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_00c4: stloc.s 28
+			IL_00c6: ldloc.s 28
+			IL_00c8: stloc.s 8
+			IL_00ca: ldc.i4.0
+			IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d0: stloc.s 9
+			IL_00d2: ldc.r8 0.0
+			IL_00db: stloc.s 10
+			// loop start (head: IL_00dd)
+				IL_00dd: ldloc.s 10
+				IL_00df: ldloc.s 8
+				IL_00e1: ldstr "length"
+				IL_00e6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00eb: clt
+				IL_00ed: brfalse IL_0189
 
-				IL_011e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
-				IL_0123: stloc.s 11
-				IL_0125: ldloc.s 8
-				IL_0127: ldloc.s 10
-				IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_012e: stloc.s 12
-				IL_0130: ldarg.0
-				IL_0131: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
-				IL_0136: ldc.i4.1
-				IL_0137: newarr [System.Runtime]System.Object
-				IL_013c: dup
-				IL_013d: ldc.i4.0
-				IL_013e: ldloc.s 12
-				IL_0140: stelem.ref
-				IL_0141: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_0146: stloc.s 30
-				IL_0148: ldloc.s 30
-				IL_014a: ldc.r8 0.0
-				IL_0153: clt
-				IL_0155: brfalse IL_01a2
+				IL_00f2: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
+				IL_00f7: stloc.s 11
+				IL_00f9: ldloc.s 8
+				IL_00fb: ldloc.s 10
+				IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0102: stloc.s 12
+				IL_0104: ldarg.0
+				IL_0105: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
+				IL_010a: ldc.i4.1
+				IL_010b: newarr [System.Runtime]System.Object
+				IL_0110: dup
+				IL_0111: ldc.i4.0
+				IL_0112: ldloc.s 12
+				IL_0114: stelem.ref
+				IL_0115: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_011a: stloc.s 30
+				IL_011c: ldloc.s 30
+				IL_011e: ldc.r8 0.0
+				IL_0127: clt
+				IL_0129: brfalse IL_0176
 
-				IL_015a: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
-				IL_015f: stloc.s 13
-				IL_0161: ldloc.s 9
-				IL_0163: ldloc.s 12
-				IL_0165: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_016a: pop
-				IL_016b: ldloc.s 12
-				IL_016d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0172: stloc.s 31
-				IL_0174: ldstr "Unsupported frontmatter key '"
-				IL_0179: ldloc.s 31
-				IL_017b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0180: stloc.s 31
-				IL_0182: ldloc.s 31
-				IL_0184: ldstr "'."
-				IL_0189: call string [System.Runtime]System.String::Concat(string, string)
-				IL_018e: stloc.s 31
-				IL_0190: ldnull
-				IL_0191: ldloc.s 4
-				IL_0193: ldstr "unknown-frontmatter-key"
-				IL_0198: ldloc.s 12
-				IL_019a: ldloc.s 31
-				IL_019c: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_01a1: pop
+				IL_012e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
+				IL_0133: stloc.s 13
+				IL_0135: ldloc.s 9
+				IL_0137: ldloc.s 12
+				IL_0139: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_013e: pop
+				IL_013f: ldloc.s 12
+				IL_0141: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0146: stloc.s 31
+				IL_0148: ldstr "Unsupported frontmatter key '"
+				IL_014d: ldloc.s 31
+				IL_014f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0154: stloc.s 31
+				IL_0156: ldloc.s 31
+				IL_0158: ldstr "'."
+				IL_015d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0162: stloc.s 31
+				IL_0164: ldnull
+				IL_0165: ldloc.s 4
+				IL_0167: ldstr "unknown-frontmatter-key"
+				IL_016c: ldloc.s 12
+				IL_016e: ldloc.s 31
+				IL_0170: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+				IL_0175: pop
 
-				IL_01a2: ldloc.s 10
-				IL_01a4: ldc.r8 1
-				IL_01ad: add
-				IL_01ae: stloc.s 10
-				IL_01b0: br IL_0109
+				IL_0176: ldloc.s 10
+				IL_0178: ldc.r8 1
+				IL_0181: add
+				IL_0182: stloc.s 10
+				IL_0184: br IL_00dd
 			// end loop
 
-			IL_01b5: ldloc.s 7
-			IL_01b7: ldstr "includes"
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c1: stloc.s 28
-			IL_01c3: ldc.i4.1
-			IL_01c4: newarr [System.Runtime]System.Object
-			IL_01c9: dup
-			IL_01ca: ldc.i4.0
-			IL_01cb: ldarg.0
-			IL_01cc: stelem.ref
-			IL_01cd: ldc.i4.0
-			IL_01ce: ldelem.ref
-			IL_01cf: castclass Modules.test262_metadataParser/Scope
-			IL_01d4: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_01df: ldnull
-			IL_01e0: ldloc.s 28
-			IL_01e2: ldstr "includes"
-			IL_01e7: ldloc.s 4
-			IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_01ee: stloc.s 28
+			IL_0189: ldloc.s 7
+			IL_018b: ldstr "includes"
+			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0195: stloc.s 28
+			IL_0197: ldarg.0
+			IL_0198: castclass Modules.test262_metadataParser/Scope
+			IL_019d: ldnull
+			IL_019e: ldloc.s 28
+			IL_01a0: ldstr "includes"
+			IL_01a5: ldloc.s 4
+			IL_01a7: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_01ac: stloc.s 28
+			IL_01ae: ldloc.s 28
+			IL_01b0: stloc.s 14
+			IL_01b2: ldloc.s 7
+			IL_01b4: ldstr "flags"
+			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01be: stloc.s 28
+			IL_01c0: ldarg.0
+			IL_01c1: castclass Modules.test262_metadataParser/Scope
+			IL_01c6: ldnull
+			IL_01c7: ldloc.s 28
+			IL_01c9: ldstr "flags"
+			IL_01ce: ldloc.s 4
+			IL_01d0: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_01d5: stloc.s 28
+			IL_01d7: ldloc.s 28
+			IL_01d9: stloc.s 15
+			IL_01db: ldloc.s 7
+			IL_01dd: ldstr "features"
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e7: stloc.s 28
+			IL_01e9: ldarg.0
+			IL_01ea: castclass Modules.test262_metadataParser/Scope
+			IL_01ef: ldnull
 			IL_01f0: ldloc.s 28
-			IL_01f2: stloc.s 14
-			IL_01f4: ldloc.s 7
-			IL_01f6: ldstr "flags"
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0200: stloc.s 28
-			IL_0202: ldc.i4.1
-			IL_0203: newarr [System.Runtime]System.Object
-			IL_0208: dup
-			IL_0209: ldc.i4.0
-			IL_020a: ldarg.0
-			IL_020b: stelem.ref
-			IL_020c: ldc.i4.0
-			IL_020d: ldelem.ref
-			IL_020e: castclass Modules.test262_metadataParser/Scope
-			IL_0213: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_021e: ldnull
-			IL_021f: ldloc.s 28
-			IL_0221: ldstr "flags"
-			IL_0226: ldloc.s 4
-			IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_022d: stloc.s 28
-			IL_022f: ldloc.s 28
-			IL_0231: stloc.s 15
-			IL_0233: ldloc.s 7
-			IL_0235: ldstr "features"
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023f: stloc.s 28
-			IL_0241: ldc.i4.1
-			IL_0242: newarr [System.Runtime]System.Object
-			IL_0247: dup
-			IL_0248: ldc.i4.0
-			IL_0249: ldarg.0
-			IL_024a: stelem.ref
-			IL_024b: ldc.i4.0
-			IL_024c: ldelem.ref
-			IL_024d: castclass Modules.test262_metadataParser/Scope
-			IL_0252: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_025d: ldnull
-			IL_025e: ldloc.s 28
-			IL_0260: ldstr "features"
-			IL_0265: ldloc.s 4
-			IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_026c: stloc.s 28
-			IL_026e: ldloc.s 28
-			IL_0270: stloc.s 16
-			IL_0272: ldloc.s 7
-			IL_0274: ldstr "locale"
-			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027e: stloc.s 28
-			IL_0280: ldc.i4.1
-			IL_0281: newarr [System.Runtime]System.Object
-			IL_0286: dup
-			IL_0287: ldc.i4.0
-			IL_0288: ldarg.0
-			IL_0289: stelem.ref
-			IL_028a: ldc.i4.0
-			IL_028b: ldelem.ref
-			IL_028c: castclass Modules.test262_metadataParser/Scope
-			IL_0291: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0297: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_029c: ldnull
-			IL_029d: ldloc.s 28
-			IL_029f: ldstr "locale"
-			IL_02a4: ldloc.s 4
-			IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_02ab: stloc.s 28
-			IL_02ad: ldloc.s 28
-			IL_02af: stloc.s 17
-			IL_02b1: ldloc.s 7
-			IL_02b3: ldstr "defines"
-			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02bd: stloc.s 28
-			IL_02bf: ldc.i4.1
-			IL_02c0: newarr [System.Runtime]System.Object
-			IL_02c5: dup
-			IL_02c6: ldc.i4.0
-			IL_02c7: ldarg.0
-			IL_02c8: stelem.ref
-			IL_02c9: ldc.i4.0
-			IL_02ca: ldelem.ref
-			IL_02cb: castclass Modules.test262_metadataParser/Scope
-			IL_02d0: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_02d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_02db: ldnull
-			IL_02dc: ldloc.s 28
-			IL_02de: ldstr "defines"
-			IL_02e3: ldloc.s 4
-			IL_02e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_02ea: stloc.s 28
-			IL_02ec: ldloc.s 28
-			IL_02ee: stloc.s 18
-			IL_02f0: ldloc.s 7
-			IL_02f2: ldstr "negative"
-			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02fc: stloc.s 28
-			IL_02fe: ldc.i4.1
-			IL_02ff: newarr [System.Runtime]System.Object
-			IL_0304: dup
-			IL_0305: ldc.i4.0
-			IL_0306: ldarg.0
-			IL_0307: stelem.ref
-			IL_0308: ldc.i4.0
-			IL_0309: ldelem.ref
-			IL_030a: castclass Modules.test262_metadataParser/Scope
-			IL_030f: ldftn object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-			IL_0315: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_031a: ldnull
-			IL_031b: ldloc.s 28
-			IL_031d: ldloc.s 4
-			IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0324: stloc.s 28
-			IL_0326: ldloc.s 28
-			IL_0328: stloc.s 19
-			IL_032a: ldc.r8 0.0
-			IL_0333: stloc.s 20
-			// loop start (head: IL_0335)
-				IL_0335: ldloc.s 20
-				IL_0337: ldloc.s 15
-				IL_0339: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_033e: clt
-				IL_0340: brfalse IL_03f7
+			IL_01f2: ldstr "features"
+			IL_01f7: ldloc.s 4
+			IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_01fe: stloc.s 28
+			IL_0200: ldloc.s 28
+			IL_0202: stloc.s 16
+			IL_0204: ldloc.s 7
+			IL_0206: ldstr "locale"
+			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0210: stloc.s 28
+			IL_0212: ldarg.0
+			IL_0213: castclass Modules.test262_metadataParser/Scope
+			IL_0218: ldnull
+			IL_0219: ldloc.s 28
+			IL_021b: ldstr "locale"
+			IL_0220: ldloc.s 4
+			IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0227: stloc.s 28
+			IL_0229: ldloc.s 28
+			IL_022b: stloc.s 17
+			IL_022d: ldloc.s 7
+			IL_022f: ldstr "defines"
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0239: stloc.s 28
+			IL_023b: ldarg.0
+			IL_023c: castclass Modules.test262_metadataParser/Scope
+			IL_0241: ldnull
+			IL_0242: ldloc.s 28
+			IL_0244: ldstr "defines"
+			IL_0249: ldloc.s 4
+			IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0250: stloc.s 28
+			IL_0252: ldloc.s 28
+			IL_0254: stloc.s 18
+			IL_0256: ldloc.s 7
+			IL_0258: ldstr "negative"
+			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0262: stloc.s 28
+			IL_0264: ldarg.0
+			IL_0265: castclass Modules.test262_metadataParser/Scope
+			IL_026a: ldnull
+			IL_026b: ldloc.s 28
+			IL_026d: ldloc.s 4
+			IL_026f: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+			IL_0274: stloc.s 28
+			IL_0276: ldloc.s 28
+			IL_0278: stloc.s 19
+			IL_027a: ldc.r8 0.0
+			IL_0283: stloc.s 20
+			// loop start (head: IL_0285)
+				IL_0285: ldloc.s 20
+				IL_0287: ldloc.s 15
+				IL_0289: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_028e: clt
+				IL_0290: brfalse IL_0347
 
-				IL_0345: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
-				IL_034a: stloc.s 21
-				IL_034c: ldarg.0
-				IL_034d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-				IL_0352: stloc.s 32
-				IL_0354: ldloc.s 32
-				IL_0356: ldc.i4.1
-				IL_0357: newarr [System.Runtime]System.Object
-				IL_035c: dup
-				IL_035d: ldc.i4.0
-				IL_035e: ldloc.s 15
-				IL_0360: ldloc.s 20
-				IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0367: stelem.ref
-				IL_0368: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_036d: stloc.s 30
-				IL_036f: ldloc.s 30
-				IL_0371: ldc.r8 0.0
-				IL_037a: clt
-				IL_037c: brfalse IL_03e4
+				IL_0295: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
+				IL_029a: stloc.s 21
+				IL_029c: ldarg.0
+				IL_029d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+				IL_02a2: stloc.s 32
+				IL_02a4: ldloc.s 32
+				IL_02a6: ldc.i4.1
+				IL_02a7: newarr [System.Runtime]System.Object
+				IL_02ac: dup
+				IL_02ad: ldc.i4.0
+				IL_02ae: ldloc.s 15
+				IL_02b0: ldloc.s 20
+				IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02b7: stelem.ref
+				IL_02b8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_02bd: stloc.s 30
+				IL_02bf: ldloc.s 30
+				IL_02c1: ldc.r8 0.0
+				IL_02ca: clt
+				IL_02cc: brfalse IL_0334
 
-				IL_0381: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
-				IL_0386: stloc.s 22
-				IL_0388: ldloc.s 15
-				IL_038a: ldloc.s 20
-				IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0391: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0396: stloc.s 31
-				IL_0398: ldstr "flags:"
-				IL_039d: ldloc.s 31
-				IL_039f: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03a4: stloc.s 31
-				IL_03a6: ldloc.s 15
-				IL_03a8: ldloc.s 20
-				IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_03af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_03b4: stloc.s 33
-				IL_03b6: ldstr "Unsupported flag '"
-				IL_03bb: ldloc.s 33
-				IL_03bd: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03c2: stloc.s 33
-				IL_03c4: ldloc.s 33
-				IL_03c6: ldstr "'."
-				IL_03cb: call string [System.Runtime]System.String::Concat(string, string)
-				IL_03d0: stloc.s 33
-				IL_03d2: ldnull
-				IL_03d3: ldloc.s 4
-				IL_03d5: ldstr "unknown-flag"
-				IL_03da: ldloc.s 31
-				IL_03dc: ldloc.s 33
-				IL_03de: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_03e3: pop
+				IL_02d1: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
+				IL_02d6: stloc.s 22
+				IL_02d8: ldloc.s 15
+				IL_02da: ldloc.s 20
+				IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_02e6: stloc.s 31
+				IL_02e8: ldstr "flags:"
+				IL_02ed: ldloc.s 31
+				IL_02ef: call string [System.Runtime]System.String::Concat(string, string)
+				IL_02f4: stloc.s 31
+				IL_02f6: ldloc.s 15
+				IL_02f8: ldloc.s 20
+				IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0304: stloc.s 33
+				IL_0306: ldstr "Unsupported flag '"
+				IL_030b: ldloc.s 33
+				IL_030d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0312: stloc.s 33
+				IL_0314: ldloc.s 33
+				IL_0316: ldstr "'."
+				IL_031b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0320: stloc.s 33
+				IL_0322: ldnull
+				IL_0323: ldloc.s 4
+				IL_0325: ldstr "unknown-flag"
+				IL_032a: ldloc.s 31
+				IL_032c: ldloc.s 33
+				IL_032e: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+				IL_0333: pop
 
-				IL_03e4: ldloc.s 20
-				IL_03e6: ldc.r8 1
-				IL_03ef: add
-				IL_03f0: stloc.s 20
-				IL_03f2: br IL_0335
+				IL_0334: ldloc.s 20
+				IL_0336: ldc.r8 1
+				IL_033f: add
+				IL_0340: stloc.s 20
+				IL_0342: br IL_0285
 			// end loop
 
-			IL_03f7: ldc.i4.1
-			IL_03f8: newarr [System.Runtime]System.Object
-			IL_03fd: dup
-			IL_03fe: ldc.i4.0
-			IL_03ff: ldarg.0
-			IL_0400: stelem.ref
-			IL_0401: ldc.i4.0
-			IL_0402: ldelem.ref
-			IL_0403: castclass Modules.test262_metadataParser/Scope
-			IL_0408: ldftn object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_040e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
+			IL_0347: ldarg.0
+			IL_0348: castclass Modules.test262_metadataParser/Scope
+			IL_034d: ldnull
+			IL_034e: ldloc.s 15
+			IL_0350: ldloc.s 14
+			IL_0352: ldloc.2
+			IL_0353: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0358: stloc.s 28
+			IL_035a: ldloc.s 28
+			IL_035c: stloc.s 23
+			IL_035e: ldloc.s 23
+			IL_0360: ldstr "strictMode"
+			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036a: ldstr "conflicting-flags"
+			IL_036f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0374: stloc.s 25
+			IL_0376: ldloc.s 25
+			IL_0378: brfalse IL_039c
+
+			IL_037d: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
+			IL_0382: stloc.s 24
+			IL_0384: ldnull
+			IL_0385: ldloc.s 4
+			IL_0387: ldstr "conflicting-strictness-flags"
+			IL_038c: ldstr "flags"
+			IL_0391: ldstr "Multiple strictness/source-type flags were declared together."
+			IL_0396: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+			IL_039b: pop
+
+			IL_039c: ldloc.1
+			IL_039d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a2: stloc.s 25
+			IL_03a4: ldloc.s 25
+			IL_03a6: brtrue IL_03b8
+
+			IL_03ab: ldc.i4.0
+			IL_03ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03b1: stloc.s 34
+			IL_03b3: br IL_03bb
+
+			IL_03b8: ldloc.1
+			IL_03b9: stloc.s 34
+
+			IL_03bb: ldloc.2
+			IL_03bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03c1: stloc.s 25
+			IL_03c3: ldloc.s 25
+			IL_03c5: brtrue IL_03d7
+
+			IL_03ca: ldc.i4.0
+			IL_03cb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03d0: stloc.s 36
+			IL_03d2: br IL_03da
+
+			IL_03d7: ldloc.2
+			IL_03d8: stloc.s 36
+
+			IL_03da: ldloc.s 7
+			IL_03dc: ldstr "description"
+			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e6: stloc.s 28
+			IL_03e8: ldarg.0
+			IL_03e9: castclass Modules.test262_metadataParser/Scope
+			IL_03ee: ldnull
+			IL_03ef: ldloc.s 28
+			IL_03f1: ldstr "description"
+			IL_03f6: ldloc.s 4
+			IL_03f8: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_03fd: stloc.s 28
+			IL_03ff: ldloc.s 7
+			IL_0401: ldstr "info"
+			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040b: stloc.s 37
+			IL_040d: ldarg.0
+			IL_040e: castclass Modules.test262_metadataParser/Scope
 			IL_0413: ldnull
-			IL_0414: ldloc.s 15
-			IL_0416: ldloc.s 14
-			IL_0418: ldloc.2
-			IL_0419: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_041e: stloc.s 28
-			IL_0420: ldloc.s 28
-			IL_0422: stloc.s 23
-			IL_0424: ldloc.s 23
-			IL_0426: ldstr "strictMode"
+			IL_0414: ldloc.s 37
+			IL_0416: ldstr "info"
+			IL_041b: ldloc.s 4
+			IL_041d: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0422: stloc.s 37
+			IL_0424: ldloc.s 7
+			IL_0426: ldstr "esid"
 			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0430: ldstr "conflicting-flags"
-			IL_0435: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_043a: stloc.s 25
-			IL_043c: ldloc.s 25
-			IL_043e: brfalse IL_0462
-
-			IL_0443: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
-			IL_0448: stloc.s 24
-			IL_044a: ldnull
-			IL_044b: ldloc.s 4
-			IL_044d: ldstr "conflicting-strictness-flags"
-			IL_0452: ldstr "flags"
-			IL_0457: ldstr "Multiple strictness/source-type flags were declared together."
-			IL_045c: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0461: pop
-
-			IL_0462: ldloc.1
-			IL_0463: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0468: stloc.s 25
-			IL_046a: ldloc.s 25
-			IL_046c: brtrue IL_047e
-
-			IL_0471: ldc.i4.0
-			IL_0472: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0477: stloc.s 34
-			IL_0479: br IL_0481
-
-			IL_047e: ldloc.1
-			IL_047f: stloc.s 34
-
-			IL_0481: ldloc.2
-			IL_0482: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0487: stloc.s 25
-			IL_0489: ldloc.s 25
-			IL_048b: brtrue IL_049d
-
-			IL_0490: ldc.i4.0
-			IL_0491: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0496: stloc.s 36
-			IL_0498: br IL_04a0
-
-			IL_049d: ldloc.2
-			IL_049e: stloc.s 36
-
-			IL_04a0: ldloc.s 7
-			IL_04a2: ldstr "description"
-			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04ac: stloc.s 28
-			IL_04ae: ldc.i4.1
-			IL_04af: newarr [System.Runtime]System.Object
-			IL_04b4: dup
-			IL_04b5: ldc.i4.0
-			IL_04b6: ldarg.0
-			IL_04b7: stelem.ref
-			IL_04b8: ldc.i4.0
-			IL_04b9: ldelem.ref
-			IL_04ba: castclass Modules.test262_metadataParser/Scope
-			IL_04bf: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_04c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_04ca: ldnull
-			IL_04cb: ldloc.s 28
-			IL_04cd: ldstr "description"
-			IL_04d2: ldloc.s 4
-			IL_04d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_04d9: stloc.s 28
-			IL_04db: ldloc.s 7
-			IL_04dd: ldstr "info"
-			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04e7: stloc.s 37
-			IL_04e9: ldc.i4.1
-			IL_04ea: newarr [System.Runtime]System.Object
-			IL_04ef: dup
-			IL_04f0: ldc.i4.0
-			IL_04f1: ldarg.0
-			IL_04f2: stelem.ref
-			IL_04f3: ldc.i4.0
-			IL_04f4: ldelem.ref
-			IL_04f5: castclass Modules.test262_metadataParser/Scope
-			IL_04fa: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0500: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0505: ldnull
-			IL_0506: ldloc.s 37
-			IL_0508: ldstr "info"
-			IL_050d: ldloc.s 4
-			IL_050f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0514: stloc.s 37
-			IL_0516: ldloc.s 7
-			IL_0518: ldstr "esid"
-			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0522: stloc.s 38
-			IL_0524: ldc.i4.1
-			IL_0525: newarr [System.Runtime]System.Object
-			IL_052a: dup
-			IL_052b: ldc.i4.0
-			IL_052c: ldarg.0
-			IL_052d: stelem.ref
-			IL_052e: ldc.i4.0
-			IL_052f: ldelem.ref
-			IL_0530: castclass Modules.test262_metadataParser/Scope
-			IL_0535: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_053b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_0540: ldnull
-			IL_0541: ldloc.s 38
-			IL_0543: ldstr "esid"
-			IL_0548: ldloc.s 4
-			IL_054a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_054f: stloc.s 38
-			IL_0551: ldloc.s 7
-			IL_0553: ldstr "es5id"
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_055d: stloc.s 39
-			IL_055f: ldc.i4.1
-			IL_0560: newarr [System.Runtime]System.Object
-			IL_0565: dup
-			IL_0566: ldc.i4.0
-			IL_0567: ldarg.0
-			IL_0568: stelem.ref
-			IL_0569: ldc.i4.0
-			IL_056a: ldelem.ref
-			IL_056b: castclass Modules.test262_metadataParser/Scope
-			IL_0570: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0576: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_057b: ldnull
-			IL_057c: ldloc.s 39
-			IL_057e: ldstr "es5id"
-			IL_0583: ldloc.s 4
-			IL_0585: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_058a: stloc.s 39
-			IL_058c: ldloc.s 7
-			IL_058e: ldstr "es6id"
-			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0598: stloc.s 40
-			IL_059a: ldc.i4.1
-			IL_059b: newarr [System.Runtime]System.Object
+			IL_0430: stloc.s 38
+			IL_0432: ldarg.0
+			IL_0433: castclass Modules.test262_metadataParser/Scope
+			IL_0438: ldnull
+			IL_0439: ldloc.s 38
+			IL_043b: ldstr "esid"
+			IL_0440: ldloc.s 4
+			IL_0442: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0447: stloc.s 38
+			IL_0449: ldloc.s 7
+			IL_044b: ldstr "es5id"
+			IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0455: stloc.s 39
+			IL_0457: ldarg.0
+			IL_0458: castclass Modules.test262_metadataParser/Scope
+			IL_045d: ldnull
+			IL_045e: ldloc.s 39
+			IL_0460: ldstr "es5id"
+			IL_0465: ldloc.s 4
+			IL_0467: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_046c: stloc.s 39
+			IL_046e: ldloc.s 7
+			IL_0470: ldstr "es6id"
+			IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_047a: stloc.s 40
+			IL_047c: ldarg.0
+			IL_047d: castclass Modules.test262_metadataParser/Scope
+			IL_0482: ldnull
+			IL_0483: ldloc.s 40
+			IL_0485: ldstr "es6id"
+			IL_048a: ldloc.s 4
+			IL_048c: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0491: stloc.s 40
+			IL_0493: ldloc.s 7
+			IL_0495: ldstr "author"
+			IL_049a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_049f: stloc.s 41
+			IL_04a1: ldarg.0
+			IL_04a2: castclass Modules.test262_metadataParser/Scope
+			IL_04a7: ldnull
+			IL_04a8: ldloc.s 41
+			IL_04aa: ldstr "author"
+			IL_04af: ldloc.s 4
+			IL_04b1: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_04b6: stloc.s 41
+			IL_04b8: ldarg.0
+			IL_04b9: castclass Modules.test262_metadataParser/Scope
+			IL_04be: ldnull
+			IL_04bf: ldloc.1
+			IL_04c0: ldloc.s 19
+			IL_04c2: ldloc.s 23
+			IL_04c4: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_04c9: stloc.s 42
+			IL_04cb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04d0: dup
+			IL_04d1: ldstr "filePath"
+			IL_04d6: ldloc.s 34
+			IL_04d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04dd: dup
+			IL_04de: ldstr "fileName"
+			IL_04e3: ldloc.s 36
+			IL_04e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04ea: dup
+			IL_04eb: ldstr "hasFrontmatter"
+			IL_04f0: ldloc.s 5
+			IL_04f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04f7: dup
+			IL_04f8: ldstr "frontmatter"
+			IL_04fd: ldloc.s 7
+			IL_04ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0504: dup
+			IL_0505: ldstr "unknownKeys"
+			IL_050a: ldloc.s 9
+			IL_050c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0511: dup
+			IL_0512: ldstr "description"
+			IL_0517: ldloc.s 28
+			IL_0519: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_051e: dup
+			IL_051f: ldstr "info"
+			IL_0524: ldloc.s 37
+			IL_0526: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_052b: dup
+			IL_052c: ldstr "esid"
+			IL_0531: ldloc.s 38
+			IL_0533: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0538: dup
+			IL_0539: ldstr "es5id"
+			IL_053e: ldloc.s 39
+			IL_0540: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0545: dup
+			IL_0546: ldstr "es6id"
+			IL_054b: ldloc.s 40
+			IL_054d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0552: dup
+			IL_0553: ldstr "author"
+			IL_0558: ldloc.s 41
+			IL_055a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_055f: dup
+			IL_0560: ldstr "includes"
+			IL_0565: ldloc.s 14
+			IL_0567: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_056c: dup
+			IL_056d: ldstr "flags"
+			IL_0572: ldloc.s 15
+			IL_0574: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0579: dup
+			IL_057a: ldstr "features"
+			IL_057f: ldloc.s 16
+			IL_0581: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0586: dup
+			IL_0587: ldstr "locale"
+			IL_058c: ldloc.s 17
+			IL_058e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0593: dup
+			IL_0594: ldstr "defines"
+			IL_0599: ldloc.s 18
+			IL_059b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_05a0: dup
-			IL_05a1: ldc.i4.0
-			IL_05a2: ldarg.0
-			IL_05a3: stelem.ref
-			IL_05a4: ldc.i4.0
-			IL_05a5: ldelem.ref
-			IL_05a6: castclass Modules.test262_metadataParser/Scope
-			IL_05ab: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_05b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_05b6: ldnull
-			IL_05b7: ldloc.s 40
-			IL_05b9: ldstr "es6id"
-			IL_05be: ldloc.s 4
-			IL_05c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_05c5: stloc.s 40
-			IL_05c7: ldloc.s 7
-			IL_05c9: ldstr "author"
-			IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d3: stloc.s 41
-			IL_05d5: ldc.i4.1
-			IL_05d6: newarr [System.Runtime]System.Object
-			IL_05db: dup
-			IL_05dc: ldc.i4.0
-			IL_05dd: ldarg.0
-			IL_05de: stelem.ref
-			IL_05df: ldc.i4.0
-			IL_05e0: ldelem.ref
-			IL_05e1: castclass Modules.test262_metadataParser/Scope
-			IL_05e6: ldftn object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_05ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_05f1: ldnull
-			IL_05f2: ldloc.s 41
-			IL_05f4: ldstr "author"
-			IL_05f9: ldloc.s 4
-			IL_05fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0600: stloc.s 41
-			IL_0602: ldc.i4.1
-			IL_0603: newarr [System.Runtime]System.Object
-			IL_0608: dup
-			IL_0609: ldc.i4.0
-			IL_060a: ldarg.0
-			IL_060b: stelem.ref
-			IL_060c: ldc.i4.0
-			IL_060d: ldelem.ref
-			IL_060e: castclass Modules.test262_metadataParser/Scope
-			IL_0613: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0619: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::.ctor(object, native int)
-			IL_061e: ldnull
-			IL_061f: ldloc.1
-			IL_0620: ldloc.s 19
-			IL_0622: ldloc.s 23
-			IL_0624: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes3::Invoke(object, object, object, object)
-			IL_0629: stloc.s 42
-			IL_062b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0630: dup
-			IL_0631: ldstr "filePath"
-			IL_0636: ldloc.s 34
-			IL_0638: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_063d: dup
-			IL_063e: ldstr "fileName"
-			IL_0643: ldloc.s 36
-			IL_0645: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_064a: dup
-			IL_064b: ldstr "hasFrontmatter"
-			IL_0650: ldloc.s 5
-			IL_0652: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0657: dup
-			IL_0658: ldstr "frontmatter"
-			IL_065d: ldloc.s 7
-			IL_065f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0664: dup
-			IL_0665: ldstr "unknownKeys"
-			IL_066a: ldloc.s 9
-			IL_066c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0671: dup
-			IL_0672: ldstr "description"
-			IL_0677: ldloc.s 28
-			IL_0679: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_067e: dup
-			IL_067f: ldstr "info"
-			IL_0684: ldloc.s 37
-			IL_0686: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_068b: dup
-			IL_068c: ldstr "esid"
-			IL_0691: ldloc.s 38
-			IL_0693: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0698: dup
-			IL_0699: ldstr "es5id"
-			IL_069e: ldloc.s 39
-			IL_06a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06a5: dup
-			IL_06a6: ldstr "es6id"
-			IL_06ab: ldloc.s 40
-			IL_06ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06b2: dup
-			IL_06b3: ldstr "author"
-			IL_06b8: ldloc.s 41
-			IL_06ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06bf: dup
-			IL_06c0: ldstr "includes"
-			IL_06c5: ldloc.s 14
-			IL_06c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06cc: dup
-			IL_06cd: ldstr "flags"
-			IL_06d2: ldloc.s 15
-			IL_06d4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06d9: dup
-			IL_06da: ldstr "features"
-			IL_06df: ldloc.s 16
-			IL_06e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06e6: dup
-			IL_06e7: ldstr "locale"
-			IL_06ec: ldloc.s 17
-			IL_06ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_06f3: dup
-			IL_06f4: ldstr "defines"
-			IL_06f9: ldloc.s 18
-			IL_06fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0700: dup
-			IL_0701: ldstr "negative"
-			IL_0706: ldloc.s 19
-			IL_0708: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_070d: dup
-			IL_070e: ldstr "execution"
-			IL_0713: ldloc.s 23
-			IL_0715: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_071a: dup
-			IL_071b: ldstr "mvpBlockers"
-			IL_0720: ldloc.s 42
-			IL_0722: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0727: dup
-			IL_0728: ldstr "unsupported"
-			IL_072d: ldloc.s 4
-			IL_072f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0734: stloc.s 43
-			IL_0736: ldloc.s 43
-			IL_0738: ret
+			IL_05a1: ldstr "negative"
+			IL_05a6: ldloc.s 19
+			IL_05a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05ad: dup
+			IL_05ae: ldstr "execution"
+			IL_05b3: ldloc.s 23
+			IL_05b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05ba: dup
+			IL_05bb: ldstr "mvpBlockers"
+			IL_05c0: ldloc.s 42
+			IL_05c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05c7: dup
+			IL_05c8: ldstr "unsupported"
+			IL_05cd: ldloc.s 4
+			IL_05cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05d4: stloc.s 43
+			IL_05d6: ldloc.s 43
+			IL_05d8: ret
 		} // end of method parseTest262Metadata::__js_call__
 
 	} // end of class parseTest262Metadata
@@ -8948,7 +8121,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6843
+				// Method begins at RVA 0x606c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8975,9 +8148,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x6424
+			// Method begins at RVA 0x5c58
 			// Header size: 12
-			// Code size: 80 (0x50)
+			// Code size: 69 (0x45)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -9003,24 +8176,17 @@
 			IL_002b: ldarg.2
 			IL_002c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 			IL_0031: stloc.2
-			IL_0032: ldc.i4.1
-			IL_0033: newarr [System.Runtime]System.Object
-			IL_0038: dup
-			IL_0039: ldc.i4.0
-			IL_003a: ldarg.0
-			IL_003b: stelem.ref
-			IL_003c: ldc.i4.0
-			IL_003d: ldelem.ref
-			IL_003e: castclass Modules.test262_metadataParser/Scope
-			IL_0043: ldnull
-			IL_0044: ldloc.0
-			IL_0045: ldloc.2
-			IL_0046: tail.
-			IL_0048: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-			IL_004d: ret
+			IL_0032: ldarg.0
+			IL_0033: castclass Modules.test262_metadataParser/Scope
+			IL_0038: ldnull
+			IL_0039: ldloc.0
+			IL_003a: ldloc.2
+			IL_003b: tail.
+			IL_003d: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+			IL_0042: ret
 
-			IL_004e: ldnull
-			IL_004f: ret
+			IL_0043: ldnull
+			IL_0044: ret
 		} // end of method parseTest262File::__js_call__
 
 	} // end of class parseTest262File
@@ -9082,7 +8248,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x64e3
+			// Method begins at RVA 0x5d0c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -9106,7 +8272,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x238c
+		// Method begins at RVA 0x2320
 		// Header size: 12
 		// Code size: 1428 (0x594)
 		.maxstack 8
@@ -9672,7 +8838,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x684c
+		// Method begins at RVA 0x6075
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Array_Map_NestedParam
+﻿// IL code: Array_Map_NestedParam
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2239
+					// Method begins at RVA 0x2225
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21d8
 				// Header size: 12
 				// Code size: 34 (0x22)
 				.maxstack 8
@@ -90,7 +90,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2242
+					// Method begins at RVA 0x222e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -114,7 +114,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x221a
+				// Method begins at RVA 0x2206
 				// Header size: 1
 				// Code size: 12 (0xc)
 				.maxstack 8
@@ -143,7 +143,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2230
+				// Method begins at RVA 0x221c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -170,7 +170,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2158
+			// Method begins at RVA 0x2144
 			// Header size: 12
 			// Code size: 133 (0x85)
 			.maxstack 8
@@ -261,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2227
+			// Method begins at RVA 0x2213
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -285,7 +285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2254
+				// Method begins at RVA 0x2240
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x224b
+			// Method begins at RVA 0x2237
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -329,7 +329,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 252 (0xfc)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Map_NestedParam/Scope,
@@ -377,64 +377,55 @@
 		IL_0052: ldstr "ccc"
 		IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_005c: stloc.s 6
-		IL_005e: ldc.i4.1
-		IL_005f: newarr [System.Runtime]System.Object
-		IL_0064: dup
-		IL_0065: ldc.i4.0
-		IL_0066: ldloc.0
-		IL_0067: stelem.ref
-		IL_0068: ldc.i4.0
-		IL_0069: ldelem.ref
-		IL_006a: castclass Modules.Array_Map_NestedParam/Scope
-		IL_006f: ldftn object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
-		IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_007a: ldnull
-		IL_007b: ldloc.s 6
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0082: stloc.s 5
-		IL_0084: ldloc.s 5
-		IL_0086: stloc.2
-		IL_0087: ldc.r8 0.0
-		IL_0090: box [System.Runtime]System.Double
-		IL_0095: stloc.3
-		// loop start (head: IL_0096)
-			IL_0096: ldloc.2
-			IL_0097: ldstr "length"
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a1: stloc.s 5
-			IL_00a3: ldloc.3
-			IL_00a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a9: stloc.s 7
-			IL_00ab: ldloc.s 7
-			IL_00ad: ldloc.s 5
-			IL_00af: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b4: clt
-			IL_00b6: brfalse IL_00fb
+		IL_005e: ldloc.0
+		IL_005f: castclass Modules.Array_Map_NestedParam/Scope
+		IL_0064: ldnull
+		IL_0065: ldloc.s 6
+		IL_0067: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
+		IL_006c: stloc.s 5
+		IL_006e: ldloc.s 5
+		IL_0070: stloc.2
+		IL_0071: ldc.r8 0.0
+		IL_007a: box [System.Runtime]System.Double
+		IL_007f: stloc.3
+		// loop start (head: IL_0080)
+			IL_0080: ldloc.2
+			IL_0081: ldstr "length"
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008b: stloc.s 5
+			IL_008d: ldloc.3
+			IL_008e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0093: stloc.s 7
+			IL_0095: ldloc.s 7
+			IL_0097: ldloc.s 5
+			IL_0099: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009e: clt
+			IL_00a0: brfalse IL_00e5
 
-			IL_00bb: newobj instance void Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40::.ctor()
-			IL_00c0: stloc.s 4
-			IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c7: ldloc.2
-			IL_00c8: ldloc.3
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00d3: pop
-			IL_00d4: ldloc.3
-			IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00da: stloc.s 7
-			IL_00dc: ldloc.s 7
-			IL_00de: ldc.r8 1
-			IL_00e7: add
-			IL_00e8: stloc.s 7
-			IL_00ea: ldloc.s 7
-			IL_00ec: box [System.Runtime]System.Double
-			IL_00f1: stloc.s 8
-			IL_00f3: ldloc.s 8
-			IL_00f5: stloc.3
-			IL_00f6: br IL_0096
+			IL_00a5: newobj instance void Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40::.ctor()
+			IL_00aa: stloc.s 4
+			IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00b1: ldloc.2
+			IL_00b2: ldloc.3
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00bd: pop
+			IL_00be: ldloc.3
+			IL_00bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00c4: stloc.s 7
+			IL_00c6: ldloc.s 7
+			IL_00c8: ldc.r8 1
+			IL_00d1: add
+			IL_00d2: stloc.s 7
+			IL_00d4: ldloc.s 7
+			IL_00d6: box [System.Runtime]System.Double
+			IL_00db: stloc.s 8
+			IL_00dd: ldloc.s 8
+			IL_00df: stloc.3
+			IL_00e0: br IL_0080
 		// end loop
 
-		IL_00fb: ret
+		IL_00e5: ret
 	} // end of method Array_Map_NestedParam::__js_module_init__
 
 } // end of class Modules.Array_Map_NestedParam
@@ -446,7 +437,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225d
+		// Method begins at RVA 0x2249
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_BlockBody_Return.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_BlockBody_Return
+﻿// IL code: ArrowFunction_BlockBody_Return
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2101
+				// Method begins at RVA 0x20fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20dc
 			// Header size: 12
 			// Code size: 12 (0xc)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20f4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,13 +105,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 125 (0x7d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_BlockBody_Return/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_BlockBody_Return/Scope::.ctor()
@@ -141,22 +140,19 @@
 		IL_0045: stloc.2
 		IL_0046: ldloc.2
 		IL_0047: stloc.1
-		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004d: stloc.3
-		IL_004e: ldloc.1
-		IL_004f: ldloc.3
-		IL_0050: ldc.r8 4
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: ldc.r8 3
-		IL_0067: box [System.Runtime]System.Double
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0071: stloc.2
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: ldstr "x is "
-		IL_007c: ldloc.2
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_0048: ldnull
+		IL_0049: ldc.r8 4
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: ldc.r8 3
+		IL_0060: box [System.Runtime]System.Double
+		IL_0065: call object Modules.ArrowFunction_BlockBody_Return/ArrowFunction_L3C13::__js_call__(object, object, object)
+		IL_006a: stloc.2
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0070: ldstr "x is "
+		IL_0075: ldloc.2
+		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_007b: pop
+		IL_007c: ret
 	} // end of method ArrowFunction_BlockBody_Return::__js_module_init__
 
 } // end of class Modules.ArrowFunction_BlockBody_Return
@@ -168,7 +164,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210a
+		// Method begins at RVA 0x2106
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_CapturesOuterVariable.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_CapturesOuterVariable
+﻿// IL code: ArrowFunction_CapturesOuterVariable
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211e
+				// Method begins at RVA 0x211a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -85,7 +85,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2115
+			// Method begins at RVA 0x2111
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -111,13 +111,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 149 (0x95)
+		// Code size: 148 (0x94)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_CapturesOuterVariable/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_CapturesOuterVariable/Scope::.ctor()
@@ -158,20 +157,19 @@
 		IL_0064: stloc.2
 		IL_0065: ldloc.2
 		IL_0066: stloc.1
-		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006c: stloc.3
-		IL_006d: ldloc.1
-		IL_006e: ldloc.3
-		IL_006f: ldc.r8 3
-		IL_0078: box [System.Runtime]System.Double
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0082: stloc.2
-		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0088: ldstr "product is "
-		IL_008d: ldloc.2
-		IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0093: pop
-		IL_0094: ret
+		IL_0067: ldloc.0
+		IL_0068: castclass Modules.ArrowFunction_CapturesOuterVariable/Scope
+		IL_006d: ldnull
+		IL_006e: ldc.r8 3
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: call object Modules.ArrowFunction_CapturesOuterVariable/ArrowFunction_L4C13::__js_call__(class Modules.ArrowFunction_CapturesOuterVariable/Scope, object, object)
+		IL_0081: stloc.2
+		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0087: ldstr "product is "
+		IL_008c: ldloc.2
+		IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0092: pop
+		IL_0093: ret
 	} // end of method ArrowFunction_CapturesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_CapturesOuterVariable
@@ -183,7 +181,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2127
+		// Method begins at RVA 0x2123
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_ClosureMutatesOuterVariable
+﻿// IL code: ArrowFunction_ClosureMutatesOuterVariable
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d6
+					// Method begins at RVA 0x21be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2180
+				// Method begins at RVA 0x2168
 				// Header size: 12
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cd
+				// Method begins at RVA 0x21b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,7 +119,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x211c
+			// Method begins at RVA 0x2104
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -184,7 +184,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -210,7 +210,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 190 (0xbe)
+		// Code size: 168 (0xa8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope,
@@ -241,52 +241,43 @@
 		IL_0030: stloc.3
 		IL_0031: ldloc.3
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope
-		IL_0044: ldftn object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: ldc.r8 10
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0063: stloc.3
-		IL_0064: ldloc.3
-		IL_0065: stloc.2
-		IL_0066: ldloc.2
-		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0071: stloc.3
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: ldstr "First increment:"
-		IL_007c: ldloc.3
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0082: pop
-		IL_0083: ldloc.2
-		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_008e: stloc.3
-		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0094: ldstr "Second increment:"
-		IL_0099: ldloc.3
-		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_009f: pop
-		IL_00a0: ldloc.2
-		IL_00a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00ab: stloc.3
-		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b1: ldstr "Third increment:"
-		IL_00b6: ldloc.3
-		IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00bc: pop
-		IL_00bd: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope
+		IL_0039: ldnull
+		IL_003a: ldc.r8 10
+		IL_0043: box [System.Runtime]System.Double
+		IL_0048: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, object)
+		IL_004d: stloc.3
+		IL_004e: ldloc.3
+		IL_004f: stloc.2
+		IL_0050: ldloc.2
+		IL_0051: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005b: stloc.3
+		IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0061: ldstr "First increment:"
+		IL_0066: ldloc.3
+		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_006c: pop
+		IL_006d: ldloc.2
+		IL_006e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0078: stloc.3
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007e: ldstr "Second increment:"
+		IL_0083: ldloc.3
+		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0089: pop
+		IL_008a: ldloc.2
+		IL_008b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0095: stloc.3
+		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009b: ldstr "Third increment:"
+		IL_00a0: ldloc.3
+		IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a6: pop
+		IL_00a7: ret
 	} // end of method ArrowFunction_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_ClosureMutatesOuterVariable
@@ -298,7 +289,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21df
+		// Method begins at RVA 0x21c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterExpression.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterExpression.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_DefaultParameterExpression
+﻿// IL code: ArrowFunction_DefaultParameterExpression
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -27,7 +27,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2175
+				// Method begins at RVA 0x2165
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,7 +53,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2114
 			// Header size: 12
 			// Code size: 60 (0x3c)
 			.maxstack 8
@@ -98,7 +98,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216c
+			// Method begins at RVA 0x215c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -124,13 +124,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 199 (0xc7)
+		// Code size: 181 (0xb5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_DefaultParameterExpression/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_DefaultParameterExpression/Scope::.ctor()
@@ -160,37 +159,31 @@
 		IL_0045: stloc.2
 		IL_0046: ldloc.2
 		IL_0047: stloc.1
-		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004d: stloc.3
-		IL_004e: ldloc.1
-		IL_004f: ldloc.3
-		IL_0050: ldc.r8 5
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0063: pop
-		IL_0064: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0069: stloc.3
-		IL_006a: ldloc.1
-		IL_006b: ldloc.3
-		IL_006c: ldc.r8 5
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: ldc.r8 8
-		IL_0083: box [System.Runtime]System.Double
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_008d: pop
-		IL_008e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0093: stloc.3
-		IL_0094: ldloc.1
-		IL_0095: ldloc.3
-		IL_0096: ldc.r8 5
-		IL_009f: box [System.Runtime]System.Double
-		IL_00a4: ldc.r8 8
-		IL_00ad: box [System.Runtime]System.Double
-		IL_00b2: ldc.r8 20
-		IL_00bb: box [System.Runtime]System.Double
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_00c5: pop
-		IL_00c6: ret
+		IL_0048: ldnull
+		IL_0049: ldc.r8 5
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: ldnull
+		IL_0058: ldnull
+		IL_0059: call object Modules.ArrowFunction_DefaultParameterExpression/ArrowFunction_L4C19::__js_call__(object, object, object, object)
+		IL_005e: pop
+		IL_005f: ldnull
+		IL_0060: ldc.r8 5
+		IL_0069: box [System.Runtime]System.Double
+		IL_006e: ldc.r8 8
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: ldnull
+		IL_007d: call object Modules.ArrowFunction_DefaultParameterExpression/ArrowFunction_L4C19::__js_call__(object, object, object, object)
+		IL_0082: pop
+		IL_0083: ldnull
+		IL_0084: ldc.r8 5
+		IL_008d: box [System.Runtime]System.Double
+		IL_0092: ldc.r8 8
+		IL_009b: box [System.Runtime]System.Double
+		IL_00a0: ldc.r8 20
+		IL_00a9: box [System.Runtime]System.Double
+		IL_00ae: call object Modules.ArrowFunction_DefaultParameterExpression/ArrowFunction_L4C19::__js_call__(object, object, object, object)
+		IL_00b3: pop
+		IL_00b4: ret
 	} // end of method ArrowFunction_DefaultParameterExpression::__js_module_init__
 
 } // end of class Modules.ArrowFunction_DefaultParameterExpression
@@ -202,7 +195,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217e
+		// Method begins at RVA 0x216e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterValue.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_DefaultParameterValue.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_DefaultParameterValue
+﻿// IL code: ArrowFunction_DefaultParameterValue
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x231d
+				// Method begins at RVA 0x22e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x21f8
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -96,7 +96,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2326
+				// Method begins at RVA 0x22ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2264
+			// Method begins at RVA 0x222c
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -170,7 +170,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x232f
+				// Method begins at RVA 0x22f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x229c
+			// Method begins at RVA 0x2264
 			// Header size: 12
 			// Code size: 108 (0x6c)
 			.maxstack 8
@@ -254,7 +254,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2314
+			// Method begins at RVA 0x22dc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -280,15 +280,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 468 (0x1d4)
+		// Code size: 412 (0x19c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_DefaultParameterValue/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object,
-			[5] object[]
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_DefaultParameterValue/Scope::.ctor()
@@ -368,70 +367,58 @@
 		IL_00d3: stloc.s 4
 		IL_00d5: ldloc.s 4
 		IL_00d7: stloc.3
-		IL_00d8: ldloc.1
-		IL_00d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00e3: pop
-		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00e9: stloc.s 5
-		IL_00eb: ldloc.1
-		IL_00ec: ldloc.s 5
-		IL_00ee: ldstr "Alice"
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00f8: pop
-		IL_00f9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00fe: stloc.s 5
-		IL_0100: ldloc.2
-		IL_0101: ldloc.s 5
+		IL_00d8: ldnull
+		IL_00d9: ldnull
+		IL_00da: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L4C15::__js_call__(object, object)
+		IL_00df: pop
+		IL_00e0: ldnull
+		IL_00e1: ldstr "Alice"
+		IL_00e6: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L4C15::__js_call__(object, object)
+		IL_00eb: pop
+		IL_00ec: ldnull
+		IL_00ed: ldc.r8 5
+		IL_00f6: box [System.Runtime]System.Double
+		IL_00fb: ldnull
+		IL_00fc: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L8C13::__js_call__(object, object, object)
+		IL_0101: pop
+		IL_0102: ldnull
 		IL_0103: ldc.r8 5
 		IL_010c: box [System.Runtime]System.Double
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0116: pop
-		IL_0117: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_011c: stloc.s 5
-		IL_011e: ldloc.2
-		IL_011f: ldloc.s 5
-		IL_0121: ldc.r8 5
-		IL_012a: box [System.Runtime]System.Double
-		IL_012f: ldc.r8 15
-		IL_0138: box [System.Runtime]System.Double
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0142: pop
-		IL_0143: ldloc.3
-		IL_0144: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_014e: pop
-		IL_014f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0154: stloc.s 5
-		IL_0156: ldloc.3
-		IL_0157: ldloc.s 5
-		IL_0159: ldc.r8 2
-		IL_0162: box [System.Runtime]System.Double
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_016c: pop
-		IL_016d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0172: stloc.s 5
-		IL_0174: ldloc.3
-		IL_0175: ldloc.s 5
-		IL_0177: ldc.r8 2
-		IL_0180: box [System.Runtime]System.Double
-		IL_0185: ldc.r8 4
-		IL_018e: box [System.Runtime]System.Double
-		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0198: pop
-		IL_0199: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_019e: stloc.s 5
-		IL_01a0: ldloc.3
-		IL_01a1: ldloc.s 5
-		IL_01a3: ldc.r8 2
-		IL_01ac: box [System.Runtime]System.Double
-		IL_01b1: ldc.r8 4
-		IL_01ba: box [System.Runtime]System.Double
-		IL_01bf: ldc.r8 3
-		IL_01c8: box [System.Runtime]System.Double
-		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_01d2: pop
-		IL_01d3: ret
+		IL_0111: ldc.r8 15
+		IL_011a: box [System.Runtime]System.Double
+		IL_011f: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L8C13::__js_call__(object, object, object)
+		IL_0124: pop
+		IL_0125: ldnull
+		IL_0126: ldnull
+		IL_0127: ldnull
+		IL_0128: ldnull
+		IL_0129: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L12C15::__js_call__(object, object, object, object)
+		IL_012e: pop
+		IL_012f: ldnull
+		IL_0130: ldc.r8 2
+		IL_0139: box [System.Runtime]System.Double
+		IL_013e: ldnull
+		IL_013f: ldnull
+		IL_0140: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L12C15::__js_call__(object, object, object, object)
+		IL_0145: pop
+		IL_0146: ldnull
+		IL_0147: ldc.r8 2
+		IL_0150: box [System.Runtime]System.Double
+		IL_0155: ldc.r8 4
+		IL_015e: box [System.Runtime]System.Double
+		IL_0163: ldnull
+		IL_0164: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L12C15::__js_call__(object, object, object, object)
+		IL_0169: pop
+		IL_016a: ldnull
+		IL_016b: ldc.r8 2
+		IL_0174: box [System.Runtime]System.Double
+		IL_0179: ldc.r8 4
+		IL_0182: box [System.Runtime]System.Double
+		IL_0187: ldc.r8 3
+		IL_0190: box [System.Runtime]System.Double
+		IL_0195: call object Modules.ArrowFunction_DefaultParameterValue/ArrowFunction_L12C15::__js_call__(object, object, object, object)
+		IL_019a: pop
+		IL_019b: ret
 	} // end of method ArrowFunction_DefaultParameterValue::__js_module_init__
 
 } // end of class Modules.ArrowFunction_DefaultParameterValue
@@ -443,7 +430,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2338
+		// Method begins at RVA 0x2300
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_GlobalFunctionCallsGlobalFunction
+﻿// IL code: ArrowFunction_GlobalFunctionCallsGlobalFunction
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2187
+				// Method begins at RVA 0x2179
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2126
+			// Method begins at RVA 0x2127
 			// Header size: 1
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2190
+				// Method begins at RVA 0x2182
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -95,9 +95,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2147
+			// Method begins at RVA 0x2148
 			// Header size: 1
-			// Code size: 54 (0x36)
+			// Code size: 39 (0x27)
 			.maxstack 8
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -106,18 +106,11 @@
 			IL_0013: box [System.Runtime]System.Double
 			IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_001d: pop
-			IL_001e: ldarg.0
-			IL_001f: ldfld object Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
-			IL_0024: ldc.i4.1
-			IL_0025: newarr [System.Runtime]System.Object
-			IL_002a: dup
-			IL_002b: ldc.i4.0
-			IL_002c: ldarg.0
-			IL_002d: stelem.ref
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0033: pop
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_001e: ldnull
+			IL_001f: call object Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/ArrowFunction_L4C20::__js_call__(object)
+			IL_0024: pop
+			IL_0025: ldnull
+			IL_0026: ret
 		} // end of method ArrowFunction_L8C25::__js_call__
 
 	} // end of class ArrowFunction_L8C25
@@ -137,7 +130,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217e
+			// Method begins at RVA 0x2170
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -163,7 +156,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 203 (0xcb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/Scope,
@@ -232,17 +225,18 @@
 		IL_009c: stloc.2
 		IL_009d: ldloc.2
 		IL_009e: stloc.1
-		IL_009f: ldloc.1
-		IL_00a0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00aa: pop
-		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b0: ldstr "finally is now"
-		IL_00b5: ldc.r8 3
-		IL_00be: box [System.Runtime]System.Double
-		IL_00c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_009f: ldloc.0
+		IL_00a0: castclass Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/Scope
+		IL_00a5: ldnull
+		IL_00a6: call object Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/ArrowFunction_L8C25::__js_call__(class Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction/Scope, object)
+		IL_00ab: pop
+		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b1: ldstr "finally is now"
+		IL_00b6: ldc.r8 3
+		IL_00bf: box [System.Runtime]System.Double
+		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00c9: pop
+		IL_00ca: ret
 	} // end of method ArrowFunction_GlobalFunctionCallsGlobalFunction::__js_module_init__
 
 } // end of class Modules.ArrowFunction_GlobalFunctionCallsGlobalFunction
@@ -254,7 +248,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2199
+		// Method begins at RVA 0x218b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+﻿// IL code: ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -204,14 +204,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 144 (0x90)
+		// Code size: 141 (0x8d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
-			[4] object[]
+			[3] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::.ctor()
@@ -252,21 +251,20 @@
 		IL_0060: stloc.3
 		IL_0061: ldloc.3
 		IL_0062: stloc.1
-		IL_0063: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0068: stloc.s 4
-		IL_006a: ldloc.1
-		IL_006b: ldloc.s 4
-		IL_006d: ldc.r8 123
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0080: stloc.3
-		IL_0081: ldloc.3
-		IL_0082: stloc.2
-		IL_0083: ldloc.2
-		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_008e: pop
-		IL_008f: ret
+		IL_0063: ldloc.0
+		IL_0064: castclass Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
+		IL_0069: ldnull
+		IL_006a: ldc.r8 123
+		IL_0073: box [System.Runtime]System.Double
+		IL_0078: call object Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/ArrowFunction_L5C15::__js_call__(class Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
+		IL_007d: stloc.3
+		IL_007e: ldloc.3
+		IL_007f: stloc.2
+		IL_0080: ldloc.2
+		IL_0081: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_008b: pop
+		IL_008c: ret
 	} // end of method ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::__js_module_init__
 
 } // end of class Modules.ArrowFunction_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GlobalFunctionWithMultipleParameters.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_GlobalFunctionWithMultipleParameters
+﻿// IL code: ArrowFunction_GlobalFunctionWithMultipleParameters
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x251a
+				// Method begins at RVA 0x24a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23d2
+			// Method begins at RVA 0x235a
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2523
+				// Method begins at RVA 0x24ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23e6
+			// Method begins at RVA 0x236e
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -145,7 +145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x252c
+				// Method begins at RVA 0x24b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -171,7 +171,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23fb
+			// Method begins at RVA 0x2383
 			// Header size: 1
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -225,7 +225,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2535
+				// Method begins at RVA 0x24bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -252,7 +252,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2423
+			// Method begins at RVA 0x23ab
 			// Header size: 1
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -311,7 +311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x253e
+				// Method begins at RVA 0x24c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -339,7 +339,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2450
+			// Method begins at RVA 0x23d8
 			// Header size: 1
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -404,7 +404,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2547
+				// Method begins at RVA 0x24cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -433,7 +433,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2484
+			// Method begins at RVA 0x240c
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -502,7 +502,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2511
+			// Method begins at RVA 0x2499
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -528,7 +528,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 886 (0x376)
+		// Code size: 766 (0x2fe)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/Scope,
@@ -538,8 +538,7 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object,
-			[8] object[]
+			[7] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/Scope::.ctor()
@@ -694,136 +693,67 @@
 		IL_01a7: stloc.s 7
 		IL_01a9: ldloc.s 7
 		IL_01ab: stloc.s 6
-		IL_01ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01b2: stloc.s 8
-		IL_01b4: ldloc.1
-		IL_01b5: ldloc.s 8
-		IL_01b7: ldc.r8 1
-		IL_01c0: box [System.Runtime]System.Double
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_01ca: pop
-		IL_01cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01d0: stloc.s 8
-		IL_01d2: ldloc.2
-		IL_01d3: ldloc.s 8
-		IL_01d5: ldc.r8 1
-		IL_01de: box [System.Runtime]System.Double
-		IL_01e3: ldc.r8 2
-		IL_01ec: box [System.Runtime]System.Double
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_01f6: pop
-		IL_01f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01fc: stloc.s 8
-		IL_01fe: ldloc.3
-		IL_01ff: ldloc.s 8
-		IL_0201: ldc.r8 1
-		IL_020a: box [System.Runtime]System.Double
-		IL_020f: ldc.r8 2
-		IL_0218: box [System.Runtime]System.Double
-		IL_021d: ldc.r8 3
-		IL_0226: box [System.Runtime]System.Double
-		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_0230: pop
-		IL_0231: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0236: stloc.s 8
-		IL_0238: ldloc.s 4
-		IL_023a: ldloc.s 8
-		IL_023c: ldc.i4.4
-		IL_023d: newarr [System.Runtime]System.Object
-		IL_0242: dup
-		IL_0243: ldc.i4.0
-		IL_0244: ldc.r8 1
-		IL_024d: box [System.Runtime]System.Double
-		IL_0252: stelem.ref
-		IL_0253: dup
-		IL_0254: ldc.i4.1
-		IL_0255: ldc.r8 2
-		IL_025e: box [System.Runtime]System.Double
-		IL_0263: stelem.ref
-		IL_0264: dup
-		IL_0265: ldc.i4.2
-		IL_0266: ldc.r8 3
-		IL_026f: box [System.Runtime]System.Double
-		IL_0274: stelem.ref
-		IL_0275: dup
-		IL_0276: ldc.i4.3
-		IL_0277: ldc.r8 4
-		IL_0280: box [System.Runtime]System.Double
-		IL_0285: stelem.ref
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_028b: pop
-		IL_028c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0291: stloc.s 8
-		IL_0293: ldloc.s 5
-		IL_0295: ldloc.s 8
-		IL_0297: ldc.i4.5
-		IL_0298: newarr [System.Runtime]System.Object
-		IL_029d: dup
-		IL_029e: ldc.i4.0
-		IL_029f: ldc.r8 1
-		IL_02a8: box [System.Runtime]System.Double
-		IL_02ad: stelem.ref
-		IL_02ae: dup
-		IL_02af: ldc.i4.1
-		IL_02b0: ldc.r8 2
-		IL_02b9: box [System.Runtime]System.Double
-		IL_02be: stelem.ref
-		IL_02bf: dup
-		IL_02c0: ldc.i4.2
-		IL_02c1: ldc.r8 3
-		IL_02ca: box [System.Runtime]System.Double
-		IL_02cf: stelem.ref
-		IL_02d0: dup
-		IL_02d1: ldc.i4.3
-		IL_02d2: ldc.r8 4
-		IL_02db: box [System.Runtime]System.Double
-		IL_02e0: stelem.ref
-		IL_02e1: dup
-		IL_02e2: ldc.i4.4
-		IL_02e3: ldc.r8 5
-		IL_02ec: box [System.Runtime]System.Double
-		IL_02f1: stelem.ref
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_02f7: pop
-		IL_02f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02fd: stloc.s 8
-		IL_02ff: ldloc.s 6
-		IL_0301: ldloc.s 8
-		IL_0303: ldc.i4.6
-		IL_0304: newarr [System.Runtime]System.Object
-		IL_0309: dup
-		IL_030a: ldc.i4.0
-		IL_030b: ldc.r8 1
-		IL_0314: box [System.Runtime]System.Double
-		IL_0319: stelem.ref
-		IL_031a: dup
-		IL_031b: ldc.i4.1
-		IL_031c: ldc.r8 2
-		IL_0325: box [System.Runtime]System.Double
-		IL_032a: stelem.ref
-		IL_032b: dup
-		IL_032c: ldc.i4.2
-		IL_032d: ldc.r8 3
-		IL_0336: box [System.Runtime]System.Double
-		IL_033b: stelem.ref
-		IL_033c: dup
-		IL_033d: ldc.i4.3
-		IL_033e: ldc.r8 4
-		IL_0347: box [System.Runtime]System.Double
-		IL_034c: stelem.ref
-		IL_034d: dup
-		IL_034e: ldc.i4.4
-		IL_034f: ldc.r8 5
-		IL_0358: box [System.Runtime]System.Double
-		IL_035d: stelem.ref
-		IL_035e: dup
-		IL_035f: ldc.i4.5
-		IL_0360: ldc.r8 6
-		IL_0369: box [System.Runtime]System.Double
-		IL_036e: stelem.ref
-		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0374: pop
-		IL_0375: ret
+		IL_01ad: ldnull
+		IL_01ae: ldc.r8 1
+		IL_01b7: box [System.Runtime]System.Double
+		IL_01bc: call object Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/ArrowFunction_L3C12::__js_call__(object, object)
+		IL_01c1: pop
+		IL_01c2: ldnull
+		IL_01c3: ldc.r8 1
+		IL_01cc: box [System.Runtime]System.Double
+		IL_01d1: ldc.r8 2
+		IL_01da: box [System.Runtime]System.Double
+		IL_01df: call object Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/ArrowFunction_L7C12::__js_call__(object, object, object)
+		IL_01e4: pop
+		IL_01e5: ldnull
+		IL_01e6: ldc.r8 1
+		IL_01ef: box [System.Runtime]System.Double
+		IL_01f4: ldc.r8 2
+		IL_01fd: box [System.Runtime]System.Double
+		IL_0202: ldc.r8 3
+		IL_020b: box [System.Runtime]System.Double
+		IL_0210: call object Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/ArrowFunction_L11C12::__js_call__(object, object, object, object)
+		IL_0215: pop
+		IL_0216: ldnull
+		IL_0217: ldc.r8 1
+		IL_0220: box [System.Runtime]System.Double
+		IL_0225: ldc.r8 2
+		IL_022e: box [System.Runtime]System.Double
+		IL_0233: ldc.r8 3
+		IL_023c: box [System.Runtime]System.Double
+		IL_0241: ldc.r8 4
+		IL_024a: box [System.Runtime]System.Double
+		IL_024f: call object Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/ArrowFunction_L15C12::__js_call__(object, object, object, object, object)
+		IL_0254: pop
+		IL_0255: ldnull
+		IL_0256: ldc.r8 1
+		IL_025f: box [System.Runtime]System.Double
+		IL_0264: ldc.r8 2
+		IL_026d: box [System.Runtime]System.Double
+		IL_0272: ldc.r8 3
+		IL_027b: box [System.Runtime]System.Double
+		IL_0280: ldc.r8 4
+		IL_0289: box [System.Runtime]System.Double
+		IL_028e: ldc.r8 5
+		IL_0297: box [System.Runtime]System.Double
+		IL_029c: call object Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/ArrowFunction_L19C12::__js_call__(object, object, object, object, object, object)
+		IL_02a1: pop
+		IL_02a2: ldnull
+		IL_02a3: ldc.r8 1
+		IL_02ac: box [System.Runtime]System.Double
+		IL_02b1: ldc.r8 2
+		IL_02ba: box [System.Runtime]System.Double
+		IL_02bf: ldc.r8 3
+		IL_02c8: box [System.Runtime]System.Double
+		IL_02cd: ldc.r8 4
+		IL_02d6: box [System.Runtime]System.Double
+		IL_02db: ldc.r8 5
+		IL_02e4: box [System.Runtime]System.Double
+		IL_02e9: ldc.r8 6
+		IL_02f2: box [System.Runtime]System.Double
+		IL_02f7: call object Modules.ArrowFunction_GlobalFunctionWithMultipleParameters/ArrowFunction_L23C12::__js_call__(object, object, object, object, object, object, object)
+		IL_02fc: pop
+		IL_02fd: ret
 	} // end of method ArrowFunction_GlobalFunctionWithMultipleParameters::__js_module_init__
 
 } // end of class Modules.ArrowFunction_GlobalFunctionWithMultipleParameters
@@ -835,7 +765,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2550
+		// Method begins at RVA 0x24d8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_MaxParameters_32.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_MaxParameters_32.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_MaxParameters_32
+﻿// IL code: ArrowFunction_MaxParameters_32
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x230b
+				// Method begins at RVA 0x2286
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22fe
+			// Method begins at RVA 0x2279
 			// Header size: 1
 			// Code size: 3 (0x3)
 			.maxstack 8
@@ -133,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2302
+			// Method begins at RVA 0x227d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,13 +159,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 674 (0x2a2)
-		.maxstack 8
+		// Code size: 541 (0x21d)
+		.maxstack 34
 		.locals init (
 			[0] class Modules.ArrowFunction_MaxParameters_32/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_MaxParameters_32/Scope::.ctor()
@@ -195,179 +194,78 @@
 		IL_0046: stloc.2
 		IL_0047: ldloc.2
 		IL_0048: stloc.1
-		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004e: stloc.3
-		IL_004f: ldloc.1
-		IL_0050: ldloc.3
-		IL_0051: ldc.i4.s 32
-		IL_0053: newarr [System.Runtime]System.Object
-		IL_0058: dup
-		IL_0059: ldc.i4.0
-		IL_005a: ldc.r8 1
-		IL_0063: box [System.Runtime]System.Double
-		IL_0068: stelem.ref
-		IL_0069: dup
-		IL_006a: ldc.i4.1
-		IL_006b: ldc.r8 2
-		IL_0074: box [System.Runtime]System.Double
-		IL_0079: stelem.ref
-		IL_007a: dup
-		IL_007b: ldc.i4.2
-		IL_007c: ldc.r8 3
-		IL_0085: box [System.Runtime]System.Double
-		IL_008a: stelem.ref
-		IL_008b: dup
-		IL_008c: ldc.i4.3
-		IL_008d: ldc.r8 4
-		IL_0096: box [System.Runtime]System.Double
-		IL_009b: stelem.ref
-		IL_009c: dup
-		IL_009d: ldc.i4.4
-		IL_009e: ldc.r8 5
+		IL_0049: ldnull
+		IL_004a: ldc.r8 1
+		IL_0053: box [System.Runtime]System.Double
+		IL_0058: ldc.r8 2
+		IL_0061: box [System.Runtime]System.Double
+		IL_0066: ldc.r8 3
+		IL_006f: box [System.Runtime]System.Double
+		IL_0074: ldc.r8 4
+		IL_007d: box [System.Runtime]System.Double
+		IL_0082: ldc.r8 5
+		IL_008b: box [System.Runtime]System.Double
+		IL_0090: ldc.r8 6
+		IL_0099: box [System.Runtime]System.Double
+		IL_009e: ldc.r8 7
 		IL_00a7: box [System.Runtime]System.Double
-		IL_00ac: stelem.ref
-		IL_00ad: dup
-		IL_00ae: ldc.i4.5
-		IL_00af: ldc.r8 6
-		IL_00b8: box [System.Runtime]System.Double
-		IL_00bd: stelem.ref
-		IL_00be: dup
-		IL_00bf: ldc.i4.6
-		IL_00c0: ldc.r8 7
-		IL_00c9: box [System.Runtime]System.Double
-		IL_00ce: stelem.ref
-		IL_00cf: dup
-		IL_00d0: ldc.i4.7
-		IL_00d1: ldc.r8 8
-		IL_00da: box [System.Runtime]System.Double
-		IL_00df: stelem.ref
-		IL_00e0: dup
-		IL_00e1: ldc.i4.8
-		IL_00e2: ldc.r8 9
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: stelem.ref
-		IL_00f1: dup
-		IL_00f2: ldc.i4.s 9
-		IL_00f4: ldc.r8 10
-		IL_00fd: box [System.Runtime]System.Double
-		IL_0102: stelem.ref
-		IL_0103: dup
-		IL_0104: ldc.i4.s 10
-		IL_0106: ldc.r8 11
-		IL_010f: box [System.Runtime]System.Double
-		IL_0114: stelem.ref
-		IL_0115: dup
-		IL_0116: ldc.i4.s 11
-		IL_0118: ldc.r8 12
-		IL_0121: box [System.Runtime]System.Double
-		IL_0126: stelem.ref
-		IL_0127: dup
-		IL_0128: ldc.i4.s 12
-		IL_012a: ldc.r8 13
+		IL_00ac: ldc.r8 8
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: ldc.r8 9
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: ldc.r8 10
+		IL_00d1: box [System.Runtime]System.Double
+		IL_00d6: ldc.r8 11
+		IL_00df: box [System.Runtime]System.Double
+		IL_00e4: ldc.r8 12
+		IL_00ed: box [System.Runtime]System.Double
+		IL_00f2: ldc.r8 13
+		IL_00fb: box [System.Runtime]System.Double
+		IL_0100: ldc.r8 14
+		IL_0109: box [System.Runtime]System.Double
+		IL_010e: ldc.r8 15
+		IL_0117: box [System.Runtime]System.Double
+		IL_011c: ldc.r8 16
+		IL_0125: box [System.Runtime]System.Double
+		IL_012a: ldc.r8 17
 		IL_0133: box [System.Runtime]System.Double
-		IL_0138: stelem.ref
-		IL_0139: dup
-		IL_013a: ldc.i4.s 13
-		IL_013c: ldc.r8 14
-		IL_0145: box [System.Runtime]System.Double
-		IL_014a: stelem.ref
-		IL_014b: dup
-		IL_014c: ldc.i4.s 14
-		IL_014e: ldc.r8 15
-		IL_0157: box [System.Runtime]System.Double
-		IL_015c: stelem.ref
-		IL_015d: dup
-		IL_015e: ldc.i4.s 15
-		IL_0160: ldc.r8 16
-		IL_0169: box [System.Runtime]System.Double
-		IL_016e: stelem.ref
-		IL_016f: dup
-		IL_0170: ldc.i4.s 16
-		IL_0172: ldc.r8 17
-		IL_017b: box [System.Runtime]System.Double
-		IL_0180: stelem.ref
-		IL_0181: dup
-		IL_0182: ldc.i4.s 17
-		IL_0184: ldc.r8 18
-		IL_018d: box [System.Runtime]System.Double
-		IL_0192: stelem.ref
-		IL_0193: dup
-		IL_0194: ldc.i4.s 18
-		IL_0196: ldc.r8 19
-		IL_019f: box [System.Runtime]System.Double
-		IL_01a4: stelem.ref
-		IL_01a5: dup
-		IL_01a6: ldc.i4.s 19
-		IL_01a8: ldc.r8 20
+		IL_0138: ldc.r8 18
+		IL_0141: box [System.Runtime]System.Double
+		IL_0146: ldc.r8 19
+		IL_014f: box [System.Runtime]System.Double
+		IL_0154: ldc.r8 20
+		IL_015d: box [System.Runtime]System.Double
+		IL_0162: ldc.r8 21
+		IL_016b: box [System.Runtime]System.Double
+		IL_0170: ldc.r8 22
+		IL_0179: box [System.Runtime]System.Double
+		IL_017e: ldc.r8 23
+		IL_0187: box [System.Runtime]System.Double
+		IL_018c: ldc.r8 24
+		IL_0195: box [System.Runtime]System.Double
+		IL_019a: ldc.r8 25
+		IL_01a3: box [System.Runtime]System.Double
+		IL_01a8: ldc.r8 26
 		IL_01b1: box [System.Runtime]System.Double
-		IL_01b6: stelem.ref
-		IL_01b7: dup
-		IL_01b8: ldc.i4.s 20
-		IL_01ba: ldc.r8 21
-		IL_01c3: box [System.Runtime]System.Double
-		IL_01c8: stelem.ref
-		IL_01c9: dup
-		IL_01ca: ldc.i4.s 21
-		IL_01cc: ldc.r8 22
-		IL_01d5: box [System.Runtime]System.Double
-		IL_01da: stelem.ref
-		IL_01db: dup
-		IL_01dc: ldc.i4.s 22
-		IL_01de: ldc.r8 23
-		IL_01e7: box [System.Runtime]System.Double
-		IL_01ec: stelem.ref
-		IL_01ed: dup
-		IL_01ee: ldc.i4.s 23
-		IL_01f0: ldc.r8 24
-		IL_01f9: box [System.Runtime]System.Double
-		IL_01fe: stelem.ref
-		IL_01ff: dup
-		IL_0200: ldc.i4.s 24
-		IL_0202: ldc.r8 25
-		IL_020b: box [System.Runtime]System.Double
-		IL_0210: stelem.ref
-		IL_0211: dup
-		IL_0212: ldc.i4.s 25
-		IL_0214: ldc.r8 26
-		IL_021d: box [System.Runtime]System.Double
-		IL_0222: stelem.ref
-		IL_0223: dup
-		IL_0224: ldc.i4.s 26
-		IL_0226: ldc.r8 27
-		IL_022f: box [System.Runtime]System.Double
-		IL_0234: stelem.ref
-		IL_0235: dup
-		IL_0236: ldc.i4.s 27
-		IL_0238: ldc.r8 28
-		IL_0241: box [System.Runtime]System.Double
-		IL_0246: stelem.ref
-		IL_0247: dup
-		IL_0248: ldc.i4.s 28
-		IL_024a: ldc.r8 29
-		IL_0253: box [System.Runtime]System.Double
-		IL_0258: stelem.ref
-		IL_0259: dup
-		IL_025a: ldc.i4.s 29
-		IL_025c: ldc.r8 30
-		IL_0265: box [System.Runtime]System.Double
-		IL_026a: stelem.ref
-		IL_026b: dup
-		IL_026c: ldc.i4.s 30
-		IL_026e: ldc.r8 31
-		IL_0277: box [System.Runtime]System.Double
-		IL_027c: stelem.ref
-		IL_027d: dup
-		IL_027e: ldc.i4.s 31
-		IL_0280: ldc.r8 32
-		IL_0289: box [System.Runtime]System.Double
-		IL_028e: stelem.ref
-		IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0294: stloc.2
-		IL_0295: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_029a: ldloc.2
-		IL_029b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02a0: pop
-		IL_02a1: ret
+		IL_01b6: ldc.r8 27
+		IL_01bf: box [System.Runtime]System.Double
+		IL_01c4: ldc.r8 28
+		IL_01cd: box [System.Runtime]System.Double
+		IL_01d2: ldc.r8 29
+		IL_01db: box [System.Runtime]System.Double
+		IL_01e0: ldc.r8 30
+		IL_01e9: box [System.Runtime]System.Double
+		IL_01ee: ldc.r8 31
+		IL_01f7: box [System.Runtime]System.Double
+		IL_01fc: ldc.r8 32
+		IL_0205: box [System.Runtime]System.Double
+		IL_020a: call object Modules.ArrowFunction_MaxParameters_32/ArrowFunction_L3C11::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+		IL_020f: stloc.2
+		IL_0210: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0215: ldloc.2
+		IL_0216: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_021b: pop
+		IL_021c: ret
 	} // end of method ArrowFunction_MaxParameters_32::__js_module_init__
 
 } // end of class Modules.ArrowFunction_MaxParameters_32
@@ -379,7 +277,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2314
+		// Method begins at RVA 0x228f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_NestedFunctionAccessesMultipleScopes
+﻿// IL code: ArrowFunction_NestedFunctionAccessesMultipleScopes
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b5
+					// Method begins at RVA 0x21bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2144
+				// Method begins at RVA 0x214c
 				// Header size: 12
 				// Code size: 83 (0x53)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ac
+				// Method begins at RVA 0x21b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -125,9 +125,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20cc
+			// Method begins at RVA 0x20d0
 			// Header size: 12
-			// Code size: 106 (0x6a)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/Scope,
@@ -169,17 +169,21 @@
 			IL_0054: stloc.2
 			IL_0055: ldloc.2
 			IL_0056: stloc.1
-			IL_0057: ldloc.1
-			IL_0058: ldc.i4.1
-			IL_0059: newarr [System.Runtime]System.Object
-			IL_005e: dup
-			IL_005f: ldc.i4.0
-			IL_0060: ldarg.0
-			IL_0061: stelem.ref
-			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0067: pop
-			IL_0068: ldnull
-			IL_0069: ret
+			IL_0057: ldc.i4.2
+			IL_0058: newarr [System.Runtime]System.Object
+			IL_005d: dup
+			IL_005e: ldc.i4.0
+			IL_005f: ldarg.0
+			IL_0060: stelem.ref
+			IL_0061: dup
+			IL_0062: ldc.i4.1
+			IL_0063: ldloc.0
+			IL_0064: stelem.ref
+			IL_0065: ldnull
+			IL_0066: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22/ArrowFunction_L8C28::__js_call__(object[], object)
+			IL_006b: pop
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method ArrowFunction_L5C22::__js_call__
 
 	} // end of class ArrowFunction_L5C22
@@ -198,7 +202,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a3
+			// Method begins at RVA 0x21ab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -224,7 +228,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 112 (0x70)
+		// Code size: 113 (0x71)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope,
@@ -270,11 +274,12 @@
 		IL_0060: stloc.2
 		IL_0061: ldloc.2
 		IL_0062: stloc.1
-		IL_0063: ldloc.1
-		IL_0064: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_006e: pop
-		IL_006f: ret
+		IL_0063: ldloc.0
+		IL_0064: castclass Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope
+		IL_0069: ldnull
+		IL_006a: call object Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/ArrowFunction_L5C22::__js_call__(class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes/Scope, object)
+		IL_006f: pop
+		IL_0070: ret
 	} // end of method ArrowFunction_NestedFunctionAccessesMultipleScopes::__js_module_init__
 
 } // end of class Modules.ArrowFunction_NestedFunctionAccessesMultipleScopes
@@ -286,7 +291,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21be
+		// Method begins at RVA 0x21c6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ParameterDestructuring_Object.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ParameterDestructuring_Object.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_ParameterDestructuring_Object
+﻿// IL code: ArrowFunction_ParameterDestructuring_Object
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f2
+				// Method begins at RVA 0x22de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -50,7 +50,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a4
+			// Method begins at RVA 0x2190
 			// Header size: 12
 			// Code size: 72 (0x48)
 			.maxstack 8
@@ -112,7 +112,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22fb
+				// Method begins at RVA 0x22e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -136,7 +136,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 229 (0xe5)
 			.maxstack 8
@@ -251,7 +251,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e9
+			// Method begins at RVA 0x22d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -277,14 +277,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 327 (0x147)
+		// Code size: 307 (0x133)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_ParameterDestructuring_Object/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object[]
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_ParameterDestructuring_Object/Scope::.ctor()
@@ -314,84 +314,80 @@
 		IL_0045: stloc.3
 		IL_0046: ldloc.3
 		IL_0047: stloc.1
-		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004d: stloc.s 4
-		IL_004f: ldloc.1
-		IL_0050: ldloc.s 4
-		IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0057: dup
-		IL_0058: ldstr "a"
-		IL_005d: ldc.r8 1
-		IL_0066: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_006b: dup
-		IL_006c: ldstr "b"
-		IL_0071: ldc.r8 2
-		IL_007a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0084: pop
-		IL_0085: ldnull
-		IL_0086: ldftn object Modules.ArrowFunction_ParameterDestructuring_Object/ArrowFunction_L10C16::__js_call__(object, object)
-		IL_008c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0091: ldc.i4.1
-		IL_0092: newarr [System.Runtime]System.Object
-		IL_0097: dup
-		IL_0098: ldc.i4.0
-		IL_0099: ldloc.0
-		IL_009a: stelem.ref
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00a5: ldc.i4.1
-		IL_00a6: conv.r8
-		IL_00a7: ldstr ""
-		IL_00ac: ldc.i4.0
-		IL_00ad: ldc.i4.1
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00b8: stloc.3
-		IL_00b9: ldloc.3
-		IL_00ba: ldstr "config"
-		IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_00c4: stloc.3
-		IL_00c5: ldloc.3
-		IL_00c6: stloc.2
-		IL_00c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00cc: stloc.s 4
-		IL_00ce: ldloc.2
-		IL_00cf: ldloc.s 4
-		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00d6: dup
-		IL_00d7: ldstr "host"
-		IL_00dc: ldstr "example.com"
-		IL_00e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00eb: pop
-		IL_00ec: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00f1: stloc.s 4
-		IL_00f3: ldloc.2
-		IL_00f4: ldloc.s 4
-		IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00fb: dup
-		IL_00fc: ldstr "host"
-		IL_0101: ldstr "api.test.com"
-		IL_0106: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_004d: dup
+		IL_004e: ldstr "a"
+		IL_0053: ldc.r8 1
+		IL_005c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0061: dup
+		IL_0062: ldstr "b"
+		IL_0067: ldc.r8 2
+		IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0075: stloc.s 4
+		IL_0077: ldnull
+		IL_0078: ldloc.s 4
+		IL_007a: call object Modules.ArrowFunction_ParameterDestructuring_Object/ArrowFunction_L3C14::__js_call__(object, object)
+		IL_007f: pop
+		IL_0080: ldnull
+		IL_0081: ldftn object Modules.ArrowFunction_ParameterDestructuring_Object/ArrowFunction_L10C16::__js_call__(object, object)
+		IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_008c: ldc.i4.1
+		IL_008d: newarr [System.Runtime]System.Object
+		IL_0092: dup
+		IL_0093: ldc.i4.0
+		IL_0094: ldloc.0
+		IL_0095: stelem.ref
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00a0: ldc.i4.1
+		IL_00a1: conv.r8
+		IL_00a2: ldstr ""
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldc.i4.1
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_00b3: stloc.3
+		IL_00b4: ldloc.3
+		IL_00b5: ldstr "config"
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_00bf: stloc.3
+		IL_00c0: ldloc.3
+		IL_00c1: stloc.2
+		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00c7: dup
+		IL_00c8: ldstr "host"
+		IL_00cd: ldstr "example.com"
+		IL_00d2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00d7: stloc.s 4
+		IL_00d9: ldnull
+		IL_00da: ldloc.s 4
+		IL_00dc: call object Modules.ArrowFunction_ParameterDestructuring_Object/ArrowFunction_L10C16::__js_call__(object, object)
+		IL_00e1: pop
+		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00e7: dup
+		IL_00e8: ldstr "host"
+		IL_00ed: ldstr "api.test.com"
+		IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00f7: dup
+		IL_00f8: ldstr "port"
+		IL_00fd: ldc.r8 3000
+		IL_0106: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
 		IL_010b: dup
-		IL_010c: ldstr "port"
-		IL_0111: ldc.r8 3000
-		IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_011f: dup
-		IL_0120: ldstr "secure"
-		IL_0125: ldc.i4.1
-		IL_0126: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0130: pop
-		IL_0131: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0136: stloc.s 4
-		IL_0138: ldloc.2
-		IL_0139: ldloc.s 4
-		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0145: pop
-		IL_0146: ret
+		IL_010c: ldstr "secure"
+		IL_0111: ldc.i4.1
+		IL_0112: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0117: stloc.s 4
+		IL_0119: ldnull
+		IL_011a: ldloc.s 4
+		IL_011c: call object Modules.ArrowFunction_ParameterDestructuring_Object/ArrowFunction_L10C16::__js_call__(object, object)
+		IL_0121: pop
+		IL_0122: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0127: stloc.s 4
+		IL_0129: ldnull
+		IL_012a: ldloc.s 4
+		IL_012c: call object Modules.ArrowFunction_ParameterDestructuring_Object/ArrowFunction_L10C16::__js_call__(object, object)
+		IL_0131: pop
+		IL_0132: ret
 	} // end of method ArrowFunction_ParameterDestructuring_Object::__js_module_init__
 
 } // end of class Modules.ArrowFunction_ParameterDestructuring_Object
@@ -403,7 +399,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2304
+		// Method begins at RVA 0x22f0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_RestParameters_Basic
+﻿// IL code: ArrowFunction_RestParameters_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c8
+				// Method begins at RVA 0x2208
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21da
+					// Method begins at RVA 0x221a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d1
+				// Method begins at RVA 0x2211
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +86,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2148
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -145,7 +145,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21bf
+			// Method begins at RVA 0x21ff
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -171,13 +171,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 235 (0xeb)
+		// Code size: 297 (0x129)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_RestParameters_Basic/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_RestParameters_Basic/Scope::.ctor()
@@ -215,45 +214,68 @@
 		IL_0055: stloc.2
 		IL_0056: ldloc.2
 		IL_0057: stloc.1
-		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005d: stloc.3
-		IL_005e: ldloc.1
-		IL_005f: ldloc.3
-		IL_0060: ldc.r8 1
-		IL_0069: box [System.Runtime]System.Double
-		IL_006e: ldc.r8 2
-		IL_0077: box [System.Runtime]System.Double
-		IL_007c: ldc.r8 3
-		IL_0085: box [System.Runtime]System.Double
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_008f: stloc.2
-		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0095: ldloc.2
-		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009b: pop
-		IL_009c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a1: stloc.3
-		IL_00a2: ldloc.1
-		IL_00a3: ldloc.3
-		IL_00a4: ldc.r8 10
-		IL_00ad: box [System.Runtime]System.Double
-		IL_00b2: ldc.r8 20
-		IL_00bb: box [System.Runtime]System.Double
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_00c5: stloc.2
-		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cb: ldloc.2
-		IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d1: pop
-		IL_00d2: ldloc.1
-		IL_00d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00dd: stloc.2
-		IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e3: ldloc.2
-		IL_00e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e9: pop
-		IL_00ea: ret
+		IL_0058: ldloc.0
+		IL_0059: castclass Modules.ArrowFunction_RestParameters_Basic/Scope
+		IL_005e: ldftn object Modules.ArrowFunction_RestParameters_Basic/ArrowFunction_L3C13::__js_call__(class Modules.ArrowFunction_RestParameters_Basic/Scope, object)
+		IL_0064: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0069: ldc.i4.3
+		IL_006a: newarr [System.Runtime]System.Object
+		IL_006f: dup
+		IL_0070: ldc.i4.0
+		IL_0071: ldc.r8 1
+		IL_007a: box [System.Runtime]System.Double
+		IL_007f: stelem.ref
+		IL_0080: dup
+		IL_0081: ldc.i4.1
+		IL_0082: ldc.r8 2
+		IL_008b: box [System.Runtime]System.Double
+		IL_0090: stelem.ref
+		IL_0091: dup
+		IL_0092: ldc.i4.2
+		IL_0093: ldc.r8 3
+		IL_009c: box [System.Runtime]System.Double
+		IL_00a1: stelem.ref
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_00a7: stloc.2
+		IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ad: ldloc.2
+		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b3: pop
+		IL_00b4: ldloc.0
+		IL_00b5: castclass Modules.ArrowFunction_RestParameters_Basic/Scope
+		IL_00ba: ldftn object Modules.ArrowFunction_RestParameters_Basic/ArrowFunction_L3C13::__js_call__(class Modules.ArrowFunction_RestParameters_Basic/Scope, object)
+		IL_00c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00c5: ldc.i4.2
+		IL_00c6: newarr [System.Runtime]System.Object
+		IL_00cb: dup
+		IL_00cc: ldc.i4.0
+		IL_00cd: ldc.r8 10
+		IL_00d6: box [System.Runtime]System.Double
+		IL_00db: stelem.ref
+		IL_00dc: dup
+		IL_00dd: ldc.i4.1
+		IL_00de: ldc.r8 20
+		IL_00e7: box [System.Runtime]System.Double
+		IL_00ec: stelem.ref
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_00f2: stloc.2
+		IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f8: ldloc.2
+		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fe: pop
+		IL_00ff: ldloc.0
+		IL_0100: castclass Modules.ArrowFunction_RestParameters_Basic/Scope
+		IL_0105: ldftn object Modules.ArrowFunction_RestParameters_Basic/ArrowFunction_L3C13::__js_call__(class Modules.ArrowFunction_RestParameters_Basic/Scope, object)
+		IL_010b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0110: ldc.i4.0
+		IL_0111: newarr [System.Runtime]System.Object
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_011b: stloc.2
+		IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0121: ldloc.2
+		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0127: pop
+		IL_0128: ret
 	} // end of method ArrowFunction_RestParameters_Basic::__js_module_init__
 
 } // end of class Modules.ArrowFunction_RestParameters_Basic
@@ -265,7 +287,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e3
+		// Method begins at RVA 0x2223
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_RestParameters_WithNamedParams.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_RestParameters_WithNamedParams
+﻿// IL code: ArrowFunction_RestParameters_WithNamedParams
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21db
+				// Method begins at RVA 0x220b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,7 +53,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21f6
+						// Method begins at RVA 0x2226
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -71,7 +71,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ed
+					// Method begins at RVA 0x221d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e4
+				// Method begins at RVA 0x2214
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2140
+			// Method begins at RVA 0x2170
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -189,7 +189,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d2
+			// Method begins at RVA 0x2202
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -215,13 +215,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 225 (0xe1)
+		// Code size: 276 (0x114)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_RestParameters_WithNamedParams/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_RestParameters_WithNamedParams/Scope::.ctor()
@@ -259,59 +258,75 @@
 		IL_0055: stloc.2
 		IL_0056: ldloc.2
 		IL_0057: stloc.1
-		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005d: stloc.3
-		IL_005e: ldloc.1
-		IL_005f: ldloc.3
-		IL_0060: ldc.i4.4
-		IL_0061: newarr [System.Runtime]System.Object
-		IL_0066: dup
-		IL_0067: ldc.i4.0
-		IL_0068: ldstr "-"
-		IL_006d: stelem.ref
-		IL_006e: dup
-		IL_006f: ldc.i4.1
-		IL_0070: ldstr "a"
-		IL_0075: stelem.ref
-		IL_0076: dup
-		IL_0077: ldc.i4.2
-		IL_0078: ldstr "b"
-		IL_007d: stelem.ref
-		IL_007e: dup
-		IL_007f: ldc.i4.3
-		IL_0080: ldstr "c"
-		IL_0085: stelem.ref
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_008b: stloc.2
-		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0091: ldloc.2
-		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0097: pop
-		IL_0098: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_009d: stloc.3
-		IL_009e: ldloc.1
-		IL_009f: ldloc.3
-		IL_00a0: ldstr " "
-		IL_00a5: ldstr "hello"
-		IL_00aa: ldstr "world"
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-		IL_00b4: stloc.2
-		IL_00b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ba: ldloc.2
-		IL_00bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c0: pop
-		IL_00c1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00c6: stloc.3
-		IL_00c7: ldloc.1
-		IL_00c8: ldloc.3
-		IL_00c9: ldstr ","
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_00d3: stloc.2
-		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d9: ldloc.2
-		IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00df: pop
-		IL_00e0: ret
+		IL_0058: ldloc.0
+		IL_0059: castclass Modules.ArrowFunction_RestParameters_WithNamedParams/Scope
+		IL_005e: ldftn object Modules.ArrowFunction_RestParameters_WithNamedParams/ArrowFunction_L3C17::__js_call__(class Modules.ArrowFunction_RestParameters_WithNamedParams/Scope, object, object)
+		IL_0064: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0069: ldc.i4.4
+		IL_006a: newarr [System.Runtime]System.Object
+		IL_006f: dup
+		IL_0070: ldc.i4.0
+		IL_0071: ldstr "-"
+		IL_0076: stelem.ref
+		IL_0077: dup
+		IL_0078: ldc.i4.1
+		IL_0079: ldstr "a"
+		IL_007e: stelem.ref
+		IL_007f: dup
+		IL_0080: ldc.i4.2
+		IL_0081: ldstr "b"
+		IL_0086: stelem.ref
+		IL_0087: dup
+		IL_0088: ldc.i4.3
+		IL_0089: ldstr "c"
+		IL_008e: stelem.ref
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
+		IL_0094: stloc.2
+		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009a: ldloc.2
+		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a0: pop
+		IL_00a1: ldloc.0
+		IL_00a2: castclass Modules.ArrowFunction_RestParameters_WithNamedParams/Scope
+		IL_00a7: ldftn object Modules.ArrowFunction_RestParameters_WithNamedParams/ArrowFunction_L3C17::__js_call__(class Modules.ArrowFunction_RestParameters_WithNamedParams/Scope, object, object)
+		IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00b2: ldc.i4.3
+		IL_00b3: newarr [System.Runtime]System.Object
+		IL_00b8: dup
+		IL_00b9: ldc.i4.0
+		IL_00ba: ldstr " "
+		IL_00bf: stelem.ref
+		IL_00c0: dup
+		IL_00c1: ldc.i4.1
+		IL_00c2: ldstr "hello"
+		IL_00c7: stelem.ref
+		IL_00c8: dup
+		IL_00c9: ldc.i4.2
+		IL_00ca: ldstr "world"
+		IL_00cf: stelem.ref
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
+		IL_00d5: stloc.2
+		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00db: ldloc.2
+		IL_00dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e1: pop
+		IL_00e2: ldloc.0
+		IL_00e3: castclass Modules.ArrowFunction_RestParameters_WithNamedParams/Scope
+		IL_00e8: ldftn object Modules.ArrowFunction_RestParameters_WithNamedParams/ArrowFunction_L3C17::__js_call__(class Modules.ArrowFunction_RestParameters_WithNamedParams/Scope, object, object)
+		IL_00ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f3: ldc.i4.1
+		IL_00f4: newarr [System.Runtime]System.Object
+		IL_00f9: dup
+		IL_00fa: ldc.i4.0
+		IL_00fb: ldstr ","
+		IL_0100: stelem.ref
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
+		IL_0106: stloc.2
+		IL_0107: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010c: ldloc.2
+		IL_010d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0112: pop
+		IL_0113: ret
 	} // end of method ArrowFunction_RestParameters_WithNamedParams::__js_module_init__
 
 } // end of class Modules.ArrowFunction_RestParameters_WithNamedParams
@@ -323,7 +338,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ff
+		// Method begins at RVA 0x222f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_SimpleExpression.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_SimpleExpression
+﻿// IL code: ArrowFunction_SimpleExpression
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20ff
+				// Method begins at RVA 0x20fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20dc
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f6
+			// Method begins at RVA 0x20f2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -102,13 +102,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 132 (0x84)
+		// Code size: 125 (0x7d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_SimpleExpression/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_SimpleExpression/Scope::.ctor()
@@ -138,22 +137,19 @@
 		IL_0045: stloc.2
 		IL_0046: ldloc.2
 		IL_0047: stloc.1
-		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004d: stloc.3
-		IL_004e: ldloc.1
-		IL_004f: ldloc.3
-		IL_0050: ldc.r8 1
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: ldc.r8 2
-		IL_0067: box [System.Runtime]System.Double
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0071: stloc.2
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: ldstr "x is "
-		IL_007c: ldloc.2
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0082: pop
-		IL_0083: ret
+		IL_0048: ldnull
+		IL_0049: ldc.r8 1
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: ldc.r8 2
+		IL_0060: box [System.Runtime]System.Double
+		IL_0065: call object Modules.ArrowFunction_SimpleExpression/ArrowFunction_L3C13::__js_call__(object, object, object)
+		IL_006a: stloc.2
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0070: ldstr "x is "
+		IL_0075: ldloc.2
+		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_007b: pop
+		IL_007c: ret
 	} // end of method ArrowFunction_SimpleExpression::__js_module_init__
 
 } // end of class Modules.ArrowFunction_SimpleExpression
@@ -165,7 +161,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2108
+		// Method begins at RVA 0x2104
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_SimpleAwait.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_ArrowFunction_SimpleAwait
+﻿// IL code: Async_ArrowFunction_SimpleAwait
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224c
+				// Method begins at RVA 0x2250
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x210c
+			// Method begins at RVA 0x2110
 			// Header size: 12
 			// Code size: 279 (0x117)
 			.maxstack 8
@@ -194,7 +194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2255
+				// Method begins at RVA 0x2259
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -218,7 +218,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x222f
+			// Method begins at RVA 0x2233
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -241,7 +241,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2243
+			// Method begins at RVA 0x2247
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -267,7 +267,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 173 (0xad)
+		// Code size: 178 (0xb2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ArrowFunction_SimpleAwait/Scope,
@@ -303,42 +303,47 @@
 		IL_0045: stloc.2
 		IL_0046: ldloc.2
 		IL_0047: stloc.1
-		IL_0048: ldloc.1
-		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0053: stloc.2
-		IL_0054: ldloc.2
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005a: stloc.2
-		IL_005b: ldnull
-		IL_005c: ldftn object Modules.Async_ArrowFunction_SimpleAwait/ArrowFunction_L11C19::__js_call__(object, object)
-		IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0067: ldc.i4.1
-		IL_0068: newarr [System.Runtime]System.Object
-		IL_006d: dup
-		IL_006e: ldc.i4.0
-		IL_006f: ldloc.0
-		IL_0070: stelem.ref
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_007b: ldc.i4.1
-		IL_007c: conv.r8
-		IL_007d: ldstr ""
-		IL_0082: ldc.i4.0
-		IL_0083: ldc.i4.1
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_008e: stloc.3
-		IL_008f: ldloc.2
-		IL_0090: ldstr "then"
-		IL_0095: ldloc.3
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_009b: pop
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a1: ldstr "After calling async arrow"
-		IL_00a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ab: pop
-		IL_00ac: ret
+		IL_0048: ldc.i4.1
+		IL_0049: newarr [System.Runtime]System.Object
+		IL_004e: dup
+		IL_004f: ldc.i4.0
+		IL_0050: ldloc.0
+		IL_0051: stelem.ref
+		IL_0052: ldnull
+		IL_0053: call object Modules.Async_ArrowFunction_SimpleAwait/ArrowFunction_L4C20::__js_call__(object[], object)
+		IL_0058: stloc.2
+		IL_0059: ldloc.2
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005f: stloc.2
+		IL_0060: ldnull
+		IL_0061: ldftn object Modules.Async_ArrowFunction_SimpleAwait/ArrowFunction_L11C19::__js_call__(object, object)
+		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006c: ldc.i4.1
+		IL_006d: newarr [System.Runtime]System.Object
+		IL_0072: dup
+		IL_0073: ldc.i4.0
+		IL_0074: ldloc.0
+		IL_0075: stelem.ref
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0080: ldc.i4.1
+		IL_0081: conv.r8
+		IL_0082: ldstr ""
+		IL_0087: ldc.i4.0
+		IL_0088: ldc.i4.1
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0093: stloc.3
+		IL_0094: ldloc.2
+		IL_0095: ldstr "then"
+		IL_009a: ldloc.3
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a0: pop
+		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a6: ldstr "After calling async arrow"
+		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b0: pop
+		IL_00b1: ret
 	} // end of method Async_ArrowFunction_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_ArrowFunction_SimpleAwait
@@ -350,7 +355,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x225e
+		// Method begins at RVA 0x2262
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_RealSuspension_SetTimeout
+﻿// IL code: Async_RealSuspension_SetTimeout
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x22ae
+						// Method begins at RVA 0x229a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -50,7 +50,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2255
+					// Method begins at RVA 0x2241
 					// Header size: 1
 					// Code size: 61 (0x3d)
 					.maxstack 8
@@ -106,7 +106,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22a5
+					// Method begins at RVA 0x2291
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -131,7 +131,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21cc
+				// Method begins at RVA 0x21b8
 				// Header size: 12
 				// Code size: 106 (0x6a)
 				.maxstack 8
@@ -200,7 +200,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22b7
+					// Method begins at RVA 0x22a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -223,7 +223,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2242
+				// Method begins at RVA 0x222e
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -245,7 +245,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229c
+				// Method begins at RVA 0x2288
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +271,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x210c
+			// Method begins at RVA 0x20f8
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -358,7 +358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c0
+				// Method begins at RVA 0x22ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -381,7 +381,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b7
+			// Method begins at RVA 0x21a3
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -410,7 +410,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2293
+			// Method begins at RVA 0x227f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -436,7 +436,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 175 (0xaf)
+		// Code size: 153 (0x99)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_RealSuspension_SetTimeout/Scope,
@@ -471,48 +471,39 @@
 		IL_0038: ldstr "Before calling async function"
 		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0042: pop
-		IL_0043: ldc.i4.1
-		IL_0044: newarr [System.Runtime]System.Object
-		IL_0049: dup
-		IL_004a: ldc.i4.0
-		IL_004b: ldloc.0
-		IL_004c: stelem.ref
-		IL_004d: ldc.i4.0
-		IL_004e: ldelem.ref
-		IL_004f: castclass Modules.Async_RealSuspension_SetTimeout/Scope
-		IL_0054: ldftn object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
-		IL_005a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005f: ldnull
-		IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0065: stloc.2
-		IL_0066: ldloc.2
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_006c: stloc.2
-		IL_006d: ldnull
-		IL_006e: ldftn object Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12::__js_call__(object)
-		IL_0074: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0079: ldc.i4.1
-		IL_007a: newarr [System.Runtime]System.Object
-		IL_007f: dup
-		IL_0080: ldc.i4.0
-		IL_0081: ldloc.0
-		IL_0082: stelem.ref
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_008d: ldc.i4.0
-		IL_008e: conv.r8
-		IL_008f: ldstr ""
-		IL_0094: ldc.i4.0
-		IL_0095: ldc.i4.1
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00a0: stloc.3
-		IL_00a1: ldloc.2
-		IL_00a2: ldstr "then"
-		IL_00a7: ldloc.3
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ad: pop
-		IL_00ae: ret
+		IL_0043: ldloc.0
+		IL_0044: castclass Modules.Async_RealSuspension_SetTimeout/Scope
+		IL_0049: ldnull
+		IL_004a: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
+		IL_004f: stloc.2
+		IL_0050: ldloc.2
+		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0056: stloc.2
+		IL_0057: ldnull
+		IL_0058: ldftn object Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12::__js_call__(object)
+		IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0063: ldc.i4.1
+		IL_0064: newarr [System.Runtime]System.Object
+		IL_0069: dup
+		IL_006a: ldc.i4.0
+		IL_006b: ldloc.0
+		IL_006c: stelem.ref
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0077: ldc.i4.0
+		IL_0078: conv.r8
+		IL_0079: ldstr ""
+		IL_007e: ldc.i4.0
+		IL_007f: ldc.i4.1
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_008a: stloc.3
+		IL_008b: ldloc.2
+		IL_008c: ldstr "then"
+		IL_0091: ldloc.3
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0097: pop
+		IL_0098: ret
 	} // end of method Async_RealSuspension_SetTimeout::__js_module_init__
 
 } // end of class Modules.Async_RealSuspension_SetTimeout
@@ -524,7 +515,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22c9
+		// Method begins at RVA 0x22b5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a0
+					// Method begins at RVA 0x3338
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3397
+				// Method begins at RVA 0x332f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2474
+			// Method begins at RVA 0x2434
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33a9
+				// Method begins at RVA 0x3341
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x250c
+			// Method begins at RVA 0x24cc
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33b2
+				// Method begins at RVA 0x334a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2591
+			// Method begins at RVA 0x2551
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33df
+					// Method begins at RVA 0x3377
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b21
+				// Method begins at RVA 0x2acb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33e8
+					// Method begins at RVA 0x3380
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b30
+				// Method begins at RVA 0x2ada
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3415
+						// Method begins at RVA 0x33ad
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2bd5
+					// Method begins at RVA 0x2b81
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x340c
+					// Method begins at RVA 0x33a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b40
+				// Method begins at RVA 0x2aec
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c4
+					// Method begins at RVA 0x335c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33cd
+					// Method begins at RVA 0x3365
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d6
+					// Method begins at RVA 0x336e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33fa
+						// Method begins at RVA 0x3392
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3403
+						// Method begins at RVA 0x339b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33f1
+					// Method begins at RVA 0x3389
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x341e
+					// Method begins at RVA 0x33b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3427
+					// Method begins at RVA 0x33bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33bb
+				// Method begins at RVA 0x3353
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x259c
+			// Method begins at RVA 0x255c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3430
+				// Method begins at RVA 0x33c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2ab8
+			// Method begins at RVA 0x2a78
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-			IL_0011: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1385,7 +1376,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x338e
+			// Method begins at RVA 0x3326
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1444,7 +1435,7 @@
 	{
 		// Method begins at RVA 0x2070
 		// Header size: 12
-		// Code size: 612 (0x264)
+		// Code size: 590 (0x24e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope,
@@ -1547,7 +1538,7 @@
 
 		IL_00a0: ldloc.0
 		IL_00a1: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_00a6: switch (IL_00b3, IL_0224)
+		IL_00a6: switch (IL_00b3, IL_020e)
 
 		IL_00b3: ldc.i4.1
 		IL_00b4: newarr [System.Runtime]System.Object
@@ -1634,100 +1625,91 @@
 		IL_017e: stloc.s 6
 		IL_0180: ldloc.s 6
 		IL_0182: stloc.s 4
-		IL_0184: ldc.i4.1
-		IL_0185: newarr [System.Runtime]System.Object
-		IL_018a: dup
-		IL_018b: ldc.i4.0
-		IL_018c: ldloc.0
-		IL_018d: stelem.ref
-		IL_018e: ldc.i4.0
-		IL_018f: ldelem.ref
-		IL_0190: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-		IL_0195: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
-		IL_019b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01a0: ldnull
-		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_01a6: pop
-		IL_01a7: ldarg.3
-		IL_01a8: castclass [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate
-		IL_01ad: ldstr "./Async_TopLevelAwait_ImportedNamedFunction_Dependency.js"
-		IL_01b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_01b7: stloc.s 6
-		IL_01b9: ldloc.s 6
-		IL_01bb: stloc.s 5
-		IL_01bd: ldnull
-		IL_01be: ldloc.s 5
-		IL_01c0: ldstr "run"
-		IL_01c5: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01ca: stloc.s 6
-		IL_01cc: ldc.i4.0
-		IL_01cd: newarr [System.Runtime]System.Object
-		IL_01d2: stloc.s 7
-		IL_01d4: ldloc.s 6
-		IL_01d6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01db: ldloc.s 7
-		IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_01e2: stloc.s 6
-		IL_01e4: ldloc.0
-		IL_01e5: ldc.i4.1
-		IL_01e6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_01eb: ldloc.0
-		IL_01ec: ldloc.s 6
-		IL_01ee: ldarg.0
-		IL_01ef: ldc.i4.1
-		IL_01f0: ldloc.0
-		IL_01f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-		IL_01f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-		IL_01fb: ldloc.0
-		IL_01fc: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-		IL_0201: dup
-		IL_0202: ldc.i4.0
-		IL_0203: ldloc.1
-		IL_0204: stelem.ref
-		IL_0205: dup
-		IL_0206: ldc.i4.1
-		IL_0207: ldloc.2
-		IL_0208: stelem.ref
-		IL_0209: dup
-		IL_020a: ldc.i4.2
-		IL_020b: ldloc.3
-		IL_020c: stelem.ref
-		IL_020d: dup
-		IL_020e: ldc.i4.3
-		IL_020f: ldloc.s 4
-		IL_0211: stelem.ref
-		IL_0212: dup
-		IL_0213: ldc.i4.4
-		IL_0214: ldloc.s 5
-		IL_0216: stelem.ref
-		IL_0217: pop
-		IL_0218: ldloc.0
-		IL_0219: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_021e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-		IL_0223: ret
+		IL_0184: ldloc.0
+		IL_0185: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
+		IL_018a: ldnull
+		IL_018b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
+		IL_0190: pop
+		IL_0191: ldarg.3
+		IL_0192: castclass [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate
+		IL_0197: ldstr "./Async_TopLevelAwait_ImportedNamedFunction_Dependency.js"
+		IL_019c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_01a1: stloc.s 6
+		IL_01a3: ldloc.s 6
+		IL_01a5: stloc.s 5
+		IL_01a7: ldnull
+		IL_01a8: ldloc.s 5
+		IL_01aa: ldstr "run"
+		IL_01af: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, object)
+		IL_01b4: stloc.s 6
+		IL_01b6: ldc.i4.0
+		IL_01b7: newarr [System.Runtime]System.Object
+		IL_01bc: stloc.s 7
+		IL_01be: ldloc.s 6
+		IL_01c0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01c5: ldloc.s 7
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01cc: stloc.s 6
+		IL_01ce: ldloc.0
+		IL_01cf: ldc.i4.1
+		IL_01d0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+		IL_01d5: ldloc.0
+		IL_01d6: ldloc.s 6
+		IL_01d8: ldarg.0
+		IL_01d9: ldc.i4.1
+		IL_01da: ldloc.0
+		IL_01db: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+		IL_01e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+		IL_01e5: ldloc.0
+		IL_01e6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+		IL_01eb: dup
+		IL_01ec: ldc.i4.0
+		IL_01ed: ldloc.1
+		IL_01ee: stelem.ref
+		IL_01ef: dup
+		IL_01f0: ldc.i4.1
+		IL_01f1: ldloc.2
+		IL_01f2: stelem.ref
+		IL_01f3: dup
+		IL_01f4: ldc.i4.2
+		IL_01f5: ldloc.3
+		IL_01f6: stelem.ref
+		IL_01f7: dup
+		IL_01f8: ldc.i4.3
+		IL_01f9: ldloc.s 4
+		IL_01fb: stelem.ref
+		IL_01fc: dup
+		IL_01fd: ldc.i4.4
+		IL_01fe: ldloc.s 5
+		IL_0200: stelem.ref
+		IL_0201: pop
+		IL_0202: ldloc.0
+		IL_0203: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_0208: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+		IL_020d: ret
 
-		IL_0224: ldloc.0
-		IL_0225: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::_awaited1
-		IL_022a: stloc.s 6
-		IL_022c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0231: ldloc.s 6
-		IL_0233: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0238: pop
-		IL_0239: ldloc.0
-		IL_023a: ldc.i4.m1
-		IL_023b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_0240: ldloc.0
-		IL_0241: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-		IL_024b: ldarg.0
-		IL_024c: ldc.i4.1
-		IL_024d: newarr [System.Runtime]System.Object
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_0257: pop
-		IL_0258: ldloc.0
-		IL_0259: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_025e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-		IL_0263: ret
+		IL_020e: ldloc.0
+		IL_020f: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope::_awaited1
+		IL_0214: stloc.s 6
+		IL_0216: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021b: ldloc.s 6
+		IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0222: pop
+		IL_0223: ldloc.0
+		IL_0224: ldc.i4.m1
+		IL_0225: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+		IL_022a: ldloc.0
+		IL_022b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_0230: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+		IL_0235: ldarg.0
+		IL_0236: ldc.i4.1
+		IL_0237: newarr [System.Runtime]System.Object
+		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0241: pop
+		IL_0242: ldloc.0
+		IL_0243: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_0248: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+		IL_024d: ret
 	} // end of method Async_TopLevelAwait_ImportedNamedFunction::__js_module_async_body__
 
 } // end of class Modules.Async_TopLevelAwait_ImportedNamedFunction
@@ -1747,7 +1729,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3442
+				// Method begins at RVA 0x33da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1773,7 +1755,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2bf6
+			// Method begins at RVA 0x2ba2
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1796,7 +1778,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x344b
+				// Method begins at RVA 0x33e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1820,7 +1802,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bfe
+			// Method begins at RVA 0x2baa
 			// Header size: 1
 			// Code size: 11 (0xb)
 			.maxstack 8
@@ -1847,7 +1829,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x345d
+					// Method begins at RVA 0x33f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1865,7 +1847,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3454
+				// Method begins at RVA 0x33ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1891,7 +1873,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2c0c
+			// Method begins at RVA 0x2bb8
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1966,7 +1948,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3466
+				// Method begins at RVA 0x33fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1990,7 +1972,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ca4
+			// Method begins at RVA 0x2c50
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -2064,7 +2046,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x346f
+				// Method begins at RVA 0x3407
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2089,7 +2071,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d29
+			// Method begins at RVA 0x2cd5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2117,7 +2099,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x349c
+					// Method begins at RVA 0x3434
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2141,7 +2123,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x32b9
+				// Method begins at RVA 0x324f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2167,7 +2149,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34a5
+					// Method begins at RVA 0x343d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2191,7 +2173,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x32c8
+				// Method begins at RVA 0x325e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2221,7 +2203,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34d2
+						// Method begins at RVA 0x346a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2245,7 +2227,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x336d
+					// Method begins at RVA 0x3305
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2279,7 +2261,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34c9
+					// Method begins at RVA 0x3461
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2304,7 +2286,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x32d8
+				// Method begins at RVA 0x3270
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2397,7 +2379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3481
+					// Method begins at RVA 0x3419
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2417,7 +2399,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x348a
+					// Method begins at RVA 0x3422
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2437,7 +2419,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3493
+					// Method begins at RVA 0x342b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2461,7 +2443,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34b7
+						// Method begins at RVA 0x344f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2481,7 +2463,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34c0
+						// Method begins at RVA 0x3458
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2499,7 +2481,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34ae
+					// Method begins at RVA 0x3446
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2519,7 +2501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34db
+					// Method begins at RVA 0x3473
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2539,7 +2521,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34e4
+					// Method begins at RVA 0x347c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2561,7 +2543,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3478
+				// Method begins at RVA 0x3410
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2588,7 +2570,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x2d34
+			// Method begins at RVA 0x2ce0
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3113,7 +3095,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34ed
+				// Method begins at RVA 0x3485
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3141,50 +3123,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2b 00 00 02
 			)
-			// Method begins at RVA 0x3250
+			// Method begins at RVA 0x31fc
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-			IL_0011: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3210,7 +3183,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3439
+			// Method begins at RVA 0x33d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3234,9 +3207,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x22e0
+		// Method begins at RVA 0x22cc
 		// Header size: 12
-		// Code size: 389 (0x185)
+		// Code size: 345 (0x159)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope,
@@ -3355,55 +3328,37 @@
 		IL_0105: stloc.s 5
 		IL_0107: ldloc.s 5
 		IL_0109: stloc.s 4
-		IL_010b: ldc.i4.1
-		IL_010c: newarr [System.Runtime]System.Object
-		IL_0111: dup
-		IL_0112: ldc.i4.0
-		IL_0113: ldloc.0
-		IL_0114: stelem.ref
-		IL_0115: ldc.i4.0
-		IL_0116: ldelem.ref
-		IL_0117: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_011c: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
-		IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0127: ldnull
-		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_012d: pop
-		IL_012e: ldc.i4.1
-		IL_012f: newarr [System.Runtime]System.Object
-		IL_0134: dup
-		IL_0135: ldc.i4.0
-		IL_0136: ldloc.0
-		IL_0137: stelem.ref
-		IL_0138: ldc.i4.0
-		IL_0139: ldelem.ref
-		IL_013a: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_013f: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
-		IL_0145: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_014a: ldc.i4.0
-		IL_014b: conv.r8
-		IL_014c: ldstr ""
-		IL_0151: ldc.i4.0
-		IL_0152: ldc.i4.0
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0158: stloc.s 5
-		IL_015a: ldc.i4.1
-		IL_015b: newarr [System.Runtime]System.Object
-		IL_0160: dup
-		IL_0161: ldc.i4.0
-		IL_0162: ldloc.0
-		IL_0163: stelem.ref
-		IL_0164: ldc.i4.0
-		IL_0165: ldelem.ref
-		IL_0166: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_016b: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object, object)
-		IL_0171: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0176: ldnull
-		IL_0177: ldstr "run"
-		IL_017c: ldloc.s 5
-		IL_017e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0183: pop
-		IL_0184: ret
+		IL_010b: ldloc.0
+		IL_010c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
+		IL_0111: ldnull
+		IL_0112: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
+		IL_0117: pop
+		IL_0118: ldc.i4.1
+		IL_0119: newarr [System.Runtime]System.Object
+		IL_011e: dup
+		IL_011f: ldc.i4.0
+		IL_0120: ldloc.0
+		IL_0121: stelem.ref
+		IL_0122: ldc.i4.0
+		IL_0123: ldelem.ref
+		IL_0124: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
+		IL_0129: ldftn object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
+		IL_012f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0134: ldc.i4.0
+		IL_0135: conv.r8
+		IL_0136: ldstr ""
+		IL_013b: ldc.i4.0
+		IL_013c: ldc.i4.0
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0142: stloc.s 5
+		IL_0144: ldloc.0
+		IL_0145: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
+		IL_014a: ldnull
+		IL_014b: ldstr "run"
+		IL_0150: ldloc.s 5
+		IL_0152: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object, object)
+		IL_0157: pop
+		IL_0158: ret
 	} // end of method Async_TopLevelAwait_ImportedNamedFunction_Dependency::__js_module_init__
 
 } // end of class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency
@@ -3415,7 +3370,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x34f6
+		// Method begins at RVA 0x348e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_TopLevelAwait_PendingPromise
+﻿// IL code: Async_TopLevelAwait_PendingPromise
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x233f
+						// Method begins at RVA 0x2327
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -50,7 +50,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x22dc
+					// Method begins at RVA 0x22c4
 					// Header size: 12
 					// Code size: 60 (0x3c)
 					.maxstack 8
@@ -113,7 +113,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2336
+					// Method begins at RVA 0x231e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -138,7 +138,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2264
+				// Method begins at RVA 0x224c
 				// Header size: 12
 				// Code size: 106 (0x6a)
 				.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x232d
+				// Method begins at RVA 0x2315
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,7 +237,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2208
+			// Method begins at RVA 0x21f0
 			// Header size: 12
 			// Code size: 78 (0x4e)
 			.maxstack 8
@@ -300,7 +300,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2324
+			// Method begins at RVA 0x230c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -359,7 +359,7 @@
 	{
 		// Method begins at RVA 0x2070
 		// Header size: 12
-		// Code size: 393 (0x189)
+		// Code size: 371 (0x173)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_PendingPromise/Scope,
@@ -443,7 +443,7 @@
 
 		IL_008b: ldloc.0
 		IL_008c: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_0091: switch (IL_009e, IL_0134)
+		IL_0091: switch (IL_009e, IL_011e)
 
 		IL_009e: ldc.i4.1
 		IL_009f: newarr [System.Runtime]System.Object
@@ -469,76 +469,67 @@
 		IL_00d0: ldstr "before"
 		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_00da: pop
-		IL_00db: ldc.i4.1
-		IL_00dc: newarr [System.Runtime]System.Object
-		IL_00e1: dup
-		IL_00e2: ldc.i4.0
-		IL_00e3: ldloc.0
-		IL_00e4: stelem.ref
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldelem.ref
-		IL_00e7: castclass Modules.Async_TopLevelAwait_PendingPromise/Scope
-		IL_00ec: ldftn object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
-		IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00f7: ldnull
-		IL_00f8: ldstr "done"
-		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0102: stloc.3
+		IL_00db: ldloc.0
+		IL_00dc: castclass Modules.Async_TopLevelAwait_PendingPromise/Scope
+		IL_00e1: ldnull
+		IL_00e2: ldstr "done"
+		IL_00e7: call object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
+		IL_00ec: stloc.3
+		IL_00ed: ldloc.0
+		IL_00ee: ldc.i4.1
+		IL_00ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+		IL_00f4: ldloc.0
+		IL_00f5: ldloc.3
+		IL_00f6: ldarg.0
+		IL_00f7: ldc.i4.1
+		IL_00f8: ldloc.0
+		IL_00f9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+		IL_00fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
 		IL_0103: ldloc.0
-		IL_0104: ldc.i4.1
-		IL_0105: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_010a: ldloc.0
-		IL_010b: ldloc.3
-		IL_010c: ldarg.0
-		IL_010d: ldc.i4.1
-		IL_010e: ldloc.0
-		IL_010f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-		IL_0114: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-		IL_0119: ldloc.0
-		IL_011a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-		IL_011f: dup
-		IL_0120: ldc.i4.0
-		IL_0121: ldloc.1
-		IL_0122: stelem.ref
-		IL_0123: dup
-		IL_0124: ldc.i4.1
-		IL_0125: ldloc.2
-		IL_0126: stelem.ref
-		IL_0127: pop
-		IL_0128: ldloc.0
-		IL_0129: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_012e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-		IL_0133: ret
+		IL_0104: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+		IL_0109: dup
+		IL_010a: ldc.i4.0
+		IL_010b: ldloc.1
+		IL_010c: stelem.ref
+		IL_010d: dup
+		IL_010e: ldc.i4.1
+		IL_010f: ldloc.2
+		IL_0110: stelem.ref
+		IL_0111: pop
+		IL_0112: ldloc.0
+		IL_0113: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_0118: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+		IL_011d: ret
 
-		IL_0134: ldloc.0
-		IL_0135: ldfld object Modules.Async_TopLevelAwait_PendingPromise/Scope::_awaited1
-		IL_013a: stloc.3
-		IL_013b: ldloc.3
-		IL_013c: stloc.2
-		IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0142: ldstr "value:"
-		IL_0147: ldloc.2
-		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_014d: pop
-		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0153: ldstr "after"
-		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015d: pop
-		IL_015e: ldloc.0
-		IL_015f: ldc.i4.m1
-		IL_0160: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-		IL_0165: ldloc.0
-		IL_0166: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-		IL_0170: ldarg.0
-		IL_0171: ldc.i4.1
-		IL_0172: newarr [System.Runtime]System.Object
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_017c: pop
-		IL_017d: ldloc.0
-		IL_017e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-		IL_0183: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-		IL_0188: ret
+		IL_011e: ldloc.0
+		IL_011f: ldfld object Modules.Async_TopLevelAwait_PendingPromise/Scope::_awaited1
+		IL_0124: stloc.3
+		IL_0125: ldloc.3
+		IL_0126: stloc.2
+		IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012c: ldstr "value:"
+		IL_0131: ldloc.2
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0137: pop
+		IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013d: ldstr "after"
+		IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0147: pop
+		IL_0148: ldloc.0
+		IL_0149: ldc.i4.m1
+		IL_014a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+		IL_014f: ldloc.0
+		IL_0150: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+		IL_015a: ldarg.0
+		IL_015b: ldc.i4.1
+		IL_015c: newarr [System.Runtime]System.Object
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_0166: pop
+		IL_0167: ldloc.0
+		IL_0168: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+		IL_016d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+		IL_0172: ret
 	} // end of method Async_TopLevelAwait_PendingPromise::__js_module_async_body__
 
 } // end of class Modules.Async_TopLevelAwait_PendingPromise
@@ -550,7 +541,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2348
+		// Method begins at RVA 0x2330
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_LogicalAnd_ShortCircuit
+﻿// IL code: BinaryOperator_LogicalAnd_ShortCircuit
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2138
+				// Method begins at RVA 0x2124
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2100
+			// Method begins at RVA 0x20ec
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -82,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212f
+			// Method begins at RVA 0x211b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -108,7 +108,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 163 (0xa3)
+		// Code size: 141 (0x8d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope,
@@ -151,38 +151,29 @@
 		IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.s 4
-		IL_0056: brfalse IL_0086
+		IL_0056: brfalse IL_0070
 
-		IL_005b: ldc.i4.1
-		IL_005c: newarr [System.Runtime]System.Object
-		IL_0061: dup
-		IL_0062: ldc.i4.0
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: ldc.i4.0
-		IL_0066: ldelem.ref
-		IL_0067: castclass Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope
-		IL_006c: ldftn object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
-		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0077: ldnull
-		IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_007d: stloc.3
-		IL_007e: ldloc.3
-		IL_007f: stloc.s 6
-		IL_0081: br IL_008e
+		IL_005b: ldloc.0
+		IL_005c: castclass Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope
+		IL_0061: ldnull
+		IL_0062: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
+		IL_0067: stloc.3
+		IL_0068: ldloc.3
+		IL_0069: stloc.s 6
+		IL_006b: br IL_0078
 
-		IL_0086: ldc.i4.0
-		IL_0087: box [System.Runtime]System.Boolean
-		IL_008c: stloc.s 6
+		IL_0070: ldc.i4.0
+		IL_0071: box [System.Runtime]System.Boolean
+		IL_0076: stloc.s 6
 
-		IL_008e: ldloc.s 6
-		IL_0090: stloc.2
-		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0096: ldloc.0
-		IL_0097: ldfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a1: pop
-		IL_00a2: ret
+		IL_0078: ldloc.s 6
+		IL_007a: stloc.2
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldloc.0
+		IL_0081: ldfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
+		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008b: pop
+		IL_008c: ret
 	} // end of method BinaryOperator_LogicalAnd_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalAnd_ShortCircuit
@@ -194,7 +185,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2141
+		// Method begins at RVA 0x212d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_LogicalOr_ShortCircuit
+﻿// IL code: BinaryOperator_LogicalOr_ShortCircuit
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2138
+				// Method begins at RVA 0x2124
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2100
+			// Method begins at RVA 0x20ec
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -82,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212f
+			// Method begins at RVA 0x211b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -108,7 +108,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 163 (0xa3)
+		// Code size: 141 (0x8d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope,
@@ -151,38 +151,29 @@
 		IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.s 4
-		IL_0056: brtrue IL_0086
+		IL_0056: brtrue IL_0070
 
-		IL_005b: ldc.i4.1
-		IL_005c: newarr [System.Runtime]System.Object
-		IL_0061: dup
-		IL_0062: ldc.i4.0
-		IL_0063: ldloc.0
-		IL_0064: stelem.ref
-		IL_0065: ldc.i4.0
-		IL_0066: ldelem.ref
-		IL_0067: castclass Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope
-		IL_006c: ldftn object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
-		IL_0072: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0077: ldnull
-		IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_007d: stloc.3
-		IL_007e: ldloc.3
-		IL_007f: stloc.s 6
-		IL_0081: br IL_008e
+		IL_005b: ldloc.0
+		IL_005c: castclass Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope
+		IL_0061: ldnull
+		IL_0062: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
+		IL_0067: stloc.3
+		IL_0068: ldloc.3
+		IL_0069: stloc.s 6
+		IL_006b: br IL_0078
 
-		IL_0086: ldc.i4.1
-		IL_0087: box [System.Runtime]System.Boolean
-		IL_008c: stloc.s 6
+		IL_0070: ldc.i4.1
+		IL_0071: box [System.Runtime]System.Boolean
+		IL_0076: stloc.s 6
 
-		IL_008e: ldloc.s 6
-		IL_0090: stloc.2
-		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0096: ldloc.0
-		IL_0097: ldfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a1: pop
-		IL_00a2: ret
+		IL_0078: ldloc.s 6
+		IL_007a: stloc.2
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldloc.0
+		IL_0081: ldfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
+		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008b: pop
+		IL_008c: ret
 	} // end of method BinaryOperator_LogicalOr_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalOr_ShortCircuit
@@ -194,7 +185,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2141
+		// Method begins at RVA 0x212d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+﻿// IL code: BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213f
+				// Method begins at RVA 0x2129
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x210f
+			// Method begins at RVA 0x20f9
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2136
+			// Method begins at RVA 0x2120
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,7 +105,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 179 (0xb3)
+		// Code size: 157 (0x9d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope,
@@ -147,45 +147,36 @@
 		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0053: stloc.s 4
 		IL_0055: ldloc.2
-		IL_0056: brfalse IL_0096
+		IL_0056: brfalse IL_0080
 
 		IL_005b: ldloc.2
 		IL_005c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0061: brtrue IL_0096
+		IL_0061: brtrue IL_0080
 
-		IL_0066: ldc.i4.1
-		IL_0067: newarr [System.Runtime]System.Object
-		IL_006c: dup
-		IL_006d: ldc.i4.0
-		IL_006e: ldloc.0
-		IL_006f: stelem.ref
-		IL_0070: ldc.i4.0
-		IL_0071: ldelem.ref
-		IL_0072: castclass Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope
-		IL_0077: ldftn object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
-		IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0082: ldnull
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0088: stloc.3
-		IL_0089: ldloc.2
-		IL_008a: ldloc.3
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_0090: stloc.3
-		IL_0091: br IL_0098
+		IL_0066: ldloc.0
+		IL_0067: castclass Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope
+		IL_006c: ldnull
+		IL_006d: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldloc.3
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_007a: stloc.3
+		IL_007b: br IL_0082
 
-		IL_0096: ldnull
-		IL_0097: stloc.3
+		IL_0080: ldnull
+		IL_0081: stloc.3
 
-		IL_0098: ldloc.s 4
-		IL_009a: ldloc.3
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: ldloc.0
-		IL_00a7: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
-		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b1: pop
-		IL_00b2: ret
+		IL_0082: ldloc.s 4
+		IL_0084: ldloc.3
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008a: pop
+		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0090: ldloc.0
+		IL_0091: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
+		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009b: pop
+		IL_009c: ret
 	} // end of method BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
@@ -197,7 +188,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2148
+		// Method begins at RVA 0x2132
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_StrictEqualCapturedVariable
+﻿// IL code: BinaryOperator_StrictEqualCapturedVariable
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e0
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f2
+					// Method begins at RVA 0x21de
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e9
+				// Method begins at RVA 0x21d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -87,7 +87,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20e4
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -155,7 +155,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2204
+					// Method begins at RVA 0x21f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -176,7 +176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fb
+				// Method begins at RVA 0x21e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -200,7 +200,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x2140
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -276,7 +276,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d7
+			// Method begins at RVA 0x21c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -302,7 +302,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 156 (0x9c)
+		// Code size: 134 (0x86)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope,
@@ -351,26 +351,17 @@
 		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
 		IL_0066: stloc.2
-		IL_0067: ldc.i4.1
-		IL_0068: newarr [System.Runtime]System.Object
-		IL_006d: dup
-		IL_006e: ldc.i4.0
-		IL_006f: ldloc.0
-		IL_0070: stelem.ref
-		IL_0071: ldc.i4.0
-		IL_0072: ldelem.ref
-		IL_0073: castclass Modules.BinaryOperator_StrictEqualCapturedVariable/Scope
-		IL_0078: ldftn object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
-		IL_007e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0083: ldnull
-		IL_0084: ldloc.2
-		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_008a: pop
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0090: ldstr "done"
-		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009a: pop
-		IL_009b: ret
+		IL_0067: ldloc.0
+		IL_0068: castclass Modules.BinaryOperator_StrictEqualCapturedVariable/Scope
+		IL_006d: ldnull
+		IL_006e: ldloc.2
+		IL_006f: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
+		IL_0074: pop
+		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007a: ldstr "done"
+		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0084: pop
+		IL_0085: ret
 	} // end of method BinaryOperator_StrictEqualCapturedVariable::__js_module_init__
 
 } // end of class Modules.BinaryOperator_StrictEqualCapturedVariable
@@ -382,7 +373,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220d
+		// Method begins at RVA 0x21f9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+﻿// IL code: Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2196
+					// Method begins at RVA 0x217e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x219f
+					// Method begins at RVA 0x2187
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x212c
+				// Method begins at RVA 0x2114
 				// Header size: 12
 				// Code size: 76 (0x4c)
 				.maxstack 8
@@ -124,7 +124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x218d
+				// Method begins at RVA 0x2175
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -150,7 +150,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 96 (0x60)
 			.maxstack 8
@@ -218,7 +218,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x216c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -244,7 +244,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope,
@@ -277,21 +277,12 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "Hello from global"
 		IL_0039: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-		IL_003e: ldc.i4.1
-		IL_003f: newarr [System.Runtime]System.Object
-		IL_0044: dup
-		IL_0045: ldc.i4.0
-		IL_0046: ldloc.0
-		IL_0047: stelem.ref
-		IL_0048: ldc.i4.0
-		IL_0049: ldelem.ref
-		IL_004a: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
-		IL_004f: ldftn object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
-		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005a: ldnull
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_003e: ldloc.0
+		IL_003f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
+		IL_0044: ldnull
+		IL_0045: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
@@ -303,7 +294,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a8
+		// Method begins at RVA 0x2190
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+﻿// IL code: Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217e
+					// Method begins at RVA 0x2166
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2187
+					// Method begins at RVA 0x216f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2120
+				// Method begins at RVA 0x2108
 				// Header size: 12
 				// Code size: 64 (0x40)
 				.maxstack 8
@@ -119,7 +119,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2175
+				// Method begins at RVA 0x215d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -145,7 +145,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -208,7 +208,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216c
+			// Method begins at RVA 0x2154
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -234,7 +234,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope,
@@ -267,21 +267,12 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "Hello from global"
 		IL_0039: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-		IL_003e: ldc.i4.1
-		IL_003f: newarr [System.Runtime]System.Object
-		IL_0044: dup
-		IL_0045: ldc.i4.0
-		IL_0046: ldloc.0
-		IL_0047: stelem.ref
-		IL_0048: ldc.i4.0
-		IL_0049: ldelem.ref
-		IL_004a: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_004f: ldftn object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005a: ldnull
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_003e: ldloc.0
+		IL_003f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
+		IL_0044: ldnull
+		IL_0045: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
@@ -293,7 +284,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2190
+		// Method begins at RVA 0x2178
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+﻿// IL code: Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2172
+					// Method begins at RVA 0x215e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217b
+					// Method begins at RVA 0x2167
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2120
+				// Method begins at RVA 0x210c
 				// Header size: 12
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2169
+				// Method begins at RVA 0x2155
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -142,7 +142,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20a0
 			// Header size: 12
 			// Code size: 96 (0x60)
 			.maxstack 8
@@ -207,7 +207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2160
+			// Method begins at RVA 0x214c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -233,7 +233,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope,
@@ -263,21 +263,12 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope
-		IL_0044: ldftn object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
@@ -289,7 +280,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2184
+		// Method begins at RVA 0x2170
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassConstructor_AccessFunctionVariable_Log
+﻿// IL code: Classes_ClassConstructor_AccessFunctionVariable_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x215a
+					// Method begins at RVA 0x2146
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2163
+					// Method begins at RVA 0x214f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2114
+				// Method begins at RVA 0x2100
 				// Header size: 12
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2151
+				// Method begins at RVA 0x213d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -137,7 +137,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20a0
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -197,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2148
+			// Method begins at RVA 0x2134
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -223,7 +223,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope,
@@ -253,21 +253,12 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope
-		IL_0044: ldftn object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log
@@ -279,7 +270,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x216c
+		// Method begins at RVA 0x2158
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassConstructor_New_In_ArrowFunction
+﻿// IL code: Classes_ClassConstructor_New_In_ArrowFunction
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a7
+				// Method begins at RVA 0x21ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2124
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2195
+				// Method begins at RVA 0x2199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219e
+				// Method begins at RVA 0x21a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -134,7 +134,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x217d
+			// Method begins at RVA 0x2181
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -164,7 +164,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218c
+			// Method begins at RVA 0x2190
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -190,7 +190,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 196 (0xc4)
+		// Code size: 197 (0xc5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_New_In_ArrowFunction/Scope,
@@ -257,19 +257,20 @@
 		IL_0098: stloc.s 5
 		IL_009a: ldloc.s 5
 		IL_009c: stloc.1
-		IL_009d: ldloc.1
-		IL_009e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00a8: stloc.s 5
-		IL_00aa: ldloc.s 5
-		IL_00ac: stloc.2
-		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b2: ldloc.2
-		IL_00b3: ldstr "n"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c2: pop
-		IL_00c3: ret
+		IL_009d: ldloc.0
+		IL_009e: castclass Modules.Classes_ClassConstructor_New_In_ArrowFunction/Scope
+		IL_00a3: ldnull
+		IL_00a4: call object Modules.Classes_ClassConstructor_New_In_ArrowFunction/ArrowFunction_L9C14::__js_call__(class Modules.Classes_ClassConstructor_New_In_ArrowFunction/Scope, object)
+		IL_00a9: stloc.s 5
+		IL_00ab: ldloc.s 5
+		IL_00ad: stloc.2
+		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b3: ldloc.2
+		IL_00b4: ldstr "n"
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c3: pop
+		IL_00c4: ret
 	} // end of method Classes_ClassConstructor_New_In_ArrowFunction::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_New_In_ArrowFunction
@@ -281,7 +282,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b0
+		// Method begins at RVA 0x21b4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log
+﻿// IL code: Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c3
+					// Method begins at RVA 0x21c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21cc
+					// Method begins at RVA 0x21d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2158
+				// Method begins at RVA 0x215c
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,7 +92,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2174
+				// Method begins at RVA 0x2178
 				// Header size: 1
 				// Code size: 60 (0x3c)
 				.maxstack 8
@@ -136,7 +136,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ba
+				// Method begins at RVA 0x21be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +162,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20cc
+			// Method begins at RVA 0x20d0
 			// Header size: 12
 			// Code size: 126 (0x7e)
 			.maxstack 8
@@ -241,7 +241,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b1
+			// Method begins at RVA 0x21b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -267,7 +267,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 112 (0x70)
+		// Code size: 113 (0x71)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope,
@@ -313,11 +313,12 @@
 		IL_0060: stloc.2
 		IL_0061: ldloc.2
 		IL_0062: stloc.1
-		IL_0063: ldloc.1
-		IL_0064: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_006e: pop
-		IL_006f: ret
+		IL_0063: ldloc.0
+		IL_0064: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope
+		IL_0069: ldnull
+		IL_006a: call object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_006f: pop
+		IL_0070: ret
 	} // end of method Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log
@@ -329,7 +330,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d5
+		// Method begins at RVA 0x21d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassMethod_AccessArrowFunctionVariable_Log
+﻿// IL code: Classes_ClassMethod_AccessArrowFunctionVariable_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -250,7 +250,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 101 (0x65)
+		// Code size: 102 (0x66)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/Scope,
@@ -293,11 +293,12 @@
 		IL_0055: stloc.2
 		IL_0056: ldloc.2
 		IL_0057: stloc.1
-		IL_0058: ldloc.1
-		IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0063: pop
-		IL_0064: ret
+		IL_0058: ldloc.0
+		IL_0059: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/Scope
+		IL_005e: ldnull
+		IL_005f: call object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27::__js_call__(class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/Scope, object)
+		IL_0064: pop
+		IL_0065: ret
 	} // end of method Classes_ClassMethod_AccessArrowFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+﻿// IL code: Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b7
+					// Method begins at RVA 0x219f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c0
+					// Method begins at RVA 0x21a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x214c
+				// Method begins at RVA 0x2134
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,7 +92,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2168
+				// Method begins at RVA 0x2150
 				// Header size: 1
 				// Code size: 60 (0x3c)
 				.maxstack 8
@@ -136,7 +136,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ae
+				// Method begins at RVA 0x2196
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +162,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 126 (0x7e)
 			.maxstack 8
@@ -244,7 +244,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a5
+			// Method begins at RVA 0x218d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -270,7 +270,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope,
@@ -303,21 +303,12 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "Hello from global"
 		IL_0039: stfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-		IL_003e: ldc.i4.1
-		IL_003f: newarr [System.Runtime]System.Object
-		IL_0044: dup
-		IL_0045: ldc.i4.0
-		IL_0046: ldloc.0
-		IL_0047: stelem.ref
-		IL_0048: ldc.i4.0
-		IL_0049: ldelem.ref
-		IL_004a: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_004f: ldftn object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005a: ldnull
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_003e: ldloc.0
+		IL_003f: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
+		IL_0044: ldnull
+		IL_0045: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
@@ -329,7 +320,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c9
+		// Method begins at RVA 0x21b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassMethod_AccessFunctionVariable_Log
+﻿// IL code: Classes_ClassMethod_AccessFunctionVariable_Log
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218e
+					// Method begins at RVA 0x217a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2197
+					// Method begins at RVA 0x2183
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2140
+				// Method begins at RVA 0x212c
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,7 +92,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x215c
+				// Method begins at RVA 0x2148
 				// Header size: 1
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2185
+				// Method begins at RVA 0x2171
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20a0
 			// Header size: 12
 			// Code size: 126 (0x7e)
 			.maxstack 8
@@ -232,7 +232,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217c
+			// Method begins at RVA 0x2168
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -258,7 +258,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope,
@@ -288,21 +288,12 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope
-		IL_0044: ldftn object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method Classes_ClassMethod_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariable_Log
@@ -314,7 +305,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a0
+		// Method begins at RVA 0x218c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_Inheritance_SuperCapturedScopeVar
+﻿// IL code: Classes_Inheritance_SuperCapturedScopeVar
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2360
+					// Method begins at RVA 0x234c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2369
+					// Method begins at RVA 0x2355
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22d4
+				// Method begins at RVA 0x22c0
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,7 +92,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2330
+				// Method begins at RVA 0x231c
 				// Header size: 1
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -121,7 +121,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2372
+					// Method begins at RVA 0x235e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -141,7 +141,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x237b
+					// Method begins at RVA 0x2367
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -167,7 +167,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22f0
+				// Method begins at RVA 0x22dc
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -194,7 +194,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2314
+				// Method begins at RVA 0x2300
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -229,7 +229,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2357
+				// Method begins at RVA 0x2343
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +255,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20a0
 			// Header size: 12
 			// Code size: 531 (0x213)
 			.maxstack 8
@@ -510,7 +510,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x234e
+			// Method begins at RVA 0x233a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -536,7 +536,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope,
@@ -566,21 +566,12 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope
-		IL_0044: ldftn object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method Classes_Inheritance_SuperCapturedScopeVar::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperCapturedScopeVar
@@ -592,7 +583,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2384
+		// Method begins at RVA 0x2370
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: CommonJS_Require_Basic
+﻿// IL code: CommonJS_Require_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ff
+				// Method begins at RVA 0x23d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a1
+			// Method begins at RVA 0x2273
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241a
+				// Method begins at RVA 0x23ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -96,7 +96,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x2278
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -137,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2408
+				// Method begins at RVA 0x23dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -157,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2411
+				// Method begins at RVA 0x23e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,7 +183,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e4
+			// Method begins at RVA 0x22b8
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -207,7 +207,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2300
+			// Method begins at RVA 0x22d4
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -259,7 +259,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23f6
+			// Method begins at RVA 0x23ca
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -285,7 +285,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 297 (0x129)
+		// Code size: 275 (0x113)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Basic/Scope,
@@ -385,21 +385,12 @@
 		IL_00fa: ldstr "Log"
 		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_0104: pop
-		IL_0105: ldc.i4.1
-		IL_0106: newarr [System.Runtime]System.Object
-		IL_010b: dup
-		IL_010c: ldc.i4.0
-		IL_010d: ldloc.0
-		IL_010e: stelem.ref
-		IL_010f: ldc.i4.0
-		IL_0110: ldelem.ref
-		IL_0111: castclass Modules.CommonJS_Require_Basic/Scope
-		IL_0116: ldftn object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
-		IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0121: ldnull
-		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0127: pop
-		IL_0128: ret
+		IL_0105: ldloc.0
+		IL_0106: castclass Modules.CommonJS_Require_Basic/Scope
+		IL_010b: ldnull
+		IL_010c: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
+		IL_0111: pop
+		IL_0112: ret
 	} // end of method CommonJS_Require_Basic::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Basic
@@ -425,7 +416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x2400
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -449,7 +440,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x234a
+			// Method begins at RVA 0x231e
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -471,7 +462,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2447
+				// Method begins at RVA 0x241b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -497,7 +488,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2350
+			// Method begins at RVA 0x2324
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -538,7 +529,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2435
+				// Method begins at RVA 0x2409
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -558,7 +549,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243e
+				// Method begins at RVA 0x2412
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -584,7 +575,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2390
+			// Method begins at RVA 0x2364
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -608,7 +599,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23ac
+			// Method begins at RVA 0x2380
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -660,7 +651,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2423
+			// Method begins at RVA 0x23f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -684,9 +675,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2188
+		// Method begins at RVA 0x2170
 		// Header size: 12
-		// Code size: 269 (0x10d)
+		// Code size: 247 (0xf7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Dependency/Scope,
@@ -778,21 +769,12 @@
 		IL_00de: ldstr "Log"
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_00e8: pop
-		IL_00e9: ldc.i4.1
-		IL_00ea: newarr [System.Runtime]System.Object
-		IL_00ef: dup
-		IL_00f0: ldc.i4.0
-		IL_00f1: ldloc.0
-		IL_00f2: stelem.ref
-		IL_00f3: ldc.i4.0
-		IL_00f4: ldelem.ref
-		IL_00f5: castclass Modules.CommonJS_Require_Dependency/Scope
-		IL_00fa: ldftn object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
-		IL_0100: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0105: ldnull
-		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_010b: pop
-		IL_010c: ret
+		IL_00e9: ldloc.0
+		IL_00ea: castclass Modules.CommonJS_Require_Dependency/Scope
+		IL_00ef: ldnull
+		IL_00f0: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
+		IL_00f5: pop
+		IL_00f6: ret
 	} // end of method CommonJS_Require_Dependency::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Dependency
@@ -804,7 +786,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2450
+		// Method begins at RVA 0x2424
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -1,4 +1,4 @@
-// IL code: a
+﻿// IL code: a
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2416
+			// Method begins at RVA 0x23ea
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2428
+				// Method begins at RVA 0x23fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,7 +110,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22c1
+			// Method begins at RVA 0x2293
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2443
+				// Method begins at RVA 0x2417
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x22c4
+			// Method begins at RVA 0x2298
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -199,7 +199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2431
+				// Method begins at RVA 0x2405
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -219,7 +219,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243a
+				// Method begins at RVA 0x240e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -245,7 +245,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2304
+			// Method begins at RVA 0x22d8
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -269,7 +269,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2320
+			// Method begins at RVA 0x22f4
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -321,7 +321,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x241f
+			// Method begins at RVA 0x23f3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -347,7 +347,7 @@
 	{
 		// Method begins at RVA 0x208c
 		// Header size: 12
-		// Code size: 269 (0x10d)
+		// Code size: 247 (0xf7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.b/Scope,
@@ -439,21 +439,12 @@
 		IL_00de: ldstr "Log"
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_00e8: pop
-		IL_00e9: ldc.i4.1
-		IL_00ea: newarr [System.Runtime]System.Object
-		IL_00ef: dup
-		IL_00f0: ldc.i4.0
-		IL_00f1: ldloc.0
-		IL_00f2: stelem.ref
-		IL_00f3: ldc.i4.0
-		IL_00f4: ldelem.ref
-		IL_00f5: castclass Modules.b/Scope
-		IL_00fa: ldftn object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
-		IL_0100: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0105: ldnull
-		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_010b: pop
-		IL_010c: ret
+		IL_00e9: ldloc.0
+		IL_00ea: castclass Modules.b/Scope
+		IL_00ef: ldnull
+		IL_00f0: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
+		IL_00f5: pop
+		IL_00f6: ret
 	} // end of method b::__js_module_init__
 
 } // end of class Modules.b
@@ -479,7 +470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2455
+				// Method begins at RVA 0x2429
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -503,7 +494,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x236a
+			// Method begins at RVA 0x233e
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -525,7 +516,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2470
+				// Method begins at RVA 0x2444
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -551,7 +542,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2370
+			// Method begins at RVA 0x2344
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -592,7 +583,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245e
+				// Method begins at RVA 0x2432
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -612,7 +603,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2467
+				// Method begins at RVA 0x243b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -638,7 +629,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b0
+			// Method begins at RVA 0x2384
 			// Header size: 12
 			// Code size: 16 (0x10)
 			.maxstack 8
@@ -662,7 +653,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23cc
+			// Method begins at RVA 0x23a0
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -714,7 +705,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x244c
+			// Method begins at RVA 0x2420
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -738,9 +729,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21a8
+		// Method begins at RVA 0x2190
 		// Header size: 12
-		// Code size: 269 (0x10d)
+		// Code size: 247 (0xf7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.helpers_b/Scope,
@@ -832,21 +823,12 @@
 		IL_00de: ldstr "Log"
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_00e8: pop
-		IL_00e9: ldc.i4.1
-		IL_00ea: newarr [System.Runtime]System.Object
-		IL_00ef: dup
-		IL_00f0: ldc.i4.0
-		IL_00f1: ldloc.0
-		IL_00f2: stelem.ref
-		IL_00f3: ldc.i4.0
-		IL_00f4: ldelem.ref
-		IL_00f5: castclass Modules.helpers_b/Scope
-		IL_00fa: ldftn object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
-		IL_0100: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0105: ldnull
-		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_010b: pop
-		IL_010c: ret
+		IL_00e9: ldloc.0
+		IL_00ea: castclass Modules.helpers_b/Scope
+		IL_00ef: ldnull
+		IL_00f0: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
+		IL_00f5: pop
+		IL_00f6: ret
 	} // end of method helpers_b::__js_module_init__
 
 } // end of class Modules.helpers_b
@@ -858,7 +840,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2479
+		// Method begins at RVA 0x244d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -1,4 +1,4 @@
-// IL code: CommonJS_Require_OptionalChain_InNestedFunction
+﻿// IL code: CommonJS_Require_OptionalChain_InNestedFunction
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21bb
+						// Method begins at RVA 0x21a7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b2
+					// Method begins at RVA 0x219e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c4
+					// Method begins at RVA 0x21b0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a9
+				// Method begins at RVA 0x2195
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 127 (0x7f)
 			.maxstack 8
@@ -202,7 +202,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a0
+			// Method begins at RVA 0x218c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -228,7 +228,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 111 (0x6f)
+		// Code size: 89 (0x59)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope,
@@ -262,25 +262,16 @@
 		IL_003c: stloc.2
 		IL_003d: ldloc.2
 		IL_003e: stloc.1
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: ldc.i4.0
-		IL_004a: ldelem.ref
-		IL_004b: castclass Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope
-		IL_0050: ldftn object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
-		IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005b: ldnull
-		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0061: stloc.2
-		IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0067: ldloc.2
-		IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006d: pop
-		IL_006e: ret
+		IL_003f: ldloc.0
+		IL_0040: castclass Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope
+		IL_0045: ldnull
+		IL_0046: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
+		IL_004b: stloc.2
+		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0051: ldloc.2
+		IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0057: pop
+		IL_0058: ret
 	} // end of method CommonJS_Require_OptionalChain_InNestedFunction::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_OptionalChain_InNestedFunction
@@ -296,7 +287,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21cd
+			// Method begins at RVA 0x21b9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -320,7 +311,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20cc
+		// Method begins at RVA 0x20b8
 		// Header size: 12
 		// Code size: 43 (0x2b)
 		.maxstack 8
@@ -355,7 +346,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d6
+		// Method begins at RVA 0x21c2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_Conditional_Ternary_ShortCircuit
+﻿// IL code: ControlFlow_Conditional_Ternary_ShortCircuit
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216c
+				// Method begins at RVA 0x2140
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -82,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2163
+			// Method begins at RVA 0x2137
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -108,7 +108,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 216 (0xd8)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope,
@@ -150,55 +150,37 @@
 		IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_005c: stloc.s 5
 		IL_005e: ldloc.s 5
-		IL_0060: brfalse IL_0091
+		IL_0060: brfalse IL_007b
 
-		IL_0065: ldc.i4.1
-		IL_0066: newarr [System.Runtime]System.Object
-		IL_006b: dup
-		IL_006c: ldc.i4.0
-		IL_006d: ldloc.0
-		IL_006e: stelem.ref
-		IL_006f: ldc.i4.0
-		IL_0070: ldelem.ref
-		IL_0071: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
-		IL_0076: ldftn object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
-		IL_007c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0065: ldloc.0
+		IL_0066: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
+		IL_006b: ldnull
+		IL_006c: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
+		IL_0071: stloc.s 4
+		IL_0073: ldloc.s 4
+		IL_0075: stloc.2
+		IL_0076: br IL_008c
+
+		IL_007b: ldloc.0
+		IL_007c: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
 		IL_0081: ldnull
-		IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
+		IL_0082: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
 		IL_0087: stloc.s 4
 		IL_0089: ldloc.s 4
 		IL_008b: stloc.2
-		IL_008c: br IL_00b8
 
-		IL_0091: ldc.i4.1
-		IL_0092: newarr [System.Runtime]System.Object
-		IL_0097: dup
-		IL_0098: ldc.i4.0
-		IL_0099: ldloc.0
-		IL_009a: stelem.ref
-		IL_009b: ldc.i4.0
-		IL_009c: ldelem.ref
-		IL_009d: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
-		IL_00a2: ldftn object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
-		IL_00a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ad: ldnull
-		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00b3: stloc.s 4
-		IL_00b5: ldloc.s 4
-		IL_00b7: stloc.2
-
-		IL_00b8: ldloc.2
-		IL_00b9: stloc.3
-		IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bf: ldloc.3
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c5: pop
-		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cb: ldloc.0
-		IL_00cc: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
-		IL_00d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d6: pop
-		IL_00d7: ret
+		IL_008c: ldloc.2
+		IL_008d: stloc.3
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: ldloc.3
+		IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0099: pop
+		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009f: ldloc.0
+		IL_00a0: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
+		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method ControlFlow_Conditional_Ternary_ShortCircuit::__js_module_init__
 
 } // end of class Modules.ControlFlow_Conditional_Ternary_ShortCircuit
@@ -210,7 +192,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2175
+		// Method begins at RVA 0x2149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_ForOf_ClosureCallback
+﻿// IL code: ControlFlow_ForOf_ClosureCallback
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2242
+					// Method begins at RVA 0x222e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -53,7 +53,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2254
+						// Method begins at RVA 0x2240
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -71,7 +71,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x224b
+					// Method begins at RVA 0x2237
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -95,7 +95,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x213c
+				// Method begins at RVA 0x2128
 				// Header size: 12
 				// Code size: 215 (0xd7)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2239
+				// Method begins at RVA 0x2225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -248,7 +248,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x20d0
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 80 (0x50)
 			.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225d
+				// Method begins at RVA 0x2249
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x2118
 			// Header size: 1
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -365,7 +365,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x221c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -391,7 +391,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 115 (0x73)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_ClosureCallback/Scope,
@@ -431,22 +431,13 @@
 		IL_0047: ldc.i4.1
 		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_004d: stloc.2
-		IL_004e: ldc.i4.1
-		IL_004f: newarr [System.Runtime]System.Object
-		IL_0054: dup
-		IL_0055: ldc.i4.0
-		IL_0056: ldloc.0
-		IL_0057: stelem.ref
-		IL_0058: ldc.i4.0
-		IL_0059: ldelem.ref
-		IL_005a: castclass Modules.ControlFlow_ForOf_ClosureCallback/Scope
-		IL_005f: ldftn object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
-		IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_006a: ldnull
-		IL_006b: ldloc.2
-		IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0071: pop
-		IL_0072: ret
+		IL_004e: ldloc.0
+		IL_004f: castclass Modules.ControlFlow_ForOf_ClosureCallback/Scope
+		IL_0054: ldnull
+		IL_0055: ldloc.2
+		IL_0056: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method ControlFlow_ForOf_ClosureCallback::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_ClosureCallback
@@ -458,7 +449,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2266
+		// Method begins at RVA 0x2252
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ControlFlow_LabeledStatement_CapturesParentVar
+﻿// IL code: ControlFlow_LabeledStatement_CapturesParentVar
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d3
+					// Method begins at RVA 0x21bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2138
+				// Method begins at RVA 0x2124
 				// Header size: 12
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21e5
+						// Method begins at RVA 0x21d1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -104,7 +104,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21dc
+					// Method begins at RVA 0x21c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -128,7 +128,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2158
+				// Method begins at RVA 0x2144
 				// Header size: 12
 				// Code size: 93 (0x5d)
 				.maxstack 8
@@ -196,7 +196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ca
+				// Method begins at RVA 0x21b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -222,7 +222,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x20c8
+			// Method begins at RVA 0x20b4
 			// Header size: 12
 			// Code size: 100 (0x64)
 			.maxstack 8
@@ -292,7 +292,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c1
+			// Method begins at RVA 0x21ad
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -318,7 +318,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 107 (0x6b)
+		// Code size: 85 (0x55)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope,
@@ -349,29 +349,20 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope
-		IL_0044: ldftn object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: stloc.2
-		IL_0056: ldc.i4.0
-		IL_0057: newarr [System.Runtime]System.Object
-		IL_005c: stloc.3
-		IL_005d: ldloc.2
-		IL_005e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0063: ldloc.3
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0069: pop
-		IL_006a: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
+		IL_003f: stloc.2
+		IL_0040: ldc.i4.0
+		IL_0041: newarr [System.Runtime]System.Object
+		IL_0046: stloc.3
+		IL_0047: ldloc.2
+		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004d: ldloc.3
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0053: pop
+		IL_0054: ret
 	} // end of method ControlFlow_LabeledStatement_CapturesParentVar::__js_module_init__
 
 } // end of class Modules.ControlFlow_LabeledStatement_CapturesParentVar
@@ -383,7 +374,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ee
+		// Method begins at RVA 0x21da
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Arrow_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Arrow_Capture_HasScopesParameter.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Arrow_Capture_HasScopesParameter
+﻿// IL code: Arrow_Capture_HasScopesParameter
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2125
+				// Method begins at RVA 0x2121
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -90,7 +90,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211c
+			// Method begins at RVA 0x2118
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -116,13 +116,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 149 (0x95)
+		// Code size: 148 (0x94)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Arrow_Capture_HasScopesParameter/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.Arrow_Capture_HasScopesParameter/Scope::.ctor()
@@ -164,19 +163,18 @@
 		IL_0069: stloc.2
 		IL_006a: ldloc.2
 		IL_006b: stloc.1
-		IL_006c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0071: stloc.3
-		IL_0072: ldloc.1
-		IL_0073: ldloc.3
-		IL_0074: ldc.r8 5
-		IL_007d: box [System.Runtime]System.Double
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0087: stloc.2
-		IL_0088: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008d: ldloc.2
-		IL_008e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0093: pop
-		IL_0094: ret
+		IL_006c: ldloc.0
+		IL_006d: castclass Modules.Arrow_Capture_HasScopesParameter/Scope
+		IL_0072: ldnull
+		IL_0073: ldc.r8 5
+		IL_007c: box [System.Runtime]System.Double
+		IL_0081: call object Modules.Arrow_Capture_HasScopesParameter/ArrowFunction_L6C15::__js_call__(class Modules.Arrow_Capture_HasScopesParameter/Scope, object, object)
+		IL_0086: stloc.2
+		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008c: ldloc.2
+		IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0092: pop
+		IL_0093: ret
 	} // end of method Arrow_Capture_HasScopesParameter::__js_module_init__
 
 } // end of class Modules.Arrow_Capture_HasScopesParameter
@@ -188,7 +186,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212e
+		// Method begins at RVA 0x212a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Arrow_NoCapture_NoScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Arrow_NoCapture_NoScopesParameter.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Arrow_NoCapture_NoScopesParameter
+﻿// IL code: Arrow_NoCapture_NoScopesParameter
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2106
+				// Method begins at RVA 0x20fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -51,7 +51,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20dc
+			// Method begins at RVA 0x20d4
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20fd
+			// Method begins at RVA 0x20f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,13 +105,12 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 127 (0x7f)
+		// Code size: 120 (0x78)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Arrow_NoCapture_NoScopesParameter/Scope,
 			[1] object,
-			[2] object,
-			[3] object[]
+			[2] object
 		)
 
 		IL_0000: newobj instance void Modules.Arrow_NoCapture_NoScopesParameter/Scope::.ctor()
@@ -141,21 +140,18 @@
 		IL_0045: stloc.2
 		IL_0046: ldloc.2
 		IL_0047: stloc.1
-		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004d: stloc.3
-		IL_004e: ldloc.1
-		IL_004f: ldloc.3
-		IL_0050: ldc.r8 4
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: ldc.r8 7
-		IL_0067: box [System.Runtime]System.Double
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0071: stloc.2
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: ldloc.2
-		IL_0078: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007d: pop
-		IL_007e: ret
+		IL_0048: ldnull
+		IL_0049: ldc.r8 4
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: ldc.r8 7
+		IL_0060: box [System.Runtime]System.Double
+		IL_0065: call object Modules.Arrow_NoCapture_NoScopesParameter/ArrowFunction_L4C18::__js_call__(object, object, object)
+		IL_006a: stloc.2
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0070: ldloc.2
+		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0076: pop
+		IL_0077: ret
 	} // end of method Arrow_NoCapture_NoScopesParameter::__js_module_init__
 
 } // end of class Modules.Arrow_NoCapture_NoScopesParameter
@@ -167,7 +163,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x210f
+		// Method begins at RVA 0x2107
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Arguments_Basics
+﻿// IL code: Function_Arguments_Basics
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23db
+				// Method begins at RVA 0x23cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -50,7 +50,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a8
+			// Method begins at RVA 0x219c
 			// Header size: 12
 			// Code size: 143 (0x8f)
 			.maxstack 8
@@ -116,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23ed
+					// Method begins at RVA 0x23e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -140,7 +140,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x233c
+				// Method begins at RVA 0x2330
 				// Header size: 12
 				// Code size: 74 (0x4a)
 				.maxstack 8
@@ -185,7 +185,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23e4
+				// Method begins at RVA 0x23d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -212,7 +212,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2244
+			// Method begins at RVA 0x2238
 			// Header size: 12
 			// Code size: 126 (0x7e)
 			.maxstack 8
@@ -302,7 +302,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23ff
+					// Method begins at RVA 0x23f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -325,7 +325,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2394
+				// Method begins at RVA 0x2388
 				// Header size: 12
 				// Code size: 50 (0x32)
 				.maxstack 8
@@ -369,7 +369,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f6
+				// Method begins at RVA 0x23ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -392,7 +392,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22c4
 			// Header size: 12
 			// Code size: 95 (0x5f)
 			.maxstack 8
@@ -456,7 +456,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23d2
+			// Method begins at RVA 0x23c6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -482,7 +482,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 330 (0x14a)
+		// Code size: 319 (0x13f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Basics/Scope,
@@ -572,40 +572,33 @@
 		IL_00e0: stelem.ref
 		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
 		IL_00e6: pop
-		IL_00e7: ldc.i4.1
-		IL_00e8: newarr [System.Runtime]System.Object
-		IL_00ed: dup
-		IL_00ee: ldc.i4.0
-		IL_00ef: ldloc.0
-		IL_00f0: stelem.ref
-		IL_00f1: ldc.i4.0
-		IL_00f2: ldelem.ref
-		IL_00f3: castclass Modules.Function_Arguments_Basics/Scope
-		IL_00f8: ldftn object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
-		IL_00fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0103: ldc.i4.3
-		IL_0104: newarr [System.Runtime]System.Object
-		IL_0109: dup
-		IL_010a: ldc.i4.0
-		IL_010b: ldc.r8 7
-		IL_0114: box [System.Runtime]System.Double
-		IL_0119: stelem.ref
-		IL_011a: dup
-		IL_011b: ldc.i4.1
-		IL_011c: ldc.r8 8
-		IL_0125: box [System.Runtime]System.Double
-		IL_012a: stelem.ref
-		IL_012b: dup
-		IL_012c: ldc.i4.2
-		IL_012d: ldc.r8 9
-		IL_0136: box [System.Runtime]System.Double
-		IL_013b: stelem.ref
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_0141: pop
-		IL_0142: ldnull
-		IL_0143: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
-		IL_0148: pop
-		IL_0149: ret
+		IL_00e7: ldloc.0
+		IL_00e8: castclass Modules.Function_Arguments_Basics/Scope
+		IL_00ed: ldftn object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
+		IL_00f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00f8: ldc.i4.3
+		IL_00f9: newarr [System.Runtime]System.Object
+		IL_00fe: dup
+		IL_00ff: ldc.i4.0
+		IL_0100: ldc.r8 7
+		IL_0109: box [System.Runtime]System.Double
+		IL_010e: stelem.ref
+		IL_010f: dup
+		IL_0110: ldc.i4.1
+		IL_0111: ldc.r8 8
+		IL_011a: box [System.Runtime]System.Double
+		IL_011f: stelem.ref
+		IL_0120: dup
+		IL_0121: ldc.i4.2
+		IL_0122: ldc.r8 9
+		IL_012b: box [System.Runtime]System.Double
+		IL_0130: stelem.ref
+		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
+		IL_0136: pop
+		IL_0137: ldnull
+		IL_0138: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
+		IL_013d: pop
+		IL_013e: ret
 	} // end of method Function_Arguments_Basics::__js_module_init__
 
 } // end of class Modules.Function_Arguments_Basics
@@ -617,7 +610,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2408
+		// Method begins at RVA 0x23fc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Arguments_NoFalsePositive_ObjectLiteralKey
+﻿// IL code: Function_Arguments_NoFalsePositive_ObjectLiteralKey
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20fb
+				// Method begins at RVA 0x20e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20a0
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -83,7 +83,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20f2
+			// Method begins at RVA 0x20de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -109,7 +109,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope,
@@ -139,21 +139,12 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope
-		IL_0044: ldftn object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method Function_Arguments_NoFalsePositive_ObjectLiteralKey::__js_module_init__
 
 } // end of class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey
@@ -165,7 +156,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2104
+		// Method begins at RVA 0x20f0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Call_Spread_Basic
+﻿// IL code: Function_Call_Spread_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b3
+				// Method begins at RVA 0x21a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c5
+					// Method begins at RVA 0x21b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21bc
+				// Method begins at RVA 0x21b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x211c
+			// Method begins at RVA 0x2110
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21aa
+			// Method begins at RVA 0x219e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,7 +192,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 190 (0xbe)
+		// Code size: 179 (0xb3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Basic/Scope,
@@ -249,27 +249,20 @@
 		IL_0086: ldloc.s 4
 		IL_0088: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
 		IL_008d: stloc.s 5
-		IL_008f: ldc.i4.1
-		IL_0090: newarr [System.Runtime]System.Object
-		IL_0095: dup
-		IL_0096: ldc.i4.0
-		IL_0097: ldloc.0
-		IL_0098: stelem.ref
-		IL_0099: ldc.i4.0
-		IL_009a: ldelem.ref
-		IL_009b: castclass Modules.Function_Call_Spread_Basic/Scope
-		IL_00a0: ldftn object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
-		IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ab: ldc.i4.1
-		IL_00ac: newarr [System.Runtime]System.Object
-		IL_00b1: dup
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldloc.0
-		IL_00b4: stelem.ref
-		IL_00b5: ldloc.s 5
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00bc: pop
-		IL_00bd: ret
+		IL_008f: ldloc.0
+		IL_0090: castclass Modules.Function_Call_Spread_Basic/Scope
+		IL_0095: ldftn object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
+		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a0: ldc.i4.1
+		IL_00a1: newarr [System.Runtime]System.Object
+		IL_00a6: dup
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldloc.0
+		IL_00a9: stelem.ref
+		IL_00aa: ldloc.s 5
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_00b1: pop
+		IL_00b2: ret
 	} // end of method Function_Call_Spread_Basic::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Basic
@@ -281,7 +274,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ce
+		// Method begins at RVA 0x21c2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Call_Spread_EvaluationOrder
+﻿// IL code: Function_Call_Spread_EvaluationOrder
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x225f
+				// Method begins at RVA 0x2253
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2271
+					// Method begins at RVA 0x2265
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2268
+				// Method begins at RVA 0x225c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2160
+			// Method begins at RVA 0x2154
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -163,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x227a
+				// Method begins at RVA 0x226e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -187,7 +187,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f0
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -220,7 +220,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2283
+				// Method begins at RVA 0x2277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -243,7 +243,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2216
+			// Method begins at RVA 0x220a
 			// Header size: 1
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -285,7 +285,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2256
+			// Method begins at RVA 0x224a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -311,7 +311,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 257 (0x101)
+		// Code size: 246 (0xf6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_EvaluationOrder/Scope,
@@ -397,27 +397,20 @@
 		IL_00c9: ldloc.s 5
 		IL_00cb: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
 		IL_00d0: stloc.s 6
-		IL_00d2: ldc.i4.1
-		IL_00d3: newarr [System.Runtime]System.Object
-		IL_00d8: dup
-		IL_00d9: ldc.i4.0
-		IL_00da: ldloc.0
-		IL_00db: stelem.ref
-		IL_00dc: ldc.i4.0
-		IL_00dd: ldelem.ref
-		IL_00de: castclass Modules.Function_Call_Spread_EvaluationOrder/Scope
-		IL_00e3: ldftn object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
-		IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ee: ldc.i4.1
-		IL_00ef: newarr [System.Runtime]System.Object
-		IL_00f4: dup
-		IL_00f5: ldc.i4.0
-		IL_00f6: ldloc.0
-		IL_00f7: stelem.ref
-		IL_00f8: ldloc.s 6
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00ff: pop
-		IL_0100: ret
+		IL_00d2: ldloc.0
+		IL_00d3: castclass Modules.Function_Call_Spread_EvaluationOrder/Scope
+		IL_00d8: ldftn object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
+		IL_00de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00e3: ldc.i4.1
+		IL_00e4: newarr [System.Runtime]System.Object
+		IL_00e9: dup
+		IL_00ea: ldc.i4.0
+		IL_00eb: ldloc.0
+		IL_00ec: stelem.ref
+		IL_00ed: ldloc.s 6
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_00f4: pop
+		IL_00f5: ret
 	} // end of method Function_Call_Spread_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_EvaluationOrder
@@ -429,7 +422,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x228c
+		// Method begins at RVA 0x2280
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Call_Spread_Middle
+﻿// IL code: Function_Call_Spread_Middle
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c3
+				// Method begins at RVA 0x21b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d5
+					// Method begins at RVA 0x21c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cc
+				// Method begins at RVA 0x21c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x2120
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ba
+			// Method begins at RVA 0x21ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,7 +192,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 205 (0xcd)
+		// Code size: 194 (0xc2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Middle/Scope,
@@ -250,27 +250,20 @@
 		IL_0096: ldloc.3
 		IL_0097: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
 		IL_009c: stloc.s 4
-		IL_009e: ldc.i4.1
-		IL_009f: newarr [System.Runtime]System.Object
-		IL_00a4: dup
-		IL_00a5: ldc.i4.0
-		IL_00a6: ldloc.0
-		IL_00a7: stelem.ref
-		IL_00a8: ldc.i4.0
-		IL_00a9: ldelem.ref
-		IL_00aa: castclass Modules.Function_Call_Spread_Middle/Scope
-		IL_00af: ldftn object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
-		IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ba: ldc.i4.1
-		IL_00bb: newarr [System.Runtime]System.Object
-		IL_00c0: dup
-		IL_00c1: ldc.i4.0
-		IL_00c2: ldloc.0
-		IL_00c3: stelem.ref
-		IL_00c4: ldloc.s 4
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00cb: pop
-		IL_00cc: ret
+		IL_009e: ldloc.0
+		IL_009f: castclass Modules.Function_Call_Spread_Middle/Scope
+		IL_00a4: ldftn object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
+		IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00af: ldc.i4.1
+		IL_00b0: newarr [System.Runtime]System.Object
+		IL_00b5: dup
+		IL_00b6: ldc.i4.0
+		IL_00b7: ldloc.0
+		IL_00b8: stelem.ref
+		IL_00b9: ldloc.s 4
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_00c0: pop
+		IL_00c1: ret
 	} // end of method Function_Call_Spread_Middle::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Middle
@@ -282,7 +275,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21de
+		// Method begins at RVA 0x21d2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Call_Spread_Multiple
+﻿// IL code: Function_Call_Spread_Multiple
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cf
+				// Method begins at RVA 0x21c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e1
+					// Method begins at RVA 0x21d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d8
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x212c
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c6
+			// Method begins at RVA 0x21ba
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,7 +192,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 217 (0xd9)
+		// Code size: 206 (0xce)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Multiple/Scope,
@@ -254,27 +254,20 @@
 		IL_00a2: ldloc.3
 		IL_00a3: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
 		IL_00a8: stloc.s 4
-		IL_00aa: ldc.i4.1
-		IL_00ab: newarr [System.Runtime]System.Object
-		IL_00b0: dup
-		IL_00b1: ldc.i4.0
-		IL_00b2: ldloc.0
-		IL_00b3: stelem.ref
-		IL_00b4: ldc.i4.0
-		IL_00b5: ldelem.ref
-		IL_00b6: castclass Modules.Function_Call_Spread_Multiple/Scope
-		IL_00bb: ldftn object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
-		IL_00c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00c6: ldc.i4.1
-		IL_00c7: newarr [System.Runtime]System.Object
-		IL_00cc: dup
-		IL_00cd: ldc.i4.0
-		IL_00ce: ldloc.0
-		IL_00cf: stelem.ref
-		IL_00d0: ldloc.s 4
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00d7: pop
-		IL_00d8: ret
+		IL_00aa: ldloc.0
+		IL_00ab: castclass Modules.Function_Call_Spread_Multiple/Scope
+		IL_00b0: ldftn object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
+		IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00bb: ldc.i4.1
+		IL_00bc: newarr [System.Runtime]System.Object
+		IL_00c1: dup
+		IL_00c2: ldc.i4.0
+		IL_00c3: ldloc.0
+		IL_00c4: stelem.ref
+		IL_00c5: ldloc.s 4
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_00cc: pop
+		IL_00cd: ret
 	} // end of method Function_Call_Spread_Multiple::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Multiple
@@ -286,7 +279,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ea
+		// Method begins at RVA 0x21de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Call_Spread_StringIterable
+﻿// IL code: Function_Call_Spread_StringIterable
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216f
+				// Method begins at RVA 0x2167
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2181
+					// Method begins at RVA 0x2179
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2178
+				// Method begins at RVA 0x2170
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d8
+			// Method begins at RVA 0x20d0
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2166
+			// Method begins at RVA 0x215e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,7 +192,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 124 (0x7c)
+		// Code size: 113 (0x71)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_StringIterable/Scope,
@@ -233,27 +233,20 @@
 		IL_0045: ldloc.3
 		IL_0046: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
 		IL_004b: stloc.s 4
-		IL_004d: ldc.i4.1
-		IL_004e: newarr [System.Runtime]System.Object
-		IL_0053: dup
-		IL_0054: ldc.i4.0
-		IL_0055: ldloc.0
-		IL_0056: stelem.ref
-		IL_0057: ldc.i4.0
-		IL_0058: ldelem.ref
-		IL_0059: castclass Modules.Function_Call_Spread_StringIterable/Scope
-		IL_005e: ldftn object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
-		IL_0064: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: ldloc.s 4
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_007a: pop
-		IL_007b: ret
+		IL_004d: ldloc.0
+		IL_004e: castclass Modules.Function_Call_Spread_StringIterable/Scope
+		IL_0053: ldftn object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
+		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_005e: ldc.i4.1
+		IL_005f: newarr [System.Runtime]System.Object
+		IL_0064: dup
+		IL_0065: ldc.i4.0
+		IL_0066: ldloc.0
+		IL_0067: stelem.ref
+		IL_0068: ldloc.s 4
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+		IL_006f: pop
+		IL_0070: ret
 	} // end of method Function_Call_Spread_StringIterable::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_StringIterable
@@ -265,7 +258,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218a
+		// Method begins at RVA 0x2182
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Capture_HasScopesParameter
+﻿// IL code: Function_Capture_HasScopesParameter
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20e4
+				// Method begins at RVA 0x20ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d3
+			// Method begins at RVA 0x20bd
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -73,7 +73,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20db
+			// Method begins at RVA 0x20c5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -99,7 +99,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 119 (0x77)
+		// Code size: 97 (0x61)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Capture_HasScopesParameter/Scope,
@@ -133,25 +133,16 @@
 		IL_0034: ldc.r8 42
 		IL_003d: box [System.Runtime]System.Double
 		IL_0042: stfld object Modules.Function_Capture_HasScopesParameter/Scope::outerValue
-		IL_0047: ldc.i4.1
-		IL_0048: newarr [System.Runtime]System.Object
-		IL_004d: dup
-		IL_004e: ldc.i4.0
-		IL_004f: ldloc.0
-		IL_0050: stelem.ref
-		IL_0051: ldc.i4.0
-		IL_0052: ldelem.ref
-		IL_0053: castclass Modules.Function_Capture_HasScopesParameter/Scope
-		IL_0058: ldftn object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
-		IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0063: ldnull
-		IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0069: stloc.2
-		IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006f: ldloc.2
-		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0075: pop
-		IL_0076: ret
+		IL_0047: ldloc.0
+		IL_0048: castclass Modules.Function_Capture_HasScopesParameter/Scope
+		IL_004d: ldnull
+		IL_004e: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
+		IL_0053: stloc.2
+		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0059: ldloc.2
+		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005f: pop
+		IL_0060: ret
 	} // end of method Function_Capture_HasScopesParameter::__js_module_init__
 
 } // end of class Modules.Function_Capture_HasScopesParameter
@@ -163,7 +154,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20ed
+		// Method begins at RVA 0x20d7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_ClosureEscapesScope_ObjectLiteralProperty
+﻿// IL code: Function_ClosureEscapesScope_ObjectLiteralProperty
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2201
+					// Method begins at RVA 0x21d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21c0
+				// Method begins at RVA 0x2194
 				// Header size: 12
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f8
+				// Method begins at RVA 0x21cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x213c
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -182,7 +182,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ef
+			// Method begins at RVA 0x21c3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -208,7 +208,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 268 (0x10c)
+		// Code size: 224 (0xe0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope,
@@ -240,71 +240,53 @@
 		IL_0030: stloc.s 4
 		IL_0032: ldloc.s 4
 		IL_0034: stloc.1
-		IL_0035: ldc.i4.1
-		IL_0036: newarr [System.Runtime]System.Object
-		IL_003b: dup
-		IL_003c: ldc.i4.0
-		IL_003d: ldloc.0
-		IL_003e: stelem.ref
-		IL_003f: ldc.i4.0
-		IL_0040: ldelem.ref
-		IL_0041: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
-		IL_0046: ldftn object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
-		IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0051: ldnull
-		IL_0052: ldc.r8 10
-		IL_005b: box [System.Runtime]System.Double
-		IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0065: stloc.s 4
-		IL_0067: ldloc.s 4
-		IL_0069: stloc.2
-		IL_006a: ldloc.2
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: stloc.s 4
-		IL_0072: ldloc.s 4
-		IL_0074: ldstr "multiply"
-		IL_0079: ldc.r8 5
-		IL_0082: box [System.Runtime]System.Double
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_008c: stloc.s 4
-		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0093: ldstr "a.multiply(5):"
-		IL_0098: ldloc.s 4
-		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_009f: pop
-		IL_00a0: ldc.i4.1
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldloc.0
-		IL_00a9: stelem.ref
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldelem.ref
-		IL_00ac: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
-		IL_00b1: ldftn object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
-		IL_00b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00bc: ldnull
-		IL_00bd: ldc.r8 3
-		IL_00c6: box [System.Runtime]System.Double
-		IL_00cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_00d0: stloc.s 4
-		IL_00d2: ldloc.s 4
-		IL_00d4: stloc.3
-		IL_00d5: ldloc.3
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: stloc.s 4
-		IL_00dd: ldloc.s 4
-		IL_00df: ldstr "multiply"
-		IL_00e4: ldc.r8 7
-		IL_00ed: box [System.Runtime]System.Double
-		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f7: stloc.s 4
-		IL_00f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fe: ldstr "b.multiply(7):"
-		IL_0103: ldloc.s 4
-		IL_0105: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_010a: pop
-		IL_010b: ret
+		IL_0035: ldloc.0
+		IL_0036: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
+		IL_003b: ldnull
+		IL_003c: ldc.r8 10
+		IL_0045: box [System.Runtime]System.Double
+		IL_004a: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
+		IL_004f: stloc.s 4
+		IL_0051: ldloc.s 4
+		IL_0053: stloc.2
+		IL_0054: ldloc.2
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005a: stloc.s 4
+		IL_005c: ldloc.s 4
+		IL_005e: ldstr "multiply"
+		IL_0063: ldc.r8 5
+		IL_006c: box [System.Runtime]System.Double
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0076: stloc.s 4
+		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007d: ldstr "a.multiply(5):"
+		IL_0082: ldloc.s 4
+		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0089: pop
+		IL_008a: ldloc.0
+		IL_008b: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
+		IL_0090: ldnull
+		IL_0091: ldc.r8 3
+		IL_009a: box [System.Runtime]System.Double
+		IL_009f: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
+		IL_00a4: stloc.s 4
+		IL_00a6: ldloc.s 4
+		IL_00a8: stloc.3
+		IL_00a9: ldloc.3
+		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00af: stloc.s 4
+		IL_00b1: ldloc.s 4
+		IL_00b3: ldstr "multiply"
+		IL_00b8: ldc.r8 7
+		IL_00c1: box [System.Runtime]System.Double
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00cb: stloc.s 4
+		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d2: ldstr "b.multiply(7):"
+		IL_00d7: ldloc.s 4
+		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00de: pop
+		IL_00df: ret
 	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::__js_module_init__
 
 } // end of class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty
@@ -316,7 +298,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220a
+		// Method begins at RVA 0x21de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_ClosureMutatesOuterVariable
+﻿// IL code: Function_ClosureMutatesOuterVariable
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ba
+					// Method begins at RVA 0x21a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2164
+				// Method begins at RVA 0x214c
 				// Header size: 12
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -94,7 +94,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b1
+				// Method begins at RVA 0x2199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x211c
+			// Method begins at RVA 0x2104
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -178,7 +178,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21a8
+			// Method begins at RVA 0x2190
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -204,7 +204,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 190 (0xbe)
+		// Code size: 168 (0xa8)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureMutatesOuterVariable/Scope,
@@ -235,52 +235,43 @@
 		IL_0030: stloc.3
 		IL_0031: ldloc.3
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_ClosureMutatesOuterVariable/Scope
-		IL_0044: ldftn object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: ldc.r8 10
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0063: stloc.3
-		IL_0064: ldloc.3
-		IL_0065: stloc.2
-		IL_0066: ldloc.2
-		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0071: stloc.3
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: ldstr "First increment:"
-		IL_007c: ldloc.3
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0082: pop
-		IL_0083: ldloc.2
-		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_008e: stloc.3
-		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0094: ldstr "Second increment:"
-		IL_0099: ldloc.3
-		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_009f: pop
-		IL_00a0: ldloc.2
-		IL_00a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00ab: stloc.3
-		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b1: ldstr "Third increment:"
-		IL_00b6: ldloc.3
-		IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00bc: pop
-		IL_00bd: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_ClosureMutatesOuterVariable/Scope
+		IL_0039: ldnull
+		IL_003a: ldc.r8 10
+		IL_0043: box [System.Runtime]System.Double
+		IL_0048: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, object)
+		IL_004d: stloc.3
+		IL_004e: ldloc.3
+		IL_004f: stloc.2
+		IL_0050: ldloc.2
+		IL_0051: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005b: stloc.3
+		IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0061: ldstr "First increment:"
+		IL_0066: ldloc.3
+		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_006c: pop
+		IL_006d: ldloc.2
+		IL_006e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0078: stloc.3
+		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007e: ldstr "Second increment:"
+		IL_0083: ldloc.3
+		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0089: pop
+		IL_008a: ldloc.2
+		IL_008b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0095: stloc.3
+		IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009b: ldstr "Third increment:"
+		IL_00a0: ldloc.3
+		IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a6: pop
+		IL_00a7: ret
 	} // end of method Function_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.Function_ClosureMutatesOuterVariable
@@ -292,7 +283,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c3
+		// Method begins at RVA 0x21ab
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Closure_CapturedBoolean_AssignAndRead
+﻿// IL code: Function_Closure_CapturedBoolean_AssignAndRead
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x215d
+					// Method begins at RVA 0x2149
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2135
+				// Method begins at RVA 0x2121
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2154
+				// Method begins at RVA 0x2140
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,7 +106,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20a0
 			// Header size: 12
 			// Code size: 117 (0x75)
 			.maxstack 8
@@ -186,7 +186,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214b
+			// Method begins at RVA 0x2137
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -212,7 +212,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope,
@@ -242,21 +242,12 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope
-		IL_0044: ldftn object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method Function_Closure_CapturedBoolean_AssignAndRead::__js_module_init__
 
 } // end of class Modules.Function_Closure_CapturedBoolean_AssignAndRead
@@ -268,7 +259,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2166
+		// Method begins at RVA 0x2152
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+﻿// IL code: Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b0
+					// Method begins at RVA 0x2198
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x217c
+				// Method begins at RVA 0x2164
 				// Header size: 12
 				// Code size: 22 (0x16)
 				.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a7
+				// Method begins at RVA 0x218f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -110,7 +110,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20d0
+			// Method begins at RVA 0x20b8
 			// Header size: 12
 			// Code size: 158 (0x9e)
 			.maxstack 8
@@ -197,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219e
+			// Method begins at RVA 0x2186
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -223,7 +223,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 113 (0x71)
+		// Code size: 91 (0x5b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope,
@@ -253,27 +253,18 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope
-		IL_0044: ldftn object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: ldc.r8 10
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0063: stloc.2
-		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0069: ldloc.2
-		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006f: pop
-		IL_0070: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope
+		IL_0039: ldnull
+		IL_003a: ldc.r8 10
+		IL_0043: box [System.Runtime]System.Double
+		IL_0048: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
+		IL_004d: stloc.2
+		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0053: ldloc.2
+		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0059: pop
+		IL_005a: ret
 	} // end of method Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter::__js_module_init__
 
 } // end of class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
@@ -285,7 +276,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b9
+		// Method begins at RVA 0x21a1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_GlobalFunctionCallsGlobalFunction
+﻿// IL code: Function_GlobalFunctionCallsGlobalFunction
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2145
+				// Method begins at RVA 0x212f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20f3
+			// Method begins at RVA 0x20dd
 			// Header size: 1
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214e
+				// Method begins at RVA 0x2138
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x211b
+			// Method begins at RVA 0x2105
 			// Header size: 1
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -133,7 +133,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213c
+			// Method begins at RVA 0x2126
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,7 +159,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 151 (0x97)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope,
@@ -202,27 +202,18 @@
 		IL_004e: ldloc.0
 		IL_004f: ldloc.2
 		IL_0050: stfld object Modules.Function_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
-		IL_0055: ldc.i4.1
-		IL_0056: newarr [System.Runtime]System.Object
-		IL_005b: dup
-		IL_005c: ldc.i4.0
-		IL_005d: ldloc.0
-		IL_005e: stelem.ref
-		IL_005f: ldc.i4.0
-		IL_0060: ldelem.ref
-		IL_0061: castclass Modules.Function_GlobalFunctionCallsGlobalFunction/Scope
-		IL_0066: ldftn object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
-		IL_006c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0071: ldnull
-		IL_0072: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0077: pop
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldstr "finally is now"
-		IL_0082: ldc.r8 3
-		IL_008b: box [System.Runtime]System.Double
-		IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0095: pop
-		IL_0096: ret
+		IL_0055: ldloc.0
+		IL_0056: castclass Modules.Function_GlobalFunctionCallsGlobalFunction/Scope
+		IL_005b: ldnull
+		IL_005c: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
+		IL_0061: pop
+		IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0067: ldstr "finally is now"
+		IL_006c: ldc.r8 3
+		IL_0075: box [System.Runtime]System.Double
+		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Function_GlobalFunctionCallsGlobalFunction::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionCallsGlobalFunction
@@ -234,7 +225,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2157
+		// Method begins at RVA 0x2141
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_GlobalFunctionChangesGlobalVariableValue
+﻿// IL code: Function_GlobalFunctionChangesGlobalVariableValue
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e4
+				// Method begins at RVA 0x21d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x213c
+			// Method begins at RVA 0x2128
 			// Header size: 12
 			// Code size: 147 (0x93)
 			.maxstack 8
@@ -140,7 +140,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21db
+			// Method begins at RVA 0x21c7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -166,7 +166,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 224 (0xe0)
+		// Code size: 202 (0xca)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope,
@@ -228,46 +228,37 @@
 		IL_0080: stelem.ref
 		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_0086: pop
-		IL_0087: ldc.i4.1
-		IL_0088: newarr [System.Runtime]System.Object
-		IL_008d: dup
-		IL_008e: ldc.i4.0
-		IL_008f: ldloc.0
-		IL_0090: stelem.ref
-		IL_0091: ldc.i4.0
-		IL_0092: ldelem.ref
-		IL_0093: castclass Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope
-		IL_0098: ldftn object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
-		IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00a3: ldnull
-		IL_00a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00a9: pop
-		IL_00aa: ldloc.0
-		IL_00ab: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
-		IL_00b0: stloc.2
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b6: ldc.i4.4
-		IL_00b7: newarr [System.Runtime]System.Object
-		IL_00bc: dup
-		IL_00bd: ldc.i4.0
-		IL_00be: ldstr "End - counter:"
-		IL_00c3: stelem.ref
-		IL_00c4: dup
-		IL_00c5: ldc.i4.1
-		IL_00c6: ldloc.2
-		IL_00c7: stelem.ref
-		IL_00c8: dup
-		IL_00c9: ldc.i4.2
-		IL_00ca: ldstr "message:"
-		IL_00cf: stelem.ref
-		IL_00d0: dup
-		IL_00d1: ldc.i4.3
-		IL_00d2: ldloc.0
-		IL_00d3: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
-		IL_00d8: stelem.ref
-		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00de: pop
-		IL_00df: ret
+		IL_0087: ldloc.0
+		IL_0088: castclass Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope
+		IL_008d: ldnull
+		IL_008e: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
+		IL_0093: pop
+		IL_0094: ldloc.0
+		IL_0095: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
+		IL_009a: stloc.2
+		IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a0: ldc.i4.4
+		IL_00a1: newarr [System.Runtime]System.Object
+		IL_00a6: dup
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldstr "End - counter:"
+		IL_00ad: stelem.ref
+		IL_00ae: dup
+		IL_00af: ldc.i4.1
+		IL_00b0: ldloc.2
+		IL_00b1: stelem.ref
+		IL_00b2: dup
+		IL_00b3: ldc.i4.2
+		IL_00b4: ldstr "message:"
+		IL_00b9: stelem.ref
+		IL_00ba: dup
+		IL_00bb: ldc.i4.3
+		IL_00bc: ldloc.0
+		IL_00bd: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
+		IL_00c2: stelem.ref
+		IL_00c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00c8: pop
+		IL_00c9: ret
 	} // end of method Function_GlobalFunctionChangesGlobalVariableValue::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionChangesGlobalVariableValue
@@ -279,7 +270,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ed
+		// Method begins at RVA 0x21d9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_GlobalFunctionLogsGlobalVariable
+﻿// IL code: Function_GlobalFunctionLogsGlobalVariable
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x210a
+				// Method begins at RVA 0x20f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d2
+			// Method begins at RVA 0x20bc
 			// Header size: 1
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -88,7 +88,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2101
+			// Method begins at RVA 0x20eb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -114,7 +114,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 118 (0x76)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope,
@@ -151,21 +151,12 @@
 		IL_003f: ldc.r8 42
 		IL_0048: box [System.Runtime]System.Double
 		IL_004d: stfld object Modules.Function_GlobalFunctionLogsGlobalVariable/Scope::globalNumber
-		IL_0052: ldc.i4.1
-		IL_0053: newarr [System.Runtime]System.Object
-		IL_0058: dup
-		IL_0059: ldc.i4.0
-		IL_005a: ldloc.0
-		IL_005b: stelem.ref
-		IL_005c: ldc.i4.0
-		IL_005d: ldelem.ref
-		IL_005e: castclass Modules.Function_GlobalFunctionLogsGlobalVariable/Scope
-		IL_0063: ldftn object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
-		IL_0069: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_006e: ldnull
-		IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0074: pop
-		IL_0075: ret
+		IL_0052: ldloc.0
+		IL_0053: castclass Modules.Function_GlobalFunctionLogsGlobalVariable/Scope
+		IL_0058: ldnull
+		IL_0059: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method Function_GlobalFunctionLogsGlobalVariable::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionLogsGlobalVariable
@@ -177,7 +168,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2113
+		// Method begins at RVA 0x20fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+﻿// IL code: Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d4
+					// Method begins at RVA 0x21c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2144
+				// Method begins at RVA 0x2130
 				// Header size: 12
 				// Code size: 114 (0x72)
 				.maxstack 8
@@ -115,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x21b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -142,7 +142,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20fc
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -201,7 +201,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c2
+			// Method begins at RVA 0x21ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -227,7 +227,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 160 (0xa0)
+		// Code size: 138 (0x8a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope,
@@ -263,36 +263,27 @@
 		IL_0036: ldc.r8 10
 		IL_003f: box [System.Runtime]System.Double
 		IL_0044: stfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::outerVar
-		IL_0049: ldc.i4.1
-		IL_004a: newarr [System.Runtime]System.Object
-		IL_004f: dup
-		IL_0050: ldc.i4.0
-		IL_0051: ldloc.0
-		IL_0052: stelem.ref
-		IL_0053: ldc.i4.0
-		IL_0054: ldelem.ref
-		IL_0055: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
-		IL_005a: ldftn object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
-		IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0065: ldnull
-		IL_0066: ldc.r8 7
-		IL_006f: box [System.Runtime]System.Double
-		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0079: stloc.s 4
-		IL_007b: ldloc.s 4
-		IL_007d: stloc.2
-		IL_007e: ldloc.2
-		IL_007f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0089: stloc.s 4
-		IL_008b: ldloc.s 4
-		IL_008d: stloc.3
-		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0093: ldstr "Result:"
-		IL_0098: ldloc.3
-		IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_009e: pop
-		IL_009f: ret
+		IL_0049: ldloc.0
+		IL_004a: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
+		IL_004f: ldnull
+		IL_0050: ldc.r8 7
+		IL_0059: box [System.Runtime]System.Double
+		IL_005e: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
+		IL_0063: stloc.s 4
+		IL_0065: ldloc.s 4
+		IL_0067: stloc.2
+		IL_0068: ldloc.2
+		IL_0069: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0073: stloc.s 4
+		IL_0075: ldloc.s 4
+		IL_0077: stloc.3
+		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007d: ldstr "Result:"
+		IL_0082: ldloc.3
+		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0088: pop
+		IL_0089: ret
 	} // end of method Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
@@ -304,7 +295,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dd
+		// Method begins at RVA 0x21c9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_NestedFunctionAccessesMultipleScopes
+﻿// IL code: Function_NestedFunctionAccessesMultipleScopes
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2191
+					// Method begins at RVA 0x2179
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2120
+				// Method begins at RVA 0x2108
 				// Header size: 12
 				// Code size: 83 (0x53)
 				.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2188
+				// Method begins at RVA 0x2170
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -128,7 +128,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 82 (0x52)
 			.maxstack 8
@@ -200,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217f
+			// Method begins at RVA 0x2167
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -226,7 +226,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 98 (0x62)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope,
@@ -259,21 +259,12 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "I am global"
 		IL_0039: stfld string Modules.Function_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-		IL_003e: ldc.i4.1
-		IL_003f: newarr [System.Runtime]System.Object
-		IL_0044: dup
-		IL_0045: ldc.i4.0
-		IL_0046: ldloc.0
-		IL_0047: stelem.ref
-		IL_0048: ldc.i4.0
-		IL_0049: ldelem.ref
-		IL_004a: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
-		IL_004f: ldftn object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005a: ldnull
-		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0060: pop
-		IL_0061: ret
+		IL_003e: ldloc.0
+		IL_003f: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
+		IL_0044: ldnull
+		IL_0045: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method Function_NestedFunctionAccessesMultipleScopes::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionAccessesMultipleScopes
@@ -285,7 +276,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x219a
+		// Method begins at RVA 0x2182
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_NestedFunctionLogsOuterParameter
+﻿// IL code: Function_NestedFunctionLogsOuterParameter
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2158
+					// Method begins at RVA 0x2144
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2115
+				// Method begins at RVA 0x2101
 				// Header size: 1
 				// Code size: 48 (0x30)
 				.maxstack 8
@@ -89,7 +89,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214f
+				// Method begins at RVA 0x213b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20d0
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -173,7 +173,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2146
+			// Method begins at RVA 0x2132
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -199,7 +199,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 115 (0x73)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionLogsOuterParameter/Scope,
@@ -231,31 +231,22 @@
 		IL_0030: stloc.3
 		IL_0031: ldloc.3
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_NestedFunctionLogsOuterParameter/Scope
-		IL_0044: ldftn object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: ldstr "Value from outer"
-		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_005a: stloc.3
-		IL_005b: ldloc.3
-		IL_005c: stloc.2
-		IL_005d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0062: stloc.s 4
-		IL_0064: ldloc.2
-		IL_0065: ldloc.s 4
-		IL_0067: ldstr "Value from inner"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0071: pop
-		IL_0072: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_NestedFunctionLogsOuterParameter/Scope
+		IL_0039: ldnull
+		IL_003a: ldstr "Value from outer"
+		IL_003f: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
+		IL_0044: stloc.3
+		IL_0045: ldloc.3
+		IL_0046: stloc.2
+		IL_0047: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004c: stloc.s 4
+		IL_004e: ldloc.2
+		IL_004f: ldloc.s 4
+		IL_0051: ldstr "Value from inner"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method Function_NestedFunctionLogsOuterParameter::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionLogsOuterParameter
@@ -267,7 +258,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2161
+		// Method begins at RVA 0x214d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_NewExpression_CapturesOuterCtor
+﻿// IL code: Function_NewExpression_CapturesOuterCtor
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a5
+					// Method begins at RVA 0x2191
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2143
+				// Method begins at RVA 0x212f
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ae
+					// Method begins at RVA 0x219a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -97,7 +97,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2160
+				// Method begins at RVA 0x214c
 				// Header size: 12
 				// Code size: 39 (0x27)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219c
+				// Method begins at RVA 0x2188
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -167,7 +167,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20ac
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -252,7 +252,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2193
+			// Method begins at RVA 0x217f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -278,7 +278,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 99 (0x63)
+		// Code size: 77 (0x4d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewExpression_CapturesOuterCtor/Scope,
@@ -308,25 +308,16 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_NewExpression_CapturesOuterCtor/Scope
-		IL_0044: ldftn object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: stloc.2
-		IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005b: ldloc.2
-		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0061: pop
-		IL_0062: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_NewExpression_CapturesOuterCtor/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
+		IL_003f: stloc.2
+		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0045: ldloc.2
+		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004b: pop
+		IL_004c: ret
 	} // end of method Function_NewExpression_CapturesOuterCtor::__js_module_init__
 
 } // end of class Modules.Function_NewExpression_CapturesOuterCtor
@@ -338,7 +329,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b7
+		// Method begins at RVA 0x21a3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_NewTarget_Arrow_Inherits
+﻿// IL code: Function_NewTarget_Arrow_Inherits
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2181
+					// Method begins at RVA 0x2169
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2138
+				// Method begins at RVA 0x2120
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2178
+				// Method begins at RVA 0x2160
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -112,7 +112,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20cc
+			// Method begins at RVA 0x20b4
 			// Header size: 12
 			// Code size: 95 (0x5f)
 			.maxstack 8
@@ -182,7 +182,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216f
+			// Method begins at RVA 0x2157
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -208,7 +208,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 110 (0x6e)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewTarget_Arrow_Inherits/Scope,
@@ -244,21 +244,12 @@
 		IL_003f: newarr [System.Runtime]System.Object
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
 		IL_0049: pop
-		IL_004a: ldc.i4.1
-		IL_004b: newarr [System.Runtime]System.Object
-		IL_0050: dup
-		IL_0051: ldc.i4.0
-		IL_0052: ldloc.0
-		IL_0053: stelem.ref
-		IL_0054: ldc.i4.0
-		IL_0055: ldelem.ref
-		IL_0056: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
-		IL_005b: ldftn object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
-		IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0066: ldnull
-		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_006c: pop
-		IL_006d: ret
+		IL_004a: ldloc.0
+		IL_004b: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
+		IL_0050: ldnull
+		IL_0051: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method Function_NewTarget_Arrow_Inherits::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_Arrow_Inherits
@@ -270,7 +261,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218a
+		// Method begins at RVA 0x2172
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_NewTarget_NewVsCall
+﻿// IL code: Function_NewTarget_NewVsCall
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213b
+				// Method begins at RVA 0x2123
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20cc
+			// Method begins at RVA 0x20b4
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -112,7 +112,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2132
+			// Method begins at RVA 0x211a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -138,7 +138,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 110 (0x6e)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewTarget_NewVsCall/Scope,
@@ -174,21 +174,12 @@
 		IL_003f: newarr [System.Runtime]System.Object
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
 		IL_0049: pop
-		IL_004a: ldc.i4.1
-		IL_004b: newarr [System.Runtime]System.Object
-		IL_0050: dup
-		IL_0051: ldc.i4.0
-		IL_0052: ldloc.0
-		IL_0053: stelem.ref
-		IL_0054: ldc.i4.0
-		IL_0055: ldelem.ref
-		IL_0056: castclass Modules.Function_NewTarget_NewVsCall/Scope
-		IL_005b: ldftn object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
-		IL_0061: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0066: ldnull
-		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_006c: pop
-		IL_006d: ret
+		IL_004a: ldloc.0
+		IL_004b: castclass Modules.Function_NewTarget_NewVsCall/Scope
+		IL_0050: ldnull
+		IL_0051: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method Function_NewTarget_NewVsCall::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_NewVsCall
@@ -200,7 +191,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2144
+		// Method begins at RVA 0x212c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_RestParameters_Basic
+﻿// IL code: Function_RestParameters_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2204
+				// Method begins at RVA 0x21e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2216
+					// Method begins at RVA 0x21f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220d
+				// Method begins at RVA 0x21e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +86,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x2160
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -152,7 +152,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21fb
+			// Method begins at RVA 0x21d7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -178,7 +178,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 293 (0x125)
+		// Code size: 260 (0x104)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Basic/Scope,
@@ -208,89 +208,68 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_0044: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldc.i4.3
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldc.r8 1
-		IL_0060: box [System.Runtime]System.Double
-		IL_0065: stelem.ref
-		IL_0066: dup
-		IL_0067: ldc.i4.1
-		IL_0068: ldc.r8 2
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stelem.ref
-		IL_0077: dup
-		IL_0078: ldc.i4.2
-		IL_0079: ldc.r8 3
-		IL_0082: box [System.Runtime]System.Double
-		IL_0087: stelem.ref
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_008d: stloc.2
-		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0093: ldloc.2
-		IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0099: pop
-		IL_009a: ldc.i4.1
-		IL_009b: newarr [System.Runtime]System.Object
-		IL_00a0: dup
-		IL_00a1: ldc.i4.0
-		IL_00a2: ldloc.0
-		IL_00a3: stelem.ref
-		IL_00a4: ldc.i4.0
-		IL_00a5: ldelem.ref
-		IL_00a6: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_00ab: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_00b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00b6: ldc.i4.2
-		IL_00b7: newarr [System.Runtime]System.Object
-		IL_00bc: dup
-		IL_00bd: ldc.i4.0
-		IL_00be: ldc.r8 10
-		IL_00c7: box [System.Runtime]System.Double
-		IL_00cc: stelem.ref
-		IL_00cd: dup
-		IL_00ce: ldc.i4.1
-		IL_00cf: ldc.r8 20
-		IL_00d8: box [System.Runtime]System.Double
-		IL_00dd: stelem.ref
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_00e3: stloc.2
-		IL_00e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e9: ldloc.2
-		IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ef: pop
-		IL_00f0: ldc.i4.1
-		IL_00f1: newarr [System.Runtime]System.Object
-		IL_00f6: dup
-		IL_00f7: ldc.i4.0
-		IL_00f8: ldloc.0
-		IL_00f9: stelem.ref
-		IL_00fa: ldc.i4.0
-		IL_00fb: ldelem.ref
-		IL_00fc: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_0101: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_0107: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_010c: ldc.i4.0
-		IL_010d: newarr [System.Runtime]System.Object
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_0117: stloc.2
-		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011d: ldloc.2
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0123: pop
-		IL_0124: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_RestParameters_Basic/Scope
+		IL_0039: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
+		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0044: ldc.i4.3
+		IL_0045: newarr [System.Runtime]System.Object
+		IL_004a: dup
+		IL_004b: ldc.i4.0
+		IL_004c: ldc.r8 1
+		IL_0055: box [System.Runtime]System.Double
+		IL_005a: stelem.ref
+		IL_005b: dup
+		IL_005c: ldc.i4.1
+		IL_005d: ldc.r8 2
+		IL_0066: box [System.Runtime]System.Double
+		IL_006b: stelem.ref
+		IL_006c: dup
+		IL_006d: ldc.i4.2
+		IL_006e: ldc.r8 3
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: stelem.ref
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_0082: stloc.2
+		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0088: ldloc.2
+		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008e: pop
+		IL_008f: ldloc.0
+		IL_0090: castclass Modules.Function_RestParameters_Basic/Scope
+		IL_0095: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
+		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00a0: ldc.i4.2
+		IL_00a1: newarr [System.Runtime]System.Object
+		IL_00a6: dup
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldc.r8 10
+		IL_00b1: box [System.Runtime]System.Double
+		IL_00b6: stelem.ref
+		IL_00b7: dup
+		IL_00b8: ldc.i4.1
+		IL_00b9: ldc.r8 20
+		IL_00c2: box [System.Runtime]System.Double
+		IL_00c7: stelem.ref
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_00cd: stloc.2
+		IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d3: ldloc.2
+		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d9: pop
+		IL_00da: ldloc.0
+		IL_00db: castclass Modules.Function_RestParameters_Basic/Scope
+		IL_00e0: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
+		IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00eb: ldc.i4.0
+		IL_00ec: newarr [System.Runtime]System.Object
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
+		IL_00f6: stloc.2
+		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fc: ldloc.2
+		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0102: pop
+		IL_0103: ret
 	} // end of method Function_RestParameters_Basic::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_Basic
@@ -302,7 +281,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x221f
+		// Method begins at RVA 0x21fb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_RestParameters_MultipleNamed
+﻿// IL code: Function_RestParameters_MultipleNamed
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21fb
+				// Method begins at RVA 0x21db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x220d
+					// Method begins at RVA 0x21ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2204
+				// Method begins at RVA 0x21e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x217c
+			// Method begins at RVA 0x215c
 			// Header size: 12
 			// Code size: 106 (0x6a)
 			.maxstack 8
@@ -159,7 +159,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21f2
+			// Method begins at RVA 0x21d2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -185,7 +185,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 288 (0x120)
+		// Code size: 255 (0xff)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_MultipleNamed/Scope,
@@ -215,104 +215,83 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_0044: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_004f: ldc.i4.5
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldstr "["
-		IL_005c: stelem.ref
-		IL_005d: dup
-		IL_005e: ldc.i4.1
-		IL_005f: ldstr "]"
-		IL_0064: stelem.ref
-		IL_0065: dup
-		IL_0066: ldc.i4.2
-		IL_0067: ldstr "a"
-		IL_006c: stelem.ref
-		IL_006d: dup
-		IL_006e: ldc.i4.3
-		IL_006f: ldstr "b"
-		IL_0074: stelem.ref
-		IL_0075: dup
-		IL_0076: ldc.i4.4
-		IL_0077: ldstr "c"
-		IL_007c: stelem.ref
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_0082: stloc.2
-		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0088: ldloc.2
-		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008e: pop
-		IL_008f: ldc.i4.1
-		IL_0090: newarr [System.Runtime]System.Object
-		IL_0095: dup
-		IL_0096: ldc.i4.0
-		IL_0097: ldloc.0
-		IL_0098: stelem.ref
-		IL_0099: ldc.i4.0
-		IL_009a: ldelem.ref
-		IL_009b: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_00a0: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00ab: ldc.i4.3
-		IL_00ac: newarr [System.Runtime]System.Object
-		IL_00b1: dup
-		IL_00b2: ldc.i4.0
-		IL_00b3: ldstr "<"
-		IL_00b8: stelem.ref
-		IL_00b9: dup
-		IL_00ba: ldc.i4.1
-		IL_00bb: ldstr ">"
-		IL_00c0: stelem.ref
-		IL_00c1: dup
-		IL_00c2: ldc.i4.2
-		IL_00c3: ldstr "hello"
-		IL_00c8: stelem.ref
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_00ce: stloc.2
-		IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d4: ldloc.2
-		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00da: pop
-		IL_00db: ldc.i4.1
-		IL_00dc: newarr [System.Runtime]System.Object
-		IL_00e1: dup
-		IL_00e2: ldc.i4.0
-		IL_00e3: ldloc.0
-		IL_00e4: stelem.ref
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldelem.ref
-		IL_00e7: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_00ec: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00f7: ldc.i4.2
-		IL_00f8: newarr [System.Runtime]System.Object
-		IL_00fd: dup
-		IL_00fe: ldc.i4.0
-		IL_00ff: ldstr "{"
-		IL_0104: stelem.ref
-		IL_0105: dup
-		IL_0106: ldc.i4.1
-		IL_0107: ldstr "}"
-		IL_010c: stelem.ref
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_0112: stloc.2
-		IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0118: ldloc.2
-		IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011e: pop
-		IL_011f: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_RestParameters_MultipleNamed/Scope
+		IL_0039: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
+		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0044: ldc.i4.5
+		IL_0045: newarr [System.Runtime]System.Object
+		IL_004a: dup
+		IL_004b: ldc.i4.0
+		IL_004c: ldstr "["
+		IL_0051: stelem.ref
+		IL_0052: dup
+		IL_0053: ldc.i4.1
+		IL_0054: ldstr "]"
+		IL_0059: stelem.ref
+		IL_005a: dup
+		IL_005b: ldc.i4.2
+		IL_005c: ldstr "a"
+		IL_0061: stelem.ref
+		IL_0062: dup
+		IL_0063: ldc.i4.3
+		IL_0064: ldstr "b"
+		IL_0069: stelem.ref
+		IL_006a: dup
+		IL_006b: ldc.i4.4
+		IL_006c: ldstr "c"
+		IL_0071: stelem.ref
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
+		IL_0077: stloc.2
+		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007d: ldloc.2
+		IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0083: pop
+		IL_0084: ldloc.0
+		IL_0085: castclass Modules.Function_RestParameters_MultipleNamed/Scope
+		IL_008a: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
+		IL_0090: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_0095: ldc.i4.3
+		IL_0096: newarr [System.Runtime]System.Object
+		IL_009b: dup
+		IL_009c: ldc.i4.0
+		IL_009d: ldstr "<"
+		IL_00a2: stelem.ref
+		IL_00a3: dup
+		IL_00a4: ldc.i4.1
+		IL_00a5: ldstr ">"
+		IL_00aa: stelem.ref
+		IL_00ab: dup
+		IL_00ac: ldc.i4.2
+		IL_00ad: ldstr "hello"
+		IL_00b2: stelem.ref
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
+		IL_00b8: stloc.2
+		IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00be: ldloc.2
+		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c4: pop
+		IL_00c5: ldloc.0
+		IL_00c6: castclass Modules.Function_RestParameters_MultipleNamed/Scope
+		IL_00cb: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
+		IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_00d6: ldc.i4.2
+		IL_00d7: newarr [System.Runtime]System.Object
+		IL_00dc: dup
+		IL_00dd: ldc.i4.0
+		IL_00de: ldstr "{"
+		IL_00e3: stelem.ref
+		IL_00e4: dup
+		IL_00e5: ldc.i4.1
+		IL_00e6: ldstr "}"
+		IL_00eb: stelem.ref
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
+		IL_00f1: stloc.2
+		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f7: ldloc.2
+		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fd: pop
+		IL_00fe: ret
 	} // end of method Function_RestParameters_MultipleNamed::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_MultipleNamed
@@ -324,7 +303,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2216
+		// Method begins at RVA 0x21f6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_RestParameters_WithNamedParams
+﻿// IL code: Function_RestParameters_WithNamedParams
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2207
+				// Method begins at RVA 0x21e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2222
+						// Method begins at RVA 0x2202
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2219
+					// Method begins at RVA 0x21f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2210
+				// Method begins at RVA 0x21f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -109,7 +109,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x216c
+			// Method begins at RVA 0x214c
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -189,7 +189,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21fe
+			// Method begins at RVA 0x21de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -215,7 +215,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 272 (0x110)
+		// Code size: 239 (0xef)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_WithNamedParams/Scope,
@@ -245,96 +245,75 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_0044: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_004f: ldc.i4.4
-		IL_0050: newarr [System.Runtime]System.Object
-		IL_0055: dup
-		IL_0056: ldc.i4.0
-		IL_0057: ldstr "-"
-		IL_005c: stelem.ref
-		IL_005d: dup
-		IL_005e: ldc.i4.1
-		IL_005f: ldstr "a"
-		IL_0064: stelem.ref
-		IL_0065: dup
-		IL_0066: ldc.i4.2
-		IL_0067: ldstr "b"
-		IL_006c: stelem.ref
-		IL_006d: dup
-		IL_006e: ldc.i4.3
-		IL_006f: ldstr "c"
-		IL_0074: stelem.ref
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_007a: stloc.2
-		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0080: ldloc.2
-		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0086: pop
-		IL_0087: ldc.i4.1
-		IL_0088: newarr [System.Runtime]System.Object
-		IL_008d: dup
-		IL_008e: ldc.i4.0
-		IL_008f: ldloc.0
-		IL_0090: stelem.ref
-		IL_0091: ldc.i4.0
-		IL_0092: ldelem.ref
-		IL_0093: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_0098: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00a3: ldc.i4.3
-		IL_00a4: newarr [System.Runtime]System.Object
-		IL_00a9: dup
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldstr " "
-		IL_00b0: stelem.ref
-		IL_00b1: dup
-		IL_00b2: ldc.i4.1
-		IL_00b3: ldstr "hello"
-		IL_00b8: stelem.ref
-		IL_00b9: dup
-		IL_00ba: ldc.i4.2
-		IL_00bb: ldstr "world"
-		IL_00c0: stelem.ref
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_00c6: stloc.2
-		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cc: ldloc.2
-		IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d2: pop
-		IL_00d3: ldc.i4.1
-		IL_00d4: newarr [System.Runtime]System.Object
-		IL_00d9: dup
-		IL_00da: ldc.i4.0
-		IL_00db: ldloc.0
-		IL_00dc: stelem.ref
-		IL_00dd: ldc.i4.0
-		IL_00de: ldelem.ref
-		IL_00df: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_00e4: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_00ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00ef: ldc.i4.1
-		IL_00f0: newarr [System.Runtime]System.Object
-		IL_00f5: dup
-		IL_00f6: ldc.i4.0
-		IL_00f7: ldstr ","
-		IL_00fc: stelem.ref
-		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_0102: stloc.2
-		IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0108: ldloc.2
-		IL_0109: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010e: pop
-		IL_010f: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.Function_RestParameters_WithNamedParams/Scope
+		IL_0039: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
+		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0044: ldc.i4.4
+		IL_0045: newarr [System.Runtime]System.Object
+		IL_004a: dup
+		IL_004b: ldc.i4.0
+		IL_004c: ldstr "-"
+		IL_0051: stelem.ref
+		IL_0052: dup
+		IL_0053: ldc.i4.1
+		IL_0054: ldstr "a"
+		IL_0059: stelem.ref
+		IL_005a: dup
+		IL_005b: ldc.i4.2
+		IL_005c: ldstr "b"
+		IL_0061: stelem.ref
+		IL_0062: dup
+		IL_0063: ldc.i4.3
+		IL_0064: ldstr "c"
+		IL_0069: stelem.ref
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
+		IL_006f: stloc.2
+		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0075: ldloc.2
+		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007b: pop
+		IL_007c: ldloc.0
+		IL_007d: castclass Modules.Function_RestParameters_WithNamedParams/Scope
+		IL_0082: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
+		IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_008d: ldc.i4.3
+		IL_008e: newarr [System.Runtime]System.Object
+		IL_0093: dup
+		IL_0094: ldc.i4.0
+		IL_0095: ldstr " "
+		IL_009a: stelem.ref
+		IL_009b: dup
+		IL_009c: ldc.i4.1
+		IL_009d: ldstr "hello"
+		IL_00a2: stelem.ref
+		IL_00a3: dup
+		IL_00a4: ldc.i4.2
+		IL_00a5: ldstr "world"
+		IL_00aa: stelem.ref
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
+		IL_00b0: stloc.2
+		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b6: ldloc.2
+		IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00bc: pop
+		IL_00bd: ldloc.0
+		IL_00be: castclass Modules.Function_RestParameters_WithNamedParams/Scope
+		IL_00c3: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
+		IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_00ce: ldc.i4.1
+		IL_00cf: newarr [System.Runtime]System.Object
+		IL_00d4: dup
+		IL_00d5: ldc.i4.0
+		IL_00d6: ldstr ","
+		IL_00db: stelem.ref
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
+		IL_00e1: stloc.2
+		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e7: ldloc.2
+		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ed: pop
+		IL_00ee: ret
 	} // end of method Function_RestParameters_WithNamedParams::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_WithNamedParams
@@ -346,7 +325,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222b
+		// Method begins at RVA 0x220b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_ReturnObjectWithClosure
+﻿// IL code: Function_ReturnObjectWithClosure
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x222d
+					// Method begins at RVA 0x2201
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21ec
+				// Method begins at RVA 0x21c0
 				// Header size: 12
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2224
+				// Method begins at RVA 0x21f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x2158
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -187,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x221b
+			// Method begins at RVA 0x21ef
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -213,7 +213,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 295 (0x127)
+		// Code size: 251 (0xfb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnObjectWithClosure/Scope,
@@ -245,78 +245,60 @@
 		IL_0030: stloc.s 4
 		IL_0032: ldloc.s 4
 		IL_0034: stloc.1
-		IL_0035: ldc.i4.1
-		IL_0036: newarr [System.Runtime]System.Object
-		IL_003b: dup
-		IL_003c: ldc.i4.0
-		IL_003d: ldloc.0
-		IL_003e: stelem.ref
-		IL_003f: ldc.i4.0
-		IL_0040: ldelem.ref
-		IL_0041: castclass Modules.Function_ReturnObjectWithClosure/Scope
-		IL_0046: ldftn object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
-		IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0051: ldnull
-		IL_0052: ldc.r8 10
-		IL_005b: box [System.Runtime]System.Double
-		IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0065: stloc.s 4
-		IL_0067: ldloc.s 4
-		IL_0069: stloc.2
-		IL_006a: ldloc.2
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0070: stloc.s 4
-		IL_0072: ldloc.s 4
-		IL_0074: ldstr "multiply"
-		IL_0079: ldc.r8 5
-		IL_0082: box [System.Runtime]System.Double
-		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_008c: stloc.s 4
-		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0093: ldstr "multiply(5):"
-		IL_0098: ldloc.s 4
-		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_009f: pop
-		IL_00a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a5: ldstr "factor:"
-		IL_00aa: ldloc.2
-		IL_00ab: ldstr "factor"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00ba: pop
-		IL_00bb: ldc.i4.1
-		IL_00bc: newarr [System.Runtime]System.Object
-		IL_00c1: dup
-		IL_00c2: ldc.i4.0
-		IL_00c3: ldloc.0
-		IL_00c4: stelem.ref
-		IL_00c5: ldc.i4.0
-		IL_00c6: ldelem.ref
-		IL_00c7: castclass Modules.Function_ReturnObjectWithClosure/Scope
-		IL_00cc: ldftn object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
-		IL_00d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00d7: ldnull
-		IL_00d8: ldc.r8 3
-		IL_00e1: box [System.Runtime]System.Double
-		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_00eb: stloc.s 4
-		IL_00ed: ldloc.s 4
-		IL_00ef: stloc.3
-		IL_00f0: ldloc.3
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f6: stloc.s 4
-		IL_00f8: ldloc.s 4
-		IL_00fa: ldstr "multiply"
-		IL_00ff: ldc.r8 7
-		IL_0108: box [System.Runtime]System.Double
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0112: stloc.s 4
-		IL_0114: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0119: ldstr "calc2.multiply(7):"
-		IL_011e: ldloc.s 4
-		IL_0120: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0125: pop
-		IL_0126: ret
+		IL_0035: ldloc.0
+		IL_0036: castclass Modules.Function_ReturnObjectWithClosure/Scope
+		IL_003b: ldnull
+		IL_003c: ldc.r8 10
+		IL_0045: box [System.Runtime]System.Double
+		IL_004a: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
+		IL_004f: stloc.s 4
+		IL_0051: ldloc.s 4
+		IL_0053: stloc.2
+		IL_0054: ldloc.2
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005a: stloc.s 4
+		IL_005c: ldloc.s 4
+		IL_005e: ldstr "multiply"
+		IL_0063: ldc.r8 5
+		IL_006c: box [System.Runtime]System.Double
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0076: stloc.s 4
+		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007d: ldstr "multiply(5):"
+		IL_0082: ldloc.s 4
+		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0089: pop
+		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008f: ldstr "factor:"
+		IL_0094: ldloc.2
+		IL_0095: ldstr "factor"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a4: pop
+		IL_00a5: ldloc.0
+		IL_00a6: castclass Modules.Function_ReturnObjectWithClosure/Scope
+		IL_00ab: ldnull
+		IL_00ac: ldc.r8 3
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
+		IL_00bf: stloc.s 4
+		IL_00c1: ldloc.s 4
+		IL_00c3: stloc.3
+		IL_00c4: ldloc.3
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ca: stloc.s 4
+		IL_00cc: ldloc.s 4
+		IL_00ce: ldstr "multiply"
+		IL_00d3: ldc.r8 7
+		IL_00dc: box [System.Runtime]System.Double
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e6: stloc.s 4
+		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ed: ldstr "calc2.multiply(7):"
+		IL_00f2: ldloc.s 4
+		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00f9: pop
+		IL_00fa: ret
 	} // end of method Function_ReturnObjectWithClosure::__js_module_init__
 
 } // end of class Modules.Function_ReturnObjectWithClosure
@@ -328,7 +310,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2236
+		// Method begins at RVA 0x220a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2dc0
+					// Method begins at RVA 0x2d54
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2488
+				// Method begins at RVA 0x2430
 				// Header size: 12
 				// Code size: 270 (0x10e)
 				.maxstack 8
@@ -172,7 +172,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2db7
+				// Method begins at RVA 0x2d4b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +199,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 15 00 00 02
 			)
-			// Method begins at RVA 0x23a0
+			// Method begins at RVA 0x2348
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -273,7 +273,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2dc9
+				// Method begins at RVA 0x2d5d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -297,7 +297,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2418
+			// Method begins at RVA 0x23c0
 			// Header size: 12
 			// Code size: 97 (0x61)
 			.maxstack 8
@@ -363,7 +363,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2dae
+			// Method begins at RVA 0x2d42
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -485,7 +485,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2de6
+				// Method begins at RVA 0x2d7a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -511,7 +511,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x25a4
+			// Method begins at RVA 0x254c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -541,7 +541,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2def
+				// Method begins at RVA 0x2d83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -567,7 +567,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x25c3
+			// Method begins at RVA 0x256b
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -590,7 +590,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2df8
+				// Method begins at RVA 0x2d8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -616,7 +616,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x25cb
+			// Method begins at RVA 0x2573
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -639,7 +639,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e01
+				// Method begins at RVA 0x2d95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -665,7 +665,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x25d4
+			// Method begins at RVA 0x257c
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -703,7 +703,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e0a
+				// Method begins at RVA 0x2d9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -729,7 +729,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x260c
+			// Method begins at RVA 0x25b4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -763,7 +763,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e1c
+					// Method begins at RVA 0x2db0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -781,7 +781,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e13
+				// Method begins at RVA 0x2da7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -807,7 +807,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x262c
+			// Method begins at RVA 0x25d4
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -882,7 +882,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e25
+				// Method begins at RVA 0x2db9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -906,7 +906,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26c4
+			// Method begins at RVA 0x266c
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -980,7 +980,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e2e
+				// Method begins at RVA 0x2dc2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1005,7 +1005,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2749
+			// Method begins at RVA 0x26f1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1033,7 +1033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e5b
+					// Method begins at RVA 0x2def
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1057,7 +1057,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cd9
+				// Method begins at RVA 0x2c6b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1083,7 +1083,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e64
+					// Method begins at RVA 0x2df8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1107,7 +1107,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ce8
+				// Method begins at RVA 0x2c7a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1137,7 +1137,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e91
+						// Method begins at RVA 0x2e25
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1161,7 +1161,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2d8d
+					// Method begins at RVA 0x2d21
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -1195,7 +1195,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e88
+					// Method begins at RVA 0x2e1c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1220,7 +1220,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cf8
+				// Method begins at RVA 0x2c8c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -1313,7 +1313,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e40
+					// Method begins at RVA 0x2dd4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1333,7 +1333,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e49
+					// Method begins at RVA 0x2ddd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1353,7 +1353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e52
+					// Method begins at RVA 0x2de6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1377,7 +1377,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e76
+						// Method begins at RVA 0x2e0a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1397,7 +1397,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e7f
+						// Method begins at RVA 0x2e13
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1415,7 +1415,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e6d
+					// Method begins at RVA 0x2e01
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1435,7 +1435,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e9a
+					// Method begins at RVA 0x2e2e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1455,7 +1455,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ea3
+					// Method begins at RVA 0x2e37
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1477,7 +1477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e37
+				// Method begins at RVA 0x2dcb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1504,7 +1504,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2754
+			// Method begins at RVA 0x26fc
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2029,7 +2029,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2eac
+				// Method begins at RVA 0x2e40
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2057,50 +2057,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2c70
+			// Method begins at RVA 0x2c18
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-			IL_0011: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -2130,7 +2121,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2dd2
+			// Method begins at RVA 0x2d66
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2159,7 +2150,7 @@
 	{
 		// Method begins at RVA 0x2114
 		// Header size: 12
-		// Code size: 640 (0x280)
+		// Code size: 552 (0x228)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope,
@@ -2302,127 +2293,91 @@
 		IL_0140: stloc.s 5
 		IL_0142: ldloc.s 5
 		IL_0144: stloc.s 4
-		IL_0146: ldc.i4.1
-		IL_0147: newarr [System.Runtime]System.Object
-		IL_014c: dup
-		IL_014d: ldc.i4.0
-		IL_014e: ldloc.0
-		IL_014f: stelem.ref
-		IL_0150: ldc.i4.0
-		IL_0151: ldelem.ref
-		IL_0152: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0157: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0162: ldnull
-		IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0168: pop
-		IL_0169: ldc.i4.1
-		IL_016a: newarr [System.Runtime]System.Object
-		IL_016f: dup
-		IL_0170: ldc.i4.0
-		IL_0171: ldloc.0
-		IL_0172: stelem.ref
-		IL_0173: ldc.i4.0
-		IL_0174: ldelem.ref
-		IL_0175: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_017a: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0180: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0185: ldc.i4.0
-		IL_0186: conv.r8
-		IL_0187: ldstr ""
-		IL_018c: ldc.i4.0
-		IL_018d: ldc.i4.1
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0193: stloc.s 5
-		IL_0195: ldc.i4.1
-		IL_0196: newarr [System.Runtime]System.Object
-		IL_019b: dup
-		IL_019c: ldc.i4.0
-		IL_019d: ldloc.0
-		IL_019e: stelem.ref
-		IL_019f: ldc.i4.0
-		IL_01a0: ldelem.ref
-		IL_01a1: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01a6: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
-		IL_01ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01b1: ldnull
-		IL_01b2: ldstr "value"
-		IL_01b7: ldloc.s 5
-		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01be: pop
-		IL_01bf: ldc.i4.1
-		IL_01c0: newarr [System.Runtime]System.Object
-		IL_01c5: dup
-		IL_01c6: ldc.i4.0
-		IL_01c7: ldloc.0
-		IL_01c8: stelem.ref
-		IL_01c9: ldc.i4.0
-		IL_01ca: ldelem.ref
-		IL_01cb: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01d0: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01db: ldc.i4.0
-		IL_01dc: conv.r8
-		IL_01dd: ldstr ""
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldc.i4.1
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01e9: stloc.s 5
-		IL_01eb: ldc.i4.1
-		IL_01ec: newarr [System.Runtime]System.Object
-		IL_01f1: dup
-		IL_01f2: ldc.i4.0
-		IL_01f3: ldloc.0
-		IL_01f4: stelem.ref
-		IL_01f5: ldc.i4.0
-		IL_01f6: ldelem.ref
-		IL_01f7: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01fc: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
-		IL_0202: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0207: ldnull
-		IL_0208: ldstr "inc"
-		IL_020d: ldloc.s 5
-		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0214: pop
-		IL_0215: ldc.i4.1
-		IL_0216: newarr [System.Runtime]System.Object
-		IL_021b: dup
-		IL_021c: ldc.i4.0
-		IL_021d: ldloc.0
-		IL_021e: stelem.ref
-		IL_021f: ldc.i4.0
-		IL_0220: ldelem.ref
-		IL_0221: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0226: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_022c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0231: ldc.i4.0
-		IL_0232: conv.r8
-		IL_0233: ldstr ""
-		IL_0238: ldc.i4.0
-		IL_0239: ldc.i4.1
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_023f: stloc.s 5
-		IL_0241: ldc.i4.1
-		IL_0242: newarr [System.Runtime]System.Object
-		IL_0247: dup
-		IL_0248: ldc.i4.0
-		IL_0249: ldloc.0
-		IL_024a: stelem.ref
-		IL_024b: ldc.i4.0
-		IL_024c: ldelem.ref
-		IL_024d: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0252: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
-		IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_025d: ldnull
-		IL_025e: ldstr "default"
-		IL_0263: ldloc.s 5
-		IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_026a: pop
-		IL_026b: ldloc.0
-		IL_026c: ldc.r8 1
-		IL_0275: box [System.Runtime]System.Double
-		IL_027a: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::'value'
-		IL_027f: ret
+		IL_0146: ldloc.0
+		IL_0147: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_014c: ldnull
+		IL_014d: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+		IL_0152: pop
+		IL_0153: ldc.i4.1
+		IL_0154: newarr [System.Runtime]System.Object
+		IL_0159: dup
+		IL_015a: ldc.i4.0
+		IL_015b: ldloc.0
+		IL_015c: stelem.ref
+		IL_015d: ldc.i4.0
+		IL_015e: ldelem.ref
+		IL_015f: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_0164: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+		IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016f: ldc.i4.0
+		IL_0170: conv.r8
+		IL_0171: ldstr ""
+		IL_0176: ldc.i4.0
+		IL_0177: ldc.i4.1
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_017d: stloc.s 5
+		IL_017f: ldloc.0
+		IL_0180: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_0185: ldnull
+		IL_0186: ldstr "value"
+		IL_018b: ldloc.s 5
+		IL_018d: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
+		IL_0192: pop
+		IL_0193: ldc.i4.1
+		IL_0194: newarr [System.Runtime]System.Object
+		IL_0199: dup
+		IL_019a: ldc.i4.0
+		IL_019b: ldloc.0
+		IL_019c: stelem.ref
+		IL_019d: ldc.i4.0
+		IL_019e: ldelem.ref
+		IL_019f: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_01a4: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+		IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01af: ldc.i4.0
+		IL_01b0: conv.r8
+		IL_01b1: ldstr ""
+		IL_01b6: ldc.i4.0
+		IL_01b7: ldc.i4.1
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01bd: stloc.s 5
+		IL_01bf: ldloc.0
+		IL_01c0: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_01c5: ldnull
+		IL_01c6: ldstr "inc"
+		IL_01cb: ldloc.s 5
+		IL_01cd: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
+		IL_01d2: pop
+		IL_01d3: ldc.i4.1
+		IL_01d4: newarr [System.Runtime]System.Object
+		IL_01d9: dup
+		IL_01da: ldc.i4.0
+		IL_01db: ldloc.0
+		IL_01dc: stelem.ref
+		IL_01dd: ldc.i4.0
+		IL_01de: ldelem.ref
+		IL_01df: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_01e4: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+		IL_01ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01ef: ldc.i4.0
+		IL_01f0: conv.r8
+		IL_01f1: ldstr ""
+		IL_01f6: ldc.i4.0
+		IL_01f7: ldc.i4.1
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01fd: stloc.s 5
+		IL_01ff: ldloc.0
+		IL_0200: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_0205: ldnull
+		IL_0206: ldstr "default"
+		IL_020b: ldloc.s 5
+		IL_020d: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
+		IL_0212: pop
+		IL_0213: ldloc.0
+		IL_0214: ldc.r8 1
+		IL_021d: box [System.Runtime]System.Double
+		IL_0222: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::'value'
+		IL_0227: ret
 	} // end of method Import_DynamicImport_Esm_Namespace_Lib::__js_module_init__
 
 } // end of class Modules.Import_DynamicImport_Esm_Namespace_Lib
@@ -2434,7 +2389,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2eb5
+		// Method begins at RVA 0x2e49
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3363
+					// Method begins at RVA 0x32e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x335a
+				// Method begins at RVA 0x32da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2410
+			// Method begins at RVA 0x23b8
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x336c
+				// Method begins at RVA 0x32ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24a8
+			// Method begins at RVA 0x2450
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3375
+				// Method begins at RVA 0x32f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x252d
+			// Method begins at RVA 0x24d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a2
+					// Method begins at RVA 0x3322
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2abd
+				// Method begins at RVA 0x2a4f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33ab
+					// Method begins at RVA 0x332b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2acc
+				// Method begins at RVA 0x2a5e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33d8
+						// Method begins at RVA 0x3358
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2b71
+					// Method begins at RVA 0x2b05
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33cf
+					// Method begins at RVA 0x334f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2adc
+				// Method begins at RVA 0x2a70
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3387
+					// Method begins at RVA 0x3307
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3390
+					// Method begins at RVA 0x3310
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3399
+					// Method begins at RVA 0x3319
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33bd
+						// Method begins at RVA 0x333d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33c6
+						// Method begins at RVA 0x3346
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33b4
+					// Method begins at RVA 0x3334
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33e1
+					// Method begins at RVA 0x3361
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33ea
+					// Method begins at RVA 0x336a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x337e
+				// Method begins at RVA 0x32fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2538
+			// Method begins at RVA 0x24e0
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33f3
+				// Method begins at RVA 0x3373
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2a54
+			// Method begins at RVA 0x29fc
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportNamedFrom/Scope
-			IL_0011: ldftn object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportNamedFrom/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3351
+			// Method begins at RVA 0x32d1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 382 (0x17e)
+		// Code size: 360 (0x168)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom/Scope,
@@ -1512,60 +1503,51 @@
 		IL_00d8: stloc.s 6
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_00ef: ldftn object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_ExportNamedFrom_LibB.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 6
-		IL_010e: ldloc.s 6
-		IL_0110: stloc.s 5
-		IL_0112: ldnull
-		IL_0113: ldloc.s 5
-		IL_0115: ldstr "value"
-		IL_011a: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, object)
-		IL_011f: stloc.s 6
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0126: ldstr "value:"
-		IL_012b: ldloc.s 6
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0132: pop
-		IL_0133: ldnull
-		IL_0134: ldloc.s 5
-		IL_0136: ldstr "doubled"
-		IL_013b: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0140: stloc.s 6
-		IL_0142: ldc.i4.1
-		IL_0143: newarr [System.Runtime]System.Object
-		IL_0148: dup
-		IL_0149: ldc.i4.0
-		IL_014a: ldc.r8 5
-		IL_0153: box [System.Runtime]System.Double
-		IL_0158: stelem.ref
-		IL_0159: stloc.s 7
-		IL_015b: ldloc.s 6
-		IL_015d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0162: ldloc.s 7
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0169: stloc.s 6
-		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0170: ldstr "doubled:"
-		IL_0175: ldloc.s 6
-		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_017c: pop
-		IL_017d: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_ExportNamedFrom/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_ExportNamedFrom_LibB.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 6
+		IL_00f8: ldloc.s 6
+		IL_00fa: stloc.s 5
+		IL_00fc: ldnull
+		IL_00fd: ldloc.s 5
+		IL_00ff: ldstr "value"
+		IL_0104: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0109: stloc.s 6
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0110: ldstr "value:"
+		IL_0115: ldloc.s 6
+		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_011c: pop
+		IL_011d: ldnull
+		IL_011e: ldloc.s 5
+		IL_0120: ldstr "doubled"
+		IL_0125: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, object)
+		IL_012a: stloc.s 6
+		IL_012c: ldc.i4.1
+		IL_012d: newarr [System.Runtime]System.Object
+		IL_0132: dup
+		IL_0133: ldc.i4.0
+		IL_0134: ldc.r8 5
+		IL_013d: box [System.Runtime]System.Double
+		IL_0142: stelem.ref
+		IL_0143: stloc.s 7
+		IL_0145: ldloc.s 6
+		IL_0147: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_014c: ldloc.s 7
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0153: stloc.s 6
+		IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015a: ldstr "doubled:"
+		IL_015f: ldloc.s 6
+		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0166: pop
+		IL_0167: ret
 	} // end of method Import_ExportNamedFrom::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom
@@ -1585,7 +1567,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3405
+				// Method begins at RVA 0x3385
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1611,7 +1593,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2b92
+			// Method begins at RVA 0x2b26
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -1636,7 +1618,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x340e
+				// Method begins at RVA 0x338e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1662,7 +1644,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2ba4
+			// Method begins at RVA 0x2b38
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -1691,7 +1673,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3420
+					// Method begins at RVA 0x33a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1709,7 +1691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3417
+				// Method begins at RVA 0x3397
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1735,7 +1717,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2bb8
+			// Method begins at RVA 0x2b4c
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1810,7 +1792,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3429
+				// Method begins at RVA 0x33a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1834,7 +1816,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c50
+			// Method begins at RVA 0x2be4
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1908,7 +1890,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3432
+				// Method begins at RVA 0x33b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1933,7 +1915,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cd5
+			// Method begins at RVA 0x2c69
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1961,7 +1943,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x345f
+					// Method begins at RVA 0x33df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1985,7 +1967,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3265
+				// Method begins at RVA 0x31e3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2011,7 +1993,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3468
+					// Method begins at RVA 0x33e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2035,7 +2017,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3274
+				// Method begins at RVA 0x31f2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2065,7 +2047,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3495
+						// Method begins at RVA 0x3415
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2089,7 +2071,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3319
+					// Method begins at RVA 0x3299
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2123,7 +2105,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x348c
+					// Method begins at RVA 0x340c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2148,7 +2130,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3284
+				// Method begins at RVA 0x3204
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2241,7 +2223,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3444
+					// Method begins at RVA 0x33c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2261,7 +2243,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x344d
+					// Method begins at RVA 0x33cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2281,7 +2263,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3456
+					// Method begins at RVA 0x33d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2305,7 +2287,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x347a
+						// Method begins at RVA 0x33fa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2325,7 +2307,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3483
+						// Method begins at RVA 0x3403
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2343,7 +2325,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3471
+					// Method begins at RVA 0x33f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2363,7 +2345,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x349e
+					// Method begins at RVA 0x341e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2383,7 +2365,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34a7
+					// Method begins at RVA 0x3427
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2405,7 +2387,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x343b
+				// Method begins at RVA 0x33bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2432,7 +2414,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2ce0
+			// Method begins at RVA 0x2c74
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2957,7 +2939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34b0
+				// Method begins at RVA 0x3430
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2985,50 +2967,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x31fc
+			// Method begins at RVA 0x3190
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-			IL_0011: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3053,7 +3026,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x33fc
+			// Method begins at RVA 0x337c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3077,9 +3050,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21dc
+		// Method begins at RVA 0x21c4
 		// Header size: 12
-		// Code size: 451 (0x1c3)
+		// Code size: 385 (0x181)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom_LibB/Scope,
@@ -3180,96 +3153,69 @@
 		IL_00d8: stloc.s 5
 		IL_00da: ldloc.s 5
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_00ef: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_ExportNamedFrom_LibA.cjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 5
-		IL_010e: ldloc.0
-		IL_010f: ldloc.s 5
-		IL_0111: stfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mod_0
-		IL_0116: ldc.i4.1
-		IL_0117: newarr [System.Runtime]System.Object
-		IL_011c: dup
-		IL_011d: ldc.i4.0
-		IL_011e: ldloc.0
-		IL_011f: stelem.ref
-		IL_0120: ldc.i4.0
-		IL_0121: ldelem.ref
-		IL_0122: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0127: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0132: ldc.i4.0
-		IL_0133: conv.r8
-		IL_0134: ldstr ""
-		IL_0139: ldc.i4.0
-		IL_013a: ldc.i4.1
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0140: stloc.s 5
-		IL_0142: ldc.i4.1
-		IL_0143: newarr [System.Runtime]System.Object
-		IL_0148: dup
-		IL_0149: ldc.i4.0
-		IL_014a: ldloc.0
-		IL_014b: stelem.ref
-		IL_014c: ldc.i4.0
-		IL_014d: ldelem.ref
-		IL_014e: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0153: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object, object)
-		IL_0159: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_015e: ldnull
-		IL_015f: ldstr "value"
-		IL_0164: ldloc.s 5
-		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_016b: pop
-		IL_016c: ldc.i4.1
-		IL_016d: newarr [System.Runtime]System.Object
-		IL_0172: dup
-		IL_0173: ldc.i4.0
-		IL_0174: ldloc.0
-		IL_0175: stelem.ref
-		IL_0176: ldc.i4.0
-		IL_0177: ldelem.ref
-		IL_0178: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_017d: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0188: ldc.i4.0
-		IL_0189: conv.r8
-		IL_018a: ldstr ""
-		IL_018f: ldc.i4.0
-		IL_0190: ldc.i4.1
-		IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0196: stloc.s 5
-		IL_0198: ldc.i4.1
-		IL_0199: newarr [System.Runtime]System.Object
-		IL_019e: dup
-		IL_019f: ldc.i4.0
-		IL_01a0: ldloc.0
-		IL_01a1: stelem.ref
-		IL_01a2: ldc.i4.0
-		IL_01a3: ldelem.ref
-		IL_01a4: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_01a9: ldftn object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object, object)
-		IL_01af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01b4: ldnull
-		IL_01b5: ldstr "doubled"
-		IL_01ba: ldloc.s 5
-		IL_01bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01c1: pop
-		IL_01c2: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_ExportNamedFrom_LibA.cjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 5
+		IL_00f8: ldloc.0
+		IL_00f9: ldloc.s 5
+		IL_00fb: stfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mod_0
+		IL_0100: ldc.i4.1
+		IL_0101: newarr [System.Runtime]System.Object
+		IL_0106: dup
+		IL_0107: ldc.i4.0
+		IL_0108: ldloc.0
+		IL_0109: stelem.ref
+		IL_010a: ldc.i4.0
+		IL_010b: ldelem.ref
+		IL_010c: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+		IL_0111: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+		IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_011c: ldc.i4.0
+		IL_011d: conv.r8
+		IL_011e: ldstr ""
+		IL_0123: ldc.i4.0
+		IL_0124: ldc.i4.1
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_012a: stloc.s 5
+		IL_012c: ldloc.0
+		IL_012d: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+		IL_0132: ldnull
+		IL_0133: ldstr "value"
+		IL_0138: ldloc.s 5
+		IL_013a: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object, object)
+		IL_013f: pop
+		IL_0140: ldc.i4.1
+		IL_0141: newarr [System.Runtime]System.Object
+		IL_0146: dup
+		IL_0147: ldc.i4.0
+		IL_0148: ldloc.0
+		IL_0149: stelem.ref
+		IL_014a: ldc.i4.0
+		IL_014b: ldelem.ref
+		IL_014c: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+		IL_0151: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+		IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_015c: ldc.i4.0
+		IL_015d: conv.r8
+		IL_015e: ldstr ""
+		IL_0163: ldc.i4.0
+		IL_0164: ldc.i4.1
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_016a: stloc.s 5
+		IL_016c: ldloc.0
+		IL_016d: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+		IL_0172: ldnull
+		IL_0173: ldstr "doubled"
+		IL_0178: ldloc.s 5
+		IL_017a: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object, object)
+		IL_017f: pop
+		IL_0180: ret
 	} // end of method Import_ExportNamedFrom_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom_LibB
@@ -3289,7 +3235,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34c2
+				// Method begins at RVA 0x3442
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3313,7 +3259,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x333a
+			// Method begins at RVA 0x32ba
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -3335,7 +3281,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x34b9
+			// Method begins at RVA 0x3439
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3359,7 +3305,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x23ac
+		// Method begins at RVA 0x2354
 		// Header size: 12
 		// Code size: 86 (0x56)
 		.maxstack 8
@@ -3409,7 +3355,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x34cb
+		// Method begins at RVA 0x344b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3523
+					// Method begins at RVA 0x349b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x351a
+				// Method begins at RVA 0x3492
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2574
+			// Method begins at RVA 0x2530
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x352c
+				// Method begins at RVA 0x34a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x260c
+			// Method begins at RVA 0x25c8
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3535
+				// Method begins at RVA 0x34ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2691
+			// Method begins at RVA 0x264d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3562
+					// Method begins at RVA 0x34da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c21
+				// Method begins at RVA 0x2bc7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x356b
+					// Method begins at RVA 0x34e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c30
+				// Method begins at RVA 0x2bd6
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3598
+						// Method begins at RVA 0x3510
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2cd5
+					// Method begins at RVA 0x2c7d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x358f
+					// Method begins at RVA 0x3507
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c40
+				// Method begins at RVA 0x2be8
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3547
+					// Method begins at RVA 0x34bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3550
+					// Method begins at RVA 0x34c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3559
+					// Method begins at RVA 0x34d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x357d
+						// Method begins at RVA 0x34f5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3586
+						// Method begins at RVA 0x34fe
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3574
+					// Method begins at RVA 0x34ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35a1
+					// Method begins at RVA 0x3519
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35aa
+					// Method begins at RVA 0x3522
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x353e
+				// Method begins at RVA 0x34b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x269c
+			// Method begins at RVA 0x2658
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35b3
+				// Method begins at RVA 0x352b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2bb8
+			// Method begins at RVA 0x2b74
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportStarFrom/Scope
-			IL_0011: ldftn object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportStarFrom/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportStarFrom/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportStarFrom/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3511
+			// Method begins at RVA 0x3489
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 487 (0x1e7)
+		// Code size: 443 (0x1bb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom/Scope,
@@ -1512,87 +1503,69 @@
 		IL_00d8: stloc.s 7
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_ExportStarFrom/Scope
-		IL_00ef: ldftn object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_ExportStarFrom_LibB.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 7
-		IL_010e: ldloc.s 7
-		IL_0110: stloc.s 5
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: ldc.i4.0
-		IL_011d: ldelem.ref
-		IL_011e: castclass Modules.Import_ExportStarFrom/Scope
-		IL_0123: ldftn object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012e: ldnull
-		IL_012f: ldloc.s 5
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0136: stloc.s 7
-		IL_0138: ldloc.s 7
-		IL_013a: stloc.s 6
-		IL_013c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0141: ldstr "own:"
-		IL_0146: ldloc.s 6
-		IL_0148: ldstr "own"
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0157: pop
-		IL_0158: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_015d: ldstr "prototype"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0167: ldstr "hasOwnProperty"
-		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0176: stloc.s 7
-		IL_0178: ldloc.s 7
-		IL_017a: ldstr "call"
-		IL_017f: ldloc.s 6
-		IL_0181: ldstr "inherited"
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_018b: stloc.s 7
-		IL_018d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0192: ldstr "hasInherited:"
-		IL_0197: ldloc.s 7
-		IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_019e: pop
-		IL_019f: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_01a4: ldstr "prototype"
-		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ae: ldstr "hasOwnProperty"
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bd: stloc.s 7
-		IL_01bf: ldloc.s 7
-		IL_01c1: ldstr "call"
-		IL_01c6: ldloc.s 6
-		IL_01c8: ldstr "default"
-		IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01d2: stloc.s 7
-		IL_01d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d9: ldstr "hasDefault:"
-		IL_01de: ldloc.s 7
-		IL_01e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01e5: pop
-		IL_01e6: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_ExportStarFrom/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_ExportStarFrom_LibB.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 7
+		IL_00f8: ldloc.s 7
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.0
+		IL_00fd: castclass Modules.Import_ExportStarFrom/Scope
+		IL_0102: ldnull
+		IL_0103: ldloc.s 5
+		IL_0105: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
+		IL_010a: stloc.s 7
+		IL_010c: ldloc.s 7
+		IL_010e: stloc.s 6
+		IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0115: ldstr "own:"
+		IL_011a: ldloc.s 6
+		IL_011c: ldstr "own"
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012b: pop
+		IL_012c: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0131: ldstr "prototype"
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013b: ldstr "hasOwnProperty"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014a: stloc.s 7
+		IL_014c: ldloc.s 7
+		IL_014e: ldstr "call"
+		IL_0153: ldloc.s 6
+		IL_0155: ldstr "inherited"
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_015f: stloc.s 7
+		IL_0161: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0166: ldstr "hasInherited:"
+		IL_016b: ldloc.s 7
+		IL_016d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0172: pop
+		IL_0173: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0178: ldstr "prototype"
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0182: ldstr "hasOwnProperty"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0191: stloc.s 7
+		IL_0193: ldloc.s 7
+		IL_0195: ldstr "call"
+		IL_019a: ldloc.s 6
+		IL_019c: ldstr "default"
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01a6: stloc.s 7
+		IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ad: ldstr "hasDefault:"
+		IL_01b2: ldloc.s 7
+		IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01b9: pop
+		IL_01ba: ret
 	} // end of method Import_ExportStarFrom::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFrom
@@ -1616,7 +1589,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35fb
+					// Method begins at RVA 0x3573
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1634,7 +1607,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35f2
+				// Method begins at RVA 0x356a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1660,7 +1633,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2cf8
+			// Method begins at RVA 0x2ca0
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1735,7 +1708,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3604
+				// Method begins at RVA 0x357c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1759,7 +1732,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d90
+			// Method begins at RVA 0x2d38
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1833,7 +1806,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x360d
+				// Method begins at RVA 0x3585
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1858,7 +1831,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e15
+			// Method begins at RVA 0x2dbd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1886,7 +1859,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x363a
+					// Method begins at RVA 0x35b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1910,7 +1883,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3417
+				// Method begins at RVA 0x3391
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1936,7 +1909,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3643
+					// Method begins at RVA 0x35bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1960,7 +1933,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3426
+				// Method begins at RVA 0x33a0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1990,7 +1963,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3670
+						// Method begins at RVA 0x35e8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2014,7 +1987,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x34ed
+					// Method begins at RVA 0x3465
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2048,7 +2021,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3667
+					// Method begins at RVA 0x35df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2073,7 +2046,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3458
+				// Method begins at RVA 0x33d0
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2166,7 +2139,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x361f
+					// Method begins at RVA 0x3597
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2186,7 +2159,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3628
+					// Method begins at RVA 0x35a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2206,7 +2179,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3631
+					// Method begins at RVA 0x35a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2230,7 +2203,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3655
+						// Method begins at RVA 0x35cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2250,7 +2223,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x365e
+						// Method begins at RVA 0x35d6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2268,7 +2241,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x364c
+					// Method begins at RVA 0x35c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2288,7 +2261,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3679
+					// Method begins at RVA 0x35f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2308,7 +2281,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3682
+					// Method begins at RVA 0x35fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2330,7 +2303,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3616
+				// Method begins at RVA 0x358e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2357,7 +2330,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2e20
+			// Method begins at RVA 0x2dc8
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2882,7 +2855,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x368b
+				// Method begins at RVA 0x3603
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2910,50 +2883,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x333c
+			// Method begins at RVA 0x32e4
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_0011: ldftn object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportStarFrom_LibB/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -2973,7 +2937,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35e9
+					// Method begins at RVA 0x3561
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2997,7 +2961,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3435
+				// Method begins at RVA 0x33af
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -3032,7 +2996,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35e0
+				// Method begins at RVA 0x3558
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3059,9 +3023,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x33a8
+			// Method begins at RVA 0x3338
 			// Header size: 12
-			// Code size: 99 (0x63)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope,
@@ -3096,24 +3060,15 @@
 			IL_0035: ldc.i4.1
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_003b: stloc.2
-			IL_003c: ldc.i4.1
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldarg.0
-			IL_0045: stelem.ref
-			IL_0046: ldc.i4.0
-			IL_0047: ldelem.ref
-			IL_0048: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_004d: ldftn object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0058: ldnull
-			IL_0059: ldloc.1
-			IL_005a: ldloc.2
-			IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0060: pop
-			IL_0061: ldnull
-			IL_0062: ret
+			IL_003c: ldarg.0
+			IL_003d: castclass Modules.Import_ExportStarFrom_LibB/Scope
+			IL_0042: ldnull
+			IL_0043: ldloc.1
+			IL_0044: ldloc.2
+			IL_0045: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
+			IL_004a: pop
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L10C3::__js_call__
 
 	} // end of class FunctionExpression_L10C3
@@ -3137,7 +3092,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35ce
+					// Method begins at RVA 0x3546
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3157,7 +3112,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35d7
+					// Method begins at RVA 0x354f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3175,7 +3130,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35c5
+				// Method begins at RVA 0x353d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3202,7 +3157,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x35bc
+			// Method begins at RVA 0x3534
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3226,9 +3181,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2244
+		// Method begins at RVA 0x2218
 		// Header size: 12
-		// Code size: 654 (0x28e)
+		// Code size: 632 (0x278)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom_LibB/Scope,
@@ -3341,163 +3296,154 @@
 		IL_00da: ldloc.0
 		IL_00db: ldloc.s 9
 		IL_00dd: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_export
-		IL_00e2: ldc.i4.1
-		IL_00e3: newarr [System.Runtime]System.Object
-		IL_00e8: dup
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldloc.0
-		IL_00eb: stelem.ref
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldelem.ref
-		IL_00ee: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_00f3: ldftn object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
-		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fe: ldnull
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0104: pop
-		IL_0105: ldarg.1
-		IL_0106: ldstr "./Import_ExportStarFrom_LibA.cjs"
-		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0110: stloc.s 9
-		IL_0112: ldloc.0
-		IL_0113: ldloc.s 9
-		IL_0115: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
-		IL_011a: ldloc.0
-		IL_011b: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
-		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
-		IL_0125: stloc.s 4
-		// loop start (head: IL_0127)
-			IL_0127: ldloc.s 4
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-			IL_012e: stloc.s 9
-			IL_0130: ldloc.s 9
-			IL_0132: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0137: stloc.s 10
-			IL_0139: ldloc.s 10
-			IL_013b: brtrue IL_028d
+		IL_00e2: ldloc.0
+		IL_00e3: castclass Modules.Import_ExportStarFrom_LibB/Scope
+		IL_00e8: ldnull
+		IL_00e9: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_ExportStarFrom_LibA.cjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 9
+		IL_00fc: ldloc.0
+		IL_00fd: ldloc.s 9
+		IL_00ff: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
+		IL_0104: ldloc.0
+		IL_0105: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
+		IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
+		IL_010f: stloc.s 4
+		// loop start (head: IL_0111)
+			IL_0111: ldloc.s 4
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+			IL_0118: stloc.s 9
+			IL_011a: ldloc.s 9
+			IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0121: stloc.s 10
+			IL_0123: ldloc.s 10
+			IL_0125: brtrue IL_0277
 
-			IL_0140: ldloc.s 9
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0147: stloc.s 9
-			IL_0149: ldloc.s 9
-			IL_014b: stloc.s 5
-			IL_014d: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47::.ctor()
-			IL_0152: stloc.s 6
-			IL_0154: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-			IL_0159: ldstr "prototype"
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0163: ldstr "hasOwnProperty"
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012a: ldloc.s 9
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0131: stloc.s 9
+			IL_0133: ldloc.s 9
+			IL_0135: stloc.s 5
+			IL_0137: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47::.ctor()
+			IL_013c: stloc.s 6
+			IL_013e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+			IL_0143: ldstr "prototype"
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014d: ldstr "hasOwnProperty"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015c: stloc.s 9
+			IL_015e: ldloc.s 9
+			IL_0160: ldstr "call"
+			IL_0165: ldloc.0
+			IL_0166: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
+			IL_016b: ldloc.s 5
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_0172: stloc.s 9
 			IL_0174: ldloc.s 9
-			IL_0176: ldstr "call"
-			IL_017b: ldloc.0
-			IL_017c: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
-			IL_0181: ldloc.s 5
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0188: stloc.s 9
-			IL_018a: ldloc.s 9
-			IL_018c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0191: ldc.i4.0
-			IL_0192: ceq
-			IL_0194: stloc.s 10
-			IL_0196: ldloc.s 10
-			IL_0198: brfalse IL_01a9
+			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_017b: ldc.i4.0
+			IL_017c: ceq
+			IL_017e: stloc.s 10
+			IL_0180: ldloc.s 10
+			IL_0182: brfalse IL_0193
 
-			IL_019d: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L8C81::.ctor()
-			IL_01a2: stloc.s 7
-			IL_01a4: br IL_0288
+			IL_0187: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L8C81::.ctor()
+			IL_018c: stloc.s 7
+			IL_018e: br IL_0272
 
-			IL_01a9: ldloc.s 5
-			IL_01ab: ldstr "default"
-			IL_01b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01b5: stloc.s 10
-			IL_01b7: ldloc.s 10
-			IL_01b9: box [System.Runtime]System.Boolean
-			IL_01be: stloc.s 11
-			IL_01c0: ldloc.s 11
-			IL_01c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01c7: stloc.s 10
-			IL_01c9: ldloc.s 10
-			IL_01cb: brtrue IL_01f0
+			IL_0193: ldloc.s 5
+			IL_0195: ldstr "default"
+			IL_019a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_019f: stloc.s 10
+			IL_01a1: ldloc.s 10
+			IL_01a3: box [System.Runtime]System.Boolean
+			IL_01a8: stloc.s 11
+			IL_01aa: ldloc.s 11
+			IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01b1: stloc.s 10
+			IL_01b3: ldloc.s 10
+			IL_01b5: brtrue IL_01da
 
-			IL_01d0: ldloc.s 5
-			IL_01d2: ldstr "__esModule"
-			IL_01d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01dc: stloc.s 10
-			IL_01de: ldloc.s 10
-			IL_01e0: box [System.Runtime]System.Boolean
-			IL_01e5: stloc.s 12
-			IL_01e7: ldloc.s 12
-			IL_01e9: stloc.s 14
-			IL_01eb: br IL_01f4
+			IL_01ba: ldloc.s 5
+			IL_01bc: ldstr "__esModule"
+			IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01c6: stloc.s 10
+			IL_01c8: ldloc.s 10
+			IL_01ca: box [System.Runtime]System.Boolean
+			IL_01cf: stloc.s 12
+			IL_01d1: ldloc.s 12
+			IL_01d3: stloc.s 14
+			IL_01d5: br IL_01de
 
-			IL_01f0: ldloc.s 11
-			IL_01f2: stloc.s 14
+			IL_01da: ldloc.s 11
+			IL_01dc: stloc.s 14
 
-			IL_01f4: ldloc.s 14
-			IL_01f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01fb: stloc.s 10
-			IL_01fd: ldloc.s 10
-			IL_01ff: brtrue IL_0224
+			IL_01de: ldloc.s 14
+			IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01e5: stloc.s 10
+			IL_01e7: ldloc.s 10
+			IL_01e9: brtrue IL_020e
 
-			IL_0204: ldloc.s 5
-			IL_0206: ldstr "module.exports"
-			IL_020b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0210: stloc.s 10
-			IL_0212: ldloc.s 10
-			IL_0214: box [System.Runtime]System.Boolean
-			IL_0219: stloc.s 11
-			IL_021b: ldloc.s 11
-			IL_021d: stloc.s 14
-			IL_021f: br IL_0224
+			IL_01ee: ldloc.s 5
+			IL_01f0: ldstr "module.exports"
+			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01fa: stloc.s 10
+			IL_01fc: ldloc.s 10
+			IL_01fe: box [System.Runtime]System.Boolean
+			IL_0203: stloc.s 11
+			IL_0205: ldloc.s 11
+			IL_0207: stloc.s 14
+			IL_0209: br IL_020e
 
-			IL_0224: ldloc.s 14
-			IL_0226: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022b: stloc.s 10
-			IL_022d: ldloc.s 10
-			IL_022f: brfalse IL_0240
+			IL_020e: ldloc.s 14
+			IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0215: stloc.s 10
+			IL_0217: ldloc.s 10
+			IL_0219: brfalse IL_022a
 
-			IL_0234: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L9C116::.ctor()
-			IL_0239: stloc.s 8
-			IL_023b: br IL_0288
+			IL_021e: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L9C116::.ctor()
+			IL_0223: stloc.s 8
+			IL_0225: br IL_0272
 
-			IL_0240: ldc.i4.1
-			IL_0241: newarr [System.Runtime]System.Object
-			IL_0246: dup
-			IL_0247: ldc.i4.0
-			IL_0248: ldloc.0
-			IL_0249: stelem.ref
-			IL_024a: ldc.i4.0
-			IL_024b: ldelem.ref
-			IL_024c: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_0251: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
-			IL_0257: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_025c: ldc.i4.1
-			IL_025d: conv.r8
-			IL_025e: ldstr ""
-			IL_0263: ldc.i4.0
-			IL_0264: ldc.i4.1
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_026a: stloc.s 9
-			IL_026c: ldc.i4.1
-			IL_026d: newarr [System.Runtime]System.Object
-			IL_0272: dup
-			IL_0273: ldc.i4.0
-			IL_0274: ldloc.s 5
-			IL_0276: stelem.ref
-			IL_0277: stloc.s 16
-			IL_0279: ldloc.s 9
-			IL_027b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0280: ldloc.s 16
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0287: pop
+			IL_022a: ldc.i4.1
+			IL_022b: newarr [System.Runtime]System.Object
+			IL_0230: dup
+			IL_0231: ldc.i4.0
+			IL_0232: ldloc.0
+			IL_0233: stelem.ref
+			IL_0234: ldc.i4.0
+			IL_0235: ldelem.ref
+			IL_0236: castclass Modules.Import_ExportStarFrom_LibB/Scope
+			IL_023b: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
+			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0246: ldc.i4.1
+			IL_0247: conv.r8
+			IL_0248: ldstr ""
+			IL_024d: ldc.i4.0
+			IL_024e: ldc.i4.1
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0254: stloc.s 9
+			IL_0256: ldc.i4.1
+			IL_0257: newarr [System.Runtime]System.Object
+			IL_025c: dup
+			IL_025d: ldc.i4.0
+			IL_025e: ldloc.s 5
+			IL_0260: stelem.ref
+			IL_0261: stloc.s 16
+			IL_0263: ldloc.s 9
+			IL_0265: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_026a: ldloc.s 16
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0271: pop
 
-			IL_0288: br IL_0127
+			IL_0272: br IL_0111
 		// end loop
 
-		IL_028d: ret
+		IL_0277: ret
 	} // end of method Import_ExportStarFrom_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFrom_LibB
@@ -3517,7 +3463,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x369d
+				// Method begins at RVA 0x3615
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3540,7 +3486,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x350e
+			// Method begins at RVA 0x3486
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -3565,7 +3511,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3694
+			// Method begins at RVA 0x360c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3589,7 +3535,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x24e0
+		// Method begins at RVA 0x249c
 		// Header size: 12
 		// Code size: 133 (0x85)
 		.maxstack 8
@@ -3659,7 +3605,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x36a6
+		// Method begins at RVA 0x361e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48e4
+					// Method begins at RVA 0x47c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48db
+				// Method begins at RVA 0x47b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x293c
+			// Method begins at RVA 0x28a0
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48ed
+				// Method begins at RVA 0x47c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29d4
+			// Method begins at RVA 0x2938
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48f6
+				// Method begins at RVA 0x47d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a59
+			// Method begins at RVA 0x29bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4923
+					// Method begins at RVA 0x47ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fe9
+				// Method begins at RVA 0x2f37
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x492c
+					// Method begins at RVA 0x4808
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ff8
+				// Method begins at RVA 0x2f46
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4959
+						// Method begins at RVA 0x4835
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x309d
+					// Method begins at RVA 0x2fed
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4950
+					// Method begins at RVA 0x482c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3008
+				// Method begins at RVA 0x2f58
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4908
+					// Method begins at RVA 0x47e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4911
+					// Method begins at RVA 0x47ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x491a
+					// Method begins at RVA 0x47f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x493e
+						// Method begins at RVA 0x481a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4947
+						// Method begins at RVA 0x4823
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4935
+					// Method begins at RVA 0x4811
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4962
+					// Method begins at RVA 0x483e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x496b
+					// Method begins at RVA 0x4847
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48ff
+				// Method begins at RVA 0x47db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x2a64
+			// Method begins at RVA 0x29c8
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4974
+				// Method begins at RVA 0x4850
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x2f80
+			// Method begins at RVA 0x2ee4
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportStarFromMultiHop/Scope
-			IL_0011: ldftn object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportStarFromMultiHop/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x48d2
+			// Method begins at RVA 0x47ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 374 (0x176)
+		// Code size: 352 (0x160)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop/Scope,
@@ -1511,57 +1502,48 @@
 		IL_00d8: stloc.s 6
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_00ef: ldftn object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_ExportStarFromMultiHop_LibC.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 6
-		IL_010e: ldloc.s 6
-		IL_0110: stloc.s 5
-		IL_0112: ldnull
-		IL_0113: ldloc.s 5
-		IL_0115: ldstr "alpha"
-		IL_011a: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
-		IL_011f: stloc.s 6
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0126: ldstr "alpha:"
-		IL_012b: ldloc.s 6
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0132: pop
-		IL_0133: ldnull
-		IL_0134: ldloc.s 5
-		IL_0136: ldstr "beta"
-		IL_013b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0140: stloc.s 6
-		IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0147: ldstr "beta:"
-		IL_014c: ldloc.s 6
-		IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0153: pop
-		IL_0154: ldnull
-		IL_0155: ldloc.s 5
-		IL_0157: ldstr "gamma"
-		IL_015c: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0161: stloc.s 6
-		IL_0163: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0168: ldstr "gamma:"
-		IL_016d: ldloc.s 6
-		IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0174: pop
-		IL_0175: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_ExportStarFromMultiHop/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_ExportStarFromMultiHop_LibC.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 6
+		IL_00f8: ldloc.s 6
+		IL_00fa: stloc.s 5
+		IL_00fc: ldnull
+		IL_00fd: ldloc.s 5
+		IL_00ff: ldstr "alpha"
+		IL_0104: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0109: stloc.s 6
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0110: ldstr "alpha:"
+		IL_0115: ldloc.s 6
+		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_011c: pop
+		IL_011d: ldnull
+		IL_011e: ldloc.s 5
+		IL_0120: ldstr "beta"
+		IL_0125: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
+		IL_012a: stloc.s 6
+		IL_012c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0131: ldstr "beta:"
+		IL_0136: ldloc.s 6
+		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_013d: pop
+		IL_013e: ldnull
+		IL_013f: ldloc.s 5
+		IL_0141: ldstr "gamma"
+		IL_0146: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
+		IL_014b: stloc.s 6
+		IL_014d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0152: ldstr "gamma:"
+		IL_0157: ldloc.s 6
+		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_015e: pop
+		IL_015f: ret
 	} // end of method Import_ExportStarFromMultiHop::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop
@@ -1585,7 +1567,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49bc
+					// Method begins at RVA 0x4898
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1603,7 +1585,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49b3
+				// Method begins at RVA 0x488f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1629,7 +1611,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x30c0
+			// Method begins at RVA 0x3010
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1704,7 +1686,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49c5
+				// Method begins at RVA 0x48a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1728,7 +1710,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3158
+			// Method begins at RVA 0x30a8
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1802,7 +1784,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49ce
+				// Method begins at RVA 0x48aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1827,7 +1809,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31dd
+			// Method begins at RVA 0x312d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1855,7 +1837,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49fb
+					// Method begins at RVA 0x48d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1879,7 +1861,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37df
+				// Method begins at RVA 0x3701
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1905,7 +1887,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a04
+					// Method begins at RVA 0x48e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1929,7 +1911,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37ee
+				// Method begins at RVA 0x3710
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1959,7 +1941,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4a31
+						// Method begins at RVA 0x490d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1983,7 +1965,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x38b5
+					// Method begins at RVA 0x37d5
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2017,7 +1999,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a28
+					// Method begins at RVA 0x4904
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2042,7 +2024,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3820
+				// Method begins at RVA 0x3740
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2135,7 +2117,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49e0
+					// Method begins at RVA 0x48bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2155,7 +2137,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49e9
+					// Method begins at RVA 0x48c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2175,7 +2157,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49f2
+					// Method begins at RVA 0x48ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2199,7 +2181,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4a16
+						// Method begins at RVA 0x48f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2219,7 +2201,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4a1f
+						// Method begins at RVA 0x48fb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2237,7 +2219,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a0d
+					// Method begins at RVA 0x48e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2257,7 +2239,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a3a
+					// Method begins at RVA 0x4916
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2277,7 +2259,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a43
+					// Method begins at RVA 0x491f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2299,7 +2281,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49d7
+				// Method begins at RVA 0x48b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2326,7 +2308,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x31e8
+			// Method begins at RVA 0x3138
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2851,7 +2833,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a4c
+				// Method begins at RVA 0x4928
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2879,50 +2861,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3704
+			// Method begins at RVA 0x3654
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_0011: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -2942,7 +2915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49aa
+					// Method begins at RVA 0x4886
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2966,7 +2939,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37fd
+				// Method begins at RVA 0x371f
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -3001,7 +2974,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x49a1
+				// Method begins at RVA 0x487d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3028,9 +3001,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3770
+			// Method begins at RVA 0x36a8
 			// Header size: 12
-			// Code size: 99 (0x63)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope,
@@ -3065,24 +3038,15 @@
 			IL_0035: ldc.i4.1
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_003b: stloc.2
-			IL_003c: ldc.i4.1
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldarg.0
-			IL_0045: stelem.ref
-			IL_0046: ldc.i4.0
-			IL_0047: ldelem.ref
-			IL_0048: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_004d: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0058: ldnull
-			IL_0059: ldloc.1
-			IL_005a: ldloc.2
-			IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0060: pop
-			IL_0061: ldnull
-			IL_0062: ret
+			IL_003c: ldarg.0
+			IL_003d: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
+			IL_0042: ldnull
+			IL_0043: ldloc.1
+			IL_0044: ldloc.2
+			IL_0045: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
+			IL_004a: pop
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L10C3::__js_call__
 
 	} // end of class FunctionExpression_L10C3
@@ -3106,7 +3070,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x498f
+					// Method begins at RVA 0x486b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3126,7 +3090,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4998
+					// Method begins at RVA 0x4874
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3144,7 +3108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4986
+				// Method begins at RVA 0x4862
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3171,7 +3135,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x497d
+			// Method begins at RVA 0x4859
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3195,9 +3159,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21d4
+		// Method begins at RVA 0x21bc
 		// Header size: 12
-		// Code size: 654 (0x28e)
+		// Code size: 632 (0x278)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibC/Scope,
@@ -3310,163 +3274,154 @@
 		IL_00da: ldloc.0
 		IL_00db: ldloc.s 9
 		IL_00dd: stfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_export
-		IL_00e2: ldc.i4.1
-		IL_00e3: newarr [System.Runtime]System.Object
-		IL_00e8: dup
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldloc.0
-		IL_00eb: stelem.ref
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldelem.ref
-		IL_00ee: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_00f3: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
-		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fe: ldnull
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0104: pop
-		IL_0105: ldarg.1
-		IL_0106: ldstr "./Import_ExportStarFromMultiHop_LibB.mjs"
-		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0110: stloc.s 9
-		IL_0112: ldloc.0
-		IL_0113: ldloc.s 9
-		IL_0115: stfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
-		IL_011a: ldloc.0
-		IL_011b: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
-		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
-		IL_0125: stloc.s 4
-		// loop start (head: IL_0127)
-			IL_0127: ldloc.s 4
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-			IL_012e: stloc.s 9
-			IL_0130: ldloc.s 9
-			IL_0132: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0137: stloc.s 10
-			IL_0139: ldloc.s 10
-			IL_013b: brtrue IL_028d
+		IL_00e2: ldloc.0
+		IL_00e3: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
+		IL_00e8: ldnull
+		IL_00e9: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_ExportStarFromMultiHop_LibB.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 9
+		IL_00fc: ldloc.0
+		IL_00fd: ldloc.s 9
+		IL_00ff: stfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
+		IL_0104: ldloc.0
+		IL_0105: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
+		IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
+		IL_010f: stloc.s 4
+		// loop start (head: IL_0111)
+			IL_0111: ldloc.s 4
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+			IL_0118: stloc.s 9
+			IL_011a: ldloc.s 9
+			IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0121: stloc.s 10
+			IL_0123: ldloc.s 10
+			IL_0125: brtrue IL_0277
 
-			IL_0140: ldloc.s 9
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0147: stloc.s 9
-			IL_0149: ldloc.s 9
-			IL_014b: stloc.s 5
-			IL_014d: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47::.ctor()
-			IL_0152: stloc.s 6
-			IL_0154: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-			IL_0159: ldstr "prototype"
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0163: ldstr "hasOwnProperty"
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012a: ldloc.s 9
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0131: stloc.s 9
+			IL_0133: ldloc.s 9
+			IL_0135: stloc.s 5
+			IL_0137: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47::.ctor()
+			IL_013c: stloc.s 6
+			IL_013e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+			IL_0143: ldstr "prototype"
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014d: ldstr "hasOwnProperty"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015c: stloc.s 9
+			IL_015e: ldloc.s 9
+			IL_0160: ldstr "call"
+			IL_0165: ldloc.0
+			IL_0166: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
+			IL_016b: ldloc.s 5
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_0172: stloc.s 9
 			IL_0174: ldloc.s 9
-			IL_0176: ldstr "call"
-			IL_017b: ldloc.0
-			IL_017c: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
-			IL_0181: ldloc.s 5
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0188: stloc.s 9
-			IL_018a: ldloc.s 9
-			IL_018c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0191: ldc.i4.0
-			IL_0192: ceq
-			IL_0194: stloc.s 10
-			IL_0196: ldloc.s 10
-			IL_0198: brfalse IL_01a9
+			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_017b: ldc.i4.0
+			IL_017c: ceq
+			IL_017e: stloc.s 10
+			IL_0180: ldloc.s 10
+			IL_0182: brfalse IL_0193
 
-			IL_019d: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L8C81::.ctor()
-			IL_01a2: stloc.s 7
-			IL_01a4: br IL_0288
+			IL_0187: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L8C81::.ctor()
+			IL_018c: stloc.s 7
+			IL_018e: br IL_0272
 
-			IL_01a9: ldloc.s 5
-			IL_01ab: ldstr "default"
-			IL_01b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01b5: stloc.s 10
-			IL_01b7: ldloc.s 10
-			IL_01b9: box [System.Runtime]System.Boolean
-			IL_01be: stloc.s 11
-			IL_01c0: ldloc.s 11
-			IL_01c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01c7: stloc.s 10
-			IL_01c9: ldloc.s 10
-			IL_01cb: brtrue IL_01f0
+			IL_0193: ldloc.s 5
+			IL_0195: ldstr "default"
+			IL_019a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_019f: stloc.s 10
+			IL_01a1: ldloc.s 10
+			IL_01a3: box [System.Runtime]System.Boolean
+			IL_01a8: stloc.s 11
+			IL_01aa: ldloc.s 11
+			IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01b1: stloc.s 10
+			IL_01b3: ldloc.s 10
+			IL_01b5: brtrue IL_01da
 
-			IL_01d0: ldloc.s 5
-			IL_01d2: ldstr "__esModule"
-			IL_01d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01dc: stloc.s 10
-			IL_01de: ldloc.s 10
-			IL_01e0: box [System.Runtime]System.Boolean
-			IL_01e5: stloc.s 12
-			IL_01e7: ldloc.s 12
-			IL_01e9: stloc.s 14
-			IL_01eb: br IL_01f4
+			IL_01ba: ldloc.s 5
+			IL_01bc: ldstr "__esModule"
+			IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01c6: stloc.s 10
+			IL_01c8: ldloc.s 10
+			IL_01ca: box [System.Runtime]System.Boolean
+			IL_01cf: stloc.s 12
+			IL_01d1: ldloc.s 12
+			IL_01d3: stloc.s 14
+			IL_01d5: br IL_01de
 
-			IL_01f0: ldloc.s 11
-			IL_01f2: stloc.s 14
+			IL_01da: ldloc.s 11
+			IL_01dc: stloc.s 14
 
-			IL_01f4: ldloc.s 14
-			IL_01f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01fb: stloc.s 10
-			IL_01fd: ldloc.s 10
-			IL_01ff: brtrue IL_0224
+			IL_01de: ldloc.s 14
+			IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01e5: stloc.s 10
+			IL_01e7: ldloc.s 10
+			IL_01e9: brtrue IL_020e
 
-			IL_0204: ldloc.s 5
-			IL_0206: ldstr "module.exports"
-			IL_020b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0210: stloc.s 10
-			IL_0212: ldloc.s 10
-			IL_0214: box [System.Runtime]System.Boolean
-			IL_0219: stloc.s 11
-			IL_021b: ldloc.s 11
-			IL_021d: stloc.s 14
-			IL_021f: br IL_0224
+			IL_01ee: ldloc.s 5
+			IL_01f0: ldstr "module.exports"
+			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01fa: stloc.s 10
+			IL_01fc: ldloc.s 10
+			IL_01fe: box [System.Runtime]System.Boolean
+			IL_0203: stloc.s 11
+			IL_0205: ldloc.s 11
+			IL_0207: stloc.s 14
+			IL_0209: br IL_020e
 
-			IL_0224: ldloc.s 14
-			IL_0226: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022b: stloc.s 10
-			IL_022d: ldloc.s 10
-			IL_022f: brfalse IL_0240
+			IL_020e: ldloc.s 14
+			IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0215: stloc.s 10
+			IL_0217: ldloc.s 10
+			IL_0219: brfalse IL_022a
 
-			IL_0234: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L9C116::.ctor()
-			IL_0239: stloc.s 8
-			IL_023b: br IL_0288
+			IL_021e: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L9C116::.ctor()
+			IL_0223: stloc.s 8
+			IL_0225: br IL_0272
 
-			IL_0240: ldc.i4.1
-			IL_0241: newarr [System.Runtime]System.Object
-			IL_0246: dup
-			IL_0247: ldc.i4.0
-			IL_0248: ldloc.0
-			IL_0249: stelem.ref
-			IL_024a: ldc.i4.0
-			IL_024b: ldelem.ref
-			IL_024c: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_0251: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
-			IL_0257: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_025c: ldc.i4.1
-			IL_025d: conv.r8
-			IL_025e: ldstr ""
-			IL_0263: ldc.i4.0
-			IL_0264: ldc.i4.1
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_026a: stloc.s 9
-			IL_026c: ldc.i4.1
-			IL_026d: newarr [System.Runtime]System.Object
-			IL_0272: dup
-			IL_0273: ldc.i4.0
-			IL_0274: ldloc.s 5
-			IL_0276: stelem.ref
-			IL_0277: stloc.s 16
-			IL_0279: ldloc.s 9
-			IL_027b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0280: ldloc.s 16
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0287: pop
+			IL_022a: ldc.i4.1
+			IL_022b: newarr [System.Runtime]System.Object
+			IL_0230: dup
+			IL_0231: ldc.i4.0
+			IL_0232: ldloc.0
+			IL_0233: stelem.ref
+			IL_0234: ldc.i4.0
+			IL_0235: ldelem.ref
+			IL_0236: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
+			IL_023b: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
+			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0246: ldc.i4.1
+			IL_0247: conv.r8
+			IL_0248: ldstr ""
+			IL_024d: ldc.i4.0
+			IL_024e: ldc.i4.1
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0254: stloc.s 9
+			IL_0256: ldc.i4.1
+			IL_0257: newarr [System.Runtime]System.Object
+			IL_025c: dup
+			IL_025d: ldc.i4.0
+			IL_025e: ldloc.s 5
+			IL_0260: stelem.ref
+			IL_0261: stloc.s 16
+			IL_0263: ldloc.s 9
+			IL_0265: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_026a: ldloc.s 16
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0271: pop
 
-			IL_0288: br IL_0127
+			IL_0272: br IL_0111
 		// end loop
 
-		IL_028d: ret
+		IL_0277: ret
 	} // end of method Import_ExportStarFromMultiHop_LibC::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop_LibC
@@ -3486,7 +3441,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a69
+				// Method begins at RVA 0x4945
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3512,7 +3467,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x38d8
+			// Method begins at RVA 0x37f8
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3546,7 +3501,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4aa8
+					// Method begins at RVA 0x4984
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3564,7 +3519,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a9f
+				// Method begins at RVA 0x497b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3590,7 +3545,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x38f8
+			// Method begins at RVA 0x3818
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -3665,7 +3620,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ab1
+				// Method begins at RVA 0x498d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3689,7 +3644,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3990
+			// Method begins at RVA 0x38b0
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -3763,7 +3718,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4aba
+				// Method begins at RVA 0x4996
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3788,7 +3743,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3a15
+			// Method begins at RVA 0x3935
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3816,7 +3771,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ae7
+					// Method begins at RVA 0x49c3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3840,7 +3795,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4017
+				// Method begins at RVA 0x3f09
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3866,7 +3821,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4af0
+					// Method begins at RVA 0x49cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3890,7 +3845,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4026
+				// Method begins at RVA 0x3f18
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3920,7 +3875,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b1d
+						// Method begins at RVA 0x49f9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3944,7 +3899,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x40ed
+					// Method begins at RVA 0x3fdd
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -3978,7 +3933,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b14
+					// Method begins at RVA 0x49f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4003,7 +3958,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4058
+				// Method begins at RVA 0x3f48
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4096,7 +4051,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4acc
+					// Method begins at RVA 0x49a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4116,7 +4071,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ad5
+					// Method begins at RVA 0x49b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4136,7 +4091,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ade
+					// Method begins at RVA 0x49ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4160,7 +4115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b02
+						// Method begins at RVA 0x49de
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4180,7 +4135,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4b0b
+						// Method begins at RVA 0x49e7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4198,7 +4153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4af9
+					// Method begins at RVA 0x49d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4218,7 +4173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b26
+					// Method begins at RVA 0x4a02
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4238,7 +4193,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b2f
+					// Method begins at RVA 0x4a0b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4260,7 +4215,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ac3
+				// Method begins at RVA 0x499f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4287,7 +4242,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3a20
+			// Method begins at RVA 0x3940
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -4812,7 +4767,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b38
+				// Method begins at RVA 0x4a14
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4840,50 +4795,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3f3c
+			// Method begins at RVA 0x3e5c
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_0011: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -4903,7 +4849,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a96
+					// Method begins at RVA 0x4972
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4927,7 +4873,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4035
+				// Method begins at RVA 0x3f27
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -4962,7 +4908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a8d
+				// Method begins at RVA 0x4969
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4989,9 +4935,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3fa8
+			// Method begins at RVA 0x3eb0
 			// Header size: 12
-			// Code size: 99 (0x63)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope,
@@ -5026,24 +4972,15 @@
 			IL_0035: ldc.i4.1
 			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_003b: stloc.2
-			IL_003c: ldc.i4.1
-			IL_003d: newarr [System.Runtime]System.Object
-			IL_0042: dup
-			IL_0043: ldc.i4.0
-			IL_0044: ldarg.0
-			IL_0045: stelem.ref
-			IL_0046: ldc.i4.0
-			IL_0047: ldelem.ref
-			IL_0048: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_004d: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
-			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0058: ldnull
-			IL_0059: ldloc.1
-			IL_005a: ldloc.2
-			IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0060: pop
-			IL_0061: ldnull
-			IL_0062: ret
+			IL_003c: ldarg.0
+			IL_003d: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+			IL_0042: ldnull
+			IL_0043: ldloc.1
+			IL_0044: ldloc.2
+			IL_0045: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
+			IL_004a: pop
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L11C3::__js_call__
 
 	} // end of class FunctionExpression_L11C3
@@ -5068,7 +5005,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a7b
+					// Method begins at RVA 0x4957
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5088,7 +5025,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a84
+					// Method begins at RVA 0x4960
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5106,7 +5043,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a72
+				// Method begins at RVA 0x494e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5134,7 +5071,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4a55
+			// Method begins at RVA 0x4931
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5161,9 +5098,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2470
+		// Method begins at RVA 0x2440
 		// Header size: 12
-		// Code size: 751 (0x2ef)
+		// Code size: 707 (0x2c3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibB/Scope,
@@ -5276,200 +5213,182 @@
 		IL_00da: ldloc.0
 		IL_00db: ldloc.s 9
 		IL_00dd: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_export
-		IL_00e2: ldc.i4.1
-		IL_00e3: newarr [System.Runtime]System.Object
-		IL_00e8: dup
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldloc.0
-		IL_00eb: stelem.ref
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldelem.ref
-		IL_00ee: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_00f3: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fe: ldnull
-		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0104: pop
-		IL_0105: ldc.i4.1
-		IL_0106: newarr [System.Runtime]System.Object
-		IL_010b: dup
-		IL_010c: ldc.i4.0
-		IL_010d: ldloc.0
-		IL_010e: stelem.ref
-		IL_010f: ldc.i4.0
-		IL_0110: ldelem.ref
-		IL_0111: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0116: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0121: ldc.i4.0
-		IL_0122: conv.r8
-		IL_0123: ldstr ""
-		IL_0128: ldc.i4.0
-		IL_0129: ldc.i4.1
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_012f: stloc.s 9
-		IL_0131: ldc.i4.1
-		IL_0132: newarr [System.Runtime]System.Object
-		IL_0137: dup
-		IL_0138: ldc.i4.0
-		IL_0139: ldloc.0
-		IL_013a: stelem.ref
-		IL_013b: ldc.i4.0
-		IL_013c: ldelem.ref
-		IL_013d: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0142: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
-		IL_0148: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_014d: ldnull
-		IL_014e: ldstr "gamma"
-		IL_0153: ldloc.s 9
-		IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_015a: pop
-		IL_015b: ldarg.1
-		IL_015c: ldstr "./Import_ExportStarFromMultiHop_LibA.mjs"
-		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0166: stloc.s 9
-		IL_0168: ldloc.0
-		IL_0169: ldloc.s 9
-		IL_016b: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
-		IL_0170: ldloc.0
-		IL_0171: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
-		IL_0176: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
-		IL_017b: stloc.s 4
-		// loop start (head: IL_017d)
-			IL_017d: ldloc.s 4
-			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-			IL_0184: stloc.s 9
-			IL_0186: ldloc.s 9
-			IL_0188: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_018d: stloc.s 10
-			IL_018f: ldloc.s 10
-			IL_0191: brtrue IL_02e3
+		IL_00e2: ldloc.0
+		IL_00e3: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+		IL_00e8: ldnull
+		IL_00e9: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+		IL_00ee: pop
+		IL_00ef: ldc.i4.1
+		IL_00f0: newarr [System.Runtime]System.Object
+		IL_00f5: dup
+		IL_00f6: ldc.i4.0
+		IL_00f7: ldloc.0
+		IL_00f8: stelem.ref
+		IL_00f9: ldc.i4.0
+		IL_00fa: ldelem.ref
+		IL_00fb: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+		IL_0100: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+		IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_010b: ldc.i4.0
+		IL_010c: conv.r8
+		IL_010d: ldstr ""
+		IL_0112: ldc.i4.0
+		IL_0113: ldc.i4.1
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0119: stloc.s 9
+		IL_011b: ldloc.0
+		IL_011c: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+		IL_0121: ldnull
+		IL_0122: ldstr "gamma"
+		IL_0127: ldloc.s 9
+		IL_0129: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
+		IL_012e: pop
+		IL_012f: ldarg.1
+		IL_0130: ldstr "./Import_ExportStarFromMultiHop_LibA.mjs"
+		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_013a: stloc.s 9
+		IL_013c: ldloc.0
+		IL_013d: ldloc.s 9
+		IL_013f: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
+		IL_0144: ldloc.0
+		IL_0145: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
+		IL_014a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
+		IL_014f: stloc.s 4
+		// loop start (head: IL_0151)
+			IL_0151: ldloc.s 4
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+			IL_0158: stloc.s 9
+			IL_015a: ldloc.s 9
+			IL_015c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0161: stloc.s 10
+			IL_0163: ldloc.s 10
+			IL_0165: brtrue IL_02b7
 
-			IL_0196: ldloc.s 9
-			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_019d: stloc.s 9
-			IL_019f: ldloc.s 9
-			IL_01a1: stloc.s 5
-			IL_01a3: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47::.ctor()
-			IL_01a8: stloc.s 6
-			IL_01aa: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-			IL_01af: ldstr "prototype"
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b9: ldstr "hasOwnProperty"
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c8: stloc.s 9
-			IL_01ca: ldloc.s 9
-			IL_01cc: ldstr "call"
-			IL_01d1: ldloc.0
-			IL_01d2: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
-			IL_01d7: ldloc.s 5
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01de: stloc.s 9
-			IL_01e0: ldloc.s 9
-			IL_01e2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01e7: ldc.i4.0
-			IL_01e8: ceq
-			IL_01ea: stloc.s 10
-			IL_01ec: ldloc.s 10
-			IL_01ee: brfalse IL_01ff
+			IL_016a: ldloc.s 9
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0171: stloc.s 9
+			IL_0173: ldloc.s 9
+			IL_0175: stloc.s 5
+			IL_0177: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47::.ctor()
+			IL_017c: stloc.s 6
+			IL_017e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+			IL_0183: ldstr "prototype"
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_018d: ldstr "hasOwnProperty"
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019c: stloc.s 9
+			IL_019e: ldloc.s 9
+			IL_01a0: ldstr "call"
+			IL_01a5: ldloc.0
+			IL_01a6: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
+			IL_01ab: ldloc.s 5
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01b2: stloc.s 9
+			IL_01b4: ldloc.s 9
+			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01bb: ldc.i4.0
+			IL_01bc: ceq
+			IL_01be: stloc.s 10
+			IL_01c0: ldloc.s 10
+			IL_01c2: brfalse IL_01d3
 
-			IL_01f3: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L9C81::.ctor()
-			IL_01f8: stloc.s 7
-			IL_01fa: br IL_02de
+			IL_01c7: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L9C81::.ctor()
+			IL_01cc: stloc.s 7
+			IL_01ce: br IL_02b2
 
-			IL_01ff: ldloc.s 5
-			IL_0201: ldstr "default"
-			IL_0206: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_020b: stloc.s 10
-			IL_020d: ldloc.s 10
-			IL_020f: box [System.Runtime]System.Boolean
-			IL_0214: stloc.s 11
-			IL_0216: ldloc.s 11
-			IL_0218: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_021d: stloc.s 10
-			IL_021f: ldloc.s 10
-			IL_0221: brtrue IL_0246
+			IL_01d3: ldloc.s 5
+			IL_01d5: ldstr "default"
+			IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01df: stloc.s 10
+			IL_01e1: ldloc.s 10
+			IL_01e3: box [System.Runtime]System.Boolean
+			IL_01e8: stloc.s 11
+			IL_01ea: ldloc.s 11
+			IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01f1: stloc.s 10
+			IL_01f3: ldloc.s 10
+			IL_01f5: brtrue IL_021a
 
-			IL_0226: ldloc.s 5
-			IL_0228: ldstr "__esModule"
-			IL_022d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0232: stloc.s 10
-			IL_0234: ldloc.s 10
-			IL_0236: box [System.Runtime]System.Boolean
-			IL_023b: stloc.s 12
-			IL_023d: ldloc.s 12
-			IL_023f: stloc.s 14
-			IL_0241: br IL_024a
+			IL_01fa: ldloc.s 5
+			IL_01fc: ldstr "__esModule"
+			IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0206: stloc.s 10
+			IL_0208: ldloc.s 10
+			IL_020a: box [System.Runtime]System.Boolean
+			IL_020f: stloc.s 12
+			IL_0211: ldloc.s 12
+			IL_0213: stloc.s 14
+			IL_0215: br IL_021e
 
-			IL_0246: ldloc.s 11
-			IL_0248: stloc.s 14
+			IL_021a: ldloc.s 11
+			IL_021c: stloc.s 14
 
-			IL_024a: ldloc.s 14
-			IL_024c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0251: stloc.s 10
-			IL_0253: ldloc.s 10
-			IL_0255: brtrue IL_027a
+			IL_021e: ldloc.s 14
+			IL_0220: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0225: stloc.s 10
+			IL_0227: ldloc.s 10
+			IL_0229: brtrue IL_024e
 
-			IL_025a: ldloc.s 5
-			IL_025c: ldstr "module.exports"
-			IL_0261: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0266: stloc.s 10
-			IL_0268: ldloc.s 10
-			IL_026a: box [System.Runtime]System.Boolean
-			IL_026f: stloc.s 11
-			IL_0271: ldloc.s 11
-			IL_0273: stloc.s 14
-			IL_0275: br IL_027a
+			IL_022e: ldloc.s 5
+			IL_0230: ldstr "module.exports"
+			IL_0235: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_023a: stloc.s 10
+			IL_023c: ldloc.s 10
+			IL_023e: box [System.Runtime]System.Boolean
+			IL_0243: stloc.s 11
+			IL_0245: ldloc.s 11
+			IL_0247: stloc.s 14
+			IL_0249: br IL_024e
 
-			IL_027a: ldloc.s 14
-			IL_027c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0281: stloc.s 10
-			IL_0283: ldloc.s 10
-			IL_0285: brfalse IL_0296
+			IL_024e: ldloc.s 14
+			IL_0250: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0255: stloc.s 10
+			IL_0257: ldloc.s 10
+			IL_0259: brfalse IL_026a
 
-			IL_028a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L10C116::.ctor()
-			IL_028f: stloc.s 8
-			IL_0291: br IL_02de
+			IL_025e: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L10C116::.ctor()
+			IL_0263: stloc.s 8
+			IL_0265: br IL_02b2
 
+			IL_026a: ldc.i4.1
+			IL_026b: newarr [System.Runtime]System.Object
+			IL_0270: dup
+			IL_0271: ldc.i4.0
+			IL_0272: ldloc.0
+			IL_0273: stelem.ref
+			IL_0274: ldc.i4.0
+			IL_0275: ldelem.ref
+			IL_0276: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+			IL_027b: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
+			IL_0281: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0286: ldc.i4.1
+			IL_0287: conv.r8
+			IL_0288: ldstr ""
+			IL_028d: ldc.i4.0
+			IL_028e: ldc.i4.1
+			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0294: stloc.s 9
 			IL_0296: ldc.i4.1
 			IL_0297: newarr [System.Runtime]System.Object
 			IL_029c: dup
 			IL_029d: ldc.i4.0
-			IL_029e: ldloc.0
-			IL_029f: stelem.ref
-			IL_02a0: ldc.i4.0
-			IL_02a1: ldelem.ref
-			IL_02a2: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_02a7: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
-			IL_02ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_02b2: ldc.i4.1
-			IL_02b3: conv.r8
-			IL_02b4: ldstr ""
-			IL_02b9: ldc.i4.0
-			IL_02ba: ldc.i4.1
-			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_02c0: stloc.s 9
-			IL_02c2: ldc.i4.1
-			IL_02c3: newarr [System.Runtime]System.Object
-			IL_02c8: dup
-			IL_02c9: ldc.i4.0
-			IL_02ca: ldloc.s 5
-			IL_02cc: stelem.ref
-			IL_02cd: stloc.s 16
-			IL_02cf: ldloc.s 9
-			IL_02d1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_02d6: ldloc.s 16
-			IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_02dd: pop
+			IL_029e: ldloc.s 5
+			IL_02a0: stelem.ref
+			IL_02a1: stloc.s 16
+			IL_02a3: ldloc.s 9
+			IL_02a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_02aa: ldloc.s 16
+			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_02b1: pop
 
-			IL_02de: br IL_017d
+			IL_02b2: br IL_0151
 		// end loop
 
-		IL_02e3: ldloc.0
-		IL_02e4: ldstr "g"
-		IL_02e9: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::gamma
-		IL_02ee: ret
+		IL_02b7: ldloc.0
+		IL_02b8: ldstr "g"
+		IL_02bd: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::gamma
+		IL_02c2: ret
 	} // end of method Import_ExportStarFromMultiHop_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop_LibB
@@ -5489,7 +5408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b60
+				// Method begins at RVA 0x4a3c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5515,7 +5434,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4110
+			// Method begins at RVA 0x4000
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5545,7 +5464,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b69
+				// Method begins at RVA 0x4a45
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5571,7 +5490,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4130
+			// Method begins at RVA 0x4020
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5605,7 +5524,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b7b
+					// Method begins at RVA 0x4a57
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5623,7 +5542,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b72
+				// Method begins at RVA 0x4a4e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5649,7 +5568,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4150
+			// Method begins at RVA 0x4040
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -5724,7 +5643,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b84
+				// Method begins at RVA 0x4a60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5748,7 +5667,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x41e8
+			// Method begins at RVA 0x40d8
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -5822,7 +5741,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b8d
+				// Method begins at RVA 0x4a69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5847,7 +5766,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x426d
+			// Method begins at RVA 0x415d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5875,7 +5794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bba
+					// Method begins at RVA 0x4a96
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5899,7 +5818,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x47fd
+				// Method begins at RVA 0x46d7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -5925,7 +5844,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bc3
+					// Method begins at RVA 0x4a9f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5949,7 +5868,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x480c
+				// Method begins at RVA 0x46e6
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -5979,7 +5898,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bf0
+						// Method begins at RVA 0x4acc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6003,7 +5922,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x48b1
+					// Method begins at RVA 0x478d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -6037,7 +5956,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4be7
+					// Method begins at RVA 0x4ac3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6062,7 +5981,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x481c
+				// Method begins at RVA 0x46f8
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -6155,7 +6074,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b9f
+					// Method begins at RVA 0x4a7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6175,7 +6094,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ba8
+					// Method begins at RVA 0x4a84
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6195,7 +6114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bb1
+					// Method begins at RVA 0x4a8d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6219,7 +6138,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bd5
+						// Method begins at RVA 0x4ab1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6239,7 +6158,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bde
+						// Method begins at RVA 0x4aba
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6257,7 +6176,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bcc
+					// Method begins at RVA 0x4aa8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6277,7 +6196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bf9
+					// Method begins at RVA 0x4ad5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6297,7 +6216,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c02
+					// Method begins at RVA 0x4ade
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6319,7 +6238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b96
+				// Method begins at RVA 0x4a72
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6346,7 +6265,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4278
+			// Method begins at RVA 0x4168
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -6871,7 +6790,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c0b
+				// Method begins at RVA 0x4ae7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6899,50 +6818,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4794
+			// Method begins at RVA 0x4684
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-			IL_0011: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -6970,7 +6880,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4b41
+			// Method begins at RVA 0x4a1d
 			// Header size: 1
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -7000,9 +6910,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x276c
+		// Method begins at RVA 0x2710
 		// Header size: 12
-		// Code size: 452 (0x1c4)
+		// Code size: 386 (0x182)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibA/Scope,
@@ -7103,95 +7013,68 @@
 		IL_00d8: stloc.s 5
 		IL_00da: ldloc.s 5
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_00ef: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldc.i4.1
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: dup
-		IL_0108: ldc.i4.0
-		IL_0109: ldloc.0
-		IL_010a: stelem.ref
-		IL_010b: ldc.i4.0
-		IL_010c: ldelem.ref
-		IL_010d: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0112: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_011d: ldc.i4.0
-		IL_011e: conv.r8
-		IL_011f: ldstr ""
-		IL_0124: ldc.i4.0
-		IL_0125: ldc.i4.1
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_012b: stloc.s 5
-		IL_012d: ldc.i4.1
-		IL_012e: newarr [System.Runtime]System.Object
-		IL_0133: dup
-		IL_0134: ldc.i4.0
-		IL_0135: ldloc.0
-		IL_0136: stelem.ref
-		IL_0137: ldc.i4.0
-		IL_0138: ldelem.ref
-		IL_0139: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_013e: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object, object)
-		IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0149: ldnull
-		IL_014a: ldstr "alpha"
-		IL_014f: ldloc.s 5
-		IL_0151: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0156: pop
-		IL_0157: ldc.i4.1
-		IL_0158: newarr [System.Runtime]System.Object
-		IL_015d: dup
-		IL_015e: ldc.i4.0
-		IL_015f: ldloc.0
-		IL_0160: stelem.ref
-		IL_0161: ldc.i4.0
-		IL_0162: ldelem.ref
-		IL_0163: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0168: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0173: ldc.i4.0
-		IL_0174: conv.r8
-		IL_0175: ldstr ""
-		IL_017a: ldc.i4.0
-		IL_017b: ldc.i4.1
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0181: stloc.s 5
-		IL_0183: ldc.i4.1
-		IL_0184: newarr [System.Runtime]System.Object
-		IL_0189: dup
-		IL_018a: ldc.i4.0
-		IL_018b: ldloc.0
-		IL_018c: stelem.ref
-		IL_018d: ldc.i4.0
-		IL_018e: ldelem.ref
-		IL_018f: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0194: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object, object)
-		IL_019a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_019f: ldnull
-		IL_01a0: ldstr "beta"
-		IL_01a5: ldloc.s 5
-		IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01ac: pop
-		IL_01ad: ldloc.0
-		IL_01ae: ldstr "a"
-		IL_01b3: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::alpha
-		IL_01b8: ldloc.0
-		IL_01b9: ldstr "b"
-		IL_01be: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::beta
-		IL_01c3: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldc.i4.1
+		IL_00ec: newarr [System.Runtime]System.Object
+		IL_00f1: dup
+		IL_00f2: ldc.i4.0
+		IL_00f3: ldloc.0
+		IL_00f4: stelem.ref
+		IL_00f5: ldc.i4.0
+		IL_00f6: ldelem.ref
+		IL_00f7: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+		IL_00fc: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+		IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0107: ldc.i4.0
+		IL_0108: conv.r8
+		IL_0109: ldstr ""
+		IL_010e: ldc.i4.0
+		IL_010f: ldc.i4.1
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0115: stloc.s 5
+		IL_0117: ldloc.0
+		IL_0118: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+		IL_011d: ldnull
+		IL_011e: ldstr "alpha"
+		IL_0123: ldloc.s 5
+		IL_0125: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object, object)
+		IL_012a: pop
+		IL_012b: ldc.i4.1
+		IL_012c: newarr [System.Runtime]System.Object
+		IL_0131: dup
+		IL_0132: ldc.i4.0
+		IL_0133: ldloc.0
+		IL_0134: stelem.ref
+		IL_0135: ldc.i4.0
+		IL_0136: ldelem.ref
+		IL_0137: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+		IL_013c: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+		IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0147: ldc.i4.0
+		IL_0148: conv.r8
+		IL_0149: ldstr ""
+		IL_014e: ldc.i4.0
+		IL_014f: ldc.i4.1
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0155: stloc.s 5
+		IL_0157: ldloc.0
+		IL_0158: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+		IL_015d: ldnull
+		IL_015e: ldstr "beta"
+		IL_0163: ldloc.s 5
+		IL_0165: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object, object)
+		IL_016a: pop
+		IL_016b: ldloc.0
+		IL_016c: ldstr "a"
+		IL_0171: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::alpha
+		IL_0176: ldloc.0
+		IL_0177: ldstr "b"
+		IL_017c: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::beta
+		IL_0181: ret
 	} // end of method Import_ExportStarFromMultiHop_LibA::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop_LibA
@@ -7203,7 +7086,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4c14
+		// Method begins at RVA 0x4af0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3814
+					// Method begins at RVA 0x376c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x380b
+				// Method begins at RVA 0x3763
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x287c
+			// Method begins at RVA 0x27fc
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x381d
+				// Method begins at RVA 0x3775
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2914
+			// Method begins at RVA 0x2894
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3826
+				// Method begins at RVA 0x377e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2999
+			// Method begins at RVA 0x2919
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3853
+					// Method begins at RVA 0x37ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f29
+				// Method begins at RVA 0x2e93
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x385c
+					// Method begins at RVA 0x37b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f38
+				// Method begins at RVA 0x2ea2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3889
+						// Method begins at RVA 0x37e1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fdd
+					// Method begins at RVA 0x2f49
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3880
+					// Method begins at RVA 0x37d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f48
+				// Method begins at RVA 0x2eb4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3838
+					// Method begins at RVA 0x3790
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3841
+					// Method begins at RVA 0x3799
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x384a
+					// Method begins at RVA 0x37a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x386e
+						// Method begins at RVA 0x37c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3877
+						// Method begins at RVA 0x37cf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3865
+					// Method begins at RVA 0x37bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3892
+					// Method begins at RVA 0x37ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x389b
+					// Method begins at RVA 0x37f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x382f
+				// Method begins at RVA 0x3787
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x29a4
+			// Method begins at RVA 0x2924
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38a4
+				// Method begins at RVA 0x37fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2ec0
+			// Method begins at RVA 0x2e40
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ImportMeta_Url/Scope
-			IL_0011: ldftn object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ImportMeta_Url/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3802
+			// Method begins at RVA 0x375a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1196 (0x4ac)
+		// Code size: 1174 (0x496)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url/Scope,
@@ -1521,316 +1512,307 @@
 		IL_00d8: stloc.s 11
 		IL_00da: ldloc.s 11
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_00ef: ldftn object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_ImportMeta_Url_Lib.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 11
-		IL_010e: ldloc.s 11
-		IL_0110: stloc.s 5
-		IL_0112: ldarg.1
-		IL_0113: ldstr "node:url"
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_011d: stloc.s 11
-		IL_011f: ldloc.s 11
-		IL_0121: stloc.s 6
-		IL_0123: ldloc.s 6
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012a: stloc.s 11
-		IL_012c: ldarg.3
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_0132: stloc.s 12
-		IL_0134: ldloc.s 12
-		IL_0136: ldstr "url"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0140: stloc.s 12
-		IL_0142: ldloc.s 11
-		IL_0144: ldstr "fileURLToPath"
-		IL_0149: ldloc.s 12
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0150: stloc.s 12
-		IL_0152: ldloc.s 12
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0159: stloc.s 12
-		IL_015b: ldloc.s 12
-		IL_015d: ldstr "split"
-		IL_0162: ldstr "\\"
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_016c: stloc.s 12
-		IL_016e: ldloc.s 12
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0175: stloc.s 12
-		IL_0177: ldloc.s 12
-		IL_0179: ldstr "join"
-		IL_017e: ldstr "/"
-		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0188: stloc.s 12
-		IL_018a: ldloc.s 12
-		IL_018c: stloc.s 7
-		IL_018e: ldloc.s 6
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 12
-		IL_0197: ldloc.s 6
-		IL_0199: ldstr "URL"
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_ImportMeta_Url/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_ImportMeta_Url_Lib.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 11
+		IL_00f8: ldloc.s 11
+		IL_00fa: stloc.s 5
+		IL_00fc: ldarg.1
+		IL_00fd: ldstr "node:url"
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0107: stloc.s 11
+		IL_0109: ldloc.s 11
+		IL_010b: stloc.s 6
+		IL_010d: ldloc.s 6
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0114: stloc.s 11
+		IL_0116: ldarg.3
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_011c: stloc.s 12
+		IL_011e: ldloc.s 12
+		IL_0120: ldstr "url"
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012a: stloc.s 12
+		IL_012c: ldloc.s 11
+		IL_012e: ldstr "fileURLToPath"
+		IL_0133: ldloc.s 12
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013a: stloc.s 12
+		IL_013c: ldloc.s 12
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0143: stloc.s 12
+		IL_0145: ldloc.s 12
+		IL_0147: ldstr "split"
+		IL_014c: ldstr "\\"
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0156: stloc.s 12
+		IL_0158: ldloc.s 12
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_015f: stloc.s 12
+		IL_0161: ldloc.s 12
+		IL_0163: ldstr "join"
+		IL_0168: ldstr "/"
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0172: stloc.s 12
+		IL_0174: ldloc.s 12
+		IL_0176: stloc.s 7
+		IL_0178: ldloc.s 6
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017f: stloc.s 12
+		IL_0181: ldloc.s 6
+		IL_0183: ldstr "URL"
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018d: stloc.s 11
+		IL_018f: ldarg.3
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0195: stloc.s 13
+		IL_0197: ldloc.s 13
+		IL_0199: ldstr "url"
 		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a3: stloc.s 11
-		IL_01a5: ldarg.3
-		IL_01a6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_01ab: stloc.s 13
-		IL_01ad: ldloc.s 13
-		IL_01af: ldstr "url"
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b9: stloc.s 13
-		IL_01bb: ldc.i4.2
-		IL_01bc: newarr [System.Runtime]System.Object
-		IL_01c1: dup
-		IL_01c2: ldc.i4.0
-		IL_01c3: ldstr "./fixtures/main.txt"
-		IL_01c8: stelem.ref
-		IL_01c9: dup
-		IL_01ca: ldc.i4.1
-		IL_01cb: ldloc.s 13
-		IL_01cd: stelem.ref
-		IL_01ce: stloc.s 14
-		IL_01d0: ldloc.s 11
-		IL_01d2: ldloc.s 14
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_01d9: stloc.s 11
-		IL_01db: ldloc.s 12
-		IL_01dd: ldstr "fileURLToPath"
-		IL_01e2: ldloc.s 11
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01e9: stloc.s 11
-		IL_01eb: ldloc.s 11
-		IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f2: stloc.s 11
-		IL_01f4: ldloc.s 11
-		IL_01f6: ldstr "split"
-		IL_01fb: ldstr "\\"
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0205: stloc.s 11
-		IL_0207: ldloc.s 11
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020e: stloc.s 11
-		IL_0210: ldloc.s 11
-		IL_0212: ldstr "join"
-		IL_0217: ldstr "/"
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0221: stloc.s 11
-		IL_0223: ldloc.s 11
-		IL_0225: stloc.s 8
-		IL_0227: ldloc.s 6
-		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022e: stloc.s 11
-		IL_0230: ldnull
-		IL_0231: ldloc.s 5
-		IL_0233: ldstr "importedUrl"
-		IL_0238: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_023d: stloc.s 12
-		IL_023f: ldloc.s 11
-		IL_0241: ldstr "fileURLToPath"
-		IL_0246: ldloc.s 12
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_024d: stloc.s 12
-		IL_024f: ldloc.s 12
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0256: stloc.s 12
-		IL_0258: ldloc.s 12
-		IL_025a: ldstr "split"
-		IL_025f: ldstr "\\"
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0269: stloc.s 12
-		IL_026b: ldloc.s 12
-		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0272: stloc.s 12
-		IL_0274: ldloc.s 12
-		IL_0276: ldstr "join"
-		IL_027b: ldstr "/"
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0285: stloc.s 12
-		IL_0287: ldloc.s 12
-		IL_0289: stloc.s 9
-		IL_028b: ldloc.s 6
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0292: stloc.s 12
-		IL_0294: ldloc.s 6
-		IL_0296: ldstr "URL"
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a0: stloc.s 11
-		IL_02a2: ldnull
-		IL_02a3: ldloc.s 5
-		IL_02a5: ldstr "importedUrl"
-		IL_02aa: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_02af: stloc.s 13
-		IL_02b1: ldc.i4.2
-		IL_02b2: newarr [System.Runtime]System.Object
-		IL_02b7: dup
-		IL_02b8: ldc.i4.0
-		IL_02b9: ldstr "./fixtures/lib.txt"
-		IL_02be: stelem.ref
-		IL_02bf: dup
-		IL_02c0: ldc.i4.1
-		IL_02c1: ldloc.s 13
-		IL_02c3: stelem.ref
-		IL_02c4: stloc.s 14
-		IL_02c6: ldloc.s 11
-		IL_02c8: ldloc.s 14
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_02cf: stloc.s 11
-		IL_02d1: ldloc.s 12
-		IL_02d3: ldstr "fileURLToPath"
-		IL_02d8: ldloc.s 11
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02df: stloc.s 11
-		IL_02e1: ldloc.s 11
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e8: stloc.s 11
-		IL_02ea: ldloc.s 11
-		IL_02ec: ldstr "split"
-		IL_02f1: ldstr "\\"
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02fb: stloc.s 11
-		IL_02fd: ldloc.s 11
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0304: stloc.s 11
-		IL_0306: ldloc.s 11
-		IL_0308: ldstr "join"
-		IL_030d: ldstr "/"
-		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0317: stloc.s 11
-		IL_0319: ldloc.s 11
-		IL_031b: stloc.s 10
-		IL_031d: ldarg.3
-		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_0323: stloc.s 11
-		IL_0325: ldloc.s 11
-		IL_0327: ldstr "url"
-		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0331: stloc.s 11
-		IL_0333: ldloc.s 11
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_033a: stloc.s 11
-		IL_033c: ldloc.s 11
-		IL_033e: ldstr "startsWith"
-		IL_0343: ldstr "file://"
-		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_034d: stloc.s 11
-		IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0354: ldstr "main has file url:"
-		IL_0359: ldloc.s 11
-		IL_035b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0360: pop
-		IL_0361: ldarg.3
-		IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0367: stloc.s 11
-		IL_0369: ldloc.s 11
-		IL_036b: ldstr "split"
-		IL_0370: ldstr "\\"
-		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_037a: stloc.s 11
-		IL_037c: ldloc.s 11
-		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0383: stloc.s 11
-		IL_0385: ldloc.s 11
-		IL_0387: ldstr "join"
-		IL_038c: ldstr "/"
-		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0396: stloc.s 11
-		IL_0398: ldloc.s 7
-		IL_039a: ldloc.s 11
-		IL_039c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03a1: stloc.s 15
-		IL_03a3: ldloc.s 15
-		IL_03a5: box [System.Runtime]System.Boolean
-		IL_03aa: stloc.s 16
-		IL_03ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03b1: ldstr "main path matches filename:"
-		IL_03b6: ldloc.s 16
-		IL_03b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03bd: pop
-		IL_03be: ldloc.s 8
-		IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03c5: stloc.s 11
-		IL_03c7: ldloc.s 11
-		IL_03c9: ldstr "endsWith"
-		IL_03ce: ldstr "/fixtures/main.txt"
-		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03d8: stloc.s 11
-		IL_03da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03df: ldstr "main asset path:"
-		IL_03e4: ldloc.s 11
-		IL_03e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03eb: pop
-		IL_03ec: ldnull
-		IL_03ed: ldloc.s 5
-		IL_03ef: ldstr "importedUrlHasFileScheme"
-		IL_03f4: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_03f9: stloc.s 11
-		IL_03fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0400: ldstr "lib has file url:"
-		IL_0405: ldloc.s 11
-		IL_0407: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_040c: pop
-		IL_040d: ldloc.s 9
-		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0414: stloc.s 11
-		IL_0416: ldloc.s 11
-		IL_0418: ldstr "endsWith"
-		IL_041d: ldstr "/Import_ImportMeta_Url_Lib"
-		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0427: stloc.s 11
-		IL_0429: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_042e: ldstr "lib path:"
-		IL_0433: ldloc.s 11
-		IL_0435: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_043a: pop
-		IL_043b: ldloc.s 10
-		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0442: stloc.s 11
-		IL_0444: ldloc.s 11
-		IL_0446: ldstr "endsWith"
-		IL_044b: ldstr "/fixtures/lib.txt"
-		IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0455: stloc.s 11
-		IL_0457: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_045c: ldstr "lib asset path:"
-		IL_0461: ldloc.s 11
-		IL_0463: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0468: pop
-		IL_0469: ldnull
-		IL_046a: ldloc.s 5
-		IL_046c: ldstr "importedModuleFilenameMatches"
-		IL_0471: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0476: stloc.s 11
-		IL_0478: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_047d: ldstr "lib module.filename:"
-		IL_0482: ldloc.s 11
-		IL_0484: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0489: pop
-		IL_048a: ldnull
-		IL_048b: ldloc.s 5
-		IL_048d: ldstr "importedModulePathMatches"
-		IL_0492: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0497: stloc.s 11
-		IL_0499: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_049e: ldstr "lib module.path:"
-		IL_04a3: ldloc.s 11
-		IL_04a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_04aa: pop
-		IL_04ab: ret
+		IL_01a3: stloc.s 13
+		IL_01a5: ldc.i4.2
+		IL_01a6: newarr [System.Runtime]System.Object
+		IL_01ab: dup
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldstr "./fixtures/main.txt"
+		IL_01b2: stelem.ref
+		IL_01b3: dup
+		IL_01b4: ldc.i4.1
+		IL_01b5: ldloc.s 13
+		IL_01b7: stelem.ref
+		IL_01b8: stloc.s 14
+		IL_01ba: ldloc.s 11
+		IL_01bc: ldloc.s 14
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_01c3: stloc.s 11
+		IL_01c5: ldloc.s 12
+		IL_01c7: ldstr "fileURLToPath"
+		IL_01cc: ldloc.s 11
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d3: stloc.s 11
+		IL_01d5: ldloc.s 11
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01dc: stloc.s 11
+		IL_01de: ldloc.s 11
+		IL_01e0: ldstr "split"
+		IL_01e5: ldstr "\\"
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01ef: stloc.s 11
+		IL_01f1: ldloc.s 11
+		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01f8: stloc.s 11
+		IL_01fa: ldloc.s 11
+		IL_01fc: ldstr "join"
+		IL_0201: ldstr "/"
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_020b: stloc.s 11
+		IL_020d: ldloc.s 11
+		IL_020f: stloc.s 8
+		IL_0211: ldloc.s 6
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0218: stloc.s 11
+		IL_021a: ldnull
+		IL_021b: ldloc.s 5
+		IL_021d: ldstr "importedUrl"
+		IL_0222: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0227: stloc.s 12
+		IL_0229: ldloc.s 11
+		IL_022b: ldstr "fileURLToPath"
+		IL_0230: ldloc.s 12
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0237: stloc.s 12
+		IL_0239: ldloc.s 12
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0240: stloc.s 12
+		IL_0242: ldloc.s 12
+		IL_0244: ldstr "split"
+		IL_0249: ldstr "\\"
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0253: stloc.s 12
+		IL_0255: ldloc.s 12
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_025c: stloc.s 12
+		IL_025e: ldloc.s 12
+		IL_0260: ldstr "join"
+		IL_0265: ldstr "/"
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_026f: stloc.s 12
+		IL_0271: ldloc.s 12
+		IL_0273: stloc.s 9
+		IL_0275: ldloc.s 6
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027c: stloc.s 12
+		IL_027e: ldloc.s 6
+		IL_0280: ldstr "URL"
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028a: stloc.s 11
+		IL_028c: ldnull
+		IL_028d: ldloc.s 5
+		IL_028f: ldstr "importedUrl"
+		IL_0294: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0299: stloc.s 13
+		IL_029b: ldc.i4.2
+		IL_029c: newarr [System.Runtime]System.Object
+		IL_02a1: dup
+		IL_02a2: ldc.i4.0
+		IL_02a3: ldstr "./fixtures/lib.txt"
+		IL_02a8: stelem.ref
+		IL_02a9: dup
+		IL_02aa: ldc.i4.1
+		IL_02ab: ldloc.s 13
+		IL_02ad: stelem.ref
+		IL_02ae: stloc.s 14
+		IL_02b0: ldloc.s 11
+		IL_02b2: ldloc.s 14
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_02b9: stloc.s 11
+		IL_02bb: ldloc.s 12
+		IL_02bd: ldstr "fileURLToPath"
+		IL_02c2: ldloc.s 11
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02c9: stloc.s 11
+		IL_02cb: ldloc.s 11
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d2: stloc.s 11
+		IL_02d4: ldloc.s 11
+		IL_02d6: ldstr "split"
+		IL_02db: ldstr "\\"
+		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02e5: stloc.s 11
+		IL_02e7: ldloc.s 11
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ee: stloc.s 11
+		IL_02f0: ldloc.s 11
+		IL_02f2: ldstr "join"
+		IL_02f7: ldstr "/"
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0301: stloc.s 11
+		IL_0303: ldloc.s 11
+		IL_0305: stloc.s 10
+		IL_0307: ldarg.3
+		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_030d: stloc.s 11
+		IL_030f: ldloc.s 11
+		IL_0311: ldstr "url"
+		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031b: stloc.s 11
+		IL_031d: ldloc.s 11
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0324: stloc.s 11
+		IL_0326: ldloc.s 11
+		IL_0328: ldstr "startsWith"
+		IL_032d: ldstr "file://"
+		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0337: stloc.s 11
+		IL_0339: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_033e: ldstr "main has file url:"
+		IL_0343: ldloc.s 11
+		IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_034a: pop
+		IL_034b: ldarg.3
+		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0351: stloc.s 11
+		IL_0353: ldloc.s 11
+		IL_0355: ldstr "split"
+		IL_035a: ldstr "\\"
+		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0364: stloc.s 11
+		IL_0366: ldloc.s 11
+		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_036d: stloc.s 11
+		IL_036f: ldloc.s 11
+		IL_0371: ldstr "join"
+		IL_0376: ldstr "/"
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0380: stloc.s 11
+		IL_0382: ldloc.s 7
+		IL_0384: ldloc.s 11
+		IL_0386: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_038b: stloc.s 15
+		IL_038d: ldloc.s 15
+		IL_038f: box [System.Runtime]System.Boolean
+		IL_0394: stloc.s 16
+		IL_0396: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_039b: ldstr "main path matches filename:"
+		IL_03a0: ldloc.s 16
+		IL_03a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03a7: pop
+		IL_03a8: ldloc.s 8
+		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03af: stloc.s 11
+		IL_03b1: ldloc.s 11
+		IL_03b3: ldstr "endsWith"
+		IL_03b8: ldstr "/fixtures/main.txt"
+		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03c2: stloc.s 11
+		IL_03c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c9: ldstr "main asset path:"
+		IL_03ce: ldloc.s 11
+		IL_03d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03d5: pop
+		IL_03d6: ldnull
+		IL_03d7: ldloc.s 5
+		IL_03d9: ldstr "importedUrlHasFileScheme"
+		IL_03de: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
+		IL_03e3: stloc.s 11
+		IL_03e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03ea: ldstr "lib has file url:"
+		IL_03ef: ldloc.s 11
+		IL_03f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03f6: pop
+		IL_03f7: ldloc.s 9
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03fe: stloc.s 11
+		IL_0400: ldloc.s 11
+		IL_0402: ldstr "endsWith"
+		IL_0407: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0411: stloc.s 11
+		IL_0413: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0418: ldstr "lib path:"
+		IL_041d: ldloc.s 11
+		IL_041f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0424: pop
+		IL_0425: ldloc.s 10
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_042c: stloc.s 11
+		IL_042e: ldloc.s 11
+		IL_0430: ldstr "endsWith"
+		IL_0435: ldstr "/fixtures/lib.txt"
+		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_043f: stloc.s 11
+		IL_0441: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0446: ldstr "lib asset path:"
+		IL_044b: ldloc.s 11
+		IL_044d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0452: pop
+		IL_0453: ldnull
+		IL_0454: ldloc.s 5
+		IL_0456: ldstr "importedModuleFilenameMatches"
+		IL_045b: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0460: stloc.s 11
+		IL_0462: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0467: ldstr "lib module.filename:"
+		IL_046c: ldloc.s 11
+		IL_046e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0473: pop
+		IL_0474: ldnull
+		IL_0475: ldloc.s 5
+		IL_0477: ldstr "importedModulePathMatches"
+		IL_047c: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0481: stloc.s 11
+		IL_0483: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0488: ldstr "lib module.path:"
+		IL_048d: ldloc.s 11
+		IL_048f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0494: pop
+		IL_0495: ret
 	} // end of method Import_ImportMeta_Url::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url
@@ -1850,7 +1832,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38e2
+				// Method begins at RVA 0x383a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1876,7 +1858,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3000
+			// Method begins at RVA 0x2f6c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1906,7 +1888,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38eb
+				// Method begins at RVA 0x3843
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1932,7 +1914,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3020
+			// Method begins at RVA 0x2f8c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1962,7 +1944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38f4
+				// Method begins at RVA 0x384c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1988,7 +1970,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3040
+			// Method begins at RVA 0x2fac
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2018,7 +2000,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38fd
+				// Method begins at RVA 0x3855
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2044,7 +2026,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3060
+			// Method begins at RVA 0x2fcc
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2078,7 +2060,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x390f
+					// Method begins at RVA 0x3867
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2096,7 +2078,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3906
+				// Method begins at RVA 0x385e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2122,7 +2104,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3080
+			// Method begins at RVA 0x2fec
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -2197,7 +2179,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3918
+				// Method begins at RVA 0x3870
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2221,7 +2203,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3118
+			// Method begins at RVA 0x3084
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -2295,7 +2277,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3921
+				// Method begins at RVA 0x3879
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2320,7 +2302,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x319d
+			// Method begins at RVA 0x3109
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2348,7 +2330,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x394e
+					// Method begins at RVA 0x38a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2372,7 +2354,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x372d
+				// Method begins at RVA 0x3683
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2398,7 +2380,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3957
+					// Method begins at RVA 0x38af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2422,7 +2404,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x373c
+				// Method begins at RVA 0x3692
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2452,7 +2434,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3984
+						// Method begins at RVA 0x38dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2476,7 +2458,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x37e1
+					// Method begins at RVA 0x3739
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2510,7 +2492,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x397b
+					// Method begins at RVA 0x38d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2535,7 +2517,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x374c
+				// Method begins at RVA 0x36a4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2628,7 +2610,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3933
+					// Method begins at RVA 0x388b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2648,7 +2630,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x393c
+					// Method begins at RVA 0x3894
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2668,7 +2650,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3945
+					// Method begins at RVA 0x389d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2692,7 +2674,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3969
+						// Method begins at RVA 0x38c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2712,7 +2694,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3972
+						// Method begins at RVA 0x38ca
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2730,7 +2712,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3960
+					// Method begins at RVA 0x38b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2750,7 +2732,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x398d
+					// Method begins at RVA 0x38e5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2770,7 +2752,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3996
+					// Method begins at RVA 0x38ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2792,7 +2774,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x392a
+				// Method begins at RVA 0x3882
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2819,7 +2801,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x31a8
+			// Method begins at RVA 0x3114
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3344,7 +3326,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x399f
+				// Method begins at RVA 0x38f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3372,50 +3354,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x36c4
+			// Method begins at RVA 0x3630
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-			IL_0011: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3456,7 +3429,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x38ad
+			// Method begins at RVA 0x3805
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3492,9 +3465,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2508
+		// Method begins at RVA 0x24f4
 		// Header size: 12
-		// Code size: 871 (0x367)
+		// Code size: 761 (0x2f9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url_Lib/Scope,
@@ -3598,239 +3571,194 @@
 		IL_00d8: stloc.s 5
 		IL_00da: ldloc.s 5
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_00ef: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldc.i4.1
-		IL_0102: newarr [System.Runtime]System.Object
-		IL_0107: dup
-		IL_0108: ldc.i4.0
-		IL_0109: ldloc.0
-		IL_010a: stelem.ref
-		IL_010b: ldc.i4.0
-		IL_010c: ldelem.ref
-		IL_010d: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0112: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_011d: ldc.i4.0
-		IL_011e: conv.r8
-		IL_011f: ldstr ""
-		IL_0124: ldc.i4.0
-		IL_0125: ldc.i4.1
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_012b: stloc.s 5
-		IL_012d: ldc.i4.1
-		IL_012e: newarr [System.Runtime]System.Object
-		IL_0133: dup
-		IL_0134: ldc.i4.0
-		IL_0135: ldloc.0
-		IL_0136: stelem.ref
-		IL_0137: ldc.i4.0
-		IL_0138: ldelem.ref
-		IL_0139: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_013e: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0149: ldnull
-		IL_014a: ldstr "importedUrl"
-		IL_014f: ldloc.s 5
-		IL_0151: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0156: pop
-		IL_0157: ldc.i4.1
-		IL_0158: newarr [System.Runtime]System.Object
-		IL_015d: dup
-		IL_015e: ldc.i4.0
-		IL_015f: ldloc.0
-		IL_0160: stelem.ref
-		IL_0161: ldc.i4.0
-		IL_0162: ldelem.ref
-		IL_0163: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0168: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0173: ldc.i4.0
-		IL_0174: conv.r8
-		IL_0175: ldstr ""
-		IL_017a: ldc.i4.0
-		IL_017b: ldc.i4.1
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0181: stloc.s 5
-		IL_0183: ldc.i4.1
-		IL_0184: newarr [System.Runtime]System.Object
-		IL_0189: dup
-		IL_018a: ldc.i4.0
-		IL_018b: ldloc.0
-		IL_018c: stelem.ref
-		IL_018d: ldc.i4.0
-		IL_018e: ldelem.ref
-		IL_018f: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0194: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_019a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_019f: ldnull
-		IL_01a0: ldstr "importedUrlHasFileScheme"
-		IL_01a5: ldloc.s 5
-		IL_01a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01ac: pop
-		IL_01ad: ldc.i4.1
-		IL_01ae: newarr [System.Runtime]System.Object
-		IL_01b3: dup
-		IL_01b4: ldc.i4.0
-		IL_01b5: ldloc.0
-		IL_01b6: stelem.ref
-		IL_01b7: ldc.i4.0
-		IL_01b8: ldelem.ref
-		IL_01b9: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_01be: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_01c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01c9: ldc.i4.0
-		IL_01ca: conv.r8
-		IL_01cb: ldstr ""
-		IL_01d0: ldc.i4.0
-		IL_01d1: ldc.i4.1
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01d7: stloc.s 5
-		IL_01d9: ldc.i4.1
-		IL_01da: newarr [System.Runtime]System.Object
-		IL_01df: dup
-		IL_01e0: ldc.i4.0
-		IL_01e1: ldloc.0
-		IL_01e2: stelem.ref
-		IL_01e3: ldc.i4.0
-		IL_01e4: ldelem.ref
-		IL_01e5: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_01ea: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_01f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01f5: ldnull
-		IL_01f6: ldstr "importedModuleFilenameMatches"
-		IL_01fb: ldloc.s 5
-		IL_01fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0202: pop
-		IL_0203: ldc.i4.1
-		IL_0204: newarr [System.Runtime]System.Object
-		IL_0209: dup
-		IL_020a: ldc.i4.0
-		IL_020b: ldloc.0
-		IL_020c: stelem.ref
-		IL_020d: ldc.i4.0
-		IL_020e: ldelem.ref
-		IL_020f: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0214: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_021a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_021f: ldc.i4.0
-		IL_0220: conv.r8
-		IL_0221: ldstr ""
-		IL_0226: ldc.i4.0
-		IL_0227: ldc.i4.1
-		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_022d: stloc.s 5
-		IL_022f: ldc.i4.1
-		IL_0230: newarr [System.Runtime]System.Object
-		IL_0235: dup
-		IL_0236: ldc.i4.0
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldc.i4.1
+		IL_00ec: newarr [System.Runtime]System.Object
+		IL_00f1: dup
+		IL_00f2: ldc.i4.0
+		IL_00f3: ldloc.0
+		IL_00f4: stelem.ref
+		IL_00f5: ldc.i4.0
+		IL_00f6: ldelem.ref
+		IL_00f7: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_00fc: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0107: ldc.i4.0
+		IL_0108: conv.r8
+		IL_0109: ldstr ""
+		IL_010e: ldc.i4.0
+		IL_010f: ldc.i4.1
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0115: stloc.s 5
+		IL_0117: ldloc.0
+		IL_0118: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_011d: ldnull
+		IL_011e: ldstr "importedUrl"
+		IL_0123: ldloc.s 5
+		IL_0125: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
+		IL_012a: pop
+		IL_012b: ldc.i4.1
+		IL_012c: newarr [System.Runtime]System.Object
+		IL_0131: dup
+		IL_0132: ldc.i4.0
+		IL_0133: ldloc.0
+		IL_0134: stelem.ref
+		IL_0135: ldc.i4.0
+		IL_0136: ldelem.ref
+		IL_0137: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_013c: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0147: ldc.i4.0
+		IL_0148: conv.r8
+		IL_0149: ldstr ""
+		IL_014e: ldc.i4.0
+		IL_014f: ldc.i4.1
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0155: stloc.s 5
+		IL_0157: ldloc.0
+		IL_0158: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_015d: ldnull
+		IL_015e: ldstr "importedUrlHasFileScheme"
+		IL_0163: ldloc.s 5
+		IL_0165: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
+		IL_016a: pop
+		IL_016b: ldc.i4.1
+		IL_016c: newarr [System.Runtime]System.Object
+		IL_0171: dup
+		IL_0172: ldc.i4.0
+		IL_0173: ldloc.0
+		IL_0174: stelem.ref
+		IL_0175: ldc.i4.0
+		IL_0176: ldelem.ref
+		IL_0177: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_017c: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0187: ldc.i4.0
+		IL_0188: conv.r8
+		IL_0189: ldstr ""
+		IL_018e: ldc.i4.0
+		IL_018f: ldc.i4.1
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0195: stloc.s 5
+		IL_0197: ldloc.0
+		IL_0198: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_019d: ldnull
+		IL_019e: ldstr "importedModuleFilenameMatches"
+		IL_01a3: ldloc.s 5
+		IL_01a5: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
+		IL_01aa: pop
+		IL_01ab: ldc.i4.1
+		IL_01ac: newarr [System.Runtime]System.Object
+		IL_01b1: dup
+		IL_01b2: ldc.i4.0
+		IL_01b3: ldloc.0
+		IL_01b4: stelem.ref
+		IL_01b5: ldc.i4.0
+		IL_01b6: ldelem.ref
+		IL_01b7: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_01bc: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_01c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01c7: ldc.i4.0
+		IL_01c8: conv.r8
+		IL_01c9: ldstr ""
+		IL_01ce: ldc.i4.0
+		IL_01cf: ldc.i4.1
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01d5: stloc.s 5
+		IL_01d7: ldloc.0
+		IL_01d8: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_01dd: ldnull
+		IL_01de: ldstr "importedModulePathMatches"
+		IL_01e3: ldloc.s 5
+		IL_01e5: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
+		IL_01ea: pop
+		IL_01eb: ldarg.3
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_01f1: stloc.s 5
+		IL_01f3: ldloc.s 5
+		IL_01f5: ldstr "url"
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ff: stloc.s 5
+		IL_0201: ldloc.0
+		IL_0202: ldloc.s 5
+		IL_0204: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
+		IL_0209: ldloc.0
+		IL_020a: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
+		IL_020f: ldstr "Cannot access 'importedUrl' before initialization"
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_0219: stloc.s 5
+		IL_021b: ldloc.s 5
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0222: stloc.s 5
+		IL_0224: ldloc.s 5
+		IL_0226: ldstr "startsWith"
+		IL_022b: ldstr "file://"
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0235: stloc.s 5
 		IL_0237: ldloc.0
-		IL_0238: stelem.ref
-		IL_0239: ldc.i4.0
-		IL_023a: ldelem.ref
-		IL_023b: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0240: ldftn object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_0246: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_024b: ldnull
-		IL_024c: ldstr "importedModulePathMatches"
-		IL_0251: ldloc.s 5
-		IL_0253: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0258: pop
-		IL_0259: ldarg.3
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_025f: stloc.s 5
-		IL_0261: ldloc.s 5
-		IL_0263: ldstr "url"
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026d: stloc.s 5
-		IL_026f: ldloc.0
-		IL_0270: ldloc.s 5
-		IL_0272: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
-		IL_0277: ldloc.0
-		IL_0278: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
-		IL_027d: ldstr "Cannot access 'importedUrl' before initialization"
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0287: stloc.s 5
-		IL_0289: ldloc.s 5
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0290: stloc.s 5
-		IL_0292: ldloc.s 5
-		IL_0294: ldstr "startsWith"
-		IL_0299: ldstr "file://"
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02a3: stloc.s 5
-		IL_02a5: ldloc.0
-		IL_02a6: ldloc.s 5
-		IL_02a8: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrlHasFileScheme
-		IL_02ad: ldarg.2
-		IL_02ae: ldstr "filename"
-		IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b8: ldarg.3
-		IL_02b9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02be: stloc.s 6
-		IL_02c0: ldloc.s 6
-		IL_02c2: box [System.Runtime]System.Boolean
-		IL_02c7: stloc.s 7
-		IL_02c9: ldloc.0
-		IL_02ca: ldloc.s 7
-		IL_02cc: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModuleFilenameMatches
-		IL_02d1: ldarg.2
-		IL_02d2: ldstr "path"
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02e1: stloc.s 5
-		IL_02e3: ldloc.s 5
-		IL_02e5: ldstr "split"
-		IL_02ea: ldstr "\\"
-		IL_02ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02f4: stloc.s 5
-		IL_02f6: ldloc.s 5
-		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fd: stloc.s 5
-		IL_02ff: ldloc.s 5
-		IL_0301: ldstr "join"
-		IL_0306: ldstr "/"
-		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0310: stloc.s 5
-		IL_0312: ldarg.s __dirname
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0319: stloc.s 8
-		IL_031b: ldloc.s 8
-		IL_031d: ldstr "split"
-		IL_0322: ldstr "\\"
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_032c: stloc.s 8
-		IL_032e: ldloc.s 8
-		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0335: stloc.s 8
-		IL_0337: ldloc.s 8
-		IL_0339: ldstr "join"
-		IL_033e: ldstr "/"
-		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0348: stloc.s 8
-		IL_034a: ldloc.s 5
-		IL_034c: ldloc.s 8
-		IL_034e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0353: stloc.s 6
-		IL_0355: ldloc.s 6
-		IL_0357: box [System.Runtime]System.Boolean
-		IL_035c: stloc.s 7
-		IL_035e: ldloc.0
-		IL_035f: ldloc.s 7
-		IL_0361: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModulePathMatches
-		IL_0366: ret
+		IL_0238: ldloc.s 5
+		IL_023a: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrlHasFileScheme
+		IL_023f: ldarg.2
+		IL_0240: ldstr "filename"
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024a: ldarg.3
+		IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0250: stloc.s 6
+		IL_0252: ldloc.s 6
+		IL_0254: box [System.Runtime]System.Boolean
+		IL_0259: stloc.s 7
+		IL_025b: ldloc.0
+		IL_025c: ldloc.s 7
+		IL_025e: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModuleFilenameMatches
+		IL_0263: ldarg.2
+		IL_0264: ldstr "path"
+		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0273: stloc.s 5
+		IL_0275: ldloc.s 5
+		IL_0277: ldstr "split"
+		IL_027c: ldstr "\\"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0286: stloc.s 5
+		IL_0288: ldloc.s 5
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028f: stloc.s 5
+		IL_0291: ldloc.s 5
+		IL_0293: ldstr "join"
+		IL_0298: ldstr "/"
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02a2: stloc.s 5
+		IL_02a4: ldarg.s __dirname
+		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02ab: stloc.s 8
+		IL_02ad: ldloc.s 8
+		IL_02af: ldstr "split"
+		IL_02b4: ldstr "\\"
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02be: stloc.s 8
+		IL_02c0: ldloc.s 8
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c7: stloc.s 8
+		IL_02c9: ldloc.s 8
+		IL_02cb: ldstr "join"
+		IL_02d0: ldstr "/"
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02da: stloc.s 8
+		IL_02dc: ldloc.s 5
+		IL_02de: ldloc.s 8
+		IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02e5: stloc.s 6
+		IL_02e7: ldloc.s 6
+		IL_02e9: box [System.Runtime]System.Boolean
+		IL_02ee: stloc.s 7
+		IL_02f0: ldloc.0
+		IL_02f1: ldloc.s 7
+		IL_02f3: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModulePathMatches
+		IL_02f8: ret
 	} // end of method Import_ImportMeta_Url_Lib::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url_Lib
@@ -3842,7 +3770,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x39a8
+		// Method begins at RVA 0x3900
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4050
+					// Method begins at RVA 0x3f50
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4047
+				// Method begins at RVA 0x3f47
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x2884
+			// Method begins at RVA 0x27c0
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4059
+				// Method begins at RVA 0x3f59
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x291c
+			// Method begins at RVA 0x2858
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4062
+				// Method begins at RVA 0x3f62
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29a1
+			// Method begins at RVA 0x28dd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x408f
+					// Method begins at RVA 0x3f8f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f31
+				// Method begins at RVA 0x2e57
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4098
+					// Method begins at RVA 0x3f98
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f40
+				// Method begins at RVA 0x2e66
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x40c5
+						// Method begins at RVA 0x3fc5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fe5
+					// Method begins at RVA 0x2f0d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40bc
+					// Method begins at RVA 0x3fbc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f50
+				// Method begins at RVA 0x2e78
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4074
+					// Method begins at RVA 0x3f74
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x407d
+					// Method begins at RVA 0x3f7d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4086
+					// Method begins at RVA 0x3f86
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x40aa
+						// Method begins at RVA 0x3faa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x40b3
+						// Method begins at RVA 0x3fb3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40a1
+					// Method begins at RVA 0x3fa1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40ce
+					// Method begins at RVA 0x3fce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40d7
+					// Method begins at RVA 0x3fd7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x406b
+				// Method begins at RVA 0x3f6b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x29ac
+			// Method begins at RVA 0x28e8
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40e0
+				// Method begins at RVA 0x3fe0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x2ec8
+			// Method begins at RVA 0x2e04
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_LiveBindings_Cycle/Scope
-			IL_0011: ldftn object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_LiveBindings_Cycle/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x403e
+			// Method begins at RVA 0x3f3e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 728 (0x2d8)
+		// Code size: 706 (0x2c2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle/Scope,
@@ -1513,171 +1504,162 @@
 		IL_00d8: stloc.s 7
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_00ef: ldftn object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_LiveBindings_Cycle_A.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 7
-		IL_010e: ldloc.s 7
-		IL_0110: stloc.s 5
-		IL_0112: ldarg.1
-		IL_0113: ldstr "./Import_LiveBindings_Cycle_B.mjs"
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_011d: stloc.s 7
-		IL_011f: ldloc.s 7
-		IL_0121: stloc.s 6
-		IL_0123: ldnull
-		IL_0124: ldloc.s 5
-		IL_0126: ldstr "a"
-		IL_012b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0130: stloc.s 7
-		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0137: ldstr "a0:"
-		IL_013c: ldloc.s 7
-		IL_013e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0143: pop
-		IL_0144: ldnull
-		IL_0145: ldloc.s 6
-		IL_0147: ldstr "b"
-		IL_014c: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0151: stloc.s 7
-		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0158: ldstr "b0:"
-		IL_015d: ldloc.s 7
-		IL_015f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0164: pop
-		IL_0165: ldnull
-		IL_0166: ldloc.s 5
-		IL_0168: ldstr "getBFromA"
-		IL_016d: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0172: stloc.s 7
-		IL_0174: ldc.i4.0
-		IL_0175: newarr [System.Runtime]System.Object
-		IL_017a: stloc.s 8
-		IL_017c: ldloc.s 7
-		IL_017e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0183: ldloc.s 8
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_018a: stloc.s 7
-		IL_018c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0191: ldstr "a->b:"
-		IL_0196: ldloc.s 7
-		IL_0198: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_019d: pop
-		IL_019e: ldnull
-		IL_019f: ldloc.s 6
-		IL_01a1: ldstr "getAFromB"
-		IL_01a6: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01ab: stloc.s 7
-		IL_01ad: ldc.i4.0
-		IL_01ae: newarr [System.Runtime]System.Object
-		IL_01b3: stloc.s 8
-		IL_01b5: ldloc.s 7
-		IL_01b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01bc: ldloc.s 8
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_01c3: stloc.s 7
-		IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ca: ldstr "b->a:"
-		IL_01cf: ldloc.s 7
-		IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01d6: pop
-		IL_01d7: ldnull
-		IL_01d8: ldloc.s 5
-		IL_01da: ldstr "incA"
-		IL_01df: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01e4: stloc.s 7
-		IL_01e6: ldc.i4.0
-		IL_01e7: newarr [System.Runtime]System.Object
-		IL_01ec: stloc.s 8
-		IL_01ee: ldloc.s 7
-		IL_01f0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f5: ldloc.s 8
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_01fc: pop
-		IL_01fd: ldnull
-		IL_01fe: ldloc.s 6
-		IL_0200: ldstr "incB"
-		IL_0205: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_020a: stloc.s 7
-		IL_020c: ldc.i4.0
-		IL_020d: newarr [System.Runtime]System.Object
-		IL_0212: stloc.s 8
-		IL_0214: ldloc.s 7
-		IL_0216: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_021b: ldloc.s 8
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0222: pop
-		IL_0223: ldnull
-		IL_0224: ldloc.s 5
-		IL_0226: ldstr "a"
-		IL_022b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0230: stloc.s 7
-		IL_0232: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0237: ldstr "a1:"
-		IL_023c: ldloc.s 7
-		IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0243: pop
-		IL_0244: ldnull
-		IL_0245: ldloc.s 6
-		IL_0247: ldstr "b"
-		IL_024c: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0251: stloc.s 7
-		IL_0253: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0258: ldstr "b1:"
-		IL_025d: ldloc.s 7
-		IL_025f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0264: pop
-		IL_0265: ldnull
-		IL_0266: ldloc.s 5
-		IL_0268: ldstr "getBFromA"
-		IL_026d: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0272: stloc.s 7
-		IL_0274: ldc.i4.0
-		IL_0275: newarr [System.Runtime]System.Object
-		IL_027a: stloc.s 8
-		IL_027c: ldloc.s 7
-		IL_027e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0283: ldloc.s 8
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_028a: stloc.s 7
-		IL_028c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0291: ldstr "a->b1:"
-		IL_0296: ldloc.s 7
-		IL_0298: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_029d: pop
-		IL_029e: ldnull
-		IL_029f: ldloc.s 6
-		IL_02a1: ldstr "getAFromB"
-		IL_02a6: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_02ab: stloc.s 7
-		IL_02ad: ldc.i4.0
-		IL_02ae: newarr [System.Runtime]System.Object
-		IL_02b3: stloc.s 8
-		IL_02b5: ldloc.s 7
-		IL_02b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02bc: ldloc.s 8
-		IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_02c3: stloc.s 7
-		IL_02c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ca: ldstr "b->a1:"
-		IL_02cf: ldloc.s 7
-		IL_02d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02d6: pop
-		IL_02d7: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_LiveBindings_Cycle/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_LiveBindings_Cycle_A.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 7
+		IL_00f8: ldloc.s 7
+		IL_00fa: stloc.s 5
+		IL_00fc: ldarg.1
+		IL_00fd: ldstr "./Import_LiveBindings_Cycle_B.mjs"
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0107: stloc.s 7
+		IL_0109: ldloc.s 7
+		IL_010b: stloc.s 6
+		IL_010d: ldnull
+		IL_010e: ldloc.s 5
+		IL_0110: ldstr "a"
+		IL_0115: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_011a: stloc.s 7
+		IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0121: ldstr "a0:"
+		IL_0126: ldloc.s 7
+		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012d: pop
+		IL_012e: ldnull
+		IL_012f: ldloc.s 6
+		IL_0131: ldstr "b"
+		IL_0136: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_013b: stloc.s 7
+		IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0142: ldstr "b0:"
+		IL_0147: ldloc.s 7
+		IL_0149: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_014e: pop
+		IL_014f: ldnull
+		IL_0150: ldloc.s 5
+		IL_0152: ldstr "getBFromA"
+		IL_0157: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_015c: stloc.s 7
+		IL_015e: ldc.i4.0
+		IL_015f: newarr [System.Runtime]System.Object
+		IL_0164: stloc.s 8
+		IL_0166: ldloc.s 7
+		IL_0168: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_016d: ldloc.s 8
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0174: stloc.s 7
+		IL_0176: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017b: ldstr "a->b:"
+		IL_0180: ldloc.s 7
+		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0187: pop
+		IL_0188: ldnull
+		IL_0189: ldloc.s 6
+		IL_018b: ldstr "getAFromB"
+		IL_0190: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0195: stloc.s 7
+		IL_0197: ldc.i4.0
+		IL_0198: newarr [System.Runtime]System.Object
+		IL_019d: stloc.s 8
+		IL_019f: ldloc.s 7
+		IL_01a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a6: ldloc.s 8
+		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01ad: stloc.s 7
+		IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b4: ldstr "b->a:"
+		IL_01b9: ldloc.s 7
+		IL_01bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01c0: pop
+		IL_01c1: ldnull
+		IL_01c2: ldloc.s 5
+		IL_01c4: ldstr "incA"
+		IL_01c9: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_01ce: stloc.s 7
+		IL_01d0: ldc.i4.0
+		IL_01d1: newarr [System.Runtime]System.Object
+		IL_01d6: stloc.s 8
+		IL_01d8: ldloc.s 7
+		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01df: ldloc.s 8
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01e6: pop
+		IL_01e7: ldnull
+		IL_01e8: ldloc.s 6
+		IL_01ea: ldstr "incB"
+		IL_01ef: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_01f4: stloc.s 7
+		IL_01f6: ldc.i4.0
+		IL_01f7: newarr [System.Runtime]System.Object
+		IL_01fc: stloc.s 8
+		IL_01fe: ldloc.s 7
+		IL_0200: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0205: ldloc.s 8
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_020c: pop
+		IL_020d: ldnull
+		IL_020e: ldloc.s 5
+		IL_0210: ldstr "a"
+		IL_0215: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_021a: stloc.s 7
+		IL_021c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0221: ldstr "a1:"
+		IL_0226: ldloc.s 7
+		IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_022d: pop
+		IL_022e: ldnull
+		IL_022f: ldloc.s 6
+		IL_0231: ldstr "b"
+		IL_0236: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_023b: stloc.s 7
+		IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0242: ldstr "b1:"
+		IL_0247: ldloc.s 7
+		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_024e: pop
+		IL_024f: ldnull
+		IL_0250: ldloc.s 5
+		IL_0252: ldstr "getBFromA"
+		IL_0257: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_025c: stloc.s 7
+		IL_025e: ldc.i4.0
+		IL_025f: newarr [System.Runtime]System.Object
+		IL_0264: stloc.s 8
+		IL_0266: ldloc.s 7
+		IL_0268: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_026d: ldloc.s 8
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0274: stloc.s 7
+		IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027b: ldstr "a->b1:"
+		IL_0280: ldloc.s 7
+		IL_0282: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0287: pop
+		IL_0288: ldnull
+		IL_0289: ldloc.s 6
+		IL_028b: ldstr "getAFromB"
+		IL_0290: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0295: stloc.s 7
+		IL_0297: ldc.i4.0
+		IL_0298: newarr [System.Runtime]System.Object
+		IL_029d: stloc.s 8
+		IL_029f: ldloc.s 7
+		IL_02a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02a6: ldloc.s 8
+		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_02ad: stloc.s 7
+		IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02b4: ldstr "b->a1:"
+		IL_02b9: ldloc.s 7
+		IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02c0: pop
+		IL_02c1: ret
 	} // end of method Import_LiveBindings_Cycle::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Cycle
@@ -1697,7 +1679,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40fd
+				// Method begins at RVA 0x3ffd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1723,7 +1705,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3008
+			// Method begins at RVA 0x2f30
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1753,7 +1735,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4106
+				// Method begins at RVA 0x4006
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1779,7 +1761,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3027
+			// Method begins at RVA 0x2f4f
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1802,7 +1784,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x410f
+				// Method begins at RVA 0x400f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1828,7 +1810,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x302f
+			// Method begins at RVA 0x2f57
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1851,7 +1833,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4118
+				// Method begins at RVA 0x4018
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1877,7 +1859,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3038
+			// Method begins at RVA 0x2f60
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1915,7 +1897,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4121
+				// Method begins at RVA 0x4021
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1941,7 +1923,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x3070
+			// Method begins at RVA 0x2f98
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -1988,7 +1970,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4133
+					// Method begins at RVA 0x4033
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2006,7 +1988,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x412a
+				// Method begins at RVA 0x402a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2032,7 +2014,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x30a0
+			// Method begins at RVA 0x2fc8
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -2107,7 +2089,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x413c
+				// Method begins at RVA 0x403c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2131,7 +2113,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3138
+			// Method begins at RVA 0x3060
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -2205,7 +2187,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4145
+				// Method begins at RVA 0x4045
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2230,7 +2212,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x31bd
+			// Method begins at RVA 0x30e5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2258,7 +2240,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4172
+					// Method begins at RVA 0x4072
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2282,7 +2264,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x374d
+				// Method begins at RVA 0x365f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2308,7 +2290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x417b
+					// Method begins at RVA 0x407b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2332,7 +2314,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x375c
+				// Method begins at RVA 0x366e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2362,7 +2344,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x41a8
+						// Method begins at RVA 0x40a8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2386,7 +2368,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3801
+					// Method begins at RVA 0x3715
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2420,7 +2402,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x419f
+					// Method begins at RVA 0x409f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2445,7 +2427,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x376c
+				// Method begins at RVA 0x3680
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2538,7 +2520,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4157
+					// Method begins at RVA 0x4057
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2558,7 +2540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4160
+					// Method begins at RVA 0x4060
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2578,7 +2560,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4169
+					// Method begins at RVA 0x4069
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2602,7 +2584,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x418d
+						// Method begins at RVA 0x408d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2622,7 +2604,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4196
+						// Method begins at RVA 0x4096
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2640,7 +2622,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4184
+					// Method begins at RVA 0x4084
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2660,7 +2642,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41b1
+					// Method begins at RVA 0x40b1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2680,7 +2662,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x41ba
+					// Method begins at RVA 0x40ba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2702,7 +2684,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x414e
+				// Method begins at RVA 0x404e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2729,7 +2711,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x31c8
+			// Method begins at RVA 0x30f0
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3254,7 +3236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41c3
+				// Method begins at RVA 0x40c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3282,50 +3264,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x36e4
+			// Method begins at RVA 0x360c
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-			IL_0011: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3356,7 +3329,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x40e9
+			// Method begins at RVA 0x3fe9
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3383,9 +3356,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2334
+		// Method begins at RVA 0x2320
 		// Header size: 12
-		// Code size: 665 (0x299)
+		// Code size: 577 (0x241)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_A/Scope,
@@ -3528,134 +3501,98 @@
 		IL_0145: stloc.s 4
 		IL_0147: ldloc.s 4
 		IL_0149: stloc.3
-		IL_014a: ldc.i4.1
-		IL_014b: newarr [System.Runtime]System.Object
-		IL_0150: dup
-		IL_0151: ldc.i4.0
-		IL_0152: ldloc.0
-		IL_0153: stelem.ref
-		IL_0154: ldc.i4.0
-		IL_0155: ldelem.ref
-		IL_0156: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_015b: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0166: ldnull
-		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_016c: pop
-		IL_016d: ldc.i4.1
-		IL_016e: newarr [System.Runtime]System.Object
-		IL_0173: dup
-		IL_0174: ldc.i4.0
-		IL_0175: ldloc.0
-		IL_0176: stelem.ref
-		IL_0177: ldc.i4.0
-		IL_0178: ldelem.ref
-		IL_0179: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_017e: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0189: ldc.i4.0
-		IL_018a: conv.r8
-		IL_018b: ldstr ""
-		IL_0190: ldc.i4.0
-		IL_0191: ldc.i4.1
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0197: stloc.s 4
-		IL_0199: ldc.i4.1
-		IL_019a: newarr [System.Runtime]System.Object
-		IL_019f: dup
-		IL_01a0: ldc.i4.0
-		IL_01a1: ldloc.0
-		IL_01a2: stelem.ref
-		IL_01a3: ldc.i4.0
-		IL_01a4: ldelem.ref
-		IL_01a5: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01aa: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
-		IL_01b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01b5: ldnull
-		IL_01b6: ldstr "a"
-		IL_01bb: ldloc.s 4
-		IL_01bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01c2: pop
-		IL_01c3: ldc.i4.1
-		IL_01c4: newarr [System.Runtime]System.Object
-		IL_01c9: dup
-		IL_01ca: ldc.i4.0
-		IL_01cb: ldloc.0
-		IL_01cc: stelem.ref
-		IL_01cd: ldc.i4.0
-		IL_01ce: ldelem.ref
-		IL_01cf: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01d4: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_01da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01df: ldc.i4.0
-		IL_01e0: conv.r8
-		IL_01e1: ldstr ""
-		IL_01e6: ldc.i4.0
-		IL_01e7: ldc.i4.1
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01ed: stloc.s 4
-		IL_01ef: ldc.i4.1
-		IL_01f0: newarr [System.Runtime]System.Object
-		IL_01f5: dup
-		IL_01f6: ldc.i4.0
-		IL_01f7: ldloc.0
-		IL_01f8: stelem.ref
-		IL_01f9: ldc.i4.0
-		IL_01fa: ldelem.ref
-		IL_01fb: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0200: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
-		IL_0206: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_020b: ldnull
-		IL_020c: ldstr "incA"
-		IL_0211: ldloc.s 4
-		IL_0213: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0218: pop
-		IL_0219: ldc.i4.1
-		IL_021a: newarr [System.Runtime]System.Object
-		IL_021f: dup
-		IL_0220: ldc.i4.0
-		IL_0221: ldloc.0
-		IL_0222: stelem.ref
-		IL_0223: ldc.i4.0
-		IL_0224: ldelem.ref
-		IL_0225: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_022a: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0230: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0235: ldc.i4.0
-		IL_0236: conv.r8
-		IL_0237: ldstr ""
-		IL_023c: ldc.i4.0
-		IL_023d: ldc.i4.1
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0243: stloc.s 4
-		IL_0245: ldc.i4.1
-		IL_0246: newarr [System.Runtime]System.Object
-		IL_024b: dup
-		IL_024c: ldc.i4.0
-		IL_024d: ldloc.0
-		IL_024e: stelem.ref
-		IL_024f: ldc.i4.0
-		IL_0250: ldelem.ref
-		IL_0251: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0256: ldftn object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
-		IL_025c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0261: ldnull
-		IL_0262: ldstr "getBFromA"
-		IL_0267: ldloc.s 4
-		IL_0269: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_026e: pop
-		IL_026f: ldarg.1
-		IL_0270: ldstr "./Import_LiveBindings_Cycle_B.mjs"
-		IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_027a: stloc.s 4
-		IL_027c: ldloc.0
-		IL_027d: ldloc.s 4
-		IL_027f: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mod_0
-		IL_0284: ldloc.0
-		IL_0285: ldc.r8 1
-		IL_028e: box [System.Runtime]System.Double
-		IL_0293: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::a
-		IL_0298: ret
+		IL_014a: ldloc.0
+		IL_014b: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_0150: ldnull
+		IL_0151: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+		IL_0156: pop
+		IL_0157: ldc.i4.1
+		IL_0158: newarr [System.Runtime]System.Object
+		IL_015d: dup
+		IL_015e: ldc.i4.0
+		IL_015f: ldloc.0
+		IL_0160: stelem.ref
+		IL_0161: ldc.i4.0
+		IL_0162: ldelem.ref
+		IL_0163: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_0168: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0173: ldc.i4.0
+		IL_0174: conv.r8
+		IL_0175: ldstr ""
+		IL_017a: ldc.i4.0
+		IL_017b: ldc.i4.1
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0181: stloc.s 4
+		IL_0183: ldloc.0
+		IL_0184: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_0189: ldnull
+		IL_018a: ldstr "a"
+		IL_018f: ldloc.s 4
+		IL_0191: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
+		IL_0196: pop
+		IL_0197: ldc.i4.1
+		IL_0198: newarr [System.Runtime]System.Object
+		IL_019d: dup
+		IL_019e: ldc.i4.0
+		IL_019f: ldloc.0
+		IL_01a0: stelem.ref
+		IL_01a1: ldc.i4.0
+		IL_01a2: ldelem.ref
+		IL_01a3: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_01a8: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+		IL_01ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01b3: ldc.i4.0
+		IL_01b4: conv.r8
+		IL_01b5: ldstr ""
+		IL_01ba: ldc.i4.0
+		IL_01bb: ldc.i4.1
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01c1: stloc.s 4
+		IL_01c3: ldloc.0
+		IL_01c4: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_01c9: ldnull
+		IL_01ca: ldstr "incA"
+		IL_01cf: ldloc.s 4
+		IL_01d1: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
+		IL_01d6: pop
+		IL_01d7: ldc.i4.1
+		IL_01d8: newarr [System.Runtime]System.Object
+		IL_01dd: dup
+		IL_01de: ldc.i4.0
+		IL_01df: ldloc.0
+		IL_01e0: stelem.ref
+		IL_01e1: ldc.i4.0
+		IL_01e2: ldelem.ref
+		IL_01e3: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_01e8: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+		IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01f3: ldc.i4.0
+		IL_01f4: conv.r8
+		IL_01f5: ldstr ""
+		IL_01fa: ldc.i4.0
+		IL_01fb: ldc.i4.1
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0201: stloc.s 4
+		IL_0203: ldloc.0
+		IL_0204: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_0209: ldnull
+		IL_020a: ldstr "getBFromA"
+		IL_020f: ldloc.s 4
+		IL_0211: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
+		IL_0216: pop
+		IL_0217: ldarg.1
+		IL_0218: ldstr "./Import_LiveBindings_Cycle_B.mjs"
+		IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0222: stloc.s 4
+		IL_0224: ldloc.0
+		IL_0225: ldloc.s 4
+		IL_0227: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mod_0
+		IL_022c: ldloc.0
+		IL_022d: ldc.r8 1
+		IL_0236: box [System.Runtime]System.Double
+		IL_023b: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::a
+		IL_0240: ret
 	} // end of method Import_LiveBindings_Cycle_A::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Cycle_A
@@ -3675,7 +3612,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41e0
+				// Method begins at RVA 0x40e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3701,7 +3638,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3824
+			// Method begins at RVA 0x3738
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3731,7 +3668,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41e9
+				// Method begins at RVA 0x40e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3757,7 +3694,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3843
+			// Method begins at RVA 0x3757
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3780,7 +3717,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41f2
+				// Method begins at RVA 0x40f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3806,7 +3743,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x384b
+			// Method begins at RVA 0x375f
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3829,7 +3766,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41fb
+				// Method begins at RVA 0x40fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3855,7 +3792,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3854
+			// Method begins at RVA 0x3768
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -3893,7 +3830,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4204
+				// Method begins at RVA 0x4104
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3919,7 +3856,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x388c
+			// Method begins at RVA 0x37a0
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -3966,7 +3903,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4216
+					// Method begins at RVA 0x4116
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3984,7 +3921,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x420d
+				// Method begins at RVA 0x410d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4010,7 +3947,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x38bc
+			// Method begins at RVA 0x37d0
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -4085,7 +4022,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x421f
+				// Method begins at RVA 0x411f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4109,7 +4046,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3954
+			// Method begins at RVA 0x3868
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -4183,7 +4120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4228
+				// Method begins at RVA 0x4128
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4208,7 +4145,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x39d9
+			// Method begins at RVA 0x38ed
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4236,7 +4173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4255
+					// Method begins at RVA 0x4155
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4260,7 +4197,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f69
+				// Method begins at RVA 0x3e67
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -4286,7 +4223,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x425e
+					// Method begins at RVA 0x415e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4310,7 +4247,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f78
+				// Method begins at RVA 0x3e76
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -4340,7 +4277,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x428b
+						// Method begins at RVA 0x418b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4364,7 +4301,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x401d
+					// Method begins at RVA 0x3f1d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -4398,7 +4335,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4282
+					// Method begins at RVA 0x4182
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4423,7 +4360,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f88
+				// Method begins at RVA 0x3e88
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4516,7 +4453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x423a
+					// Method begins at RVA 0x413a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4536,7 +4473,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4243
+					// Method begins at RVA 0x4143
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4556,7 +4493,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x424c
+					// Method begins at RVA 0x414c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4580,7 +4517,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4270
+						// Method begins at RVA 0x4170
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4600,7 +4537,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4279
+						// Method begins at RVA 0x4179
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4618,7 +4555,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4267
+					// Method begins at RVA 0x4167
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4638,7 +4575,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4294
+					// Method begins at RVA 0x4194
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4658,7 +4595,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x429d
+					// Method begins at RVA 0x419d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4680,7 +4617,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4231
+				// Method begins at RVA 0x4131
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4707,7 +4644,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x39e4
+			// Method begins at RVA 0x38f8
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -5232,7 +5169,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x42a6
+				// Method begins at RVA 0x41a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5260,50 +5197,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3f00
+			// Method begins at RVA 0x3e14
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-			IL_0011: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -5334,7 +5262,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x41cc
+			// Method begins at RVA 0x40cc
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5361,9 +5289,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x25dc
+		// Method begins at RVA 0x2570
 		// Header size: 12
-		// Code size: 665 (0x299)
+		// Code size: 577 (0x241)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_B/Scope,
@@ -5506,134 +5434,98 @@
 		IL_0145: stloc.s 4
 		IL_0147: ldloc.s 4
 		IL_0149: stloc.3
-		IL_014a: ldc.i4.1
-		IL_014b: newarr [System.Runtime]System.Object
-		IL_0150: dup
-		IL_0151: ldc.i4.0
-		IL_0152: ldloc.0
-		IL_0153: stelem.ref
-		IL_0154: ldc.i4.0
-		IL_0155: ldelem.ref
-		IL_0156: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_015b: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0166: ldnull
-		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_016c: pop
-		IL_016d: ldc.i4.1
-		IL_016e: newarr [System.Runtime]System.Object
-		IL_0173: dup
-		IL_0174: ldc.i4.0
-		IL_0175: ldloc.0
-		IL_0176: stelem.ref
-		IL_0177: ldc.i4.0
-		IL_0178: ldelem.ref
-		IL_0179: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_017e: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0184: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0189: ldc.i4.0
-		IL_018a: conv.r8
-		IL_018b: ldstr ""
-		IL_0190: ldc.i4.0
-		IL_0191: ldc.i4.1
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0197: stloc.s 4
-		IL_0199: ldc.i4.1
-		IL_019a: newarr [System.Runtime]System.Object
-		IL_019f: dup
-		IL_01a0: ldc.i4.0
-		IL_01a1: ldloc.0
-		IL_01a2: stelem.ref
-		IL_01a3: ldc.i4.0
-		IL_01a4: ldelem.ref
-		IL_01a5: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01aa: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
-		IL_01b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01b5: ldnull
-		IL_01b6: ldstr "b"
-		IL_01bb: ldloc.s 4
-		IL_01bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01c2: pop
-		IL_01c3: ldc.i4.1
-		IL_01c4: newarr [System.Runtime]System.Object
-		IL_01c9: dup
-		IL_01ca: ldc.i4.0
-		IL_01cb: ldloc.0
-		IL_01cc: stelem.ref
-		IL_01cd: ldc.i4.0
-		IL_01ce: ldelem.ref
-		IL_01cf: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01d4: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_01da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01df: ldc.i4.0
-		IL_01e0: conv.r8
-		IL_01e1: ldstr ""
-		IL_01e6: ldc.i4.0
-		IL_01e7: ldc.i4.1
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01ed: stloc.s 4
-		IL_01ef: ldc.i4.1
-		IL_01f0: newarr [System.Runtime]System.Object
-		IL_01f5: dup
-		IL_01f6: ldc.i4.0
-		IL_01f7: ldloc.0
-		IL_01f8: stelem.ref
-		IL_01f9: ldc.i4.0
-		IL_01fa: ldelem.ref
-		IL_01fb: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0200: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
-		IL_0206: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_020b: ldnull
-		IL_020c: ldstr "incB"
-		IL_0211: ldloc.s 4
-		IL_0213: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0218: pop
-		IL_0219: ldc.i4.1
-		IL_021a: newarr [System.Runtime]System.Object
-		IL_021f: dup
-		IL_0220: ldc.i4.0
-		IL_0221: ldloc.0
-		IL_0222: stelem.ref
-		IL_0223: ldc.i4.0
-		IL_0224: ldelem.ref
-		IL_0225: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_022a: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0230: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0235: ldc.i4.0
-		IL_0236: conv.r8
-		IL_0237: ldstr ""
-		IL_023c: ldc.i4.0
-		IL_023d: ldc.i4.1
-		IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0243: stloc.s 4
-		IL_0245: ldc.i4.1
-		IL_0246: newarr [System.Runtime]System.Object
-		IL_024b: dup
-		IL_024c: ldc.i4.0
-		IL_024d: ldloc.0
-		IL_024e: stelem.ref
-		IL_024f: ldc.i4.0
-		IL_0250: ldelem.ref
-		IL_0251: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0256: ldftn object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
-		IL_025c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0261: ldnull
-		IL_0262: ldstr "getAFromB"
-		IL_0267: ldloc.s 4
-		IL_0269: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_026e: pop
-		IL_026f: ldarg.1
-		IL_0270: ldstr "./Import_LiveBindings_Cycle_A.mjs"
-		IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_027a: stloc.s 4
-		IL_027c: ldloc.0
-		IL_027d: ldloc.s 4
-		IL_027f: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mod_0
-		IL_0284: ldloc.0
-		IL_0285: ldc.r8 10
-		IL_028e: box [System.Runtime]System.Double
-		IL_0293: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::b
-		IL_0298: ret
+		IL_014a: ldloc.0
+		IL_014b: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_0150: ldnull
+		IL_0151: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+		IL_0156: pop
+		IL_0157: ldc.i4.1
+		IL_0158: newarr [System.Runtime]System.Object
+		IL_015d: dup
+		IL_015e: ldc.i4.0
+		IL_015f: ldloc.0
+		IL_0160: stelem.ref
+		IL_0161: ldc.i4.0
+		IL_0162: ldelem.ref
+		IL_0163: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_0168: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0173: ldc.i4.0
+		IL_0174: conv.r8
+		IL_0175: ldstr ""
+		IL_017a: ldc.i4.0
+		IL_017b: ldc.i4.1
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0181: stloc.s 4
+		IL_0183: ldloc.0
+		IL_0184: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_0189: ldnull
+		IL_018a: ldstr "b"
+		IL_018f: ldloc.s 4
+		IL_0191: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
+		IL_0196: pop
+		IL_0197: ldc.i4.1
+		IL_0198: newarr [System.Runtime]System.Object
+		IL_019d: dup
+		IL_019e: ldc.i4.0
+		IL_019f: ldloc.0
+		IL_01a0: stelem.ref
+		IL_01a1: ldc.i4.0
+		IL_01a2: ldelem.ref
+		IL_01a3: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_01a8: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+		IL_01ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01b3: ldc.i4.0
+		IL_01b4: conv.r8
+		IL_01b5: ldstr ""
+		IL_01ba: ldc.i4.0
+		IL_01bb: ldc.i4.1
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01c1: stloc.s 4
+		IL_01c3: ldloc.0
+		IL_01c4: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_01c9: ldnull
+		IL_01ca: ldstr "incB"
+		IL_01cf: ldloc.s 4
+		IL_01d1: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
+		IL_01d6: pop
+		IL_01d7: ldc.i4.1
+		IL_01d8: newarr [System.Runtime]System.Object
+		IL_01dd: dup
+		IL_01de: ldc.i4.0
+		IL_01df: ldloc.0
+		IL_01e0: stelem.ref
+		IL_01e1: ldc.i4.0
+		IL_01e2: ldelem.ref
+		IL_01e3: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_01e8: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+		IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01f3: ldc.i4.0
+		IL_01f4: conv.r8
+		IL_01f5: ldstr ""
+		IL_01fa: ldc.i4.0
+		IL_01fb: ldc.i4.1
+		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0201: stloc.s 4
+		IL_0203: ldloc.0
+		IL_0204: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_0209: ldnull
+		IL_020a: ldstr "getAFromB"
+		IL_020f: ldloc.s 4
+		IL_0211: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
+		IL_0216: pop
+		IL_0217: ldarg.1
+		IL_0218: ldstr "./Import_LiveBindings_Cycle_A.mjs"
+		IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0222: stloc.s 4
+		IL_0224: ldloc.0
+		IL_0225: ldloc.s 4
+		IL_0227: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mod_0
+		IL_022c: ldloc.0
+		IL_022d: ldc.r8 10
+		IL_0236: box [System.Runtime]System.Double
+		IL_023b: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::b
+		IL_0240: ret
 	} // end of method Import_LiveBindings_Cycle_B::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Cycle_B
@@ -5645,7 +5537,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x42af
+		// Method begins at RVA 0x41af
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3354
+					// Method begins at RVA 0x32d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x334b
+				// Method begins at RVA 0x32cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x23dc
+			// Method begins at RVA 0x2384
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x335d
+				// Method begins at RVA 0x32dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2474
+			// Method begins at RVA 0x241c
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3366
+				// Method begins at RVA 0x32e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24f9
+			// Method begins at RVA 0x24a1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3393
+					// Method begins at RVA 0x3313
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a89
+				// Method begins at RVA 0x2a1b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x339c
+					// Method begins at RVA 0x331c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a98
+				// Method begins at RVA 0x2a2a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33c9
+						// Method begins at RVA 0x3349
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2b3d
+					// Method begins at RVA 0x2ad1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c0
+					// Method begins at RVA 0x3340
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2aa8
+				// Method begins at RVA 0x2a3c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3378
+					// Method begins at RVA 0x32f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3381
+					// Method begins at RVA 0x3301
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x338a
+					// Method begins at RVA 0x330a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33ae
+						// Method begins at RVA 0x332e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33b7
+						// Method begins at RVA 0x3337
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a5
+					// Method begins at RVA 0x3325
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d2
+					// Method begins at RVA 0x3352
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33db
+					// Method begins at RVA 0x335b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x336f
+				// Method begins at RVA 0x32ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2504
+			// Method begins at RVA 0x24ac
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33e4
+				// Method begins at RVA 0x3364
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2a20
+			// Method begins at RVA 0x29c8
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_LiveBindings_Named/Scope
-			IL_0011: ldftn object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_LiveBindings_Named/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3342
+			// Method begins at RVA 0x32c2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 379 (0x17b)
+		// Code size: 357 (0x165)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named/Scope,
@@ -1512,60 +1503,51 @@
 		IL_00d8: stloc.s 6
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_00ef: ldftn object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_LiveBindings_Named_Lib.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 6
-		IL_010e: ldloc.s 6
-		IL_0110: stloc.s 5
-		IL_0112: ldnull
-		IL_0113: ldloc.s 5
-		IL_0115: ldstr "x"
-		IL_011a: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
-		IL_011f: stloc.s 6
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0126: ldstr "x0:"
-		IL_012b: ldloc.s 6
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0132: pop
-		IL_0133: ldnull
-		IL_0134: ldloc.s 5
-		IL_0136: ldstr "inc"
-		IL_013b: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0140: stloc.s 6
-		IL_0142: ldc.i4.0
-		IL_0143: newarr [System.Runtime]System.Object
-		IL_0148: stloc.s 7
-		IL_014a: ldloc.s 6
-		IL_014c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0151: ldloc.s 7
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0158: pop
-		IL_0159: ldnull
-		IL_015a: ldloc.s 5
-		IL_015c: ldstr "x"
-		IL_0161: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0166: stloc.s 6
-		IL_0168: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016d: ldstr "x1:"
-		IL_0172: ldloc.s 6
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0179: pop
-		IL_017a: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_LiveBindings_Named/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_LiveBindings_Named_Lib.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 6
+		IL_00f8: ldloc.s 6
+		IL_00fa: stloc.s 5
+		IL_00fc: ldnull
+		IL_00fd: ldloc.s 5
+		IL_00ff: ldstr "x"
+		IL_0104: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0109: stloc.s 6
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0110: ldstr "x0:"
+		IL_0115: ldloc.s 6
+		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_011c: pop
+		IL_011d: ldnull
+		IL_011e: ldloc.s 5
+		IL_0120: ldstr "inc"
+		IL_0125: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
+		IL_012a: stloc.s 6
+		IL_012c: ldc.i4.0
+		IL_012d: newarr [System.Runtime]System.Object
+		IL_0132: stloc.s 7
+		IL_0134: ldloc.s 6
+		IL_0136: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_013b: ldloc.s 7
+		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0142: pop
+		IL_0143: ldnull
+		IL_0144: ldloc.s 5
+		IL_0146: ldstr "x"
+		IL_014b: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0150: stloc.s 6
+		IL_0152: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0157: ldstr "x1:"
+		IL_015c: ldloc.s 6
+		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0163: pop
+		IL_0164: ret
 	} // end of method Import_LiveBindings_Named::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Named
@@ -1585,7 +1567,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3401
+				// Method begins at RVA 0x3381
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1611,7 +1593,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b60
+			// Method begins at RVA 0x2af4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1641,7 +1623,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x340a
+				// Method begins at RVA 0x338a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1667,7 +1649,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b7f
+			// Method begins at RVA 0x2b13
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1690,7 +1672,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3413
+				// Method begins at RVA 0x3393
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1716,7 +1698,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b88
+			// Method begins at RVA 0x2b1c
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1758,7 +1740,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3425
+					// Method begins at RVA 0x33a5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1776,7 +1758,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x341c
+				// Method begins at RVA 0x339c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1802,7 +1784,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2bc0
+			// Method begins at RVA 0x2b54
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1877,7 +1859,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x342e
+				// Method begins at RVA 0x33ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1901,7 +1883,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c58
+			// Method begins at RVA 0x2bec
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1975,7 +1957,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3437
+				// Method begins at RVA 0x33b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2000,7 +1982,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cdd
+			// Method begins at RVA 0x2c71
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2028,7 +2010,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3464
+					// Method begins at RVA 0x33e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2052,7 +2034,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x326d
+				// Method begins at RVA 0x31eb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2078,7 +2060,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x346d
+					// Method begins at RVA 0x33ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2102,7 +2084,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x327c
+				// Method begins at RVA 0x31fa
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2132,7 +2114,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x349a
+						// Method begins at RVA 0x341a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2156,7 +2138,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3321
+					// Method begins at RVA 0x32a1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2190,7 +2172,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3491
+					// Method begins at RVA 0x3411
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2215,7 +2197,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x328c
+				// Method begins at RVA 0x320c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2308,7 +2290,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3449
+					// Method begins at RVA 0x33c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2328,7 +2310,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3452
+					// Method begins at RVA 0x33d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2348,7 +2330,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x345b
+					// Method begins at RVA 0x33db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2372,7 +2354,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x347f
+						// Method begins at RVA 0x33ff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2392,7 +2374,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3488
+						// Method begins at RVA 0x3408
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2410,7 +2392,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3476
+					// Method begins at RVA 0x33f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2430,7 +2412,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34a3
+					// Method begins at RVA 0x3423
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2450,7 +2432,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34ac
+					// Method begins at RVA 0x342c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2472,7 +2454,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3440
+				// Method begins at RVA 0x33c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2499,7 +2481,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2ce8
+			// Method begins at RVA 0x2c7c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3024,7 +3006,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34b5
+				// Method begins at RVA 0x3435
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3052,50 +3034,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x3204
+			// Method begins at RVA 0x3198
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-			IL_0011: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3122,7 +3095,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x33ed
+			// Method begins at RVA 0x336d
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3149,9 +3122,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21d8
+		// Method begins at RVA 0x21c4
 		// Header size: 12
-		// Code size: 502 (0x1f6)
+		// Code size: 436 (0x1b4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named_Lib/Scope,
@@ -3273,93 +3246,66 @@
 		IL_010c: stloc.s 5
 		IL_010e: ldloc.s 5
 		IL_0110: stloc.s 4
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: ldc.i4.0
-		IL_011d: ldelem.ref
-		IL_011e: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0123: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_012e: ldnull
-		IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0134: pop
-		IL_0135: ldc.i4.1
-		IL_0136: newarr [System.Runtime]System.Object
-		IL_013b: dup
-		IL_013c: ldc.i4.0
-		IL_013d: ldloc.0
-		IL_013e: stelem.ref
-		IL_013f: ldc.i4.0
-		IL_0140: ldelem.ref
-		IL_0141: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0146: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_014c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0151: ldc.i4.0
-		IL_0152: conv.r8
-		IL_0153: ldstr ""
-		IL_0158: ldc.i4.0
-		IL_0159: ldc.i4.1
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_015f: stloc.s 5
-		IL_0161: ldc.i4.1
-		IL_0162: newarr [System.Runtime]System.Object
-		IL_0167: dup
-		IL_0168: ldc.i4.0
-		IL_0169: ldloc.0
-		IL_016a: stelem.ref
-		IL_016b: ldc.i4.0
-		IL_016c: ldelem.ref
-		IL_016d: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0172: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object, object)
-		IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_017d: ldnull
-		IL_017e: ldstr "x"
-		IL_0183: ldloc.s 5
-		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_018a: pop
-		IL_018b: ldc.i4.1
-		IL_018c: newarr [System.Runtime]System.Object
-		IL_0191: dup
-		IL_0192: ldc.i4.0
-		IL_0193: ldloc.0
-		IL_0194: stelem.ref
-		IL_0195: ldc.i4.0
-		IL_0196: ldelem.ref
-		IL_0197: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_019c: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_01a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01a7: ldc.i4.0
-		IL_01a8: conv.r8
-		IL_01a9: ldstr ""
-		IL_01ae: ldc.i4.0
-		IL_01af: ldc.i4.1
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01b5: stloc.s 5
-		IL_01b7: ldc.i4.1
-		IL_01b8: newarr [System.Runtime]System.Object
-		IL_01bd: dup
-		IL_01be: ldc.i4.0
-		IL_01bf: ldloc.0
-		IL_01c0: stelem.ref
-		IL_01c1: ldc.i4.0
-		IL_01c2: ldelem.ref
-		IL_01c3: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_01c8: ldftn object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object, object)
-		IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01d3: ldnull
-		IL_01d4: ldstr "inc"
-		IL_01d9: ldloc.s 5
-		IL_01db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01e0: pop
-		IL_01e1: ldloc.0
-		IL_01e2: ldc.r8 1
-		IL_01eb: box [System.Runtime]System.Double
-		IL_01f0: stfld object Modules.Import_LiveBindings_Named_Lib/Scope::x
-		IL_01f5: ret
+		IL_0112: ldloc.0
+		IL_0113: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+		IL_0118: ldnull
+		IL_0119: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+		IL_011e: pop
+		IL_011f: ldc.i4.1
+		IL_0120: newarr [System.Runtime]System.Object
+		IL_0125: dup
+		IL_0126: ldc.i4.0
+		IL_0127: ldloc.0
+		IL_0128: stelem.ref
+		IL_0129: ldc.i4.0
+		IL_012a: ldelem.ref
+		IL_012b: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+		IL_0130: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+		IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_013b: ldc.i4.0
+		IL_013c: conv.r8
+		IL_013d: ldstr ""
+		IL_0142: ldc.i4.0
+		IL_0143: ldc.i4.1
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0149: stloc.s 5
+		IL_014b: ldloc.0
+		IL_014c: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+		IL_0151: ldnull
+		IL_0152: ldstr "x"
+		IL_0157: ldloc.s 5
+		IL_0159: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object, object)
+		IL_015e: pop
+		IL_015f: ldc.i4.1
+		IL_0160: newarr [System.Runtime]System.Object
+		IL_0165: dup
+		IL_0166: ldc.i4.0
+		IL_0167: ldloc.0
+		IL_0168: stelem.ref
+		IL_0169: ldc.i4.0
+		IL_016a: ldelem.ref
+		IL_016b: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+		IL_0170: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+		IL_0176: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_017b: ldc.i4.0
+		IL_017c: conv.r8
+		IL_017d: ldstr ""
+		IL_0182: ldc.i4.0
+		IL_0183: ldc.i4.1
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0189: stloc.s 5
+		IL_018b: ldloc.0
+		IL_018c: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+		IL_0191: ldnull
+		IL_0192: ldstr "inc"
+		IL_0197: ldloc.s 5
+		IL_0199: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object, object)
+		IL_019e: pop
+		IL_019f: ldloc.0
+		IL_01a0: ldc.r8 1
+		IL_01a9: box [System.Runtime]System.Double
+		IL_01ae: stfld object Modules.Import_LiveBindings_Named_Lib/Scope::x
+		IL_01b3: ret
 	} // end of method Import_LiveBindings_Named_Lib::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Named_Lib
@@ -3371,7 +3317,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x34be
+		// Method begins at RVA 0x343e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3588
+					// Method begins at RVA 0x34dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x357f
+				// Method begins at RVA 0x34d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x25e8
+			// Method begins at RVA 0x2564
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3591
+				// Method begins at RVA 0x34e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2680
+			// Method begins at RVA 0x25fc
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x359a
+				// Method begins at RVA 0x34ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2705
+			// Method begins at RVA 0x2681
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35c7
+					// Method begins at RVA 0x351b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c95
+				// Method begins at RVA 0x2bfb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35d0
+					// Method begins at RVA 0x3524
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ca4
+				// Method begins at RVA 0x2c0a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35fd
+						// Method begins at RVA 0x3551
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2d49
+					// Method begins at RVA 0x2cb1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35f4
+					// Method begins at RVA 0x3548
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cb4
+				// Method begins at RVA 0x2c1c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35ac
+					// Method begins at RVA 0x3500
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35b5
+					// Method begins at RVA 0x3509
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35be
+					// Method begins at RVA 0x3512
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35e2
+						// Method begins at RVA 0x3536
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35eb
+						// Method begins at RVA 0x353f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35d9
+					// Method begins at RVA 0x352d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3606
+					// Method begins at RVA 0x355a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x360f
+					// Method begins at RVA 0x3563
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35a3
+				// Method begins at RVA 0x34f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2710
+			// Method begins at RVA 0x268c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3618
+				// Method begins at RVA 0x356c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2c2c
+			// Method begins at RVA 0x2ba8
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_Namespace_Esm_Basic/Scope
-			IL_0011: ldftn object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_Namespace_Esm_Basic/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3576
+			// Method begins at RVA 0x34ca
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 768 (0x300)
+		// Code size: 724 (0x2d4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic/Scope,
@@ -1512,166 +1503,148 @@
 		IL_00d8: stloc.s 7
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_00ef: ldftn object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_Namespace_Esm_Basic_Lib.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 7
-		IL_010e: ldloc.s 7
-		IL_0110: stloc.s 5
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: ldc.i4.0
-		IL_011d: ldelem.ref
-		IL_011e: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_0123: ldftn object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012e: ldnull
-		IL_012f: ldloc.s 5
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0136: stloc.s 7
-		IL_0138: ldloc.s 7
-		IL_013a: stloc.s 6
-		IL_013c: ldloc.s 6
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0143: stloc.s 7
-		IL_0145: ldloc.s 7
-		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014c: stloc.s 7
-		IL_014e: ldloc.s 7
-		IL_0150: ldstr "sort"
-		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_015a: stloc.s 7
-		IL_015c: ldloc.s 7
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0163: stloc.s 7
-		IL_0165: ldloc.s 7
-		IL_0167: ldstr "join"
-		IL_016c: ldstr ","
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0176: stloc.s 7
-		IL_0178: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017d: ldstr "keys:"
-		IL_0182: ldloc.s 7
-		IL_0184: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0189: pop
-		IL_018a: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_018f: ldstr "prototype"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0199: ldstr "propertyIsEnumerable"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a8: stloc.s 7
-		IL_01aa: ldloc.s 7
-		IL_01ac: ldstr "call"
-		IL_01b1: ldloc.s 6
-		IL_01b3: ldstr "default"
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01bd: stloc.s 7
-		IL_01bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c4: ldstr "enum.default:"
-		IL_01c9: ldloc.s 7
-		IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01d0: pop
-		IL_01d1: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_01d6: ldstr "prototype"
-		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e0: ldstr "propertyIsEnumerable"
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ef: stloc.s 7
-		IL_01f1: ldloc.s 7
-		IL_01f3: ldstr "call"
-		IL_01f8: ldloc.s 6
-		IL_01fa: ldstr "inc"
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0204: stloc.s 7
-		IL_0206: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_020b: ldstr "enum.inc:"
-		IL_0210: ldloc.s 7
-		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0217: pop
-		IL_0218: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_021d: ldstr "prototype"
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0227: ldstr "propertyIsEnumerable"
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0236: stloc.s 7
-		IL_0238: ldloc.s 7
-		IL_023a: ldstr "call"
-		IL_023f: ldloc.s 6
-		IL_0241: ldstr "x"
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_024b: stloc.s 7
-		IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0252: ldstr "enum.x:"
-		IL_0257: ldloc.s 7
-		IL_0259: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_025e: pop
-		IL_025f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0264: ldstr "x0:"
-		IL_0269: ldloc.s 6
-		IL_026b: ldstr "x"
-		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_027a: pop
-		IL_027b: ldloc.s 6
-		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0282: stloc.s 7
-		IL_0284: ldloc.s 7
-		IL_0286: ldstr "default"
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0290: stloc.s 7
-		IL_0292: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0297: ldstr "def0:"
-		IL_029c: ldloc.s 7
-		IL_029e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02a3: pop
-		IL_02a4: ldloc.s 6
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ab: stloc.s 7
-		IL_02ad: ldloc.s 7
-		IL_02af: ldstr "inc"
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_02b9: pop
-		IL_02ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02bf: ldstr "x1:"
-		IL_02c4: ldloc.s 6
-		IL_02c6: ldstr "x"
-		IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02d5: pop
-		IL_02d6: ldloc.s 6
-		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02dd: stloc.s 7
-		IL_02df: ldloc.s 7
-		IL_02e1: ldstr "default"
-		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_02eb: stloc.s 7
-		IL_02ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f2: ldstr "def1:"
-		IL_02f7: ldloc.s 7
-		IL_02f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02fe: pop
-		IL_02ff: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_Namespace_Esm_Basic/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_Namespace_Esm_Basic_Lib.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 7
+		IL_00f8: ldloc.s 7
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.0
+		IL_00fd: castclass Modules.Import_Namespace_Esm_Basic/Scope
+		IL_0102: ldnull
+		IL_0103: ldloc.s 5
+		IL_0105: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
+		IL_010a: stloc.s 7
+		IL_010c: ldloc.s 7
+		IL_010e: stloc.s 6
+		IL_0110: ldloc.s 6
+		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0117: stloc.s 7
+		IL_0119: ldloc.s 7
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0120: stloc.s 7
+		IL_0122: ldloc.s 7
+		IL_0124: ldstr "sort"
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_012e: stloc.s 7
+		IL_0130: ldloc.s 7
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0137: stloc.s 7
+		IL_0139: ldloc.s 7
+		IL_013b: ldstr "join"
+		IL_0140: ldstr ","
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_014a: stloc.s 7
+		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0151: ldstr "keys:"
+		IL_0156: ldloc.s 7
+		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_015d: pop
+		IL_015e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0163: ldstr "prototype"
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_016d: ldstr "propertyIsEnumerable"
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017c: stloc.s 7
+		IL_017e: ldloc.s 7
+		IL_0180: ldstr "call"
+		IL_0185: ldloc.s 6
+		IL_0187: ldstr "default"
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0191: stloc.s 7
+		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0198: ldstr "enum.default:"
+		IL_019d: ldloc.s 7
+		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01a4: pop
+		IL_01a5: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_01aa: ldstr "prototype"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b4: ldstr "propertyIsEnumerable"
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c3: stloc.s 7
+		IL_01c5: ldloc.s 7
+		IL_01c7: ldstr "call"
+		IL_01cc: ldloc.s 6
+		IL_01ce: ldstr "inc"
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01d8: stloc.s 7
+		IL_01da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01df: ldstr "enum.inc:"
+		IL_01e4: ldloc.s 7
+		IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01eb: pop
+		IL_01ec: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_01f1: ldstr "prototype"
+		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01fb: ldstr "propertyIsEnumerable"
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020a: stloc.s 7
+		IL_020c: ldloc.s 7
+		IL_020e: ldstr "call"
+		IL_0213: ldloc.s 6
+		IL_0215: ldstr "x"
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_021f: stloc.s 7
+		IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0226: ldstr "enum.x:"
+		IL_022b: ldloc.s 7
+		IL_022d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0232: pop
+		IL_0233: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0238: ldstr "x0:"
+		IL_023d: ldloc.s 6
+		IL_023f: ldstr "x"
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_024e: pop
+		IL_024f: ldloc.s 6
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0256: stloc.s 7
+		IL_0258: ldloc.s 7
+		IL_025a: ldstr "default"
+		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0264: stloc.s 7
+		IL_0266: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_026b: ldstr "def0:"
+		IL_0270: ldloc.s 7
+		IL_0272: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0277: pop
+		IL_0278: ldloc.s 6
+		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027f: stloc.s 7
+		IL_0281: ldloc.s 7
+		IL_0283: ldstr "inc"
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_028d: pop
+		IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0293: ldstr "x1:"
+		IL_0298: ldloc.s 6
+		IL_029a: ldstr "x"
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02a9: pop
+		IL_02aa: ldloc.s 6
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b1: stloc.s 7
+		IL_02b3: ldloc.s 7
+		IL_02b5: ldstr "default"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_02bf: stloc.s 7
+		IL_02c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c6: ldstr "def1:"
+		IL_02cb: ldloc.s 7
+		IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02d2: pop
+		IL_02d3: ret
 	} // end of method Import_Namespace_Esm_Basic::__js_module_init__
 
 } // end of class Modules.Import_Namespace_Esm_Basic
@@ -1691,7 +1664,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3635
+				// Method begins at RVA 0x3589
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1717,7 +1690,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2d6c
+			// Method begins at RVA 0x2cd4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1747,7 +1720,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x363e
+				// Method begins at RVA 0x3592
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1773,7 +1746,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2d8b
+			// Method begins at RVA 0x2cf3
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1796,7 +1769,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3647
+				// Method begins at RVA 0x359b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1822,7 +1795,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2d93
+			// Method begins at RVA 0x2cfb
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1845,7 +1818,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3650
+				// Method begins at RVA 0x35a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1871,7 +1844,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2d9c
+			// Method begins at RVA 0x2d04
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1909,7 +1882,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3659
+				// Method begins at RVA 0x35ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1935,7 +1908,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2dd4
+			// Method begins at RVA 0x2d3c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1969,7 +1942,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x366b
+					// Method begins at RVA 0x35bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1987,7 +1960,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3662
+				// Method begins at RVA 0x35b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2013,7 +1986,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2df4
+			// Method begins at RVA 0x2d5c
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -2088,7 +2061,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3674
+				// Method begins at RVA 0x35c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2112,7 +2085,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e8c
+			// Method begins at RVA 0x2df4
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -2186,7 +2159,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x367d
+				// Method begins at RVA 0x35d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2211,7 +2184,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f11
+			// Method begins at RVA 0x2e79
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2239,7 +2212,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36aa
+					// Method begins at RVA 0x35fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2263,7 +2236,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x34a1
+				// Method begins at RVA 0x33f3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2289,7 +2262,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36b3
+					// Method begins at RVA 0x3607
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2313,7 +2286,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x34b0
+				// Method begins at RVA 0x3402
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2343,7 +2316,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x36e0
+						// Method begins at RVA 0x3634
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2367,7 +2340,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3555
+					// Method begins at RVA 0x34a9
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2401,7 +2374,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36d7
+					// Method begins at RVA 0x362b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2426,7 +2399,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x34c0
+				// Method begins at RVA 0x3414
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2519,7 +2492,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x368f
+					// Method begins at RVA 0x35e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2539,7 +2512,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3698
+					// Method begins at RVA 0x35ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2559,7 +2532,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36a1
+					// Method begins at RVA 0x35f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2583,7 +2556,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x36c5
+						// Method begins at RVA 0x3619
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2603,7 +2576,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x36ce
+						// Method begins at RVA 0x3622
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2621,7 +2594,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36bc
+					// Method begins at RVA 0x3610
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2641,7 +2614,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36e9
+					// Method begins at RVA 0x363d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2661,7 +2634,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36f2
+					// Method begins at RVA 0x3646
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2683,7 +2656,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3686
+				// Method begins at RVA 0x35da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2710,7 +2683,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2f1c
+			// Method begins at RVA 0x2e84
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3235,7 +3208,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36fb
+				// Method begins at RVA 0x364f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3263,50 +3236,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x3438
+			// Method begins at RVA 0x33a0
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-			IL_0011: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3335,7 +3299,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3621
+			// Method begins at RVA 0x3575
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3362,9 +3326,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x235c
+		// Method begins at RVA 0x2330
 		// Header size: 12
-		// Code size: 640 (0x280)
+		// Code size: 552 (0x228)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic_Lib/Scope,
@@ -3507,127 +3471,91 @@
 		IL_0140: stloc.s 5
 		IL_0142: ldloc.s 5
 		IL_0144: stloc.s 4
-		IL_0146: ldc.i4.1
-		IL_0147: newarr [System.Runtime]System.Object
-		IL_014c: dup
-		IL_014d: ldc.i4.0
-		IL_014e: ldloc.0
-		IL_014f: stelem.ref
-		IL_0150: ldc.i4.0
-		IL_0151: ldelem.ref
-		IL_0152: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0157: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0162: ldnull
-		IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0168: pop
-		IL_0169: ldc.i4.1
-		IL_016a: newarr [System.Runtime]System.Object
-		IL_016f: dup
-		IL_0170: ldc.i4.0
-		IL_0171: ldloc.0
-		IL_0172: stelem.ref
-		IL_0173: ldc.i4.0
-		IL_0174: ldelem.ref
-		IL_0175: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_017a: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0180: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0185: ldc.i4.0
-		IL_0186: conv.r8
-		IL_0187: ldstr ""
-		IL_018c: ldc.i4.0
-		IL_018d: ldc.i4.1
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0193: stloc.s 5
-		IL_0195: ldc.i4.1
-		IL_0196: newarr [System.Runtime]System.Object
-		IL_019b: dup
-		IL_019c: ldc.i4.0
-		IL_019d: ldloc.0
-		IL_019e: stelem.ref
-		IL_019f: ldc.i4.0
-		IL_01a0: ldelem.ref
-		IL_01a1: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01a6: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
-		IL_01ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01b1: ldnull
-		IL_01b2: ldstr "x"
-		IL_01b7: ldloc.s 5
-		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01be: pop
-		IL_01bf: ldc.i4.1
-		IL_01c0: newarr [System.Runtime]System.Object
-		IL_01c5: dup
-		IL_01c6: ldc.i4.0
-		IL_01c7: ldloc.0
-		IL_01c8: stelem.ref
-		IL_01c9: ldc.i4.0
-		IL_01ca: ldelem.ref
-		IL_01cb: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01d0: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01db: ldc.i4.0
-		IL_01dc: conv.r8
-		IL_01dd: ldstr ""
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldc.i4.1
-		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01e9: stloc.s 5
-		IL_01eb: ldc.i4.1
-		IL_01ec: newarr [System.Runtime]System.Object
-		IL_01f1: dup
-		IL_01f2: ldc.i4.0
-		IL_01f3: ldloc.0
-		IL_01f4: stelem.ref
-		IL_01f5: ldc.i4.0
-		IL_01f6: ldelem.ref
-		IL_01f7: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01fc: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
-		IL_0202: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0207: ldnull
-		IL_0208: ldstr "inc"
-		IL_020d: ldloc.s 5
-		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0214: pop
-		IL_0215: ldc.i4.1
-		IL_0216: newarr [System.Runtime]System.Object
-		IL_021b: dup
-		IL_021c: ldc.i4.0
-		IL_021d: ldloc.0
-		IL_021e: stelem.ref
-		IL_021f: ldc.i4.0
-		IL_0220: ldelem.ref
-		IL_0221: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0226: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_022c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0231: ldc.i4.0
-		IL_0232: conv.r8
-		IL_0233: ldstr ""
-		IL_0238: ldc.i4.0
-		IL_0239: ldc.i4.1
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_023f: stloc.s 5
-		IL_0241: ldc.i4.1
-		IL_0242: newarr [System.Runtime]System.Object
-		IL_0247: dup
-		IL_0248: ldc.i4.0
-		IL_0249: ldloc.0
-		IL_024a: stelem.ref
-		IL_024b: ldc.i4.0
-		IL_024c: ldelem.ref
-		IL_024d: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0252: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
-		IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_025d: ldnull
-		IL_025e: ldstr "default"
-		IL_0263: ldloc.s 5
-		IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_026a: pop
-		IL_026b: ldloc.0
-		IL_026c: ldc.r8 1
-		IL_0275: box [System.Runtime]System.Double
-		IL_027a: stfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::x
-		IL_027f: ret
+		IL_0146: ldloc.0
+		IL_0147: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_014c: ldnull
+		IL_014d: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+		IL_0152: pop
+		IL_0153: ldc.i4.1
+		IL_0154: newarr [System.Runtime]System.Object
+		IL_0159: dup
+		IL_015a: ldc.i4.0
+		IL_015b: ldloc.0
+		IL_015c: stelem.ref
+		IL_015d: ldc.i4.0
+		IL_015e: ldelem.ref
+		IL_015f: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_0164: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+		IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016f: ldc.i4.0
+		IL_0170: conv.r8
+		IL_0171: ldstr ""
+		IL_0176: ldc.i4.0
+		IL_0177: ldc.i4.1
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_017d: stloc.s 5
+		IL_017f: ldloc.0
+		IL_0180: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_0185: ldnull
+		IL_0186: ldstr "x"
+		IL_018b: ldloc.s 5
+		IL_018d: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
+		IL_0192: pop
+		IL_0193: ldc.i4.1
+		IL_0194: newarr [System.Runtime]System.Object
+		IL_0199: dup
+		IL_019a: ldc.i4.0
+		IL_019b: ldloc.0
+		IL_019c: stelem.ref
+		IL_019d: ldc.i4.0
+		IL_019e: ldelem.ref
+		IL_019f: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_01a4: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+		IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01af: ldc.i4.0
+		IL_01b0: conv.r8
+		IL_01b1: ldstr ""
+		IL_01b6: ldc.i4.0
+		IL_01b7: ldc.i4.1
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01bd: stloc.s 5
+		IL_01bf: ldloc.0
+		IL_01c0: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_01c5: ldnull
+		IL_01c6: ldstr "inc"
+		IL_01cb: ldloc.s 5
+		IL_01cd: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
+		IL_01d2: pop
+		IL_01d3: ldc.i4.1
+		IL_01d4: newarr [System.Runtime]System.Object
+		IL_01d9: dup
+		IL_01da: ldc.i4.0
+		IL_01db: ldloc.0
+		IL_01dc: stelem.ref
+		IL_01dd: ldc.i4.0
+		IL_01de: ldelem.ref
+		IL_01df: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_01e4: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+		IL_01ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01ef: ldc.i4.0
+		IL_01f0: conv.r8
+		IL_01f1: ldstr ""
+		IL_01f6: ldc.i4.0
+		IL_01f7: ldc.i4.1
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01fd: stloc.s 5
+		IL_01ff: ldloc.0
+		IL_0200: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_0205: ldnull
+		IL_0206: ldstr "default"
+		IL_020b: ldloc.s 5
+		IL_020d: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
+		IL_0212: pop
+		IL_0213: ldloc.0
+		IL_0214: ldc.r8 1
+		IL_021d: box [System.Runtime]System.Double
+		IL_0222: stfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::x
+		IL_0227: ret
 	} // end of method Import_Namespace_Esm_Basic_Lib::__js_module_init__
 
 } // end of class Modules.Import_Namespace_Esm_Basic_Lib
@@ -3639,7 +3567,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3704
+		// Method begins at RVA 0x3658
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dac
+					// Method begins at RVA 0x3cdc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3da3
+				// Method begins at RVA 0x3cd3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x26c0
+			// Method begins at RVA 0x262c
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3db5
+				// Method begins at RVA 0x3ce5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2758
+			// Method begins at RVA 0x26c4
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3dbe
+				// Method begins at RVA 0x3cee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27dd
+			// Method begins at RVA 0x2749
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3deb
+					// Method begins at RVA 0x3d1b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d6d
+				// Method begins at RVA 0x2cc3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3df4
+					// Method begins at RVA 0x3d24
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d7c
+				// Method begins at RVA 0x2cd2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3e21
+						// Method begins at RVA 0x3d51
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2e21
+					// Method begins at RVA 0x2d79
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e18
+					// Method begins at RVA 0x3d48
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d8c
+				// Method begins at RVA 0x2ce4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dd0
+					// Method begins at RVA 0x3d00
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dd9
+					// Method begins at RVA 0x3d09
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3de2
+					// Method begins at RVA 0x3d12
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3e06
+						// Method begins at RVA 0x3d36
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3e0f
+						// Method begins at RVA 0x3d3f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dfd
+					// Method begins at RVA 0x3d2d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e2a
+					// Method begins at RVA 0x3d5a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e33
+					// Method begins at RVA 0x3d63
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3dc7
+				// Method begins at RVA 0x3cf7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x27e8
+			// Method begins at RVA 0x2754
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e3c
+				// Method begins at RVA 0x3d6c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d04
+			// Method begins at RVA 0x2c70
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-			IL_0011: ldftn object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3d9a
+			// Method begins at RVA 0x3cca
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 680 (0x2a8)
+		// Code size: 658 (0x292)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable/Scope,
@@ -1515,153 +1506,144 @@
 		IL_00d8: stloc.s 7
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_00ef: ldftn object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_Namespace_FromCjs_Stable_A.mjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 7
-		IL_010e: ldloc.s 7
-		IL_0110: stloc.s 5
-		IL_0112: ldarg.1
-		IL_0113: ldstr "./Import_Namespace_FromCjs_Stable_B.mjs"
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_011d: stloc.s 7
-		IL_011f: ldloc.s 7
-		IL_0121: stloc.s 6
-		IL_0123: ldnull
-		IL_0124: ldloc.s 5
-		IL_0126: ldstr "ns"
-		IL_012b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0130: stloc.s 7
-		IL_0132: ldnull
-		IL_0133: ldloc.s 6
-		IL_0135: ldstr "ns"
-		IL_013a: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_013f: stloc.s 8
-		IL_0141: ldloc.s 7
-		IL_0143: ldloc.s 8
-		IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_014a: stloc.s 9
-		IL_014c: ldloc.s 9
-		IL_014e: box [System.Runtime]System.Boolean
-		IL_0153: stloc.s 10
-		IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015a: ldstr "same:"
-		IL_015f: ldloc.s 10
-		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0166: pop
-		IL_0167: ldnull
-		IL_0168: ldloc.s 5
-		IL_016a: ldstr "ns"
-		IL_016f: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0174: stloc.s 8
-		IL_0176: ldloc.s 8
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_017d: stloc.s 8
-		IL_017f: ldloc.s 8
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0186: stloc.s 8
-		IL_0188: ldloc.s 8
-		IL_018a: ldstr "sort"
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0194: stloc.s 8
-		IL_0196: ldloc.s 8
-		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019d: stloc.s 8
-		IL_019f: ldloc.s 8
-		IL_01a1: ldstr "join"
-		IL_01a6: ldstr ","
-		IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01b0: stloc.s 8
-		IL_01b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b7: ldstr "keys:"
-		IL_01bc: ldloc.s 8
-		IL_01be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01c3: pop
-		IL_01c4: ldnull
-		IL_01c5: ldloc.s 5
-		IL_01c7: ldstr "ns"
-		IL_01cc: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01d1: stloc.s 8
-		IL_01d3: ldloc.s 8
-		IL_01d5: ldstr "default"
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01df: stloc.s 8
-		IL_01e1: ldnull
-		IL_01e2: ldloc.s 5
-		IL_01e4: ldstr "ns"
-		IL_01e9: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01ee: stloc.s 7
-		IL_01f0: ldloc.s 7
-		IL_01f2: ldstr "module.exports"
-		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01fc: stloc.s 7
-		IL_01fe: ldloc.s 8
-		IL_0200: ldloc.s 7
-		IL_0202: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0207: stloc.s 9
-		IL_0209: ldloc.s 9
-		IL_020b: box [System.Runtime]System.Boolean
-		IL_0210: stloc.s 10
-		IL_0212: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0217: ldstr "defaultIsModuleExports:"
-		IL_021c: ldloc.s 10
-		IL_021e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0223: pop
-		IL_0224: ldnull
-		IL_0225: ldloc.s 5
-		IL_0227: ldstr "ns"
-		IL_022c: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0231: stloc.s 7
-		IL_0233: ldloc.s 7
-		IL_0235: ldstr "x"
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_023f: stloc.s 7
-		IL_0241: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0246: ldstr "x0:"
-		IL_024b: ldloc.s 7
-		IL_024d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0252: pop
-		IL_0253: ldnull
-		IL_0254: ldloc.s 5
-		IL_0256: ldstr "ns"
-		IL_025b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0260: stloc.s 7
-		IL_0262: ldloc.s 7
-		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0269: stloc.s 7
-		IL_026b: ldloc.s 7
-		IL_026d: ldstr "inc"
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0277: pop
-		IL_0278: ldnull
-		IL_0279: ldloc.s 6
-		IL_027b: ldstr "ns"
-		IL_0280: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0285: stloc.s 7
-		IL_0287: ldloc.s 7
-		IL_0289: ldstr "x"
-		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0293: stloc.s 7
-		IL_0295: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_029a: ldstr "x1:"
-		IL_029f: ldloc.s 7
-		IL_02a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02a6: pop
-		IL_02a7: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_Namespace_FromCjs_Stable_A.mjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 7
+		IL_00f8: ldloc.s 7
+		IL_00fa: stloc.s 5
+		IL_00fc: ldarg.1
+		IL_00fd: ldstr "./Import_Namespace_FromCjs_Stable_B.mjs"
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0107: stloc.s 7
+		IL_0109: ldloc.s 7
+		IL_010b: stloc.s 6
+		IL_010d: ldnull
+		IL_010e: ldloc.s 5
+		IL_0110: ldstr "ns"
+		IL_0115: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_011a: stloc.s 7
+		IL_011c: ldnull
+		IL_011d: ldloc.s 6
+		IL_011f: ldstr "ns"
+		IL_0124: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0129: stloc.s 8
+		IL_012b: ldloc.s 7
+		IL_012d: ldloc.s 8
+		IL_012f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0134: stloc.s 9
+		IL_0136: ldloc.s 9
+		IL_0138: box [System.Runtime]System.Boolean
+		IL_013d: stloc.s 10
+		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0144: ldstr "same:"
+		IL_0149: ldloc.s 10
+		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0150: pop
+		IL_0151: ldnull
+		IL_0152: ldloc.s 5
+		IL_0154: ldstr "ns"
+		IL_0159: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_015e: stloc.s 8
+		IL_0160: ldloc.s 8
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0167: stloc.s 8
+		IL_0169: ldloc.s 8
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0170: stloc.s 8
+		IL_0172: ldloc.s 8
+		IL_0174: ldstr "sort"
+		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_017e: stloc.s 8
+		IL_0180: ldloc.s 8
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0187: stloc.s 8
+		IL_0189: ldloc.s 8
+		IL_018b: ldstr "join"
+		IL_0190: ldstr ","
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_019a: stloc.s 8
+		IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a1: ldstr "keys:"
+		IL_01a6: ldloc.s 8
+		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01ad: pop
+		IL_01ae: ldnull
+		IL_01af: ldloc.s 5
+		IL_01b1: ldstr "ns"
+		IL_01b6: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_01bb: stloc.s 8
+		IL_01bd: ldloc.s 8
+		IL_01bf: ldstr "default"
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c9: stloc.s 8
+		IL_01cb: ldnull
+		IL_01cc: ldloc.s 5
+		IL_01ce: ldstr "ns"
+		IL_01d3: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_01d8: stloc.s 7
+		IL_01da: ldloc.s 7
+		IL_01dc: ldstr "module.exports"
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01e6: stloc.s 7
+		IL_01e8: ldloc.s 8
+		IL_01ea: ldloc.s 7
+		IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01f1: stloc.s 9
+		IL_01f3: ldloc.s 9
+		IL_01f5: box [System.Runtime]System.Boolean
+		IL_01fa: stloc.s 10
+		IL_01fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0201: ldstr "defaultIsModuleExports:"
+		IL_0206: ldloc.s 10
+		IL_0208: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_020d: pop
+		IL_020e: ldnull
+		IL_020f: ldloc.s 5
+		IL_0211: ldstr "ns"
+		IL_0216: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_021b: stloc.s 7
+		IL_021d: ldloc.s 7
+		IL_021f: ldstr "x"
+		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0229: stloc.s 7
+		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0230: ldstr "x0:"
+		IL_0235: ldloc.s 7
+		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_023c: pop
+		IL_023d: ldnull
+		IL_023e: ldloc.s 5
+		IL_0240: ldstr "ns"
+		IL_0245: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_024a: stloc.s 7
+		IL_024c: ldloc.s 7
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0253: stloc.s 7
+		IL_0255: ldloc.s 7
+		IL_0257: ldstr "inc"
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0261: pop
+		IL_0262: ldnull
+		IL_0263: ldloc.s 6
+		IL_0265: ldstr "ns"
+		IL_026a: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
+		IL_026f: stloc.s 7
+		IL_0271: ldloc.s 7
+		IL_0273: ldstr "x"
+		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_027d: stloc.s 7
+		IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0284: ldstr "x1:"
+		IL_0289: ldloc.s 7
+		IL_028b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0290: pop
+		IL_0291: ret
 	} // end of method Import_Namespace_FromCjs_Stable::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable
@@ -1681,7 +1663,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e4e
+				// Method begins at RVA 0x3d7e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1707,7 +1689,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2e42
+			// Method begins at RVA 0x2d9a
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1734,7 +1716,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e60
+					// Method begins at RVA 0x3d90
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1752,7 +1734,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e57
+				// Method begins at RVA 0x3d87
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1778,7 +1760,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2e4c
+			// Method begins at RVA 0x2da4
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1853,7 +1835,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e69
+				// Method begins at RVA 0x3d99
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1877,7 +1859,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ee4
+			// Method begins at RVA 0x2e3c
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1951,7 +1933,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e72
+				// Method begins at RVA 0x3da2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1976,7 +1958,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f69
+			// Method begins at RVA 0x2ec1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2004,7 +1986,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e9f
+					// Method begins at RVA 0x3dcf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2028,7 +2010,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x34f9
+				// Method begins at RVA 0x343b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2054,7 +2036,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ea8
+					// Method begins at RVA 0x3dd8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2078,7 +2060,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3508
+				// Method begins at RVA 0x344a
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2108,7 +2090,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3ed5
+						// Method begins at RVA 0x3e05
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2132,7 +2114,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x35ad
+					// Method begins at RVA 0x34f1
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2166,7 +2148,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ecc
+					// Method begins at RVA 0x3dfc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2191,7 +2173,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3518
+				// Method begins at RVA 0x345c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2284,7 +2266,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e84
+					// Method begins at RVA 0x3db4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2304,7 +2286,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e8d
+					// Method begins at RVA 0x3dbd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2324,7 +2306,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e96
+					// Method begins at RVA 0x3dc6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2348,7 +2330,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3eba
+						// Method begins at RVA 0x3dea
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2368,7 +2350,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3ec3
+						// Method begins at RVA 0x3df3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2386,7 +2368,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3eb1
+					// Method begins at RVA 0x3de1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2406,7 +2388,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ede
+					// Method begins at RVA 0x3e0e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2426,7 +2408,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ee7
+					// Method begins at RVA 0x3e17
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2448,7 +2430,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e7b
+				// Method begins at RVA 0x3dab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2475,7 +2457,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2f74
+			// Method begins at RVA 0x2ecc
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3000,7 +2982,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ef0
+				// Method begins at RVA 0x3e20
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3028,50 +3010,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x3490
+			// Method begins at RVA 0x33e8
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-			IL_0011: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3097,7 +3070,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3e45
+			// Method begins at RVA 0x3d75
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3121,9 +3094,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2304
+		// Method begins at RVA 0x22f0
 		// Header size: 12
-		// Code size: 407 (0x197)
+		// Code size: 341 (0x155)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_A/Scope,
@@ -3225,79 +3198,52 @@
 		IL_00d8: stloc.s 6
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_00ef: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 6
-		IL_010e: ldloc.s 6
-		IL_0110: stloc.s 5
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: ldc.i4.0
-		IL_011d: ldelem.ref
-		IL_011e: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0123: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012e: ldnull
-		IL_012f: ldloc.s 5
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0136: stloc.s 6
-		IL_0138: ldloc.0
-		IL_0139: ldloc.s 6
-		IL_013b: stfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::ns
-		IL_0140: ldc.i4.1
-		IL_0141: newarr [System.Runtime]System.Object
-		IL_0146: dup
-		IL_0147: ldc.i4.0
-		IL_0148: ldloc.0
-		IL_0149: stelem.ref
-		IL_014a: ldc.i4.0
-		IL_014b: ldelem.ref
-		IL_014c: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0151: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_015c: ldc.i4.0
-		IL_015d: conv.r8
-		IL_015e: ldstr ""
-		IL_0163: ldc.i4.0
-		IL_0164: ldc.i4.1
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_016a: stloc.s 6
-		IL_016c: ldc.i4.1
-		IL_016d: newarr [System.Runtime]System.Object
-		IL_0172: dup
-		IL_0173: ldc.i4.0
-		IL_0174: ldloc.0
-		IL_0175: stelem.ref
-		IL_0176: ldc.i4.0
-		IL_0177: ldelem.ref
-		IL_0178: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_017d: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object, object)
-		IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0188: ldnull
-		IL_0189: ldstr "ns"
-		IL_018e: ldloc.s 6
-		IL_0190: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0195: pop
-		IL_0196: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 6
+		IL_00f8: ldloc.s 6
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.0
+		IL_00fd: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
+		IL_0102: ldnull
+		IL_0103: ldloc.s 5
+		IL_0105: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
+		IL_010a: stloc.s 6
+		IL_010c: ldloc.0
+		IL_010d: ldloc.s 6
+		IL_010f: stfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::ns
+		IL_0114: ldc.i4.1
+		IL_0115: newarr [System.Runtime]System.Object
+		IL_011a: dup
+		IL_011b: ldc.i4.0
+		IL_011c: ldloc.0
+		IL_011d: stelem.ref
+		IL_011e: ldc.i4.0
+		IL_011f: ldelem.ref
+		IL_0120: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
+		IL_0125: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+		IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0130: ldc.i4.0
+		IL_0131: conv.r8
+		IL_0132: ldstr ""
+		IL_0137: ldc.i4.0
+		IL_0138: ldc.i4.1
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_013e: stloc.s 6
+		IL_0140: ldloc.0
+		IL_0141: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
+		IL_0146: ldnull
+		IL_0147: ldstr "ns"
+		IL_014c: ldloc.s 6
+		IL_014e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object, object)
+		IL_0153: pop
+		IL_0154: ret
 	} // end of method Import_Namespace_FromCjs_Stable_A::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable_A
@@ -3317,7 +3263,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f02
+				// Method begins at RVA 0x3e32
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3343,7 +3289,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4b 00 00 02
 			)
-			// Method begins at RVA 0x35d0
+			// Method begins at RVA 0x3514
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3385,7 +3331,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3ef9
+			// Method begins at RVA 0x3e29
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3409,7 +3355,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x24a8
+		// Method begins at RVA 0x2454
 		// Header size: 12
 		// Code size: 103 (0x67)
 		.maxstack 8
@@ -3475,7 +3421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f14
+				// Method begins at RVA 0x3e44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3501,7 +3447,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3610
+			// Method begins at RVA 0x3554
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3528,7 +3474,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f26
+					// Method begins at RVA 0x3e56
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3546,7 +3492,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f1d
+				// Method begins at RVA 0x3e4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3572,7 +3518,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3618
+			// Method begins at RVA 0x355c
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -3647,7 +3593,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f2f
+				// Method begins at RVA 0x3e5f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3671,7 +3617,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x36b0
+			// Method begins at RVA 0x35f4
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -3745,7 +3691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f38
+				// Method begins at RVA 0x3e68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3770,7 +3716,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3735
+			// Method begins at RVA 0x3679
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3798,7 +3744,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f65
+					// Method begins at RVA 0x3e95
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3822,7 +3768,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cc5
+				// Method begins at RVA 0x3bf3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3848,7 +3794,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f6e
+					// Method begins at RVA 0x3e9e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3872,7 +3818,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3cd4
+				// Method begins at RVA 0x3c02
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3902,7 +3848,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3f9b
+						// Method begins at RVA 0x3ecb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3926,7 +3872,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3d79
+					// Method begins at RVA 0x3ca9
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -3960,7 +3906,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f92
+					// Method begins at RVA 0x3ec2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3985,7 +3931,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3ce4
+				// Method begins at RVA 0x3c14
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4078,7 +4024,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f4a
+					// Method begins at RVA 0x3e7a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4098,7 +4044,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f53
+					// Method begins at RVA 0x3e83
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4118,7 +4064,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f5c
+					// Method begins at RVA 0x3e8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4142,7 +4088,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3f80
+						// Method begins at RVA 0x3eb0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4162,7 +4108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3f89
+						// Method begins at RVA 0x3eb9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4180,7 +4126,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f77
+					// Method begins at RVA 0x3ea7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4200,7 +4146,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fa4
+					// Method begins at RVA 0x3ed4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4220,7 +4166,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fad
+					// Method begins at RVA 0x3edd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4242,7 +4188,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f41
+				// Method begins at RVA 0x3e71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4269,7 +4215,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3740
+			// Method begins at RVA 0x3684
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -4794,7 +4740,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fb6
+				// Method begins at RVA 0x3ee6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4822,50 +4768,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3c5c
+			// Method begins at RVA 0x3ba0
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-			IL_0011: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -4891,7 +4828,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3f0b
+			// Method begins at RVA 0x3e3b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4915,9 +4852,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x251c
+		// Method begins at RVA 0x24c8
 		// Header size: 12
-		// Code size: 407 (0x197)
+		// Code size: 341 (0x155)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_B/Scope,
@@ -5019,79 +4956,52 @@
 		IL_00d8: stloc.s 6
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_00ef: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 6
-		IL_010e: ldloc.s 6
-		IL_0110: stloc.s 5
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: ldc.i4.0
-		IL_011d: ldelem.ref
-		IL_011e: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0123: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012e: ldnull
-		IL_012f: ldloc.s 5
-		IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0136: stloc.s 6
-		IL_0138: ldloc.0
-		IL_0139: ldloc.s 6
-		IL_013b: stfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::ns
-		IL_0140: ldc.i4.1
-		IL_0141: newarr [System.Runtime]System.Object
-		IL_0146: dup
-		IL_0147: ldc.i4.0
-		IL_0148: ldloc.0
-		IL_0149: stelem.ref
-		IL_014a: ldc.i4.0
-		IL_014b: ldelem.ref
-		IL_014c: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0151: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_015c: ldc.i4.0
-		IL_015d: conv.r8
-		IL_015e: ldstr ""
-		IL_0163: ldc.i4.0
-		IL_0164: ldc.i4.1
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_016a: stloc.s 6
-		IL_016c: ldc.i4.1
-		IL_016d: newarr [System.Runtime]System.Object
-		IL_0172: dup
-		IL_0173: ldc.i4.0
-		IL_0174: ldloc.0
-		IL_0175: stelem.ref
-		IL_0176: ldc.i4.0
-		IL_0177: ldelem.ref
-		IL_0178: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_017d: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object, object)
-		IL_0183: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0188: ldnull
-		IL_0189: ldstr "ns"
-		IL_018e: ldloc.s 6
-		IL_0190: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0195: pop
-		IL_0196: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 6
+		IL_00f8: ldloc.s 6
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.0
+		IL_00fd: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
+		IL_0102: ldnull
+		IL_0103: ldloc.s 5
+		IL_0105: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
+		IL_010a: stloc.s 6
+		IL_010c: ldloc.0
+		IL_010d: ldloc.s 6
+		IL_010f: stfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::ns
+		IL_0114: ldc.i4.1
+		IL_0115: newarr [System.Runtime]System.Object
+		IL_011a: dup
+		IL_011b: ldc.i4.0
+		IL_011c: ldloc.0
+		IL_011d: stelem.ref
+		IL_011e: ldc.i4.0
+		IL_011f: ldelem.ref
+		IL_0120: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
+		IL_0125: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+		IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0130: ldc.i4.0
+		IL_0131: conv.r8
+		IL_0132: ldstr ""
+		IL_0137: ldc.i4.0
+		IL_0138: ldc.i4.1
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_013e: stloc.s 6
+		IL_0140: ldloc.0
+		IL_0141: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
+		IL_0146: ldnull
+		IL_0147: ldstr "ns"
+		IL_014c: ldloc.s 6
+		IL_014e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object, object)
+		IL_0153: pop
+		IL_0154: ret
 	} // end of method Import_Namespace_FromCjs_Stable_B::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable_B
@@ -5103,7 +5013,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3fbf
+		// Method begins at RVA 0x3eef
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b06
+			// Method begins at RVA 0x2a9a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,7 +106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b23
+				// Method begins at RVA 0x2ab7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x233c
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b2c
+				// Method begins at RVA 0x2ac0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -188,7 +188,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x235b
+			// Method begins at RVA 0x2303
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b35
+				// Method begins at RVA 0x2ac9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -236,7 +236,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2364
+			// Method begins at RVA 0x230c
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3e
+				// Method begins at RVA 0x2ad2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -291,7 +291,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x237a
+			// Method begins at RVA 0x2322
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -318,7 +318,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b50
+					// Method begins at RVA 0x2ae4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -336,7 +336,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b47
+				// Method begins at RVA 0x2adb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -362,7 +362,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2384
+			// Method begins at RVA 0x232c
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -437,7 +437,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b59
+				// Method begins at RVA 0x2aed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -461,7 +461,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x241c
+			// Method begins at RVA 0x23c4
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -535,7 +535,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b62
+				// Method begins at RVA 0x2af6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -560,7 +560,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24a1
+			// Method begins at RVA 0x2449
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -588,7 +588,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b8f
+					// Method begins at RVA 0x2b23
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a31
+				// Method begins at RVA 0x29c3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -638,7 +638,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b98
+					// Method begins at RVA 0x2b2c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -662,7 +662,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a40
+				// Method begins at RVA 0x29d2
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -692,7 +692,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bc5
+						// Method begins at RVA 0x2b59
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -716,7 +716,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2ae5
+					// Method begins at RVA 0x2a79
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -750,7 +750,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bbc
+					// Method begins at RVA 0x2b50
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -775,7 +775,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a50
+				// Method begins at RVA 0x29e4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -868,7 +868,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b74
+					// Method begins at RVA 0x2b08
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -888,7 +888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b7d
+					// Method begins at RVA 0x2b11
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -908,7 +908,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b86
+					// Method begins at RVA 0x2b1a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -932,7 +932,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2baa
+						// Method begins at RVA 0x2b3e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -952,7 +952,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2bb3
+						// Method begins at RVA 0x2b47
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -970,7 +970,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ba1
+					// Method begins at RVA 0x2b35
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -990,7 +990,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bce
+					// Method begins at RVA 0x2b62
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1010,7 +1010,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2bd7
+					// Method begins at RVA 0x2b6b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1032,7 +1032,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b6b
+				// Method begins at RVA 0x2aff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1059,7 +1059,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24ac
+			// Method begins at RVA 0x2454
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1584,7 +1584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2be0
+				// Method begins at RVA 0x2b74
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1612,50 +1612,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x29c8
+			// Method begins at RVA 0x2970
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_RequireEsmModule_Lib/Scope
-			IL_0011: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_RequireEsmModule_Lib/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1684,7 +1675,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2b0f
+			// Method begins at RVA 0x2aa3
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1713,7 +1704,7 @@
 	{
 		// Method begins at RVA 0x20e8
 		// Header size: 12
-		// Code size: 583 (0x247)
+		// Code size: 495 (0x1ef)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_RequireEsmModule_Lib/Scope,
@@ -1827,130 +1818,94 @@
 		IL_00fc: stloc.s 5
 		IL_00fe: ldloc.s 5
 		IL_0100: stloc.s 4
-		IL_0102: ldc.i4.1
-		IL_0103: newarr [System.Runtime]System.Object
-		IL_0108: dup
-		IL_0109: ldc.i4.0
-		IL_010a: ldloc.0
-		IL_010b: stelem.ref
-		IL_010c: ldc.i4.0
-		IL_010d: ldelem.ref
-		IL_010e: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0113: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_011e: ldnull
-		IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0124: pop
-		IL_0125: ldc.i4.1
-		IL_0126: newarr [System.Runtime]System.Object
-		IL_012b: dup
-		IL_012c: ldc.i4.0
-		IL_012d: ldloc.0
-		IL_012e: stelem.ref
-		IL_012f: ldc.i4.0
-		IL_0130: ldelem.ref
-		IL_0131: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0136: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_013c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0141: ldc.i4.0
-		IL_0142: conv.r8
-		IL_0143: ldstr ""
-		IL_0148: ldc.i4.0
-		IL_0149: ldc.i4.1
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_014f: stloc.s 5
-		IL_0151: ldc.i4.1
-		IL_0152: newarr [System.Runtime]System.Object
-		IL_0157: dup
-		IL_0158: ldc.i4.0
-		IL_0159: ldloc.0
-		IL_015a: stelem.ref
-		IL_015b: ldc.i4.0
-		IL_015c: ldelem.ref
-		IL_015d: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0162: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
-		IL_0168: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_016d: ldnull
-		IL_016e: ldstr "named"
-		IL_0173: ldloc.s 5
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_017a: pop
-		IL_017b: ldc.i4.1
-		IL_017c: newarr [System.Runtime]System.Object
-		IL_0181: dup
-		IL_0182: ldc.i4.0
-		IL_0183: ldloc.0
-		IL_0184: stelem.ref
-		IL_0185: ldc.i4.0
-		IL_0186: ldelem.ref
-		IL_0187: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_018c: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0192: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0197: ldc.i4.0
-		IL_0198: conv.r8
-		IL_0199: ldstr ""
-		IL_019e: ldc.i4.0
-		IL_019f: ldc.i4.1
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01a5: stloc.s 5
-		IL_01a7: ldc.i4.1
-		IL_01a8: newarr [System.Runtime]System.Object
-		IL_01ad: dup
-		IL_01ae: ldc.i4.0
-		IL_01af: ldloc.0
-		IL_01b0: stelem.ref
-		IL_01b1: ldc.i4.0
-		IL_01b2: ldelem.ref
-		IL_01b3: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_01b8: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
-		IL_01be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01c3: ldnull
-		IL_01c4: ldstr "sum"
-		IL_01c9: ldloc.s 5
-		IL_01cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01d0: pop
-		IL_01d1: ldloc.0
-		IL_01d2: ldc.r8 7
-		IL_01db: box [System.Runtime]System.Double
-		IL_01e0: stfld object Modules.Import_RequireEsmModule_Lib/Scope::named
-		IL_01e5: ldloc.0
-		IL_01e6: ldstr "esm-default"
-		IL_01eb: stfld string Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_default_0
-		IL_01f0: ldc.i4.1
-		IL_01f1: newarr [System.Runtime]System.Object
-		IL_01f6: dup
-		IL_01f7: ldc.i4.0
-		IL_01f8: ldloc.0
-		IL_01f9: stelem.ref
-		IL_01fa: ldc.i4.0
-		IL_01fb: ldelem.ref
-		IL_01fc: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0201: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0207: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_020c: ldc.i4.0
-		IL_020d: conv.r8
-		IL_020e: ldstr ""
-		IL_0213: ldc.i4.0
-		IL_0214: ldc.i4.1
-		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_021a: stloc.s 5
-		IL_021c: ldc.i4.1
-		IL_021d: newarr [System.Runtime]System.Object
-		IL_0222: dup
-		IL_0223: ldc.i4.0
-		IL_0224: ldloc.0
-		IL_0225: stelem.ref
-		IL_0226: ldc.i4.0
-		IL_0227: ldelem.ref
-		IL_0228: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_022d: ldftn object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
-		IL_0233: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0238: ldnull
-		IL_0239: ldstr "default"
-		IL_023e: ldloc.s 5
-		IL_0240: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0245: pop
-		IL_0246: ret
+		IL_0102: ldloc.0
+		IL_0103: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_0108: ldnull
+		IL_0109: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+		IL_010e: pop
+		IL_010f: ldc.i4.1
+		IL_0110: newarr [System.Runtime]System.Object
+		IL_0115: dup
+		IL_0116: ldc.i4.0
+		IL_0117: ldloc.0
+		IL_0118: stelem.ref
+		IL_0119: ldc.i4.0
+		IL_011a: ldelem.ref
+		IL_011b: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_0120: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+		IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_012b: ldc.i4.0
+		IL_012c: conv.r8
+		IL_012d: ldstr ""
+		IL_0132: ldc.i4.0
+		IL_0133: ldc.i4.1
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0139: stloc.s 5
+		IL_013b: ldloc.0
+		IL_013c: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_0141: ldnull
+		IL_0142: ldstr "named"
+		IL_0147: ldloc.s 5
+		IL_0149: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
+		IL_014e: pop
+		IL_014f: ldc.i4.1
+		IL_0150: newarr [System.Runtime]System.Object
+		IL_0155: dup
+		IL_0156: ldc.i4.0
+		IL_0157: ldloc.0
+		IL_0158: stelem.ref
+		IL_0159: ldc.i4.0
+		IL_015a: ldelem.ref
+		IL_015b: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_0160: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+		IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016b: ldc.i4.0
+		IL_016c: conv.r8
+		IL_016d: ldstr ""
+		IL_0172: ldc.i4.0
+		IL_0173: ldc.i4.1
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0179: stloc.s 5
+		IL_017b: ldloc.0
+		IL_017c: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_0181: ldnull
+		IL_0182: ldstr "sum"
+		IL_0187: ldloc.s 5
+		IL_0189: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
+		IL_018e: pop
+		IL_018f: ldloc.0
+		IL_0190: ldc.r8 7
+		IL_0199: box [System.Runtime]System.Double
+		IL_019e: stfld object Modules.Import_RequireEsmModule_Lib/Scope::named
+		IL_01a3: ldloc.0
+		IL_01a4: ldstr "esm-default"
+		IL_01a9: stfld string Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_default_0
+		IL_01ae: ldc.i4.1
+		IL_01af: newarr [System.Runtime]System.Object
+		IL_01b4: dup
+		IL_01b5: ldc.i4.0
+		IL_01b6: ldloc.0
+		IL_01b7: stelem.ref
+		IL_01b8: ldc.i4.0
+		IL_01b9: ldelem.ref
+		IL_01ba: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_01bf: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+		IL_01c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01ca: ldc.i4.0
+		IL_01cb: conv.r8
+		IL_01cc: ldstr ""
+		IL_01d1: ldc.i4.0
+		IL_01d2: ldc.i4.1
+		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01d8: stloc.s 5
+		IL_01da: ldloc.0
+		IL_01db: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_01e0: ldnull
+		IL_01e1: ldstr "default"
+		IL_01e6: ldloc.s 5
+		IL_01e8: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
+		IL_01ed: pop
+		IL_01ee: ret
 	} // end of method Import_RequireEsmModule_Lib::__js_module_init__
 
 } // end of class Modules.Import_RequireEsmModule_Lib
@@ -1962,7 +1917,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2be9
+		// Method begins at RVA 0x2b7d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a08
+					// Method begins at RVA 0x29c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ff
+				// Method begins at RVA 0x29bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2274
+			// Method begins at RVA 0x2248
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a11
+				// Method begins at RVA 0x29d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x230c
+			// Method begins at RVA 0x22e0
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a1a
+				// Method begins at RVA 0x29da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2391
+			// Method begins at RVA 0x2365
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a47
+					// Method begins at RVA 0x2a07
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2921
+				// Method begins at RVA 0x28df
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a50
+					// Method begins at RVA 0x2a10
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2930
+				// Method begins at RVA 0x28ee
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a7d
+						// Method begins at RVA 0x2a3d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x29d5
+					// Method begins at RVA 0x2995
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a74
+					// Method begins at RVA 0x2a34
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2940
+				// Method begins at RVA 0x2900
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a2c
+					// Method begins at RVA 0x29ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a35
+					// Method begins at RVA 0x29f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a3e
+					// Method begins at RVA 0x29fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a62
+						// Method begins at RVA 0x2a22
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a6b
+						// Method begins at RVA 0x2a2b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a59
+					// Method begins at RVA 0x2a19
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a86
+					// Method begins at RVA 0x2a46
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a8f
+					// Method begins at RVA 0x2a4f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a23
+				// Method begins at RVA 0x29e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x239c
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a98
+				// Method begins at RVA 0x2a58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,50 +1316,41 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x28b8
+			// Method begins at RVA 0x288c
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 71 (0x47)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Import_StaticImport_FromCjs/Scope
-			IL_0011: ldftn object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0022: pop
-			IL_0023: ldarg.0
-			IL_0024: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
-			IL_0029: stloc.0
-			IL_002a: ldloc.0
-			IL_002b: ldarg.2
-			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0031: dup
-			IL_0032: ldstr "enumerable"
-			IL_0037: ldc.i4.1
-			IL_0038: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_003d: dup
-			IL_003e: ldstr "configurable"
-			IL_0043: ldc.i4.1
-			IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0049: dup
-			IL_004a: ldstr "get"
-			IL_004f: ldarg.3
-			IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Import_StaticImport_FromCjs/Scope
+			IL_0006: ldnull
+			IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
+			IL_000c: pop
+			IL_000d: ldarg.0
+			IL_000e: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
+			IL_0013: stloc.0
+			IL_0014: ldloc.0
+			IL_0015: ldarg.2
+			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_001b: dup
+			IL_001c: ldstr "enumerable"
+			IL_0021: ldc.i4.1
+			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0027: dup
+			IL_0028: ldstr "configurable"
+			IL_002d: ldc.i4.1
+			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0033: dup
+			IL_0034: ldstr "get"
+			IL_0039: ldarg.3
+			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0044: pop
+			IL_0045: ldnull
+			IL_0046: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1383,7 +1374,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29f6
+			// Method begins at RVA 0x29b6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1400,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 475 (0x1db)
+		// Code size: 431 (0x1af)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_StaticImport_FromCjs/Scope,
@@ -1513,89 +1504,71 @@
 		IL_00d8: stloc.s 8
 		IL_00da: ldloc.s 8
 		IL_00dc: stloc.s 4
-		IL_00de: ldc.i4.1
-		IL_00df: newarr [System.Runtime]System.Object
-		IL_00e4: dup
-		IL_00e5: ldc.i4.0
-		IL_00e6: ldloc.0
-		IL_00e7: stelem.ref
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldelem.ref
-		IL_00ea: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_00ef: ldftn object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
-		IL_00f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fa: ldnull
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0100: pop
-		IL_0101: ldarg.1
-		IL_0102: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_010c: stloc.s 8
-		IL_010e: ldloc.s 8
-		IL_0110: stloc.s 5
-		IL_0112: ldarg.1
-		IL_0113: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
-		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_011d: stloc.s 8
-		IL_011f: ldloc.s 8
-		IL_0121: stloc.s 6
-		IL_0123: ldc.i4.1
-		IL_0124: newarr [System.Runtime]System.Object
-		IL_0129: dup
-		IL_012a: ldc.i4.0
-		IL_012b: ldloc.0
-		IL_012c: stelem.ref
-		IL_012d: ldc.i4.0
-		IL_012e: ldelem.ref
-		IL_012f: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_0134: ldftn object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
-		IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_013f: ldnull
-		IL_0140: ldloc.s 6
-		IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0147: stloc.s 8
-		IL_0149: ldloc.s 8
-		IL_014b: stloc.s 7
-		IL_014d: ldnull
-		IL_014e: ldloc.s 5
-		IL_0150: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
-		IL_0155: stloc.s 8
-		IL_0157: ldloc.s 8
-		IL_0159: ldstr "value"
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0163: stloc.s 8
-		IL_0165: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016a: ldstr "default.value:"
-		IL_016f: ldloc.s 8
-		IL_0171: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0176: pop
-		IL_0177: ldnull
-		IL_0178: ldloc.s 5
-		IL_017a: ldstr "value"
-		IL_017f: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0184: stloc.s 8
-		IL_0186: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_018b: ldstr "named:"
-		IL_0190: ldloc.s 8
-		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0197: pop
-		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019d: ldstr "namespace.default.value:"
-		IL_01a2: ldloc.s 7
-		IL_01a4: ldstr "default"
-		IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ae: ldstr "value"
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01bd: pop
-		IL_01be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c3: ldstr "namespace.value:"
-		IL_01c8: ldloc.s 7
-		IL_01ca: ldstr "value"
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01d9: pop
-		IL_01da: ret
+		IL_00de: ldloc.0
+		IL_00df: castclass Modules.Import_StaticImport_FromCjs/Scope
+		IL_00e4: ldnull
+		IL_00e5: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
+		IL_00ea: pop
+		IL_00eb: ldarg.1
+		IL_00ec: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00f6: stloc.s 8
+		IL_00f8: ldloc.s 8
+		IL_00fa: stloc.s 5
+		IL_00fc: ldarg.1
+		IL_00fd: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0107: stloc.s 8
+		IL_0109: ldloc.s 8
+		IL_010b: stloc.s 6
+		IL_010d: ldloc.0
+		IL_010e: castclass Modules.Import_StaticImport_FromCjs/Scope
+		IL_0113: ldnull
+		IL_0114: ldloc.s 6
+		IL_0116: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
+		IL_011b: stloc.s 8
+		IL_011d: ldloc.s 8
+		IL_011f: stloc.s 7
+		IL_0121: ldnull
+		IL_0122: ldloc.s 5
+		IL_0124: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
+		IL_0129: stloc.s 8
+		IL_012b: ldloc.s 8
+		IL_012d: ldstr "value"
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0137: stloc.s 8
+		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_013e: ldstr "default.value:"
+		IL_0143: ldloc.s 8
+		IL_0145: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_014a: pop
+		IL_014b: ldnull
+		IL_014c: ldloc.s 5
+		IL_014e: ldstr "value"
+		IL_0153: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, object)
+		IL_0158: stloc.s 8
+		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015f: ldstr "named:"
+		IL_0164: ldloc.s 8
+		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_016b: pop
+		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0171: ldstr "namespace.default.value:"
+		IL_0176: ldloc.s 7
+		IL_0178: ldstr "default"
+		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0182: ldstr "value"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0191: pop
+		IL_0192: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0197: ldstr "namespace.value:"
+		IL_019c: ldloc.s 7
+		IL_019e: ldstr "value"
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01ad: pop
+		IL_01ae: ret
 	} // end of method Import_StaticImport_FromCjs::__js_module_init__
 
 } // end of class Modules.Import_StaticImport_FromCjs
@@ -1611,7 +1584,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2aa1
+			// Method begins at RVA 0x2a61
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1635,7 +1608,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2238
+		// Method begins at RVA 0x220c
 		// Header size: 12
 		// Code size: 47 (0x2f)
 		.maxstack 8
@@ -1670,7 +1643,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2aaa
+		// Method begins at RVA 0x2a6a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Performance_Dromaeo_Object_Regexp
+﻿// IL code: Compile_Performance_Dromaeo_Object_Regexp
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e6e
+				// Method begins at RVA 0x4ba6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e77
+				// Method begins at RVA 0x4baf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e89
+					// Method begins at RVA 0x4bc1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e80
+				// Method begins at RVA 0x4bb8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e9b
+					// Method begins at RVA 0x4bd3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e92
+				// Method begins at RVA 0x4bca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ea4
+				// Method begins at RVA 0x4bdc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -349,7 +349,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ebf
+						// Method begins at RVA 0x4bf7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -369,7 +369,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ec8
+						// Method begins at RVA 0x4c00
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -387,7 +387,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4eb6
+					// Method begins at RVA 0x4bee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -405,7 +405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ead
+				// Method begins at RVA 0x4be5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -642,7 +642,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ed1
+				// Method begins at RVA 0x4c09
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -670,7 +670,7 @@
 			)
 			// Method begins at RVA 0x3380
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -684,28 +684,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 30
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 30
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L48C5::__js_call__
 
 	} // end of class FunctionExpression_L48C5
@@ -721,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4eda
+				// Method begins at RVA 0x4c12
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -747,7 +738,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x33e4
+			// Method begins at RVA 0x33cc
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -804,7 +795,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ee3
+				// Method begins at RVA 0x4c1b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -830,9 +821,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3450
+			// Method begins at RVA 0x3438
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -846,28 +837,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 30
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 30
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L61C5::__js_call__
 
 	} // end of class FunctionExpression_L61C5
@@ -883,7 +865,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4eec
+				// Method begins at RVA 0x4c24
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -909,7 +891,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x34b4
+			// Method begins at RVA 0x3484
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -966,7 +948,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ef5
+				// Method begins at RVA 0x4c2d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -992,9 +974,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3520
+			// Method begins at RVA 0x34f0
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1008,28 +990,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 100
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L71C5::__js_call__
 
 	} // end of class FunctionExpression_L71C5
@@ -1045,7 +1018,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4efe
+				// Method begins at RVA 0x4c36
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1071,7 +1044,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3584
+			// Method begins at RVA 0x353c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1128,7 +1101,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f07
+				// Method begins at RVA 0x4c3f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1154,9 +1127,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x35f0
+			// Method begins at RVA 0x35a8
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1170,28 +1143,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 100
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L83C5::__js_call__
 
 	} // end of class FunctionExpression_L83C5
@@ -1207,7 +1171,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f10
+				// Method begins at RVA 0x4c48
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1233,7 +1197,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3654
+			// Method begins at RVA 0x35f4
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1290,7 +1254,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f19
+				// Method begins at RVA 0x4c51
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,36 +1280,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x36c0
+			// Method begins at RVA 0x3660
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L93C5::__js_call__
 
 	} // end of class FunctionExpression_L93C5
@@ -1361,7 +1316,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f22
+				// Method begins at RVA 0x4c5a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1387,7 +1342,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x370c
+			// Method begins at RVA 0x3698
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1444,7 +1399,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f2b
+				// Method begins at RVA 0x4c63
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1470,36 +1425,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3778
+			// Method begins at RVA 0x3704
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L102C5::__js_call__
 
 	} // end of class FunctionExpression_L102C5
@@ -1515,7 +1461,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f34
+				// Method begins at RVA 0x4c6c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1541,7 +1487,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x37c4
+			// Method begins at RVA 0x373c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1602,7 +1548,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f3d
+				// Method begins at RVA 0x4c75
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1628,36 +1574,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3838
+			// Method begins at RVA 0x37b0
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L111C5::__js_call__
 
 	} // end of class FunctionExpression_L111C5
@@ -1673,7 +1610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f46
+				// Method begins at RVA 0x4c7e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1699,7 +1636,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3884
+			// Method begins at RVA 0x37e8
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1760,7 +1697,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f4f
+				// Method begins at RVA 0x4c87
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1786,9 +1723,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x38f8
+			// Method begins at RVA 0x385c
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -1802,28 +1739,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 100
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L120C5::__js_call__
 
 	} // end of class FunctionExpression_L120C5
@@ -1839,7 +1767,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f58
+				// Method begins at RVA 0x4c90
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1865,7 +1793,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x395c
+			// Method begins at RVA 0x38a8
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1922,7 +1850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f61
+				// Method begins at RVA 0x4c99
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1948,36 +1876,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x39c8
+			// Method begins at RVA 0x3914
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L130C5::__js_call__
 
 	} // end of class FunctionExpression_L130C5
@@ -1993,7 +1912,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f6a
+				// Method begins at RVA 0x4ca2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2019,7 +1938,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a14
+			// Method begins at RVA 0x394c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -2076,7 +1995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f73
+				// Method begins at RVA 0x4cab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2102,36 +2021,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a80
+			// Method begins at RVA 0x39b8
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L139C5::__js_call__
 
 	} // end of class FunctionExpression_L139C5
@@ -2147,7 +2057,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f7c
+				// Method begins at RVA 0x4cb4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2173,7 +2083,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3acc
+			// Method begins at RVA 0x39f0
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2234,7 +2144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f85
+				// Method begins at RVA 0x4cbd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2260,36 +2170,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b40
+			// Method begins at RVA 0x3a64
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L148C5::__js_call__
 
 	} // end of class FunctionExpression_L148C5
@@ -2305,7 +2206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f8e
+				// Method begins at RVA 0x4cc6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2331,7 +2232,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b8c
+			// Method begins at RVA 0x3a9c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2392,7 +2293,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f97
+				// Method begins at RVA 0x4ccf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2418,36 +2319,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c00
+			// Method begins at RVA 0x3b10
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L157C5::__js_call__
 
 	} // end of class FunctionExpression_L157C5
@@ -2467,7 +2359,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fa9
+					// Method begins at RVA 0x4ce1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2491,7 +2383,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4e0e
+				// Method begins at RVA 0x4b46
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -2509,7 +2401,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fa0
+				// Method begins at RVA 0x4cd8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2535,7 +2427,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c4c
+			// Method begins at RVA 0x3b48
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -2610,7 +2502,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fb2
+				// Method begins at RVA 0x4cea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2636,9 +2528,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ce0
+			// Method begins at RVA 0x3bdc
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -2652,28 +2544,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 100
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L170C5::__js_call__
 
 	} // end of class FunctionExpression_L170C5
@@ -2689,7 +2572,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fbb
+				// Method begins at RVA 0x4cf3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2715,7 +2598,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d44
+			// Method begins at RVA 0x3c28
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -2772,7 +2655,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fc4
+				// Method begins at RVA 0x4cfc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2798,36 +2681,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3db0
+			// Method begins at RVA 0x3c94
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L180C5::__js_call__
 
 	} // end of class FunctionExpression_L180C5
@@ -2843,7 +2717,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fcd
+				// Method begins at RVA 0x4d05
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2869,7 +2743,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3dfc
+			// Method begins at RVA 0x3ccc
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -2926,7 +2800,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fd6
+				// Method begins at RVA 0x4d0e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2952,36 +2826,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e68
+			// Method begins at RVA 0x3d38
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L189C5::__js_call__
 
 	} // end of class FunctionExpression_L189C5
@@ -2997,7 +2862,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fdf
+				// Method begins at RVA 0x4d17
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3023,7 +2888,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3eb4
+			// Method begins at RVA 0x3d70
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3084,7 +2949,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fe8
+				// Method begins at RVA 0x4d20
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3110,36 +2975,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f28
+			// Method begins at RVA 0x3de4
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L198C5::__js_call__
 
 	} // end of class FunctionExpression_L198C5
@@ -3155,7 +3011,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ff1
+				// Method begins at RVA 0x4d29
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3181,7 +3037,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f74
+			// Method begins at RVA 0x3e1c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3242,7 +3098,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ffa
+				// Method begins at RVA 0x4d32
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3268,9 +3124,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3fe8
+			// Method begins at RVA 0x3e90
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -3284,28 +3140,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 100
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L207C5::__js_call__
 
 	} // end of class FunctionExpression_L207C5
@@ -3321,7 +3168,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5003
+				// Method begins at RVA 0x4d3b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3347,7 +3194,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x404c
+			// Method begins at RVA 0x3edc
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -3404,7 +3251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x500c
+				// Method begins at RVA 0x4d44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3430,36 +3277,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x40b8
+			// Method begins at RVA 0x3f48
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L217C5::__js_call__
 
 	} // end of class FunctionExpression_L217C5
@@ -3475,7 +3313,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5015
+				// Method begins at RVA 0x4d4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3501,7 +3339,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4104
+			// Method begins at RVA 0x3f80
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -3558,7 +3396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x501e
+				// Method begins at RVA 0x4d56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3584,36 +3422,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4170
+			// Method begins at RVA 0x3fec
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L226C5::__js_call__
 
 	} // end of class FunctionExpression_L226C5
@@ -3629,7 +3458,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5027
+				// Method begins at RVA 0x4d5f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3655,7 +3484,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x41bc
+			// Method begins at RVA 0x4024
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3716,7 +3545,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5030
+				// Method begins at RVA 0x4d68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3742,36 +3571,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4230
+			// Method begins at RVA 0x4098
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L235C5::__js_call__
 
 	} // end of class FunctionExpression_L235C5
@@ -3787,7 +3607,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5039
+				// Method begins at RVA 0x4d71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3813,7 +3633,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x427c
+			// Method begins at RVA 0x40d0
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3874,7 +3694,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5042
+				// Method begins at RVA 0x4d7a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3900,36 +3720,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x42f0
+			// Method begins at RVA 0x4144
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L244C5::__js_call__
 
 	} // end of class FunctionExpression_L244C5
@@ -3949,7 +3760,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5054
+					// Method begins at RVA 0x4d8c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3973,7 +3784,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4e15
+				// Method begins at RVA 0x4b4d
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -3991,7 +3802,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x504b
+				// Method begins at RVA 0x4d83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4017,7 +3828,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x433c
+			// Method begins at RVA 0x417c
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -4092,7 +3903,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x505d
+				// Method begins at RVA 0x4d95
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4118,9 +3929,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x43d0
+			// Method begins at RVA 0x4210
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 64 (0x40)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -4134,28 +3945,19 @@
 			IL_0010: ldarg.0
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-			IL_0017: ldc.i4.1
-			IL_0018: newarr [System.Runtime]System.Object
-			IL_001d: dup
-			IL_001e: ldc.i4.0
-			IL_001f: ldarg.0
-			IL_0020: stelem.ref
-			IL_0021: ldc.i4.0
-			IL_0022: ldelem.ref
-			IL_0023: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0028: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_002e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0033: ldnull
-			IL_0034: ldc.r8 100
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldarg.0
-			IL_0049: ldloc.1
-			IL_004a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_004f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_0017: ldarg.0
+			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_001d: ldnull
+			IL_001e: ldc.r8 100
+			IL_0027: box [System.Runtime]System.Double
+			IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldloc.1
+			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_003e: ldnull
+			IL_003f: ret
 		} // end of method FunctionExpression_L257C5::__js_call__
 
 	} // end of class FunctionExpression_L257C5
@@ -4171,7 +3973,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5066
+				// Method begins at RVA 0x4d9e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4197,7 +3999,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4434
+			// Method begins at RVA 0x425c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -4254,7 +4056,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x506f
+				// Method begins at RVA 0x4da7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4280,36 +4082,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x44a0
+			// Method begins at RVA 0x42c8
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L267C5::__js_call__
 
 	} // end of class FunctionExpression_L267C5
@@ -4325,7 +4118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5078
+				// Method begins at RVA 0x4db0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4351,7 +4144,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x44ec
+			// Method begins at RVA 0x4300
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -4412,7 +4205,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5081
+				// Method begins at RVA 0x4db9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4438,36 +4231,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4560
+			// Method begins at RVA 0x4374
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L276C5::__js_call__
 
 	} // end of class FunctionExpression_L276C5
@@ -4483,7 +4267,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x508a
+				// Method begins at RVA 0x4dc2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4509,7 +4293,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x45ac
+			// Method begins at RVA 0x43ac
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -4570,7 +4354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5093
+				// Method begins at RVA 0x4dcb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4596,36 +4380,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4620
+			// Method begins at RVA 0x4420
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L285C5::__js_call__
 
 	} // end of class FunctionExpression_L285C5
@@ -4645,7 +4420,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50a5
+					// Method begins at RVA 0x4ddd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4670,7 +4445,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4e1c
+				// Method begins at RVA 0x4b54
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -4699,7 +4474,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x509c
+				// Method begins at RVA 0x4dd4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4725,7 +4500,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x466c
+			// Method begins at RVA 0x4458
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -4800,7 +4575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ae
+				// Method begins at RVA 0x4de6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4826,36 +4601,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4700
+			// Method begins at RVA 0x44ec
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L296C5::__js_call__
 
 	} // end of class FunctionExpression_L296C5
@@ -4875,7 +4641,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x50c0
+					// Method begins at RVA 0x4df8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4900,7 +4666,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4e44
+				// Method begins at RVA 0x4b7c
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -4928,7 +4694,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50b7
+				// Method begins at RVA 0x4def
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4954,7 +4720,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x474c
+			// Method begins at RVA 0x4524
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -5029,7 +4795,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50c9
+				// Method begins at RVA 0x4e01
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5055,36 +4821,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x47e0
+			// Method begins at RVA 0x45b8
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L309C5::__js_call__
 
 	} // end of class FunctionExpression_L309C5
@@ -5100,7 +4857,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50d2
+				// Method begins at RVA 0x4e0a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5126,7 +4883,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x482c
+			// Method begins at RVA 0x45f0
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5187,7 +4944,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50db
+				// Method begins at RVA 0x4e13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5213,36 +4970,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x48a4
+			// Method begins at RVA 0x4668
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L318C5::__js_call__
 
 	} // end of class FunctionExpression_L318C5
@@ -5258,7 +5006,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50e4
+				// Method begins at RVA 0x4e1c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5284,7 +5032,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x48f0
+			// Method begins at RVA 0x46a0
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5345,7 +5093,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ed
+				// Method begins at RVA 0x4e25
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5371,36 +5119,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4968
+			// Method begins at RVA 0x4718
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L327C5::__js_call__
 
 	} // end of class FunctionExpression_L327C5
@@ -5416,7 +5155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50f6
+				// Method begins at RVA 0x4e2e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5442,7 +5181,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x49b4
+			// Method begins at RVA 0x4750
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5504,7 +5243,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x50ff
+				// Method begins at RVA 0x4e37
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5530,36 +5269,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a30
+			// Method begins at RVA 0x47cc
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L336C5::__js_call__
 
 	} // end of class FunctionExpression_L336C5
@@ -5575,7 +5305,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5108
+				// Method begins at RVA 0x4e40
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5601,7 +5331,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a7c
+			// Method begins at RVA 0x4804
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5663,7 +5393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5111
+				// Method begins at RVA 0x4e49
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5689,36 +5419,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4af8
+			// Method begins at RVA 0x4880
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L345C5::__js_call__
 
 	} // end of class FunctionExpression_L345C5
@@ -5734,7 +5455,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x511a
+				// Method begins at RVA 0x4e52
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5760,7 +5481,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4b44
+			// Method begins at RVA 0x48b8
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5821,7 +5542,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5123
+				// Method begins at RVA 0x4e5b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5847,36 +5568,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4bbc
+			// Method begins at RVA 0x4930
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 100
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 100
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L354C5::__js_call__
 
 	} // end of class FunctionExpression_L354C5
@@ -5892,7 +5604,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x512c
+				// Method begins at RVA 0x4e64
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5918,7 +5630,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c08
+			// Method begins at RVA 0x4968
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5979,7 +5691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5135
+				// Method begins at RVA 0x4e6d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6005,36 +5717,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4c80
+			// Method begins at RVA 0x49e0
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L363C5::__js_call__
 
 	} // end of class FunctionExpression_L363C5
@@ -6050,7 +5753,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x513e
+				// Method begins at RVA 0x4e76
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6076,7 +5779,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4ccc
+			// Method begins at RVA 0x4a18
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -6138,7 +5841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5147
+				// Method begins at RVA 0x4e7f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6164,36 +5867,27 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d48
+			// Method begins at RVA 0x4a94
 			// Header size: 12
-			// Code size: 63 (0x3f)
+			// Code size: 41 (0x29)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldc.r8 50
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0030: stloc.0
-			IL_0031: ldarg.0
-			IL_0032: ldloc.0
-			IL_0033: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0038: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003d: ldnull
-			IL_003e: ret
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+			IL_0006: ldnull
+			IL_0007: ldc.r8 50
+			IL_0010: box [System.Runtime]System.Double
+			IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0027: ldnull
+			IL_0028: ret
 		} // end of method FunctionExpression_L372C5::__js_call__
 
 	} // end of class FunctionExpression_L372C5
@@ -6209,7 +5903,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5150
+				// Method begins at RVA 0x4e88
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6235,7 +5929,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4d94
+			// Method begins at RVA 0x4acc
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -6316,7 +6010,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4e65
+			// Method begins at RVA 0x4b9d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8068,7 +7762,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5159
+		// Method begins at RVA 0x4e91
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Performance_PrimeJavaScript
+﻿// IL code: Compile_Performance_PrimeJavaScript
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3267
+					// Method begins at RVA 0x3263
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x325e
+				// Method begins at RVA 0x325a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -79,7 +79,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x2464
+			// Method begins at RVA 0x2468
 			// Header size: 12
 			// Code size: 299 (0x12b)
 			.maxstack 8
@@ -238,7 +238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3270
+				// Method begins at RVA 0x326c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -265,9 +265,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
-			// Method begins at RVA 0x259c
+			// Method begins at RVA 0x25a0
 			// Header size: 12
-			// Code size: 540 (0x21c)
+			// Code size: 531 (0x213)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -406,86 +406,81 @@
 			IL_0138: ldloc.s 11
 			IL_013a: stloc.s 5
 			IL_013c: ldarg.0
-			IL_013d: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-			IL_0142: ldc.i4.1
-			IL_0143: newarr [System.Runtime]System.Object
-			IL_0148: dup
-			IL_0149: ldc.i4.0
-			IL_014a: ldarg.0
-			IL_014b: stelem.ref
-			IL_014c: ldloc.0
-			IL_014d: ldloc.1
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0153: stloc.s 11
-			IL_0155: ldloc.s 11
-			IL_0157: stloc.s 6
-			IL_0159: ldarg.0
-			IL_015a: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0164: stloc.s 11
-			IL_0166: ldloc.s 11
-			IL_0168: ldstr "now"
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0172: stloc.s 11
-			IL_0174: ldloc.s 11
-			IL_0176: stloc.s 7
-			IL_0178: ldloc.s 7
+			IL_013d: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+			IL_0142: ldnull
+			IL_0143: ldloc.0
+			IL_0144: ldloc.1
+			IL_0145: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object, object)
+			IL_014a: stloc.s 11
+			IL_014c: ldloc.s 11
+			IL_014e: stloc.s 6
+			IL_0150: ldarg.0
+			IL_0151: ldfld object Modules.Compile_Performance_PrimeJavaScript/Scope::performance
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015b: stloc.s 11
+			IL_015d: ldloc.s 11
+			IL_015f: ldstr "now"
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0169: stloc.s 11
+			IL_016b: ldloc.s 11
+			IL_016d: stloc.s 7
+			IL_016f: ldloc.s 7
+			IL_0171: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0176: stloc.s 13
+			IL_0178: ldloc.s 5
 			IL_017a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_017f: stloc.s 13
-			IL_0181: ldloc.s 5
-			IL_0183: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0188: stloc.s 14
-			IL_018a: ldloc.s 13
-			IL_018c: ldloc.s 14
-			IL_018e: sub
-			IL_018f: stloc.s 14
-			IL_0191: ldloc.s 14
-			IL_0193: ldarg.0
-			IL_0194: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
-			IL_0199: div
-			IL_019a: stloc.s 14
-			IL_019c: ldloc.s 14
-			IL_019e: stloc.s 8
-			IL_01a0: ldloc.3
-			IL_01a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01a6: stloc.s 15
-			IL_01a8: ldstr "\nrogiervandam-"
+			IL_017f: stloc.s 14
+			IL_0181: ldloc.s 13
+			IL_0183: ldloc.s 14
+			IL_0185: sub
+			IL_0186: stloc.s 14
+			IL_0188: ldloc.s 14
+			IL_018a: ldarg.0
+			IL_018b: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/Scope::NOW_UNITS_PER_SECOND
+			IL_0190: div
+			IL_0191: stloc.s 14
+			IL_0193: ldloc.s 14
+			IL_0195: stloc.s 8
+			IL_0197: ldloc.3
+			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_019d: stloc.s 15
+			IL_019f: ldstr "\nrogiervandam-"
+			IL_01a4: ldloc.s 15
+			IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ab: stloc.s 15
 			IL_01ad: ldloc.s 15
-			IL_01af: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b4: stloc.s 15
-			IL_01b6: ldloc.s 15
-			IL_01b8: ldstr ";"
-			IL_01bd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01c2: stloc.s 15
-			IL_01c4: ldloc.s 6
-			IL_01c6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01cb: stloc.s 16
-			IL_01cd: ldloc.s 15
+			IL_01af: ldstr ";"
+			IL_01b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b9: stloc.s 15
+			IL_01bb: ldloc.s 6
+			IL_01bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01c2: stloc.s 16
+			IL_01c4: ldloc.s 15
+			IL_01c6: ldloc.s 16
+			IL_01c8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01cd: stloc.s 16
 			IL_01cf: ldloc.s 16
-			IL_01d1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d6: stloc.s 16
-			IL_01d8: ldloc.s 16
-			IL_01da: ldstr ";"
-			IL_01df: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e4: stloc.s 16
-			IL_01e6: ldloc.s 8
-			IL_01e8: box [System.Runtime]System.Double
-			IL_01ed: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f2: stloc.s 15
-			IL_01f4: ldloc.s 16
+			IL_01d1: ldstr ";"
+			IL_01d6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01db: stloc.s 16
+			IL_01dd: ldloc.s 8
+			IL_01df: box [System.Runtime]System.Double
+			IL_01e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e9: stloc.s 15
+			IL_01eb: ldloc.s 16
+			IL_01ed: ldloc.s 15
+			IL_01ef: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f4: stloc.s 15
 			IL_01f6: ldloc.s 15
-			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fd: stloc.s 15
-			IL_01ff: ldloc.s 15
-			IL_0201: ldstr ";1;algorithm=base,faithful=yes,bits=1"
-			IL_0206: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020b: stloc.s 15
-			IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0212: ldloc.s 15
-			IL_0214: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0219: pop
-			IL_021a: ldnull
-			IL_021b: ret
+			IL_01f8: ldstr ";1;algorithm=base,faithful=yes,bits=1"
+			IL_01fd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0202: stloc.s 15
+			IL_0204: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0209: ldloc.s 15
+			IL_020b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0210: pop
+			IL_0211: ldnull
+			IL_0212: ret
 		} // end of method ArrowFunction_L229C14::__js_call__
 
 	} // end of class ArrowFunction_L229C14
@@ -501,7 +496,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3159
+				// Method begins at RVA 0x3155
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -521,7 +516,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3162
+				// Method begins at RVA 0x315e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -541,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x316b
+				// Method begins at RVA 0x3167
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -569,7 +564,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3186
+						// Method begins at RVA 0x3182
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -593,7 +588,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3198
+							// Method begins at RVA 0x3194
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -611,7 +606,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x318f
+						// Method begins at RVA 0x318b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -629,7 +624,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x317d
+					// Method begins at RVA 0x3179
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -657,7 +652,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x31b3
+							// Method begins at RVA 0x31af
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -675,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31aa
+						// Method begins at RVA 0x31a6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -693,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31a1
+					// Method begins at RVA 0x319d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -717,7 +712,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31c5
+						// Method begins at RVA 0x31c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -735,7 +730,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31bc
+					// Method begins at RVA 0x31b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -753,7 +748,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3174
+				// Method begins at RVA 0x3170
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -773,7 +768,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ce
+				// Method begins at RVA 0x31ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -797,7 +792,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31e0
+					// Method begins at RVA 0x31dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -815,7 +810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31d7
+				// Method begins at RVA 0x31d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -843,7 +838,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x282c
+			// Method begins at RVA 0x2828
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -892,7 +887,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2afc
+			// Method begins at RVA 0x2af8
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -962,7 +957,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28c8
+			// Method begins at RVA 0x28c4
 			// Header size: 12
 			// Code size: 552 (0x228)
 			.maxstack 8
@@ -1258,7 +1253,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b60
+			// Method begins at RVA 0x2b5c
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1322,7 +1317,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x287c
+			// Method begins at RVA 0x2878
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -1372,7 +1367,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e9
+				// Method begins at RVA 0x31e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1392,7 +1387,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f2
+				// Method begins at RVA 0x31ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1416,7 +1411,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3204
+					// Method begins at RVA 0x3200
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1434,7 +1429,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31fb
+				// Method begins at RVA 0x31f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1454,7 +1449,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x320d
+				// Method begins at RVA 0x3209
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1482,7 +1477,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3228
+						// Method begins at RVA 0x3224
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1500,7 +1495,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x321f
+					// Method begins at RVA 0x321b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1518,7 +1513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3216
+				// Method begins at RVA 0x3212
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1538,7 +1533,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3231
+				// Method begins at RVA 0x322d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1562,7 +1557,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3243
+					// Method begins at RVA 0x323f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1580,7 +1575,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x323a
+				// Method begins at RVA 0x3236
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1604,7 +1599,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3255
+					// Method begins at RVA 0x3251
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1622,7 +1617,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x324c
+				// Method begins at RVA 0x3248
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1652,7 +1647,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27c4
+			// Method begins at RVA 0x27c0
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1709,7 +1704,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bbc
+			// Method begins at RVA 0x2bb8
 			// Header size: 12
 			// Code size: 314 (0x13a)
 			.maxstack 8
@@ -1848,7 +1843,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f8c
+			// Method begins at RVA 0x2f88
 			// Header size: 12
 			// Code size: 166 (0xa6)
 			.maxstack 8
@@ -1934,7 +1929,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3040
+			// Method begins at RVA 0x303c
 			// Header size: 12
 			// Code size: 260 (0x104)
 			.maxstack 8
@@ -2052,7 +2047,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d04
+			// Method begins at RVA 0x2d00
 			// Header size: 12
 			// Code size: 633 (0x279)
 			.maxstack 8
@@ -2299,7 +2294,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3150
+			// Method begins at RVA 0x314c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2325,7 +2320,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1032 (0x408)
+		// Code size: 1033 (0x409)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -2727,12 +2722,13 @@
 		IL_03f5: stloc.s 4
 		IL_03f7: ldloc.s 4
 		IL_03f9: stloc.3
-		IL_03fa: ldloc.3
-		IL_03fb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0400: ldloc.1
-		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0406: pop
-		IL_0407: ret
+		IL_03fa: ldloc.0
+		IL_03fb: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0400: ldnull
+		IL_0401: ldloc.1
+		IL_0402: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_0407: pop
+		IL_0408: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
@@ -2744,7 +2740,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3279
+		// Method begins at RVA 0x3275
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_BumpVersion
+﻿// IL code: Compile_Scripts_BumpVersion
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38ca
+				// Method begins at RVA 0x36fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24b4
+			// Method begins at RVA 0x24a0
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38d3
+				// Method begins at RVA 0x3707
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24e0
+			// Method begins at RVA 0x24cc
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38dc
+				// Method begins at RVA 0x3710
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -168,7 +168,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2510
+			// Method begins at RVA 0x24fc
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -256,7 +256,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38ee
+					// Method begins at RVA 0x3722
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -280,7 +280,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37b0
+				// Method begins at RVA 0x35e4
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -320,7 +320,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38f7
+					// Method begins at RVA 0x372b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37dc
+				// Method begins at RVA 0x3610
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -376,7 +376,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3900
+					// Method begins at RVA 0x3734
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -394,7 +394,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38e5
+				// Method begins at RVA 0x3719
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -419,7 +419,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25a0
+			// Method begins at RVA 0x258c
 			// Header size: 12
 			// Code size: 950 (0x3b6)
 			.maxstack 8
@@ -819,7 +819,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3909
+				// Method begins at RVA 0x373d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -847,7 +847,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2974
+			// Method begins at RVA 0x2960
 			// Header size: 12
 			// Code size: 224 (0xe0)
 			.maxstack 8
@@ -977,7 +977,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x391b
+					// Method begins at RVA 0x374f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -995,7 +995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3912
+				// Method begins at RVA 0x3746
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1020,7 +1020,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a60
+			// Method begins at RVA 0x2a4c
 			// Header size: 12
 			// Code size: 195 (0xc3)
 			.maxstack 8
@@ -1120,7 +1120,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x392d
+					// Method begins at RVA 0x3761
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1138,7 +1138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3924
+				// Method begins at RVA 0x3758
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1163,7 +1163,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b30
+			// Method begins at RVA 0x2b1c
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -1260,7 +1260,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x393f
+					// Method begins at RVA 0x3773
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1278,7 +1278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3936
+				// Method begins at RVA 0x376a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1305,7 +1305,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2be8
+			// Method begins at RVA 0x2bd4
 			// Header size: 12
 			// Code size: 541 (0x21d)
 			.maxstack 8
@@ -1518,7 +1518,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3948
+				// Method begins at RVA 0x377c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1542,7 +1542,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e14
+			// Method begins at RVA 0x2e00
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1598,7 +1598,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x395a
+					// Method begins at RVA 0x378e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1623,7 +1623,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37f8
+				// Method begins at RVA 0x362c
 				// Header size: 12
 				// Code size: 102 (0x66)
 				.maxstack 8
@@ -1690,7 +1690,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3951
+				// Method begins at RVA 0x3785
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1718,7 +1718,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2e5c
+			// Method begins at RVA 0x2e48
 			// Header size: 12
 			// Code size: 375 (0x177)
 			.maxstack 8
@@ -1885,7 +1885,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3975
+					// Method begins at RVA 0x37a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1910,7 +1910,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x386c
+				// Method begins at RVA 0x36a0
 				// Header size: 12
 				// Code size: 73 (0x49)
 				.maxstack 8
@@ -1970,7 +1970,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x396c
+					// Method begins at RVA 0x37a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1990,7 +1990,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x397e
+					// Method begins at RVA 0x37b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2008,7 +2008,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3963
+				// Method begins at RVA 0x3797
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2034,9 +2034,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2fe0
+			// Method begins at RVA 0x2fcc
 			// Header size: 12
-			// Code size: 1988 (0x7c4)
+			// Code size: 1548 (0x60c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -2105,717 +2105,537 @@
 			IL_0050: ldarg.0
 			IL_0051: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
 			IL_0056: stloc.s 32
-			IL_0058: ldc.i4.1
-			IL_0059: newarr [System.Runtime]System.Object
-			IL_005e: dup
-			IL_005f: ldc.i4.0
-			IL_0060: ldarg.0
-			IL_0061: stelem.ref
-			IL_0062: ldc.i4.0
-			IL_0063: ldelem.ref
-			IL_0064: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0069: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_006f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0074: ldnull
-			IL_0075: ldloc.s 32
-			IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_007c: stloc.s 32
-			IL_007e: ldloc.s 32
-			IL_0080: stloc.3
-			IL_0081: ldarg.0
-			IL_0082: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0087: stloc.s 32
-			IL_0089: ldc.i4.1
-			IL_008a: newarr [System.Runtime]System.Object
-			IL_008f: dup
-			IL_0090: ldc.i4.0
-			IL_0091: ldarg.0
-			IL_0092: stelem.ref
-			IL_0093: ldc.i4.0
-			IL_0094: ldelem.ref
-			IL_0095: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_009a: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_00a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00a5: ldnull
-			IL_00a6: ldloc.s 32
-			IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00ad: stloc.s 32
-			IL_00af: ldloc.s 32
-			IL_00b1: stloc.s 4
-			IL_00b3: ldarg.0
-			IL_00b4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0058: ldarg.0
+			IL_0059: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_005e: ldnull
+			IL_005f: ldloc.s 32
+			IL_0061: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0066: stloc.s 32
+			IL_0068: ldloc.s 32
+			IL_006a: stloc.3
+			IL_006b: ldarg.0
+			IL_006c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0071: stloc.s 32
+			IL_0073: ldarg.0
+			IL_0074: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0079: ldnull
+			IL_007a: ldloc.s 32
+			IL_007c: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0081: stloc.s 32
+			IL_0083: ldloc.s 32
+			IL_0085: stloc.s 4
+			IL_0087: ldarg.0
+			IL_0088: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_008d: stloc.s 32
+			IL_008f: ldarg.0
+			IL_0090: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0095: ldnull
+			IL_0096: ldloc.s 32
+			IL_0098: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_009d: stloc.s 32
+			IL_009f: ldloc.s 32
+			IL_00a1: stloc.s 5
+			IL_00a3: ldarg.0
+			IL_00a4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_00a9: stloc.s 32
+			IL_00ab: ldarg.0
+			IL_00ac: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00b1: ldnull
+			IL_00b2: ldloc.s 32
+			IL_00b4: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
 			IL_00b9: stloc.s 32
-			IL_00bb: ldc.i4.1
-			IL_00bc: newarr [System.Runtime]System.Object
-			IL_00c1: dup
-			IL_00c2: ldc.i4.0
-			IL_00c3: ldarg.0
-			IL_00c4: stelem.ref
-			IL_00c5: ldc.i4.0
-			IL_00c6: ldelem.ref
-			IL_00c7: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00cc: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_00d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d7: ldnull
-			IL_00d8: ldloc.s 32
-			IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00df: stloc.s 32
-			IL_00e1: ldloc.s 32
-			IL_00e3: stloc.s 5
-			IL_00e5: ldarg.0
-			IL_00e6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_00eb: stloc.s 32
-			IL_00ed: ldc.i4.1
-			IL_00ee: newarr [System.Runtime]System.Object
-			IL_00f3: dup
-			IL_00f4: ldc.i4.0
-			IL_00f5: ldarg.0
-			IL_00f6: stelem.ref
-			IL_00f7: ldc.i4.0
-			IL_00f8: ldelem.ref
-			IL_00f9: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00fe: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0109: ldnull
-			IL_010a: ldloc.s 32
-			IL_010c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0111: stloc.s 32
-			IL_0113: ldloc.s 32
-			IL_0115: stloc.s 6
-			IL_0117: ldarg.0
-			IL_0118: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_011d: stloc.s 32
-			IL_011f: ldc.i4.1
-			IL_0120: newarr [System.Runtime]System.Object
-			IL_0125: dup
-			IL_0126: ldc.i4.0
-			IL_0127: ldarg.0
-			IL_0128: stelem.ref
-			IL_0129: ldc.i4.0
-			IL_012a: ldelem.ref
-			IL_012b: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0130: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_013b: ldnull
-			IL_013c: ldloc.s 32
-			IL_013e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0143: stloc.s 32
-			IL_0145: ldloc.s 32
-			IL_0147: stloc.s 7
-			IL_0149: ldarg.0
-			IL_014a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_014f: stloc.s 32
-			IL_0151: ldc.i4.1
-			IL_0152: newarr [System.Runtime]System.Object
-			IL_0157: dup
-			IL_0158: ldc.i4.0
-			IL_0159: ldarg.0
-			IL_015a: stelem.ref
-			IL_015b: ldc.i4.0
-			IL_015c: ldelem.ref
-			IL_015d: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0162: ldftn object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0168: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_016d: ldnull
-			IL_016e: ldloc.s 32
-			IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0175: stloc.s 32
-			IL_0177: ldloc.s 32
-			IL_0179: stloc.s 8
-			IL_017b: ldnull
-			IL_017c: ldloc.3
-			IL_017d: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
-			IL_0182: stloc.s 32
-			IL_0184: ldloc.s 32
-			IL_0186: stloc.s 9
-			IL_0188: ldc.i4.1
-			IL_0189: newarr [System.Runtime]System.Object
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldarg.0
-			IL_0191: stelem.ref
-			IL_0192: ldc.i4.0
-			IL_0193: ldelem.ref
-			IL_0194: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0199: ldftn object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_019f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_01a4: ldnull
-			IL_01a5: ldloc.1
-			IL_01a6: ldloc.s 9
-			IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_01ad: stloc.s 32
-			IL_01af: ldloc.s 32
-			IL_01b1: stloc.s 10
-			IL_01b3: ldloc.s 9
-			IL_01b5: ldloc.s 10
-			IL_01b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01bc: stloc.s 33
-			IL_01be: ldloc.s 33
-			IL_01c0: brfalse IL_0225
+			IL_00bb: ldloc.s 32
+			IL_00bd: stloc.s 6
+			IL_00bf: ldarg.0
+			IL_00c0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_00c5: stloc.s 32
+			IL_00c7: ldarg.0
+			IL_00c8: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00cd: ldnull
+			IL_00ce: ldloc.s 32
+			IL_00d0: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_00d5: stloc.s 32
+			IL_00d7: ldloc.s 32
+			IL_00d9: stloc.s 7
+			IL_00db: ldarg.0
+			IL_00dc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_00e1: stloc.s 32
+			IL_00e3: ldarg.0
+			IL_00e4: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00e9: ldnull
+			IL_00ea: ldloc.s 32
+			IL_00ec: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_00f1: stloc.s 32
+			IL_00f3: ldloc.s 32
+			IL_00f5: stloc.s 8
+			IL_00f7: ldnull
+			IL_00f8: ldloc.3
+			IL_00f9: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
+			IL_00fe: stloc.s 32
+			IL_0100: ldloc.s 32
+			IL_0102: stloc.s 9
+			IL_0104: ldarg.0
+			IL_0105: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_010a: ldnull
+			IL_010b: ldloc.1
+			IL_010c: ldloc.s 9
+			IL_010e: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0113: stloc.s 32
+			IL_0115: ldloc.s 32
+			IL_0117: stloc.s 10
+			IL_0119: ldloc.s 9
+			IL_011b: ldloc.s 10
+			IL_011d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0122: stloc.s 33
+			IL_0124: ldloc.s 33
+			IL_0126: brfalse IL_018b
 
-			IL_01c5: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
-			IL_01ca: stloc.s 11
-			IL_01cc: ldloc.s 9
-			IL_01ce: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d3: stloc.s 34
-			IL_01d5: ldstr "Version unchanged ("
-			IL_01da: ldloc.s 34
-			IL_01dc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e1: stloc.s 34
-			IL_01e3: ldloc.s 34
-			IL_01e5: ldstr "); aborting."
-			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ef: stloc.s 34
-			IL_01f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01f6: ldloc.s 34
-			IL_01f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_01fd: pop
-			IL_01fe: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0208: stloc.s 32
-			IL_020a: ldloc.s 32
-			IL_020c: ldstr "exit"
-			IL_0211: ldc.r8 1
-			IL_021a: box [System.Runtime]System.Double
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0224: pop
+			IL_012b: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
+			IL_0130: stloc.s 11
+			IL_0132: ldloc.s 9
+			IL_0134: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0139: stloc.s 34
+			IL_013b: ldstr "Version unchanged ("
+			IL_0140: ldloc.s 34
+			IL_0142: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0147: stloc.s 34
+			IL_0149: ldloc.s 34
+			IL_014b: ldstr "); aborting."
+			IL_0150: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0155: stloc.s 34
+			IL_0157: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_015c: ldloc.s 34
+			IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0163: pop
+			IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016e: stloc.s 32
+			IL_0170: ldloc.s 32
+			IL_0172: ldstr "exit"
+			IL_0177: ldc.r8 1
+			IL_0180: box [System.Runtime]System.Double
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_018a: pop
 
-			IL_0225: ldc.i4.1
-			IL_0226: newarr [System.Runtime]System.Object
-			IL_022b: dup
-			IL_022c: ldc.i4.0
-			IL_022d: ldarg.0
-			IL_022e: stelem.ref
+			IL_018b: ldarg.0
+			IL_018c: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0191: ldnull
+			IL_0192: ldloc.s 8
+			IL_0194: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+			IL_0199: stloc.s 32
+			IL_019b: ldloc.s 32
+			IL_019d: brfalse IL_01ae
+
+			IL_01a2: ldloc.s 32
+			IL_01a4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_01a9: brfalse IL_01bf
+
+			IL_01ae: ldloc.s 32
+			IL_01b0: ldstr ""
+			IL_01b5: ldstr "body"
+			IL_01ba: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+
+			IL_01bf: ldloc.s 32
+			IL_01c1: ldstr "body"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cb: stloc.s 12
+			IL_01cd: ldloc.s 32
+			IL_01cf: ldstr "start"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d9: stloc.s 13
+			IL_01db: ldloc.s 32
+			IL_01dd: ldstr "end"
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e7: stloc.s 14
+			IL_01e9: ldloc.s 12
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f0: stloc.s 32
+			IL_01f2: ldstr "\\r?\\n"
+			IL_01f7: ldstr ""
+			IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0201: stloc.s 35
+			IL_0203: ldloc.s 32
+			IL_0205: ldstr "split"
+			IL_020a: ldloc.s 35
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0211: stloc.s 32
+			IL_0213: ldloc.s 32
+			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021a: stloc.s 32
+			IL_021c: ldnull
+			IL_021d: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
+			IL_0223: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0228: ldc.i4.2
+			IL_0229: newarr [System.Runtime]System.Object
+			IL_022e: dup
 			IL_022f: ldc.i4.0
-			IL_0230: ldelem.ref
-			IL_0231: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0236: ldftn object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_023c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0241: ldnull
-			IL_0242: ldloc.s 8
-			IL_0244: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0249: stloc.s 32
-			IL_024b: ldloc.s 32
-			IL_024d: brfalse IL_025e
+			IL_0230: ldarg.0
+			IL_0231: stelem.ref
+			IL_0232: dup
+			IL_0233: ldc.i4.1
+			IL_0234: ldloc.0
+			IL_0235: stelem.ref
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0240: ldc.i4.1
+			IL_0241: conv.r8
+			IL_0242: ldstr ""
+			IL_0247: ldc.i4.0
+			IL_0248: ldc.i4.1
+			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0253: stloc.s 36
+			IL_0255: ldloc.s 32
+			IL_0257: ldstr "some"
+			IL_025c: ldloc.s 36
+			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0263: stloc.s 36
+			IL_0265: ldloc.s 36
+			IL_0267: stloc.s 15
+			IL_0269: ldloc.s 15
+			IL_026b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0270: ldc.i4.0
+			IL_0271: ceq
+			IL_0273: stloc.s 33
+			IL_0275: ldloc.s 33
+			IL_0277: box [System.Runtime]System.Boolean
+			IL_027c: stloc.s 37
+			IL_027e: ldloc.s 37
+			IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0285: stloc.s 33
+			IL_0287: ldloc.s 33
+			IL_0289: brfalse IL_0296
 
-			IL_0252: ldloc.s 32
-			IL_0254: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0259: brfalse IL_026f
+			IL_028e: ldloc.2
+			IL_028f: stloc.s 39
+			IL_0291: br IL_029a
 
-			IL_025e: ldloc.s 32
-			IL_0260: ldstr ""
-			IL_0265: ldstr "body"
-			IL_026a: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0296: ldloc.s 37
+			IL_0298: stloc.s 39
 
-			IL_026f: ldloc.s 32
-			IL_0271: ldstr "body"
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027b: stloc.s 12
-			IL_027d: ldloc.s 32
-			IL_027f: ldstr "start"
-			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0289: stloc.s 13
-			IL_028b: ldloc.s 32
-			IL_028d: ldstr "end"
-			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0297: stloc.s 14
-			IL_0299: ldloc.s 12
-			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a0: stloc.s 32
-			IL_02a2: ldstr "\\r?\\n"
-			IL_02a7: ldstr ""
-			IL_02ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02b1: stloc.s 35
-			IL_02b3: ldloc.s 32
-			IL_02b5: ldstr "split"
-			IL_02ba: ldloc.s 35
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02c1: stloc.s 32
-			IL_02c3: ldloc.s 32
-			IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ca: stloc.s 32
-			IL_02cc: ldnull
-			IL_02cd: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
-			IL_02d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_02d8: ldc.i4.2
-			IL_02d9: newarr [System.Runtime]System.Object
-			IL_02de: dup
-			IL_02df: ldc.i4.0
-			IL_02e0: ldarg.0
-			IL_02e1: stelem.ref
-			IL_02e2: dup
-			IL_02e3: ldc.i4.1
-			IL_02e4: ldloc.0
-			IL_02e5: stelem.ref
-			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02f0: ldc.i4.1
-			IL_02f1: conv.r8
-			IL_02f2: ldstr ""
-			IL_02f7: ldc.i4.0
-			IL_02f8: ldc.i4.1
-			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0303: stloc.s 36
-			IL_0305: ldloc.s 32
-			IL_0307: ldstr "some"
+			IL_029a: ldloc.s 39
+			IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a1: stloc.s 33
+			IL_02a3: ldloc.s 33
+			IL_02a5: brfalse IL_038f
+
+			IL_02aa: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
+			IL_02af: stloc.s 16
+			IL_02b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02b6: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c0: pop
+			IL_02c1: ldnull
+			IL_02c2: ldloc.3
+			IL_02c3: ldloc.s 10
+			IL_02c5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_02ca: stloc.s 36
+			IL_02cc: ldloc.s 36
+			IL_02ce: stloc.s 17
+			IL_02d0: ldnull
+			IL_02d1: ldloc.s 4
+			IL_02d3: ldloc.s 10
+			IL_02d5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_02da: stloc.s 36
+			IL_02dc: ldloc.s 36
+			IL_02de: stloc.s 18
+			IL_02e0: ldnull
+			IL_02e1: ldloc.s 5
+			IL_02e3: ldloc.s 10
+			IL_02e5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_02ea: stloc.s 36
+			IL_02ec: ldloc.s 36
+			IL_02ee: stloc.s 19
+			IL_02f0: ldnull
+			IL_02f1: ldloc.s 6
+			IL_02f3: ldloc.s 10
+			IL_02f5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_02fa: stloc.s 36
+			IL_02fc: ldloc.s 36
+			IL_02fe: stloc.s 20
+			IL_0300: ldnull
+			IL_0301: ldloc.s 7
+			IL_0303: ldloc.s 10
+			IL_0305: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+			IL_030a: stloc.s 36
 			IL_030c: ldloc.s 36
-			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0313: stloc.s 36
-			IL_0315: ldloc.s 36
-			IL_0317: stloc.s 15
-			IL_0319: ldloc.s 15
-			IL_031b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0320: ldc.i4.0
-			IL_0321: ceq
-			IL_0323: stloc.s 33
-			IL_0325: ldloc.s 33
-			IL_0327: box [System.Runtime]System.Boolean
-			IL_032c: stloc.s 37
-			IL_032e: ldloc.s 37
-			IL_0330: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0335: stloc.s 33
-			IL_0337: ldloc.s 33
-			IL_0339: brfalse IL_0346
-
-			IL_033e: ldloc.2
-			IL_033f: stloc.s 39
-			IL_0341: br IL_034a
-
-			IL_0346: ldloc.s 37
-			IL_0348: stloc.s 39
-
-			IL_034a: ldloc.s 39
-			IL_034c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0351: stloc.s 33
-			IL_0353: ldloc.s 33
-			IL_0355: brfalse IL_04ad
-
-			IL_035a: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
-			IL_035f: stloc.s 16
-			IL_0361: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0366: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_036b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0370: pop
-			IL_0371: ldnull
-			IL_0372: ldloc.3
-			IL_0373: ldloc.s 10
-			IL_0375: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_030e: stloc.s 21
+			IL_0310: ldarg.0
+			IL_0311: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0316: stloc.s 36
+			IL_0318: ldarg.0
+			IL_0319: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_031e: ldnull
+			IL_031f: ldloc.s 36
+			IL_0321: ldloc.s 17
+			IL_0323: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0328: pop
+			IL_0329: ldarg.0
+			IL_032a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_032f: stloc.s 36
+			IL_0331: ldarg.0
+			IL_0332: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0337: ldnull
+			IL_0338: ldloc.s 36
+			IL_033a: ldloc.s 18
+			IL_033c: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0341: pop
+			IL_0342: ldarg.0
+			IL_0343: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0348: stloc.s 36
+			IL_034a: ldarg.0
+			IL_034b: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0350: ldnull
+			IL_0351: ldloc.s 36
+			IL_0353: ldloc.s 19
+			IL_0355: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_035a: pop
+			IL_035b: ldarg.0
+			IL_035c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0361: stloc.s 36
+			IL_0363: ldarg.0
+			IL_0364: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0369: ldnull
+			IL_036a: ldloc.s 36
+			IL_036c: ldloc.s 20
+			IL_036e: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0373: pop
+			IL_0374: ldarg.0
+			IL_0375: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
 			IL_037a: stloc.s 36
-			IL_037c: ldloc.s 36
-			IL_037e: stloc.s 17
-			IL_0380: ldnull
-			IL_0381: ldloc.s 4
-			IL_0383: ldloc.s 10
-			IL_0385: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_038a: stloc.s 36
-			IL_038c: ldloc.s 36
-			IL_038e: stloc.s 18
-			IL_0390: ldnull
-			IL_0391: ldloc.s 5
-			IL_0393: ldloc.s 10
-			IL_0395: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_039a: stloc.s 36
-			IL_039c: ldloc.s 36
-			IL_039e: stloc.s 19
-			IL_03a0: ldnull
-			IL_03a1: ldloc.s 6
-			IL_03a3: ldloc.s 10
-			IL_03a5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_03aa: stloc.s 36
-			IL_03ac: ldloc.s 36
-			IL_03ae: stloc.s 20
-			IL_03b0: ldnull
-			IL_03b1: ldloc.s 7
-			IL_03b3: ldloc.s 10
-			IL_03b5: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-			IL_03ba: stloc.s 36
-			IL_03bc: ldloc.s 36
-			IL_03be: stloc.s 21
-			IL_03c0: ldarg.0
-			IL_03c1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_03c6: stloc.s 36
-			IL_03c8: ldc.i4.1
-			IL_03c9: newarr [System.Runtime]System.Object
-			IL_03ce: dup
-			IL_03cf: ldc.i4.0
-			IL_03d0: ldarg.0
-			IL_03d1: stelem.ref
-			IL_03d2: ldc.i4.0
-			IL_03d3: ldelem.ref
-			IL_03d4: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_03d9: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_03df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_03e4: ldnull
-			IL_03e5: ldloc.s 36
-			IL_03e7: ldloc.s 17
-			IL_03e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_03ee: pop
-			IL_03ef: ldarg.0
-			IL_03f0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_03f5: stloc.s 36
-			IL_03f7: ldc.i4.1
-			IL_03f8: newarr [System.Runtime]System.Object
-			IL_03fd: dup
-			IL_03fe: ldc.i4.0
-			IL_03ff: ldarg.0
-			IL_0400: stelem.ref
-			IL_0401: ldc.i4.0
-			IL_0402: ldelem.ref
-			IL_0403: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0408: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_040e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0413: ldnull
-			IL_0414: ldloc.s 36
-			IL_0416: ldloc.s 18
-			IL_0418: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_041d: pop
-			IL_041e: ldarg.0
-			IL_041f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0424: stloc.s 36
-			IL_0426: ldc.i4.1
-			IL_0427: newarr [System.Runtime]System.Object
-			IL_042c: dup
-			IL_042d: ldc.i4.0
-			IL_042e: ldarg.0
-			IL_042f: stelem.ref
-			IL_0430: ldc.i4.0
-			IL_0431: ldelem.ref
-			IL_0432: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0437: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_043d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0442: ldnull
-			IL_0443: ldloc.s 36
-			IL_0445: ldloc.s 19
-			IL_0447: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_044c: pop
-			IL_044d: ldarg.0
-			IL_044e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0453: stloc.s 36
-			IL_0455: ldc.i4.1
-			IL_0456: newarr [System.Runtime]System.Object
-			IL_045b: dup
-			IL_045c: ldc.i4.0
-			IL_045d: ldarg.0
-			IL_045e: stelem.ref
-			IL_045f: ldc.i4.0
-			IL_0460: ldelem.ref
-			IL_0461: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0466: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_046c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0471: ldnull
-			IL_0472: ldloc.s 36
-			IL_0474: ldloc.s 20
-			IL_0476: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_047b: pop
-			IL_047c: ldarg.0
-			IL_047d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0482: stloc.s 36
-			IL_0484: ldc.i4.1
-			IL_0485: newarr [System.Runtime]System.Object
-			IL_048a: dup
-			IL_048b: ldc.i4.0
-			IL_048c: ldarg.0
-			IL_048d: stelem.ref
-			IL_048e: ldc.i4.0
-			IL_048f: ldelem.ref
-			IL_0490: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0495: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_049b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_04a0: ldnull
-			IL_04a1: ldloc.s 36
-			IL_04a3: ldloc.s 21
-			IL_04a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_04aa: pop
-			IL_04ab: ldnull
-			IL_04ac: ret
+			IL_037c: ldarg.0
+			IL_037d: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0382: ldnull
+			IL_0383: ldloc.s 36
+			IL_0385: ldloc.s 21
+			IL_0387: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_038c: pop
+			IL_038d: ldnull
+			IL_038e: ret
 
-			IL_04ad: ldc.i4.1
-			IL_04ae: newarr [System.Runtime]System.Object
-			IL_04b3: dup
-			IL_04b4: ldc.i4.0
-			IL_04b5: ldarg.0
-			IL_04b6: stelem.ref
-			IL_04b7: ldc.i4.0
-			IL_04b8: ldelem.ref
-			IL_04b9: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_04be: ldftn object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_04c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_04c9: ldnull
-			IL_04ca: ldloc.s 10
-			IL_04cc: ldloc.s 12
-			IL_04ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_04d3: stloc.s 36
-			IL_04d5: ldloc.s 36
-			IL_04d7: stloc.s 22
-			IL_04d9: ldloc.s 8
-			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04e0: stloc.s 36
-			IL_04e2: ldloc.s 36
-			IL_04e4: ldstr "slice"
-			IL_04e9: ldc.r8 0.0
-			IL_04f2: box [System.Runtime]System.Double
-			IL_04f7: ldloc.s 13
-			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04fe: stloc.s 36
-			IL_0500: ldloc.s 36
-			IL_0502: stloc.s 23
-			IL_0504: ldloc.s 8
-			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_050b: stloc.s 36
-			IL_050d: ldloc.s 36
-			IL_050f: ldstr "slice"
-			IL_0514: ldloc.s 14
-			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_051b: stloc.s 36
-			IL_051d: ldloc.s 36
-			IL_051f: stloc.s 24
-			IL_0521: ldstr "\n_Nothing yet._\n\n"
-			IL_0526: stloc.s 25
-			IL_0528: ldloc.s 23
-			IL_052a: ldloc.s 25
-			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0531: stloc.s 39
-			IL_0533: ldloc.s 39
-			IL_0535: ldloc.s 22
-			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_053c: stloc.s 39
-			IL_053e: ldloc.s 39
-			IL_0540: ldloc.s 24
-			IL_0542: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0547: stloc.s 39
-			IL_0549: ldloc.s 39
-			IL_054b: stloc.s 26
-			IL_054d: ldnull
-			IL_054e: ldloc.3
-			IL_054f: ldloc.s 10
-			IL_0551: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0556: stloc.s 36
-			IL_0558: ldloc.s 36
-			IL_055a: stloc.s 27
-			IL_055c: ldnull
-			IL_055d: ldloc.s 4
-			IL_055f: ldloc.s 10
-			IL_0561: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0566: stloc.s 36
-			IL_0568: ldloc.s 36
-			IL_056a: stloc.s 28
-			IL_056c: ldnull
-			IL_056d: ldloc.s 5
-			IL_056f: ldloc.s 10
-			IL_0571: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0576: stloc.s 36
-			IL_0578: ldloc.s 36
-			IL_057a: stloc.s 29
-			IL_057c: ldnull
-			IL_057d: ldloc.s 6
-			IL_057f: ldloc.s 10
-			IL_0581: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0586: stloc.s 36
-			IL_0588: ldloc.s 36
-			IL_058a: stloc.s 30
-			IL_058c: ldnull
-			IL_058d: ldloc.s 7
-			IL_058f: ldloc.s 10
-			IL_0591: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-			IL_0596: stloc.s 36
-			IL_0598: ldloc.s 36
-			IL_059a: stloc.s 31
-			IL_059c: ldarg.0
-			IL_059d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_05a2: stloc.s 36
-			IL_05a4: ldc.i4.1
-			IL_05a5: newarr [System.Runtime]System.Object
-			IL_05aa: dup
-			IL_05ab: ldc.i4.0
-			IL_05ac: ldarg.0
-			IL_05ad: stelem.ref
-			IL_05ae: ldc.i4.0
-			IL_05af: ldelem.ref
-			IL_05b0: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_05b5: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_05bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_05c0: ldnull
-			IL_05c1: ldloc.s 36
-			IL_05c3: ldloc.s 26
-			IL_05c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_05ca: pop
-			IL_05cb: ldarg.0
-			IL_05cc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_05d1: stloc.s 36
-			IL_05d3: ldc.i4.1
-			IL_05d4: newarr [System.Runtime]System.Object
-			IL_05d9: dup
-			IL_05da: ldc.i4.0
-			IL_05db: ldarg.0
-			IL_05dc: stelem.ref
-			IL_05dd: ldc.i4.0
-			IL_05de: ldelem.ref
-			IL_05df: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_05e4: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_05ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_05ef: ldnull
-			IL_05f0: ldloc.s 36
-			IL_05f2: ldloc.s 27
-			IL_05f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
+			IL_038f: ldarg.0
+			IL_0390: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0395: ldnull
+			IL_0396: ldloc.s 10
+			IL_0398: ldloc.s 12
+			IL_039a: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_039f: stloc.s 36
+			IL_03a1: ldloc.s 36
+			IL_03a3: stloc.s 22
+			IL_03a5: ldloc.s 8
+			IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ac: stloc.s 36
+			IL_03ae: ldloc.s 36
+			IL_03b0: ldstr "slice"
+			IL_03b5: ldc.r8 0.0
+			IL_03be: box [System.Runtime]System.Double
+			IL_03c3: ldloc.s 13
+			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03ca: stloc.s 36
+			IL_03cc: ldloc.s 36
+			IL_03ce: stloc.s 23
+			IL_03d0: ldloc.s 8
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03d7: stloc.s 36
+			IL_03d9: ldloc.s 36
+			IL_03db: ldstr "slice"
+			IL_03e0: ldloc.s 14
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03e7: stloc.s 36
+			IL_03e9: ldloc.s 36
+			IL_03eb: stloc.s 24
+			IL_03ed: ldstr "\n_Nothing yet._\n\n"
+			IL_03f2: stloc.s 25
+			IL_03f4: ldloc.s 23
+			IL_03f6: ldloc.s 25
+			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03fd: stloc.s 39
+			IL_03ff: ldloc.s 39
+			IL_0401: ldloc.s 22
+			IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0408: stloc.s 39
+			IL_040a: ldloc.s 39
+			IL_040c: ldloc.s 24
+			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0413: stloc.s 39
+			IL_0415: ldloc.s 39
+			IL_0417: stloc.s 26
+			IL_0419: ldnull
+			IL_041a: ldloc.3
+			IL_041b: ldloc.s 10
+			IL_041d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0422: stloc.s 36
+			IL_0424: ldloc.s 36
+			IL_0426: stloc.s 27
+			IL_0428: ldnull
+			IL_0429: ldloc.s 4
+			IL_042b: ldloc.s 10
+			IL_042d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0432: stloc.s 36
+			IL_0434: ldloc.s 36
+			IL_0436: stloc.s 28
+			IL_0438: ldnull
+			IL_0439: ldloc.s 5
+			IL_043b: ldloc.s 10
+			IL_043d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0442: stloc.s 36
+			IL_0444: ldloc.s 36
+			IL_0446: stloc.s 29
+			IL_0448: ldnull
+			IL_0449: ldloc.s 6
+			IL_044b: ldloc.s 10
+			IL_044d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+			IL_0452: stloc.s 36
+			IL_0454: ldloc.s 36
+			IL_0456: stloc.s 30
+			IL_0458: ldnull
+			IL_0459: ldloc.s 7
+			IL_045b: ldloc.s 10
+			IL_045d: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+			IL_0462: stloc.s 36
+			IL_0464: ldloc.s 36
+			IL_0466: stloc.s 31
+			IL_0468: ldarg.0
+			IL_0469: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_046e: stloc.s 36
+			IL_0470: ldarg.0
+			IL_0471: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_0476: ldnull
+			IL_0477: ldloc.s 36
+			IL_0479: ldloc.s 26
+			IL_047b: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0480: pop
+			IL_0481: ldarg.0
+			IL_0482: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0487: stloc.s 36
+			IL_0489: ldarg.0
+			IL_048a: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_048f: ldnull
+			IL_0490: ldloc.s 36
+			IL_0492: ldloc.s 27
+			IL_0494: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_0499: pop
+			IL_049a: ldarg.0
+			IL_049b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_04a0: stloc.s 36
+			IL_04a2: ldarg.0
+			IL_04a3: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04a8: ldnull
+			IL_04a9: ldloc.s 36
+			IL_04ab: ldloc.s 28
+			IL_04ad: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04b2: pop
+			IL_04b3: ldarg.0
+			IL_04b4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_04b9: stloc.s 36
+			IL_04bb: ldarg.0
+			IL_04bc: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04c1: ldnull
+			IL_04c2: ldloc.s 36
+			IL_04c4: ldloc.s 29
+			IL_04c6: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04cb: pop
+			IL_04cc: ldarg.0
+			IL_04cd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_04d2: stloc.s 36
+			IL_04d4: ldarg.0
+			IL_04d5: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04da: ldnull
+			IL_04db: ldloc.s 36
+			IL_04dd: ldloc.s 30
+			IL_04df: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04e4: pop
+			IL_04e5: ldarg.0
+			IL_04e6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_04eb: stloc.s 36
+			IL_04ed: ldarg.0
+			IL_04ee: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_04f3: ldnull
+			IL_04f4: ldloc.s 36
+			IL_04f6: ldloc.s 31
+			IL_04f8: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+			IL_04fd: pop
+			IL_04fe: ldloc.s 9
+			IL_0500: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0505: stloc.s 34
+			IL_0507: ldstr "Bumped version: "
+			IL_050c: ldloc.s 34
+			IL_050e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0513: stloc.s 34
+			IL_0515: ldloc.s 34
+			IL_0517: ldstr " -> "
+			IL_051c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0521: stloc.s 34
+			IL_0523: ldloc.s 10
+			IL_0525: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_052a: stloc.s 40
+			IL_052c: ldloc.s 34
+			IL_052e: ldloc.s 40
+			IL_0530: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0535: stloc.s 40
+			IL_0537: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_053c: ldloc.s 40
+			IL_053e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0543: pop
+			IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0549: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_054e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0553: pop
+			IL_0554: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0559: ldstr "\nNext steps:"
+			IL_055e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0563: pop
+			IL_0564: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0569: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_056e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0573: pop
+			IL_0574: ldloc.s 10
+			IL_0576: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_057b: stloc.s 40
+			IL_057d: ldstr "  git commit -m \"chore(release): cut "
+			IL_0582: ldloc.s 40
+			IL_0584: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0589: stloc.s 40
+			IL_058b: ldloc.s 40
+			IL_058d: ldstr "\""
+			IL_0592: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0597: stloc.s 40
+			IL_0599: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_059e: ldloc.s 40
+			IL_05a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05a5: pop
+			IL_05a6: ldloc.s 10
+			IL_05a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05ad: stloc.s 40
+			IL_05af: ldstr "  git tag -a v"
+			IL_05b4: ldloc.s 40
+			IL_05b6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05bb: stloc.s 40
+			IL_05bd: ldloc.s 40
+			IL_05bf: ldstr " -m \"Release "
+			IL_05c4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05c9: stloc.s 40
+			IL_05cb: ldloc.s 10
+			IL_05cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05d2: stloc.s 34
+			IL_05d4: ldloc.s 40
+			IL_05d6: ldloc.s 34
+			IL_05d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05dd: stloc.s 34
+			IL_05df: ldloc.s 34
+			IL_05e1: ldstr "\""
+			IL_05e6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05eb: stloc.s 34
+			IL_05ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05f2: ldloc.s 34
+			IL_05f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_05f9: pop
-			IL_05fa: ldarg.0
-			IL_05fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0600: stloc.s 36
-			IL_0602: ldc.i4.1
-			IL_0603: newarr [System.Runtime]System.Object
-			IL_0608: dup
-			IL_0609: ldc.i4.0
-			IL_060a: ldarg.0
-			IL_060b: stelem.ref
-			IL_060c: ldc.i4.0
-			IL_060d: ldelem.ref
-			IL_060e: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0613: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0619: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_061e: ldnull
-			IL_061f: ldloc.s 36
-			IL_0621: ldloc.s 28
-			IL_0623: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0628: pop
-			IL_0629: ldarg.0
-			IL_062a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_062f: stloc.s 36
-			IL_0631: ldc.i4.1
-			IL_0632: newarr [System.Runtime]System.Object
-			IL_0637: dup
-			IL_0638: ldc.i4.0
-			IL_0639: ldarg.0
-			IL_063a: stelem.ref
-			IL_063b: ldc.i4.0
-			IL_063c: ldelem.ref
-			IL_063d: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0642: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0648: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_064d: ldnull
-			IL_064e: ldloc.s 36
-			IL_0650: ldloc.s 29
-			IL_0652: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0657: pop
-			IL_0658: ldarg.0
-			IL_0659: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_065e: stloc.s 36
-			IL_0660: ldc.i4.1
-			IL_0661: newarr [System.Runtime]System.Object
-			IL_0666: dup
-			IL_0667: ldc.i4.0
-			IL_0668: ldarg.0
-			IL_0669: stelem.ref
-			IL_066a: ldc.i4.0
-			IL_066b: ldelem.ref
-			IL_066c: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0671: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0677: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_067c: ldnull
-			IL_067d: ldloc.s 36
-			IL_067f: ldloc.s 30
-			IL_0681: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0686: pop
-			IL_0687: ldarg.0
-			IL_0688: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_068d: stloc.s 36
-			IL_068f: ldc.i4.1
-			IL_0690: newarr [System.Runtime]System.Object
-			IL_0695: dup
-			IL_0696: ldc.i4.0
-			IL_0697: ldarg.0
-			IL_0698: stelem.ref
-			IL_0699: ldc.i4.0
-			IL_069a: ldelem.ref
-			IL_069b: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_06a0: ldftn object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_06a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_06ab: ldnull
-			IL_06ac: ldloc.s 36
-			IL_06ae: ldloc.s 31
-			IL_06b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_06b5: pop
-			IL_06b6: ldloc.s 9
-			IL_06b8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06bd: stloc.s 34
-			IL_06bf: ldstr "Bumped version: "
-			IL_06c4: ldloc.s 34
-			IL_06c6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06cb: stloc.s 34
-			IL_06cd: ldloc.s 34
-			IL_06cf: ldstr " -> "
-			IL_06d4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06d9: stloc.s 34
-			IL_06db: ldloc.s 10
-			IL_06dd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06e2: stloc.s 40
-			IL_06e4: ldloc.s 34
-			IL_06e6: ldloc.s 40
-			IL_06e8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06ed: stloc.s 40
-			IL_06ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06f4: ldloc.s 40
-			IL_06f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06fb: pop
-			IL_06fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0701: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0706: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_070b: pop
-			IL_070c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0711: ldstr "\nNext steps:"
-			IL_0716: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_071b: pop
-			IL_071c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0721: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0726: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_072b: pop
-			IL_072c: ldloc.s 10
-			IL_072e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0733: stloc.s 40
-			IL_0735: ldstr "  git commit -m \"chore(release): cut "
-			IL_073a: ldloc.s 40
-			IL_073c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0741: stloc.s 40
-			IL_0743: ldloc.s 40
-			IL_0745: ldstr "\""
-			IL_074a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_074f: stloc.s 40
-			IL_0751: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0756: ldloc.s 40
-			IL_0758: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_075d: pop
-			IL_075e: ldloc.s 10
-			IL_0760: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0765: stloc.s 40
-			IL_0767: ldstr "  git tag -a v"
-			IL_076c: ldloc.s 40
-			IL_076e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0773: stloc.s 40
-			IL_0775: ldloc.s 40
-			IL_0777: ldstr " -m \"Release "
-			IL_077c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0781: stloc.s 40
-			IL_0783: ldloc.s 10
-			IL_0785: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_078a: stloc.s 34
-			IL_078c: ldloc.s 40
-			IL_078e: ldloc.s 34
-			IL_0790: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0795: stloc.s 34
-			IL_0797: ldloc.s 34
-			IL_0799: ldstr "\""
-			IL_079e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07a3: stloc.s 34
-			IL_07a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07aa: ldloc.s 34
-			IL_07ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07b1: pop
-			IL_07b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07b7: ldstr "  git push && git push --tags"
-			IL_07bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07c1: pop
-			IL_07c2: ldnull
-			IL_07c3: ret
+			IL_05fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05ff: ldstr "  git push && git push --tags"
+			IL_0604: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0609: pop
+			IL_060a: ldnull
+			IL_060b: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform
@@ -2850,7 +2670,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3987
+				// Method begins at RVA 0x37bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2870,7 +2690,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3990
+				// Method begins at RVA 0x37c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2908,7 +2728,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x38c1
+			// Method begins at RVA 0x36f5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2934,7 +2754,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1095 (0x447)
+		// Code size: 1073 (0x431)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
@@ -3316,73 +3136,64 @@
 		{
 			IL_038f: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C4::.ctor()
 			IL_0394: stloc.s 4
-			IL_0396: ldc.i4.1
-			IL_0397: newarr [System.Runtime]System.Object
-			IL_039c: dup
-			IL_039d: ldc.i4.0
-			IL_039e: ldloc.0
-			IL_039f: stelem.ref
-			IL_03a0: ldc.i4.0
-			IL_03a1: ldelem.ref
-			IL_03a2: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_03a7: ldftn object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
-			IL_03ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_03b2: ldnull
-			IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_03b8: pop
-			IL_03b9: leave IL_0443
+			IL_0396: ldloc.0
+			IL_0397: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_039c: ldnull
+			IL_039d: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
+			IL_03a2: pop
+			IL_03a3: leave IL_042d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03be: stloc.s 5
-			IL_03c0: ldloc.s 5
-			IL_03c2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03c7: dup
-			IL_03c8: brtrue IL_03de
+			IL_03a8: stloc.s 5
+			IL_03aa: ldloc.s 5
+			IL_03ac: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03b1: dup
+			IL_03b2: brtrue IL_03c8
 
-			IL_03cd: pop
-			IL_03ce: ldloc.s 5
-			IL_03d0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03d5: dup
-			IL_03d6: brtrue IL_03ea
+			IL_03b7: pop
+			IL_03b8: ldloc.s 5
+			IL_03ba: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03bf: dup
+			IL_03c0: brtrue IL_03d4
 
-			IL_03db: pop
-			IL_03dc: rethrow
+			IL_03c5: pop
+			IL_03c6: rethrow
 
-			IL_03de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03e3: stloc.s 6
-			IL_03e5: br IL_03ec
+			IL_03c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03cd: stloc.s 6
+			IL_03cf: br IL_03d6
 
-			IL_03ea: stloc.s 6
+			IL_03d4: stloc.s 6
 
-			IL_03ec: ldloc.s 6
-			IL_03ee: stloc.s 10
-			IL_03f0: ldloc.s 10
-			IL_03f2: stloc.s 7
-			IL_03f4: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C29::.ctor()
-			IL_03f9: stloc.s 8
-			IL_03fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0400: ldstr "ERROR:"
-			IL_0405: ldloc.s 7
-			IL_0407: ldstr "message"
-			IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0411: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object, object)
-			IL_0416: pop
-			IL_0417: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0421: stloc.s 10
-			IL_0423: ldloc.s 10
-			IL_0425: ldstr "exit"
-			IL_042a: ldc.r8 1
-			IL_0433: box [System.Runtime]System.Double
-			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_043d: pop
-			IL_043e: leave IL_0443
+			IL_03d6: ldloc.s 6
+			IL_03d8: stloc.s 10
+			IL_03da: ldloc.s 10
+			IL_03dc: stloc.s 7
+			IL_03de: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C29::.ctor()
+			IL_03e3: stloc.s 8
+			IL_03e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ea: ldstr "ERROR:"
+			IL_03ef: ldloc.s 7
+			IL_03f1: ldstr "message"
+			IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object, object)
+			IL_0400: pop
+			IL_0401: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_040b: stloc.s 10
+			IL_040d: ldloc.s 10
+			IL_040f: ldstr "exit"
+			IL_0414: ldc.r8 1
+			IL_041d: box [System.Runtime]System.Double
+			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0427: pop
+			IL_0428: leave IL_042d
 		} // end handler
 
-		IL_0443: ldnull
-		IL_0444: stloc.s 9
-		IL_0446: ret
+		IL_042d: ldnull
+		IL_042e: stloc.s 9
+		IL_0430: ret
 	} // end of method Compile_Scripts_BumpVersion::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_BumpVersion
@@ -3394,7 +3205,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3999
+		// Method begins at RVA 0x37cd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+﻿// IL code: Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3105
+				// Method begins at RVA 0x3099
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3120
+						// Method begins at RVA 0x30b4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3129
+						// Method begins at RVA 0x30bd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3132
+						// Method begins at RVA 0x30c6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x313b
+						// Method begins at RVA 0x30cf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3117
+					// Method begins at RVA 0x30ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x310e
+				// Method begins at RVA 0x30a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -169,7 +169,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 674 (0x2a2)
 			.maxstack 8
@@ -449,7 +449,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x314d
+					// Method begins at RVA 0x30e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -474,7 +474,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ad4
+				// Method begins at RVA 0x2a90
 				// Header size: 12
 				// Code size: 445 (0x1bd)
 				.maxstack 8
@@ -663,7 +663,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3156
+					// Method begins at RVA 0x30ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -687,7 +687,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ca0
+				// Method begins at RVA 0x2c5c
 				// Header size: 12
 				// Code size: 156 (0x9c)
 				.maxstack 8
@@ -773,7 +773,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x315f
+					// Method begins at RVA 0x30f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d48
+				// Method begins at RVA 0x2d04
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -843,7 +843,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3171
+						// Method begins at RVA 0x3105
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -867,7 +867,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fbc
+					// Method begins at RVA 0x2f50
 					// Header size: 12
 					// Code size: 221 (0xdd)
 					.maxstack 8
@@ -990,7 +990,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x317a
+						// Method begins at RVA 0x310e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1008,7 +1008,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3168
+					// Method begins at RVA 0x30fc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1034,9 +1034,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d74
+				// Method begins at RVA 0x2d30
 				// Header size: 12
-				// Code size: 570 (0x23a)
+				// Code size: 530 (0x212)
 				.maxstack 8
 				.locals init (
 					[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope,
@@ -1053,11 +1053,10 @@
 					[11] object,
 					[12] object,
 					[13] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-					[14] object[],
+					[14] object,
 					[15] object,
-					[16] object,
-					[17] string,
-					[18] string
+					[16] string,
+					[17] string
 				)
 
 				IL_0000: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope::.ctor()
@@ -1121,164 +1120,134 @@
 				IL_00a8: stloc.s 9
 				IL_00aa: ldloc.s 9
 				IL_00ac: stloc.2
-				IL_00ad: ldc.i4.2
-				IL_00ae: newarr [System.Runtime]System.Object
-				IL_00b3: dup
-				IL_00b4: ldc.i4.0
-				IL_00b5: ldarg.0
-				IL_00b6: ldc.i4.0
-				IL_00b7: ldelem.ref
-				IL_00b8: stelem.ref
-				IL_00b9: dup
-				IL_00ba: ldc.i4.1
-				IL_00bb: ldarg.0
-				IL_00bc: ldc.i4.1
-				IL_00bd: ldelem.ref
-				IL_00be: stelem.ref
-				IL_00bf: stloc.s 14
-				IL_00c1: ldloc.2
-				IL_00c2: ldloc.s 14
-				IL_00c4: ldarg.3
-				IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00ca: stloc.s 9
-				IL_00cc: ldloc.s 9
-				IL_00ce: stloc.3
-				IL_00cf: ldloc.3
-				IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_00d5: ldc.i4.0
-				IL_00d6: ceq
-				IL_00d8: stloc.s 10
-				IL_00da: ldloc.s 10
-				IL_00dc: box [System.Runtime]System.Boolean
-				IL_00e1: stloc.s 15
-				IL_00e3: ldloc.s 15
-				IL_00e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00ea: stloc.s 10
-				IL_00ec: ldloc.s 10
-				IL_00ee: brfalse IL_0105
+				IL_00ad: ldnull
+				IL_00ae: ldarg.3
+				IL_00af: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
+				IL_00b4: stloc.s 9
+				IL_00b6: ldloc.s 9
+				IL_00b8: stloc.3
+				IL_00b9: ldloc.3
+				IL_00ba: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00bf: ldc.i4.0
+				IL_00c0: ceq
+				IL_00c2: stloc.s 10
+				IL_00c4: ldloc.s 10
+				IL_00c6: box [System.Runtime]System.Boolean
+				IL_00cb: stloc.s 14
+				IL_00cd: ldloc.s 14
+				IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00d4: stloc.s 10
+				IL_00d6: ldloc.s 10
+				IL_00d8: brfalse IL_00ef
 
-				IL_00f3: ldarg.3
-				IL_00f4: ldstr "querySelector"
-				IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00fe: stloc.s 16
-				IL_0100: br IL_0109
+				IL_00dd: ldarg.3
+				IL_00de: ldstr "querySelector"
+				IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00e8: stloc.s 15
+				IL_00ea: br IL_00f3
 
-				IL_0105: ldloc.s 15
-				IL_0107: stloc.s 16
+				IL_00ef: ldloc.s 14
+				IL_00f1: stloc.s 15
 
-				IL_0109: ldloc.s 16
-				IL_010b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0110: stloc.s 10
-				IL_0112: ldloc.s 10
-				IL_0114: brfalse IL_016e
+				IL_00f3: ldloc.s 15
+				IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00fa: stloc.s 10
+				IL_00fc: ldloc.s 10
+				IL_00fe: brfalse IL_0146
 
-				IL_0119: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope/Block_L97C39::.ctor()
-				IL_011e: stloc.s 4
-				IL_0120: ldarg.3
-				IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0126: stloc.s 9
-				IL_0128: ldloc.s 9
-				IL_012a: ldstr "querySelector"
-				IL_012f: ldstr "code"
-				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0139: stloc.s 9
-				IL_013b: ldloc.s 9
-				IL_013d: stloc.s 5
-				IL_013f: ldloc.s 5
-				IL_0141: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0146: stloc.s 10
-				IL_0148: ldloc.s 10
-				IL_014a: brfalse IL_016e
+				IL_0103: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/Scope/Block_L97C39::.ctor()
+				IL_0108: stloc.s 4
+				IL_010a: ldarg.3
+				IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0110: stloc.s 9
+				IL_0112: ldloc.s 9
+				IL_0114: ldstr "querySelector"
+				IL_0119: ldstr "code"
+				IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0123: stloc.s 9
+				IL_0125: ldloc.s 9
+				IL_0127: stloc.s 5
+				IL_0129: ldloc.s 5
+				IL_012b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0130: stloc.s 10
+				IL_0132: ldloc.s 10
+				IL_0134: brfalse IL_0146
 
-				IL_014f: ldloc.2
-				IL_0150: ldc.i4.2
-				IL_0151: newarr [System.Runtime]System.Object
-				IL_0156: dup
-				IL_0157: ldc.i4.0
-				IL_0158: ldarg.0
-				IL_0159: ldc.i4.0
-				IL_015a: ldelem.ref
-				IL_015b: stelem.ref
-				IL_015c: dup
-				IL_015d: ldc.i4.1
-				IL_015e: ldarg.0
-				IL_015f: ldc.i4.1
-				IL_0160: ldelem.ref
-				IL_0161: stelem.ref
-				IL_0162: ldloc.s 5
-				IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0169: stloc.s 9
-				IL_016b: ldloc.s 9
-				IL_016d: stloc.3
+				IL_0139: ldnull
+				IL_013a: ldloc.s 5
+				IL_013c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/ArrowFunction_L90C29::__js_call__(object, object)
+				IL_0141: stloc.s 9
+				IL_0143: ldloc.s 9
+				IL_0145: stloc.3
 
-				IL_016e: ldloc.3
-				IL_016f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0174: stloc.s 10
-				IL_0176: ldloc.s 10
-				IL_0178: brfalse IL_019c
+				IL_0146: ldloc.3
+				IL_0147: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_014c: stloc.s 10
+				IL_014e: ldloc.s 10
+				IL_0150: brfalse IL_0174
 
-				IL_017d: ldloc.3
-				IL_017e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0183: stloc.s 17
-				IL_0185: ldstr " "
-				IL_018a: ldloc.s 17
-				IL_018c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0191: stloc.s 17
-				IL_0193: ldloc.s 17
-				IL_0195: stloc.s 6
-				IL_0197: br IL_01a3
+				IL_0155: ldloc.3
+				IL_0156: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_015b: stloc.s 16
+				IL_015d: ldstr " "
+				IL_0162: ldloc.s 16
+				IL_0164: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0169: stloc.s 16
+				IL_016b: ldloc.s 16
+				IL_016d: stloc.s 6
+				IL_016f: br IL_017b
 
-				IL_019c: ldstr ""
-				IL_01a1: stloc.s 6
+				IL_0174: ldstr ""
+				IL_0179: stloc.s 6
 
-				IL_01a3: ldloc.s 6
-				IL_01a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01aa: stloc.s 17
-				IL_01ac: ldstr "\n\n```"
-				IL_01b1: ldloc.s 17
-				IL_01b3: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01b8: stloc.s 17
-				IL_01ba: ldloc.s 17
-				IL_01bc: ldstr "\n"
-				IL_01c1: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01c6: stloc.s 17
-				IL_01c8: ldloc.s 17
-				IL_01ca: stloc.s 7
-				IL_01cc: ldloc.1
-				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01d2: stloc.s 9
-				IL_01d4: ldstr "\\n$"
-				IL_01d9: ldstr ""
-				IL_01de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_01e3: stloc.s 13
-				IL_01e5: ldloc.s 9
-				IL_01e7: ldstr "replace"
-				IL_01ec: ldloc.s 13
-				IL_01ee: ldstr ""
-				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_01f8: stloc.s 9
-				IL_01fa: ldloc.s 9
-				IL_01fc: stloc.s 8
-				IL_01fe: ldloc.s 7
-				IL_0200: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0205: stloc.s 17
-				IL_0207: ldstr ""
-				IL_020c: ldloc.s 17
-				IL_020e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0213: stloc.s 17
-				IL_0215: ldloc.s 8
-				IL_0217: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_021c: stloc.s 18
-				IL_021e: ldloc.s 17
-				IL_0220: ldloc.s 18
-				IL_0222: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0227: stloc.s 18
-				IL_0229: ldloc.s 18
-				IL_022b: ldstr "\n```\n\n"
-				IL_0230: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0235: stloc.s 18
-				IL_0237: ldloc.s 18
-				IL_0239: ret
+				IL_017b: ldloc.s 6
+				IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0182: stloc.s 16
+				IL_0184: ldstr "\n\n```"
+				IL_0189: ldloc.s 16
+				IL_018b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0190: stloc.s 16
+				IL_0192: ldloc.s 16
+				IL_0194: ldstr "\n"
+				IL_0199: call string [System.Runtime]System.String::Concat(string, string)
+				IL_019e: stloc.s 16
+				IL_01a0: ldloc.s 16
+				IL_01a2: stloc.s 7
+				IL_01a4: ldloc.1
+				IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01aa: stloc.s 9
+				IL_01ac: ldstr "\\n$"
+				IL_01b1: ldstr ""
+				IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_01bb: stloc.s 13
+				IL_01bd: ldloc.s 9
+				IL_01bf: ldstr "replace"
+				IL_01c4: ldloc.s 13
+				IL_01c6: ldstr ""
+				IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_01d0: stloc.s 9
+				IL_01d2: ldloc.s 9
+				IL_01d4: stloc.s 8
+				IL_01d6: ldloc.s 7
+				IL_01d8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01dd: stloc.s 16
+				IL_01df: ldstr ""
+				IL_01e4: ldloc.s 16
+				IL_01e6: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01eb: stloc.s 16
+				IL_01ed: ldloc.s 8
+				IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01f4: stloc.s 17
+				IL_01f6: ldloc.s 16
+				IL_01f8: ldloc.s 17
+				IL_01fa: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01ff: stloc.s 17
+				IL_0201: ldloc.s 17
+				IL_0203: ldstr "\n```\n\n"
+				IL_0208: call string [System.Runtime]System.String::Concat(string, string)
+				IL_020d: stloc.s 17
+				IL_020f: ldloc.s 17
+				IL_0211: ret
 			} // end of method FunctionExpression_L85C15::__js_call__
 
 		} // end of class FunctionExpression_L85C15
@@ -1290,7 +1259,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3144
+				// Method begins at RVA 0x30d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1317,7 +1286,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x25ac
+			// Method begins at RVA 0x2594
 			// Header size: 12
 			// Code size: 576 (0x240)
 			.maxstack 8
@@ -1542,7 +1511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3183
+				// Method begins at RVA 0x3117
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1568,9 +1537,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x27f8
+			// Method begins at RVA 0x27e0
 			// Header size: 12
-			// Code size: 717 (0x2cd)
+			// Code size: 673 (0x2a1)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1592,243 +1561,225 @@
 			IL_0005: ldstr "argv"
 			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_000f: stloc.s 7
-			IL_0011: ldc.i4.1
-			IL_0012: newarr [System.Runtime]System.Object
-			IL_0017: dup
-			IL_0018: ldc.i4.0
-			IL_0019: ldarg.0
-			IL_001a: stelem.ref
-			IL_001b: ldc.i4.0
-			IL_001c: ldelem.ref
-			IL_001d: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_0022: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-			IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_002d: ldnull
-			IL_002e: ldloc.s 7
-			IL_0030: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0035: stloc.s 7
-			IL_0037: ldloc.s 7
-			IL_0039: stloc.0
-			IL_003a: ldloc.0
-			IL_003b: ldstr "inFile"
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0045: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_004a: ldc.i4.0
-			IL_004b: ceq
-			IL_004d: stloc.s 8
-			IL_004f: ldloc.s 8
-			IL_0051: brfalse IL_007f
+			IL_0011: ldarg.0
+			IL_0012: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_0017: ldnull
+			IL_0018: ldloc.s 7
+			IL_001a: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+			IL_001f: stloc.s 7
+			IL_0021: ldloc.s 7
+			IL_0023: stloc.0
+			IL_0024: ldloc.0
+			IL_0025: ldstr "inFile"
+			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0034: ldc.i4.0
+			IL_0035: ceq
+			IL_0037: stloc.s 8
+			IL_0039: ldloc.s 8
+			IL_003b: brfalse IL_0069
 
-			IL_0056: ldstr "Missing --in <input.html>"
-			IL_005b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0065: stloc.s 7
-			IL_0067: ldloc.s 7
-			IL_0069: stloc.1
-			IL_006a: ldloc.1
-			IL_006b: isinst [System.Runtime]System.Exception
-			IL_0070: dup
-			IL_0071: brtrue IL_007e
+			IL_0040: ldstr "Missing --in <input.html>"
+			IL_0045: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_004f: stloc.s 7
+			IL_0051: ldloc.s 7
+			IL_0053: stloc.1
+			IL_0054: ldloc.1
+			IL_0055: isinst [System.Runtime]System.Exception
+			IL_005a: dup
+			IL_005b: brtrue IL_0068
 
-			IL_0076: pop
-			IL_0077: ldloc.1
-			IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_007d: throw
+			IL_0060: pop
+			IL_0061: ldloc.1
+			IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0067: throw
 
-			IL_007e: throw
+			IL_0068: throw
 
-			IL_007f: ldloc.0
-			IL_0080: ldstr "outFile"
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_008f: ldc.i4.0
-			IL_0090: ceq
-			IL_0092: stloc.s 8
-			IL_0094: ldloc.s 8
-			IL_0096: brfalse IL_00c4
+			IL_0069: ldloc.0
+			IL_006a: ldstr "outFile"
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0079: ldc.i4.0
+			IL_007a: ceq
+			IL_007c: stloc.s 8
+			IL_007e: ldloc.s 8
+			IL_0080: brfalse IL_00ae
 
-			IL_009b: ldstr "Missing --out <output.md>"
-			IL_00a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00aa: stloc.s 7
-			IL_00ac: ldloc.s 7
-			IL_00ae: stloc.2
-			IL_00af: ldloc.2
-			IL_00b0: isinst [System.Runtime]System.Exception
-			IL_00b5: dup
-			IL_00b6: brtrue IL_00c3
+			IL_0085: ldstr "Missing --out <output.md>"
+			IL_008a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0094: stloc.s 7
+			IL_0096: ldloc.s 7
+			IL_0098: stloc.2
+			IL_0099: ldloc.2
+			IL_009a: isinst [System.Runtime]System.Exception
+			IL_009f: dup
+			IL_00a0: brtrue IL_00ad
 
-			IL_00bb: pop
-			IL_00bc: ldloc.2
-			IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00c2: throw
+			IL_00a5: pop
+			IL_00a6: ldloc.2
+			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00ac: throw
 
-			IL_00c3: throw
+			IL_00ad: throw
 
-			IL_00c4: ldarg.0
-			IL_00c5: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cf: stloc.s 7
-			IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00db: stloc.s 9
-			IL_00dd: ldloc.s 9
-			IL_00df: ldstr "cwd"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00e9: stloc.s 9
-			IL_00eb: ldloc.s 7
-			IL_00ed: ldstr "resolve"
-			IL_00f2: ldloc.s 9
-			IL_00f4: ldloc.0
-			IL_00f5: ldstr "inFile"
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0104: stloc.s 9
-			IL_0106: ldloc.s 9
-			IL_0108: stloc.3
-			IL_0109: ldarg.0
-			IL_010a: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0114: stloc.s 9
-			IL_0116: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0120: stloc.s 7
-			IL_0122: ldloc.s 7
-			IL_0124: ldstr "cwd"
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_012e: stloc.s 7
-			IL_0130: ldloc.s 9
-			IL_0132: ldstr "resolve"
-			IL_0137: ldloc.s 7
-			IL_0139: ldloc.0
-			IL_013a: ldstr "outFile"
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0149: stloc.s 7
-			IL_014b: ldloc.s 7
-			IL_014d: stloc.s 4
-			IL_014f: ldarg.0
-			IL_0150: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015a: stloc.s 7
-			IL_015c: ldloc.s 7
-			IL_015e: ldstr "readFileSync"
-			IL_0163: ldloc.3
-			IL_0164: ldstr "utf8"
-			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_016e: stloc.s 7
-			IL_0170: ldloc.s 7
-			IL_0172: stloc.s 5
-			IL_0174: ldc.i4.1
-			IL_0175: newarr [System.Runtime]System.Object
-			IL_017a: dup
-			IL_017b: ldc.i4.0
-			IL_017c: ldarg.0
-			IL_017d: stelem.ref
-			IL_017e: ldc.i4.0
-			IL_017f: ldelem.ref
-			IL_0180: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_0185: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-			IL_018b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0190: ldnull
-			IL_0191: ldloc.s 5
-			IL_0193: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0198: stloc.s 7
-			IL_019a: ldloc.s 7
-			IL_019c: stloc.s 6
-			IL_019e: ldarg.0
-			IL_019f: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01a9: stloc.s 7
-			IL_01ab: ldarg.0
-			IL_01ac: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b6: stloc.s 9
-			IL_01b8: ldloc.s 9
-			IL_01ba: ldstr "dirname"
-			IL_01bf: ldloc.s 4
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c6: stloc.s 9
-			IL_01c8: ldloc.s 7
-			IL_01ca: ldstr "mkdirSync"
-			IL_01cf: ldloc.s 9
-			IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01d6: dup
-			IL_01d7: ldstr "recursive"
-			IL_01dc: ldc.i4.1
-			IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01e7: pop
-			IL_01e8: ldarg.0
-			IL_01e9: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f3: stloc.s 9
-			IL_01f5: ldloc.s 9
-			IL_01f7: ldstr "writeFileSync"
-			IL_01fc: ldloc.s 4
-			IL_01fe: ldloc.s 6
-			IL_0200: ldstr "utf8"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_020a: pop
-			IL_020b: ldloc.0
-			IL_020c: ldstr "inFile"
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0216: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_021b: stloc.s 10
-			IL_021d: ldstr "Converted "
-			IL_0222: ldloc.s 10
-			IL_0224: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0229: stloc.s 10
-			IL_022b: ldloc.s 10
-			IL_022d: ldstr " -> "
-			IL_0232: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0237: stloc.s 10
-			IL_0239: ldloc.0
-			IL_023a: ldstr "outFile"
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0244: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0249: stloc.s 11
-			IL_024b: ldloc.s 10
-			IL_024d: ldloc.s 11
-			IL_024f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0254: stloc.s 11
-			IL_0256: ldloc.s 11
-			IL_0258: ldstr " ("
-			IL_025d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0262: stloc.s 11
-			IL_0264: ldloc.s 6
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026b: stloc.s 9
-			IL_026d: ldstr "\\n"
-			IL_0272: ldstr ""
-			IL_0277: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_027c: stloc.s 12
-			IL_027e: ldloc.s 9
-			IL_0280: ldstr "split"
-			IL_0285: ldloc.s 12
-			IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_028c: stloc.s 9
-			IL_028e: ldloc.s 9
-			IL_0290: ldstr "length"
-			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029a: stloc.s 9
-			IL_029c: ldloc.s 9
-			IL_029e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02a3: stloc.s 10
-			IL_02a5: ldloc.s 11
-			IL_02a7: ldloc.s 10
-			IL_02a9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ae: stloc.s 10
-			IL_02b0: ldloc.s 10
-			IL_02b2: ldstr " lines)"
-			IL_02b7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02bc: stloc.s 10
-			IL_02be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02c3: ldloc.s 10
-			IL_02c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02ca: pop
-			IL_02cb: ldnull
-			IL_02cc: ret
+			IL_00ae: ldarg.0
+			IL_00af: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b9: stloc.s 7
+			IL_00bb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c5: stloc.s 9
+			IL_00c7: ldloc.s 9
+			IL_00c9: ldstr "cwd"
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00d3: stloc.s 9
+			IL_00d5: ldloc.s 7
+			IL_00d7: ldstr "resolve"
+			IL_00dc: ldloc.s 9
+			IL_00de: ldloc.0
+			IL_00df: ldstr "inFile"
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00ee: stloc.s 9
+			IL_00f0: ldloc.s 9
+			IL_00f2: stloc.3
+			IL_00f3: ldarg.0
+			IL_00f4: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fe: stloc.s 9
+			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010a: stloc.s 7
+			IL_010c: ldloc.s 7
+			IL_010e: ldstr "cwd"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0118: stloc.s 7
+			IL_011a: ldloc.s 9
+			IL_011c: ldstr "resolve"
+			IL_0121: ldloc.s 7
+			IL_0123: ldloc.0
+			IL_0124: ldstr "outFile"
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0133: stloc.s 7
+			IL_0135: ldloc.s 7
+			IL_0137: stloc.s 4
+			IL_0139: ldarg.0
+			IL_013a: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0144: stloc.s 7
+			IL_0146: ldloc.s 7
+			IL_0148: ldstr "readFileSync"
+			IL_014d: ldloc.3
+			IL_014e: ldstr "utf8"
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0158: stloc.s 7
+			IL_015a: ldloc.s 7
+			IL_015c: stloc.s 5
+			IL_015e: ldarg.0
+			IL_015f: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_0164: ldnull
+			IL_0165: ldloc.s 5
+			IL_0167: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+			IL_016c: stloc.s 7
+			IL_016e: ldloc.s 7
+			IL_0170: stloc.s 6
+			IL_0172: ldarg.0
+			IL_0173: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017d: stloc.s 7
+			IL_017f: ldarg.0
+			IL_0180: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018a: stloc.s 9
+			IL_018c: ldloc.s 9
+			IL_018e: ldstr "dirname"
+			IL_0193: ldloc.s 4
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_019a: stloc.s 9
+			IL_019c: ldloc.s 7
+			IL_019e: ldstr "mkdirSync"
+			IL_01a3: ldloc.s 9
+			IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01aa: dup
+			IL_01ab: ldstr "recursive"
+			IL_01b0: ldc.i4.1
+			IL_01b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01bb: pop
+			IL_01bc: ldarg.0
+			IL_01bd: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c7: stloc.s 9
+			IL_01c9: ldloc.s 9
+			IL_01cb: ldstr "writeFileSync"
+			IL_01d0: ldloc.s 4
+			IL_01d2: ldloc.s 6
+			IL_01d4: ldstr "utf8"
+			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01de: pop
+			IL_01df: ldloc.0
+			IL_01e0: ldstr "inFile"
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ef: stloc.s 10
+			IL_01f1: ldstr "Converted "
+			IL_01f6: ldloc.s 10
+			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fd: stloc.s 10
+			IL_01ff: ldloc.s 10
+			IL_0201: ldstr " -> "
+			IL_0206: call string [System.Runtime]System.String::Concat(string, string)
+			IL_020b: stloc.s 10
+			IL_020d: ldloc.0
+			IL_020e: ldstr "outFile"
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0218: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_021d: stloc.s 11
+			IL_021f: ldloc.s 10
+			IL_0221: ldloc.s 11
+			IL_0223: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0228: stloc.s 11
+			IL_022a: ldloc.s 11
+			IL_022c: ldstr " ("
+			IL_0231: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0236: stloc.s 11
+			IL_0238: ldloc.s 6
+			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023f: stloc.s 9
+			IL_0241: ldstr "\\n"
+			IL_0246: ldstr ""
+			IL_024b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0250: stloc.s 12
+			IL_0252: ldloc.s 9
+			IL_0254: ldstr "split"
+			IL_0259: ldloc.s 12
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0260: stloc.s 9
+			IL_0262: ldloc.s 9
+			IL_0264: ldstr "length"
+			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026e: stloc.s 9
+			IL_0270: ldloc.s 9
+			IL_0272: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0277: stloc.s 10
+			IL_0279: ldloc.s 11
+			IL_027b: ldloc.s 10
+			IL_027d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0282: stloc.s 10
+			IL_0284: ldloc.s 10
+			IL_0286: ldstr " lines)"
+			IL_028b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0290: stloc.s 10
+			IL_0292: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0297: ldloc.s 10
+			IL_0299: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_029e: pop
+			IL_029f: ldnull
+			IL_02a0: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1860,7 +1811,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3195
+					// Method begins at RVA 0x3129
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1880,7 +1831,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x319e
+					// Method begins at RVA 0x3132
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1898,7 +1849,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x318c
+				// Method begins at RVA 0x3120
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1924,7 +1875,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x30fc
+			// Method begins at RVA 0x3090
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1950,7 +1901,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 489 (0x1e9)
+		// Code size: 467 (0x1d3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
@@ -2062,7 +2013,7 @@
 		IL_00e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_00ed: stloc.s 11
 		IL_00ef: ldloc.s 11
-		IL_00f1: brfalse IL_01e5
+		IL_00f1: brfalse IL_01cf
 
 		IL_00f6: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29::.ctor()
 		IL_00fb: stloc.2
@@ -2070,99 +2021,90 @@
 		{
 			IL_00fc: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L132C6::.ctor()
 			IL_0101: stloc.3
-			IL_0102: ldc.i4.1
-			IL_0103: newarr [System.Runtime]System.Object
-			IL_0108: dup
-			IL_0109: ldc.i4.0
-			IL_010a: ldloc.0
-			IL_010b: stelem.ref
-			IL_010c: ldc.i4.0
-			IL_010d: ldelem.ref
-			IL_010e: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_0113: ldftn object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
-			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_011e: ldnull
-			IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0124: pop
-			IL_0125: leave IL_01e5
+			IL_0102: ldloc.0
+			IL_0103: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
+			IL_0108: ldnull
+			IL_0109: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
+			IL_010e: pop
+			IL_010f: leave IL_01cf
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_012a: stloc.s 4
-			IL_012c: ldloc.s 4
-			IL_012e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0133: dup
-			IL_0134: brtrue IL_014a
+			IL_0114: stloc.s 4
+			IL_0116: ldloc.s 4
+			IL_0118: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_011d: dup
+			IL_011e: brtrue IL_0134
 
-			IL_0139: pop
-			IL_013a: ldloc.s 4
-			IL_013c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0141: dup
-			IL_0142: brtrue IL_0156
+			IL_0123: pop
+			IL_0124: ldloc.s 4
+			IL_0126: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_012b: dup
+			IL_012c: brtrue IL_0140
 
-			IL_0147: pop
-			IL_0148: rethrow
+			IL_0131: pop
+			IL_0132: rethrow
 
-			IL_014a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_014f: stloc.s 5
-			IL_0151: br IL_0158
+			IL_0134: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0139: stloc.s 5
+			IL_013b: br IL_0142
 
-			IL_0156: stloc.s 5
+			IL_0140: stloc.s 5
 
-			IL_0158: ldloc.s 5
-			IL_015a: stloc.s 10
-			IL_015c: ldloc.s 10
-			IL_015e: stloc.s 6
-			IL_0160: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L134C16::.ctor()
-			IL_0165: stloc.s 7
-			IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_016c: stloc.s 12
-			IL_016e: ldloc.s 6
-			IL_0170: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0175: stloc.s 11
-			IL_0177: ldloc.s 11
-			IL_0179: brfalse IL_0191
+			IL_0142: ldloc.s 5
+			IL_0144: stloc.s 10
+			IL_0146: ldloc.s 10
+			IL_0148: stloc.s 6
+			IL_014a: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L134C16::.ctor()
+			IL_014f: stloc.s 7
+			IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0156: stloc.s 12
+			IL_0158: ldloc.s 6
+			IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_015f: stloc.s 11
+			IL_0161: ldloc.s 11
+			IL_0163: brfalse IL_017b
 
-			IL_017e: ldloc.s 6
-			IL_0180: ldstr "message"
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018a: stloc.s 14
-			IL_018c: br IL_0195
+			IL_0168: ldloc.s 6
+			IL_016a: ldstr "message"
+			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0174: stloc.s 14
+			IL_0176: br IL_017f
 
-			IL_0191: ldloc.s 6
-			IL_0193: stloc.s 14
+			IL_017b: ldloc.s 6
+			IL_017d: stloc.s 14
 
-			IL_0195: ldloc.s 14
-			IL_0197: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_019c: stloc.s 11
-			IL_019e: ldloc.s 11
-			IL_01a0: brfalse IL_01b8
+			IL_017f: ldloc.s 14
+			IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0186: stloc.s 11
+			IL_0188: ldloc.s 11
+			IL_018a: brfalse IL_01a2
 
-			IL_01a5: ldloc.s 6
-			IL_01a7: ldstr "message"
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01b1: stloc.s 8
-			IL_01b3: br IL_01bc
+			IL_018f: ldloc.s 6
+			IL_0191: ldstr "message"
+			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019b: stloc.s 8
+			IL_019d: br IL_01a6
 
-			IL_01b8: ldloc.s 6
-			IL_01ba: stloc.s 8
+			IL_01a2: ldloc.s 6
+			IL_01a4: stloc.s 8
 
-			IL_01bc: ldloc.s 12
-			IL_01be: ldloc.s 8
-			IL_01c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_01c5: pop
-			IL_01c6: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_01cb: ldstr "exitCode"
-			IL_01d0: ldc.r8 1
-			IL_01d9: ldc.i4.1
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_01df: pop
-			IL_01e0: leave IL_01e5
+			IL_01a6: ldloc.s 12
+			IL_01a8: ldloc.s 8
+			IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_01af: pop
+			IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_01b5: ldstr "exitCode"
+			IL_01ba: ldc.r8 1
+			IL_01c3: ldc.i4.1
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_01c9: pop
+			IL_01ca: leave IL_01cf
 		} // end handler
 
-		IL_01e5: ldnull
-		IL_01e6: stloc.s 9
-		IL_01e8: ret
+		IL_01cf: ldnull
+		IL_01d0: stloc.s 9
+		IL_01d2: ret
 	} // end of method Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
@@ -2182,7 +2124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b0
+				// Method begins at RVA 0x3144
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2205,7 +2147,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30a5
+			// Method begins at RVA 0x3039
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2234,7 +2176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31b9
+				// Method begins at RVA 0x314d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2259,7 +2201,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30a8
+			// Method begins at RVA 0x303c
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2296,7 +2238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31c2
+				// Method begins at RVA 0x3156
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2320,7 +2262,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30c0
+			// Method begins at RVA 0x3054
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2374,7 +2316,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x31a7
+			// Method begins at RVA 0x313b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2398,7 +2340,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2258
+		// Method begins at RVA 0x2240
 		// Header size: 12
 		// Code size: 152 (0x98)
 		.maxstack 8
@@ -2476,7 +2418,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x31cb
+		// Method begins at RVA 0x315f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_DecompileGeneratorTest
+﻿// IL code: Compile_Scripts_DecompileGeneratorTest
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e0
+				// Method begins at RVA 0x3040
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2244
+			// Method begins at RVA 0x2218
 			// Header size: 12
 			// Code size: 176 (0xb0)
 			.maxstack 8
@@ -128,7 +128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e9
+				// Method begins at RVA 0x3049
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -155,7 +155,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2300
+			// Method begins at RVA 0x22d4
 			// Header size: 12
 			// Code size: 175 (0xaf)
 			.maxstack 8
@@ -257,7 +257,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3104
+					// Method begins at RVA 0x3064
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -281,7 +281,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x306c
+				// Method begins at RVA 0x2fcc
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -319,7 +319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x310d
+					// Method begins at RVA 0x306d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3090
+				// Method begins at RVA 0x2ff0
 				// Header size: 12
 				// Code size: 59 (0x3b)
 				.maxstack 8
@@ -396,7 +396,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30fb
+					// Method begins at RVA 0x305b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -417,7 +417,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30f2
+				// Method begins at RVA 0x3052
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,7 +445,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3128
+						// Method begins at RVA 0x3088
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -463,7 +463,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x311f
+					// Method begins at RVA 0x307f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -481,7 +481,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3116
+				// Method begins at RVA 0x3076
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -509,7 +509,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x23bc
+			// Method begins at RVA 0x2390
 			// Header size: 12
 			// Code size: 616 (0x268)
 			.maxstack 8
@@ -787,7 +787,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x313a
+					// Method begins at RVA 0x309a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -805,7 +805,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3131
+				// Method begins at RVA 0x3091
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -833,9 +833,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x264c
+			// Method begins at RVA 0x2620
 			// Header size: 12
-			// Code size: 352 (0x160)
+			// Code size: 297 (0x129)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -851,172 +851,147 @@
 				[10] bool
 			)
 
-			IL_0000: ldc.i4.1
-			IL_0001: newarr [System.Runtime]System.Object
-			IL_0006: dup
-			IL_0007: ldc.i4.0
-			IL_0008: ldarg.0
-			IL_0009: stelem.ref
-			IL_000a: ldc.i4.0
-			IL_000b: ldelem.ref
-			IL_000c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_0011: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-			IL_0017: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_001c: ldnull
-			IL_001d: ldarg.2
-			IL_001e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0023: stloc.s 8
-			IL_0025: ldloc.s 8
-			IL_0027: brfalse IL_0038
+			IL_0000: ldarg.0
+			IL_0001: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0006: ldnull
+			IL_0007: ldarg.2
+			IL_0008: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+			IL_000d: stloc.s 8
+			IL_000f: ldloc.s 8
+			IL_0011: brfalse IL_0022
 
-			IL_002c: ldloc.s 8
-			IL_002e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0033: brfalse IL_0049
+			IL_0016: ldloc.s 8
+			IL_0018: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_001d: brfalse IL_0033
 
-			IL_0038: ldloc.s 8
-			IL_003a: ldstr ""
-			IL_003f: ldstr "0"
-			IL_0044: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0022: ldloc.s 8
+			IL_0024: ldstr ""
+			IL_0029: ldstr "0"
+			IL_002e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0049: ldloc.s 8
-			IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0050: stloc.0
-			IL_0051: ldc.i4.0
-			IL_0052: stloc.1
-			IL_0053: ldc.i4.0
-			IL_0054: stloc.2
+			IL_0033: ldloc.s 8
+			IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_003a: stloc.0
+			IL_003b: ldc.i4.0
+			IL_003c: stloc.1
+			IL_003d: ldc.i4.0
+			IL_003e: stloc.2
 			.try
 			{
-				IL_0055: ldloc.2
-				IL_0056: brtrue IL_007d
+				IL_003f: ldloc.2
+				IL_0040: brtrue IL_0067
 
-				IL_005b: ldloc.0
-				IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_0061: stloc.s 8
-				IL_0063: ldloc.s 8
-				IL_0065: brfalse IL_007b
+				IL_0045: ldloc.0
+				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_004b: stloc.s 8
+				IL_004d: ldloc.s 8
+				IL_004f: brfalse IL_0065
 
-				IL_006a: ldloc.s 8
-				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_0071: stloc.s 8
-				IL_0073: ldloc.s 8
-				IL_0075: stloc.3
-				IL_0076: br IL_007f
+				IL_0054: ldloc.s 8
+				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_005b: stloc.s 8
+				IL_005d: ldloc.s 8
+				IL_005f: stloc.3
+				IL_0060: br IL_0069
 
-				IL_007b: ldc.i4.1
-				IL_007c: stloc.2
+				IL_0065: ldc.i4.1
+				IL_0066: stloc.2
 
-				IL_007d: ldnull
-				IL_007e: stloc.3
+				IL_0067: ldnull
+				IL_0068: stloc.3
 
-				IL_007f: ldloc.2
-				IL_0080: brtrue IL_00a8
+				IL_0069: ldloc.2
+				IL_006a: brtrue IL_0092
 
-				IL_0085: ldloc.0
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_008b: stloc.s 8
-				IL_008d: ldloc.s 8
-				IL_008f: brfalse IL_00a6
+				IL_006f: ldloc.0
+				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_0075: stloc.s 8
+				IL_0077: ldloc.s 8
+				IL_0079: brfalse IL_0090
 
-				IL_0094: ldloc.s 8
-				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_009b: stloc.s 8
-				IL_009d: ldloc.s 8
-				IL_009f: stloc.s 4
-				IL_00a1: br IL_00ab
+				IL_007e: ldloc.s 8
+				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_0085: stloc.s 8
+				IL_0087: ldloc.s 8
+				IL_0089: stloc.s 4
+				IL_008b: br IL_0095
 
-				IL_00a6: ldc.i4.1
-				IL_00a7: stloc.2
+				IL_0090: ldc.i4.1
+				IL_0091: stloc.2
 
-				IL_00a8: ldnull
-				IL_00a9: stloc.s 4
+				IL_0092: ldnull
+				IL_0093: stloc.s 4
 
-				IL_00ab: ldloc.2
-				IL_00ac: brtrue IL_00b9
+				IL_0095: ldloc.2
+				IL_0096: brtrue IL_00a3
 
-				IL_00b1: ldc.i4.1
-				IL_00b2: stloc.1
-				IL_00b3: ldloc.0
-				IL_00b4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_009b: ldc.i4.1
+				IL_009c: stloc.1
+				IL_009d: ldloc.0
+				IL_009e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_00b9: ldc.i4.1
-				IL_00ba: stloc.1
-				IL_00bb: leave IL_00d3
+				IL_00a3: ldc.i4.1
+				IL_00a4: stloc.1
+				IL_00a5: leave IL_00bd
 			} // end .try
 			finally
 			{
-				IL_00c0: ldloc.1
-				IL_00c1: brtrue IL_00d2
+				IL_00aa: ldloc.1
+				IL_00ab: brtrue IL_00bc
 
-				IL_00c6: ldloc.2
-				IL_00c7: brtrue IL_00d2
+				IL_00b0: ldloc.2
+				IL_00b1: brtrue IL_00bc
 
-				IL_00cc: ldloc.0
-				IL_00cd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_00b6: ldloc.0
+				IL_00b7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00d2: endfinally
+				IL_00bc: endfinally
 			} // end handler
 
-			IL_00d3: ldarg.3
-			IL_00d4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00d9: stloc.s 9
-			IL_00db: ldstr ""
-			IL_00e0: ldloc.s 9
-			IL_00e2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00e7: stloc.s 9
-			IL_00e9: ldloc.s 9
-			IL_00eb: ldstr ".dll"
-			IL_00f0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00f5: stloc.s 9
-			IL_00f7: ldloc.s 9
-			IL_00f9: stloc.s 5
-			IL_00fb: ldc.i4.1
-			IL_00fc: newarr [System.Runtime]System.Object
-			IL_0101: dup
-			IL_0102: ldc.i4.0
-			IL_0103: ldarg.0
-			IL_0104: stelem.ref
-			IL_0105: ldc.i4.0
-			IL_0106: ldelem.ref
-			IL_0107: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_010c: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_0112: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0117: ldnull
-			IL_0118: ldloc.3
-			IL_0119: ldloc.s 5
-			IL_011b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0120: stloc.s 8
-			IL_0122: ldloc.s 8
-			IL_0124: stloc.s 6
-			IL_0126: ldloc.s 6
-			IL_0128: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012d: stloc.s 10
-			IL_012f: ldloc.s 10
-			IL_0131: brfalse IL_0140
+			IL_00bd: ldarg.3
+			IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c3: stloc.s 9
+			IL_00c5: ldstr ""
+			IL_00ca: ldloc.s 9
+			IL_00cc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d1: stloc.s 9
+			IL_00d3: ldloc.s 9
+			IL_00d5: ldstr ".dll"
+			IL_00da: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00df: stloc.s 9
+			IL_00e1: ldloc.s 9
+			IL_00e3: stloc.s 5
+			IL_00e5: ldarg.0
+			IL_00e6: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_00eb: ldnull
+			IL_00ec: ldloc.3
+			IL_00ed: ldloc.s 5
+			IL_00ef: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_00f4: stloc.s 8
+			IL_00f6: ldloc.s 8
+			IL_00f8: stloc.s 6
+			IL_00fa: ldloc.s 6
+			IL_00fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0101: stloc.s 10
+			IL_0103: ldloc.s 10
+			IL_0105: brfalse IL_0114
 
-			IL_0136: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17::.ctor()
-			IL_013b: stloc.s 7
-			IL_013d: ldloc.s 6
-			IL_013f: ret
+			IL_010a: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17::.ctor()
+			IL_010f: stloc.s 7
+			IL_0111: ldloc.s 6
+			IL_0113: ret
 
-			IL_0140: ldc.i4.1
-			IL_0141: newarr [System.Runtime]System.Object
-			IL_0146: dup
-			IL_0147: ldc.i4.0
-			IL_0148: ldarg.0
-			IL_0149: stelem.ref
-			IL_014a: ldc.i4.0
-			IL_014b: ldelem.ref
-			IL_014c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_0151: ldnull
-			IL_0152: ldloc.s 4
-			IL_0154: ldloc.s 5
-			IL_0156: tail.
-			IL_0158: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_015d: ret
+			IL_0114: ldarg.0
+			IL_0115: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_011a: ldnull
+			IL_011b: ldloc.s 4
+			IL_011d: ldloc.s 5
+			IL_011f: tail.
+			IL_0121: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_0126: ret
 
-			IL_015e: ldnull
-			IL_015f: ret
+			IL_0127: ldnull
+			IL_0128: ret
 		} // end of method tryFindLatestGeneratedAssembly::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssembly
@@ -1040,7 +1015,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3155
+						// Method begins at RVA 0x30b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1058,7 +1033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x314c
+					// Method begins at RVA 0x30ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1076,7 +1051,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3143
+				// Method begins at RVA 0x30a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1103,7 +1078,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x27c8
+			// Method begins at RVA 0x2768
 			// Header size: 12
 			// Code size: 400 (0x190)
 			.maxstack 8
@@ -1297,7 +1272,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x315e
+				// Method begins at RVA 0x30be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1324,7 +1299,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2964
+			// Method begins at RVA 0x2904
 			// Header size: 12
 			// Code size: 151 (0x97)
 			.maxstack 8
@@ -1408,7 +1383,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3170
+					// Method begins at RVA 0x30d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1432,7 +1407,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3182
+						// Method begins at RVA 0x30e2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1450,7 +1425,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3179
+					// Method begins at RVA 0x30d9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1470,7 +1445,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x318b
+					// Method begins at RVA 0x30eb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1494,7 +1469,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x319d
+						// Method begins at RVA 0x30fd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1512,7 +1487,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3194
+					// Method begins at RVA 0x30f4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1532,7 +1507,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31a6
+					// Method begins at RVA 0x3106
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1552,7 +1527,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31af
+					// Method begins at RVA 0x310f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1570,7 +1545,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3167
+				// Method begins at RVA 0x30c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1596,9 +1571,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2a08
+			// Method begins at RVA 0x29a8
 			// Header size: 12
-			// Code size: 1608 (0x648)
+			// Code size: 1542 (0x606)
 			.maxstack 9
 			.locals init (
 				[0] object,
@@ -1916,236 +1891,209 @@
 			IL_03b2: stloc.s 22
 			IL_03b4: ldloc.s 22
 			IL_03b6: stloc.s 10
-			IL_03b8: ldc.i4.1
-			IL_03b9: newarr [System.Runtime]System.Object
-			IL_03be: dup
-			IL_03bf: ldc.i4.0
-			IL_03c0: ldarg.0
-			IL_03c1: stelem.ref
-			IL_03c2: ldc.i4.0
-			IL_03c3: ldelem.ref
-			IL_03c4: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_03c9: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_03cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_03d4: ldnull
-			IL_03d5: ldloc.2
-			IL_03d6: ldloc.s 10
-			IL_03d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_03dd: stloc.s 22
-			IL_03df: ldloc.s 22
-			IL_03e1: brfalse IL_03fb
+			IL_03b8: ldarg.0
+			IL_03b9: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_03be: ldnull
+			IL_03bf: ldloc.2
+			IL_03c0: ldloc.s 10
+			IL_03c2: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_03c7: stloc.s 22
+			IL_03c9: ldloc.s 22
+			IL_03cb: brfalse IL_03e5
 
-			IL_03e6: ldloc.s 22
-			IL_03e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03ed: brtrue IL_03fb
+			IL_03d0: ldloc.s 22
+			IL_03d2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03d7: brtrue IL_03e5
 
-			IL_03f2: ldloc.s 22
-			IL_03f4: stloc.s 28
-			IL_03f6: br IL_0403
+			IL_03dc: ldloc.s 22
+			IL_03de: stloc.s 28
+			IL_03e0: br IL_03ed
 
-			IL_03fb: ldc.i4.0
-			IL_03fc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0401: stloc.s 28
+			IL_03e5: ldc.i4.0
+			IL_03e6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03eb: stloc.s 28
 
-			IL_0403: ldloc.s 28
-			IL_0405: stloc.s 11
-			IL_0407: ldloc.s 11
-			IL_0409: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_040e: ldc.i4.0
-			IL_040f: ceq
-			IL_0411: stloc.s 26
-			IL_0413: ldloc.s 26
-			IL_0415: brfalse IL_0547
+			IL_03ed: ldloc.s 28
+			IL_03ef: stloc.s 11
+			IL_03f1: ldloc.s 11
+			IL_03f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03f8: ldc.i4.0
+			IL_03f9: ceq
+			IL_03fb: stloc.s 26
+			IL_03fd: ldloc.s 26
+			IL_03ff: brfalse IL_051b
 
-			IL_041a: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
-			IL_041f: stloc.s 12
-			IL_0421: ldloc.2
-			IL_0422: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0427: stloc.s 24
-			IL_0429: ldstr "Assembly not found for category '"
-			IL_042e: ldloc.s 24
-			IL_0430: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0435: stloc.s 24
+			IL_0404: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
+			IL_0409: stloc.s 12
+			IL_040b: ldloc.2
+			IL_040c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0411: stloc.s 24
+			IL_0413: ldstr "Assembly not found for category '"
+			IL_0418: ldloc.s 24
+			IL_041a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041f: stloc.s 24
+			IL_0421: ldloc.s 24
+			IL_0423: ldstr "' and test '"
+			IL_0428: call string [System.Runtime]System.String::Concat(string, string)
+			IL_042d: stloc.s 24
+			IL_042f: ldloc.3
+			IL_0430: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0435: stloc.s 23
 			IL_0437: ldloc.s 24
-			IL_0439: ldstr "' and test '"
-			IL_043e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0443: stloc.s 24
-			IL_0445: ldloc.3
-			IL_0446: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_044b: stloc.s 23
-			IL_044d: ldloc.s 24
-			IL_044f: ldloc.s 23
-			IL_0451: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0456: stloc.s 23
-			IL_0458: ldloc.s 23
-			IL_045a: ldstr "'."
-			IL_045f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0464: stloc.s 23
-			IL_0466: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_046b: ldloc.s 23
-			IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0472: pop
-			IL_0473: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0478: ldstr "Looked under:"
-			IL_047d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0482: pop
-			IL_0483: ldc.i4.1
-			IL_0484: newarr [System.Runtime]System.Object
-			IL_0489: dup
-			IL_048a: ldc.i4.0
-			IL_048b: ldarg.0
-			IL_048c: stelem.ref
-			IL_048d: ldc.i4.0
-			IL_048e: ldelem.ref
-			IL_048f: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_0494: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-			IL_049a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_049f: ldnull
-			IL_04a0: ldloc.2
-			IL_04a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_04a6: stloc.s 22
-			IL_04a8: ldloc.s 22
-			IL_04aa: stloc.s 13
-			IL_04ac: ldc.r8 0.0
-			IL_04b5: stloc.s 14
-			// loop start (head: IL_04b7)
-				IL_04b7: ldloc.s 14
-				IL_04b9: ldloc.s 13
-				IL_04bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_04c0: clt
-				IL_04c2: brfalse IL_0510
+			IL_0439: ldloc.s 23
+			IL_043b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0440: stloc.s 23
+			IL_0442: ldloc.s 23
+			IL_0444: ldstr "'."
+			IL_0449: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044e: stloc.s 23
+			IL_0450: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0455: ldloc.s 23
+			IL_0457: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_045c: pop
+			IL_045d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0462: ldstr "Looked under:"
+			IL_0467: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_046c: pop
+			IL_046d: ldarg.0
+			IL_046e: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0473: ldnull
+			IL_0474: ldloc.2
+			IL_0475: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+			IL_047a: stloc.s 22
+			IL_047c: ldloc.s 22
+			IL_047e: stloc.s 13
+			IL_0480: ldc.r8 0.0
+			IL_0489: stloc.s 14
+			// loop start (head: IL_048b)
+				IL_048b: ldloc.s 14
+				IL_048d: ldloc.s 13
+				IL_048f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_0494: clt
+				IL_0496: brfalse IL_04e4
 
-				IL_04c7: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
-				IL_04cc: stloc.s 15
-				IL_04ce: ldloc.s 13
-				IL_04d0: ldloc.s 14
-				IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_04d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_04dc: stloc.s 23
-				IL_04de: ldstr "  - "
-				IL_04e3: ldloc.s 23
-				IL_04e5: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04ea: stloc.s 23
-				IL_04ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_04f1: ldloc.s 23
-				IL_04f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_04f8: pop
-				IL_04f9: ldloc.s 14
-				IL_04fb: ldc.r8 1
-				IL_0504: add
-				IL_0505: stloc.s 29
-				IL_0507: ldloc.s 29
-				IL_0509: stloc.s 14
-				IL_050b: br IL_04b7
+				IL_049b: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
+				IL_04a0: stloc.s 15
+				IL_04a2: ldloc.s 13
+				IL_04a4: ldloc.s 14
+				IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_04ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_04b0: stloc.s 23
+				IL_04b2: ldstr "  - "
+				IL_04b7: ldloc.s 23
+				IL_04b9: call string [System.Runtime]System.String::Concat(string, string)
+				IL_04be: stloc.s 23
+				IL_04c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_04c5: ldloc.s 23
+				IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_04cc: pop
+				IL_04cd: ldloc.s 14
+				IL_04cf: ldc.r8 1
+				IL_04d8: add
+				IL_04d9: stloc.s 29
+				IL_04db: ldloc.s 29
+				IL_04dd: stloc.s 14
+				IL_04df: br IL_048b
 			// end loop
 
-			IL_0510: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0515: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_051a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_051f: pop
-			IL_0520: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_052a: stloc.s 22
-			IL_052c: ldloc.s 22
-			IL_052e: ldstr "exit"
-			IL_0533: ldc.r8 1
-			IL_053c: box [System.Runtime]System.Double
-			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0546: pop
+			IL_04e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04e9: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_04ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_04f3: pop
+			IL_04f4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04fe: stloc.s 22
+			IL_0500: ldloc.s 22
+			IL_0502: ldstr "exit"
+			IL_0507: ldc.r8 1
+			IL_0510: box [System.Runtime]System.Double
+			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_051a: pop
 
-			IL_0547: ldloc.s 11
-			IL_0549: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_054e: stloc.s 23
-			IL_0550: ldstr "Found assembly: "
-			IL_0555: ldloc.s 23
-			IL_0557: call string [System.Runtime]System.String::Concat(string, string)
-			IL_055c: stloc.s 23
-			IL_055e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0563: ldloc.s 23
-			IL_0565: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_056a: pop
+			IL_051b: ldloc.s 11
+			IL_051d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0522: stloc.s 23
+			IL_0524: ldstr "Found assembly: "
+			IL_0529: ldloc.s 23
+			IL_052b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0530: stloc.s 23
+			IL_0532: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0537: ldloc.s 23
+			IL_0539: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_053e: pop
 			.try
 			{
-				IL_056b: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
-				IL_0570: stloc.s 16
-				IL_0572: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0577: ldstr "Opening in ILSpy..."
-				IL_057c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0581: pop
-				IL_0582: ldc.i4.1
-				IL_0583: newarr [System.Runtime]System.Object
-				IL_0588: dup
-				IL_0589: ldc.i4.0
-				IL_058a: ldarg.0
-				IL_058b: stelem.ref
-				IL_058c: ldc.i4.0
-				IL_058d: ldelem.ref
-				IL_058e: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-				IL_0593: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-				IL_0599: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-				IL_059e: ldnull
-				IL_059f: ldloc.s 11
-				IL_05a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-				IL_05a6: pop
-				IL_05a7: leave IL_0632
+				IL_053f: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
+				IL_0544: stloc.s 16
+				IL_0546: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_054b: ldstr "Opening in ILSpy..."
+				IL_0550: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0555: pop
+				IL_0556: ldarg.0
+				IL_0557: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+				IL_055c: ldnull
+				IL_055d: ldloc.s 11
+				IL_055f: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0564: pop
+				IL_0565: leave IL_05f0
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_05ac: stloc.s 17
-				IL_05ae: ldloc.s 17
-				IL_05b0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_05b5: dup
-				IL_05b6: brtrue IL_05cc
+				IL_056a: stloc.s 17
+				IL_056c: ldloc.s 17
+				IL_056e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0573: dup
+				IL_0574: brtrue IL_058a
 
-				IL_05bb: pop
-				IL_05bc: ldloc.s 17
-				IL_05be: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_05c3: dup
-				IL_05c4: brtrue IL_05d8
+				IL_0579: pop
+				IL_057a: ldloc.s 17
+				IL_057c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0581: dup
+				IL_0582: brtrue IL_0596
 
-				IL_05c9: pop
-				IL_05ca: rethrow
+				IL_0587: pop
+				IL_0588: rethrow
 
-				IL_05cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_05d1: stloc.s 18
-				IL_05d3: br IL_05da
+				IL_058a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_058f: stloc.s 18
+				IL_0591: br IL_0598
 
-				IL_05d8: stloc.s 18
+				IL_0596: stloc.s 18
 
-				IL_05da: ldloc.s 18
-				IL_05dc: stloc.s 22
-				IL_05de: ldloc.s 22
-				IL_05e0: stloc.s 19
-				IL_05e2: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
-				IL_05e7: stloc.s 20
-				IL_05e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_05ee: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_05f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_05f8: pop
-				IL_05f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_05fe: ldloc.s 19
-				IL_0600: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_0605: pop
-				IL_0606: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-				IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0610: stloc.s 22
-				IL_0612: ldloc.s 22
-				IL_0614: ldstr "exit"
-				IL_0619: ldc.r8 1
-				IL_0622: box [System.Runtime]System.Double
-				IL_0627: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_062c: pop
-				IL_062d: leave IL_0632
+				IL_0598: ldloc.s 18
+				IL_059a: stloc.s 22
+				IL_059c: ldloc.s 22
+				IL_059e: stloc.s 19
+				IL_05a0: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
+				IL_05a5: stloc.s 20
+				IL_05a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05ac: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_05b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05b6: pop
+				IL_05b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05bc: ldloc.s 19
+				IL_05be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05c3: pop
+				IL_05c4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+				IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_05ce: stloc.s 22
+				IL_05d0: ldloc.s 22
+				IL_05d2: ldstr "exit"
+				IL_05d7: ldc.r8 1
+				IL_05e0: box [System.Runtime]System.Double
+				IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_05ea: pop
+				IL_05eb: leave IL_05f0
 			} // end handler
 
-			IL_0632: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0637: ldstr "Done!"
-			IL_063c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0641: pop
-			IL_0642: ldnull
-			IL_0643: stloc.s 21
-			IL_0645: ldloc.s 21
-			IL_0647: ret
+			IL_05f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05f5: ldstr "Done!"
+			IL_05fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05ff: pop
+			IL_0600: ldnull
+			IL_0601: stloc.s 21
+			IL_0603: ldloc.s 21
+			IL_0605: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2194,7 +2142,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x30d7
+			// Method begins at RVA 0x3037
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2220,7 +2168,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 486 (0x1e6)
+		// Code size: 442 (0x1ba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_DecompileGeneratorTest/Scope,
@@ -2396,39 +2344,21 @@
 		IL_018f: ldloc.0
 		IL_0190: ldloc.3
 		IL_0191: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-		IL_0196: ldc.i4.1
-		IL_0197: newarr [System.Runtime]System.Object
-		IL_019c: dup
-		IL_019d: ldc.i4.0
-		IL_019e: ldloc.0
-		IL_019f: stelem.ref
-		IL_01a0: ldc.i4.0
-		IL_01a1: ldelem.ref
-		IL_01a2: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_01a7: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_01ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0196: ldloc.0
+		IL_0197: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+		IL_019c: ldnull
+		IL_019d: ldarg.s __dirname
+		IL_019f: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+		IL_01a4: stloc.3
+		IL_01a5: ldloc.0
+		IL_01a6: ldloc.3
+		IL_01a7: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+		IL_01ac: ldloc.0
+		IL_01ad: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
 		IL_01b2: ldnull
-		IL_01b3: ldarg.s __dirname
-		IL_01b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_01ba: stloc.3
-		IL_01bb: ldloc.0
-		IL_01bc: ldloc.3
-		IL_01bd: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-		IL_01c2: ldc.i4.1
-		IL_01c3: newarr [System.Runtime]System.Object
-		IL_01c8: dup
-		IL_01c9: ldc.i4.0
-		IL_01ca: ldloc.0
-		IL_01cb: stelem.ref
-		IL_01cc: ldc.i4.0
-		IL_01cd: ldelem.ref
-		IL_01ce: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_01d3: ldftn object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
-		IL_01d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01de: ldnull
-		IL_01df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_01e4: pop
-		IL_01e5: ret
+		IL_01b3: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
+		IL_01b8: pop
+		IL_01b9: ret
 	} // end of method Compile_Scripts_DecompileGeneratorTest::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_DecompileGeneratorTest
@@ -2440,7 +2370,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x31b8
+		// Method begins at RVA 0x3118
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+﻿// IL code: Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45a7
+				// Method begins at RVA 0x44f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -192,7 +192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45b0
+				// Method begins at RVA 0x44fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -324,7 +324,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x459e
+			// Method begins at RVA 0x44ea
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -442,7 +442,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45cb
+					// Method begins at RVA 0x4517
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -460,7 +460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45c2
+				// Method begins at RVA 0x450e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -612,7 +612,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45d4
+				// Method begins at RVA 0x4520
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -640,7 +640,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ef
+						// Method begins at RVA 0x453b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -660,7 +660,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45f8
+						// Method begins at RVA 0x4544
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -680,7 +680,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4601
+						// Method begins at RVA 0x454d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -700,7 +700,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x460a
+						// Method begins at RVA 0x4556
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -720,7 +720,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4613
+						// Method begins at RVA 0x455f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -740,7 +740,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x461c
+						// Method begins at RVA 0x4568
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -758,7 +758,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45e6
+					// Method begins at RVA 0x4532
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +776,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45dd
+				// Method begins at RVA 0x4529
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1130,7 +1130,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x466d
+							// Method begins at RVA 0x45b9
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1155,7 +1155,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4520
+						// Method begins at RVA 0x446c
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1194,7 +1194,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4676
+							// Method begins at RVA 0x45c2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1218,7 +1218,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4550
+						// Method begins at RVA 0x449c
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1291,7 +1291,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x465b
+								// Method begins at RVA 0x45a7
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1309,7 +1309,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4652
+							// Method begins at RVA 0x459e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1329,7 +1329,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4664
+							// Method begins at RVA 0x45b0
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1351,7 +1351,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4649
+						// Method begins at RVA 0x4595
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1376,9 +1376,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x409c
+					// Method begins at RVA 0x4000
 					// Header size: 12
-					// Code size: 1141 (0x475)
+					// Code size: 1119 (0x45f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1482,7 +1482,7 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 8
 					IL_00d6: ldloc.s 8
-					IL_00d8: brfalse IL_0274
+					IL_00d8: brfalse IL_025e
 
 					IL_00dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00e2: stloc.3
@@ -1608,262 +1608,253 @@
 					IL_020c: sub
 					IL_020d: box [System.Runtime]System.Double
 					IL_0212: stloc.s 19
-					IL_0214: ldc.i4.1
-					IL_0215: newarr [System.Runtime]System.Object
-					IL_021a: dup
-					IL_021b: ldc.i4.0
-					IL_021c: ldarg.0
-					IL_021d: ldc.i4.0
-					IL_021e: ldelem.ref
-					IL_021f: stelem.ref
-					IL_0220: ldc.i4.0
-					IL_0221: ldelem.ref
-					IL_0222: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0227: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-					IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-					IL_0232: ldnull
-					IL_0233: ldloc.s 5
-					IL_0235: ldloc.s 19
-					IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-					IL_023c: stloc.s 18
-					IL_023e: ldloc.s 18
-					IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0245: stloc.s 18
-					IL_0247: ldarg.0
-					IL_0248: ldc.i4.2
-					IL_0249: ldelem.ref
-					IL_024a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_024f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_0254: stloc.s 7
-					IL_0256: ldloc.s 18
-					IL_0258: ldstr "then"
-					IL_025d: ldloc.s 7
-					IL_025f: ldarg.0
-					IL_0260: ldc.i4.2
-					IL_0261: ldelem.ref
-					IL_0262: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0267: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0271: pop
-					IL_0272: ldnull
-					IL_0273: ret
+					IL_0214: ldarg.0
+					IL_0215: ldc.i4.0
+					IL_0216: ldelem.ref
+					IL_0217: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_021c: ldnull
+					IL_021d: ldloc.s 5
+					IL_021f: ldloc.s 19
+					IL_0221: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_0226: stloc.s 18
+					IL_0228: ldloc.s 18
+					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_022f: stloc.s 18
+					IL_0231: ldarg.0
+					IL_0232: ldc.i4.2
+					IL_0233: ldelem.ref
+					IL_0234: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0239: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_023e: stloc.s 7
+					IL_0240: ldloc.s 18
+					IL_0242: ldstr "then"
+					IL_0247: ldloc.s 7
+					IL_0249: ldarg.0
+					IL_024a: ldc.i4.2
+					IL_024b: ldelem.ref
+					IL_024c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0251: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_025b: pop
+					IL_025c: ldnull
+					IL_025d: ret
 
-					IL_0274: ldloc.1
-					IL_0275: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_027a: stloc.s 11
-					IL_027c: ldloc.s 11
-					IL_027e: ldc.r8 200
-					IL_0287: clt
-					IL_0289: stloc.s 8
-					IL_028b: ldloc.s 8
-					IL_028d: box [System.Runtime]System.Boolean
-					IL_0292: stloc.s 12
-					IL_0294: ldloc.s 12
-					IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_029b: stloc.s 8
-					IL_029d: ldloc.s 8
-					IL_029f: brtrue IL_02d0
+					IL_025e: ldloc.1
+					IL_025f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0264: stloc.s 11
+					IL_0266: ldloc.s 11
+					IL_0268: ldc.r8 200
+					IL_0271: clt
+					IL_0273: stloc.s 8
+					IL_0275: ldloc.s 8
+					IL_0277: box [System.Runtime]System.Boolean
+					IL_027c: stloc.s 12
+					IL_027e: ldloc.s 12
+					IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0285: stloc.s 8
+					IL_0287: ldloc.s 8
+					IL_0289: brtrue IL_02ba
 
-					IL_02a4: ldloc.1
-					IL_02a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02aa: stloc.s 11
-					IL_02ac: ldloc.s 11
-					IL_02ae: ldc.r8 300
-					IL_02b7: clt
-					IL_02b9: ldc.i4.0
-					IL_02ba: ceq
-					IL_02bc: stloc.s 8
-					IL_02be: ldloc.s 8
-					IL_02c0: box [System.Runtime]System.Boolean
-					IL_02c5: stloc.s 13
-					IL_02c7: ldloc.s 13
-					IL_02c9: stloc.s 20
-					IL_02cb: br IL_02d4
+					IL_028e: ldloc.1
+					IL_028f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0294: stloc.s 11
+					IL_0296: ldloc.s 11
+					IL_0298: ldc.r8 300
+					IL_02a1: clt
+					IL_02a3: ldc.i4.0
+					IL_02a4: ceq
+					IL_02a6: stloc.s 8
+					IL_02a8: ldloc.s 8
+					IL_02aa: box [System.Runtime]System.Boolean
+					IL_02af: stloc.s 13
+					IL_02b1: ldloc.s 13
+					IL_02b3: stloc.s 20
+					IL_02b5: br IL_02be
 
-					IL_02d0: ldloc.s 12
-					IL_02d2: stloc.s 20
+					IL_02ba: ldloc.s 12
+					IL_02bc: stloc.s 20
 
-					IL_02d4: ldloc.s 20
-					IL_02d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02db: stloc.s 8
-					IL_02dd: ldloc.s 8
-					IL_02df: brfalse IL_0388
+					IL_02be: ldloc.s 20
+					IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02c5: stloc.s 8
+					IL_02c7: ldloc.s 8
+					IL_02c9: brfalse IL_0372
 
-					IL_02e4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_02e9: stloc.s 6
-					IL_02eb: ldarg.2
-					IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02f1: stloc.s 7
-					IL_02f3: ldloc.s 7
-					IL_02f5: ldstr "resume"
-					IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02ff: pop
-					IL_0300: ldarg.0
-					IL_0301: ldc.i4.2
-					IL_0302: ldelem.ref
-					IL_0303: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0308: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_030d: stloc.s 7
-					IL_030f: ldc.i4.3
-					IL_0310: newarr [System.Runtime]System.Object
-					IL_0315: dup
-					IL_0316: ldc.i4.0
-					IL_0317: ldarg.0
-					IL_0318: ldc.i4.0
-					IL_0319: ldelem.ref
-					IL_031a: stelem.ref
-					IL_031b: dup
-					IL_031c: ldc.i4.1
-					IL_031d: ldarg.0
-					IL_031e: ldc.i4.1
-					IL_031f: ldelem.ref
-					IL_0320: stelem.ref
-					IL_0321: dup
-					IL_0322: ldc.i4.2
-					IL_0323: ldarg.0
-					IL_0324: ldc.i4.2
-					IL_0325: ldelem.ref
-					IL_0326: stelem.ref
-					IL_0327: stloc.s 16
-					IL_0329: ldloc.1
-					IL_032a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_032f: stloc.s 17
-					IL_0331: ldstr "HTTP "
-					IL_0336: ldloc.s 17
-					IL_0338: call string [System.Runtime]System.String::Concat(string, string)
-					IL_033d: stloc.s 17
-					IL_033f: ldloc.s 17
-					IL_0341: ldstr " fetching "
-					IL_0346: call string [System.Runtime]System.String::Concat(string, string)
-					IL_034b: stloc.s 17
-					IL_034d: ldarg.0
-					IL_034e: ldc.i4.1
-					IL_034f: ldelem.ref
-					IL_0350: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0355: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_035a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_035f: stloc.s 21
-					IL_0361: ldloc.s 17
-					IL_0363: ldloc.s 21
-					IL_0365: call string [System.Runtime]System.String::Concat(string, string)
-					IL_036a: stloc.s 21
-					IL_036c: ldloc.s 21
-					IL_036e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0373: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_02ce: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_02d3: stloc.s 6
+					IL_02d5: ldarg.2
+					IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02db: stloc.s 7
+					IL_02dd: ldloc.s 7
+					IL_02df: ldstr "resume"
+					IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02e9: pop
+					IL_02ea: ldarg.0
+					IL_02eb: ldc.i4.2
+					IL_02ec: ldelem.ref
+					IL_02ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02f2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02f7: stloc.s 7
+					IL_02f9: ldc.i4.3
+					IL_02fa: newarr [System.Runtime]System.Object
+					IL_02ff: dup
+					IL_0300: ldc.i4.0
+					IL_0301: ldarg.0
+					IL_0302: ldc.i4.0
+					IL_0303: ldelem.ref
+					IL_0304: stelem.ref
+					IL_0305: dup
+					IL_0306: ldc.i4.1
+					IL_0307: ldarg.0
+					IL_0308: ldc.i4.1
+					IL_0309: ldelem.ref
+					IL_030a: stelem.ref
+					IL_030b: dup
+					IL_030c: ldc.i4.2
+					IL_030d: ldarg.0
+					IL_030e: ldc.i4.2
+					IL_030f: ldelem.ref
+					IL_0310: stelem.ref
+					IL_0311: stloc.s 16
+					IL_0313: ldloc.1
+					IL_0314: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0319: stloc.s 17
+					IL_031b: ldstr "HTTP "
+					IL_0320: ldloc.s 17
+					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0327: stloc.s 17
+					IL_0329: ldloc.s 17
+					IL_032b: ldstr " fetching "
+					IL_0330: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0335: stloc.s 17
+					IL_0337: ldarg.0
+					IL_0338: ldc.i4.1
+					IL_0339: ldelem.ref
+					IL_033a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_033f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0344: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0349: stloc.s 21
+					IL_034b: ldloc.s 17
+					IL_034d: ldloc.s 21
+					IL_034f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0354: stloc.s 21
+					IL_0356: ldloc.s 21
+					IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0362: stloc.s 18
+					IL_0364: ldloc.s 7
+					IL_0366: ldloc.s 16
+					IL_0368: ldloc.s 18
+					IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_036f: pop
+					IL_0370: ldnull
+					IL_0371: ret
+
+					IL_0372: ldarg.2
+					IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0378: stloc.s 18
-					IL_037a: ldloc.s 7
-					IL_037c: ldloc.s 16
-					IL_037e: ldloc.s 18
-					IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0385: pop
-					IL_0386: ldnull
-					IL_0387: ret
-
-					IL_0388: ldarg.2
-					IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_038e: stloc.s 18
-					IL_0390: ldloc.s 18
-					IL_0392: ldstr "setEncoding"
-					IL_0397: ldstr "utf8"
-					IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_03a1: pop
-					IL_03a2: ldloc.0
-					IL_03a3: ldstr ""
-					IL_03a8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_03ad: ldarg.2
-					IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03b3: stloc.s 18
-					IL_03b5: ldnull
-					IL_03b6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_03bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_03c1: ldc.i4.4
-					IL_03c2: newarr [System.Runtime]System.Object
-					IL_03c7: dup
-					IL_03c8: ldc.i4.0
-					IL_03c9: ldarg.0
-					IL_03ca: ldc.i4.0
-					IL_03cb: ldelem.ref
-					IL_03cc: stelem.ref
-					IL_03cd: dup
-					IL_03ce: ldc.i4.1
-					IL_03cf: ldarg.0
-					IL_03d0: ldc.i4.1
-					IL_03d1: ldelem.ref
-					IL_03d2: stelem.ref
-					IL_03d3: dup
-					IL_03d4: ldc.i4.2
-					IL_03d5: ldarg.0
-					IL_03d6: ldc.i4.2
-					IL_03d7: ldelem.ref
-					IL_03d8: stelem.ref
-					IL_03d9: dup
-					IL_03da: ldc.i4.3
-					IL_03db: ldloc.0
-					IL_03dc: stelem.ref
-					IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03e7: ldc.i4.1
-					IL_03e8: conv.r8
-					IL_03e9: ldstr ""
-					IL_03ee: ldc.i4.0
-					IL_03ef: ldc.i4.1
-					IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_03fa: stloc.s 7
-					IL_03fc: ldloc.s 18
-					IL_03fe: ldstr "on"
-					IL_0403: ldstr "data"
-					IL_0408: ldloc.s 7
-					IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_040f: pop
-					IL_0410: ldarg.2
-					IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0416: stloc.s 7
-					IL_0418: ldnull
-					IL_0419: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_041f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0424: ldc.i4.4
-					IL_0425: newarr [System.Runtime]System.Object
-					IL_042a: dup
-					IL_042b: ldc.i4.0
-					IL_042c: ldarg.0
-					IL_042d: ldc.i4.0
-					IL_042e: ldelem.ref
-					IL_042f: stelem.ref
-					IL_0430: dup
-					IL_0431: ldc.i4.1
-					IL_0432: ldarg.0
-					IL_0433: ldc.i4.1
-					IL_0434: ldelem.ref
-					IL_0435: stelem.ref
-					IL_0436: dup
-					IL_0437: ldc.i4.2
-					IL_0438: ldarg.0
-					IL_0439: ldc.i4.2
-					IL_043a: ldelem.ref
-					IL_043b: stelem.ref
-					IL_043c: dup
-					IL_043d: ldc.i4.3
-					IL_043e: ldloc.0
-					IL_043f: stelem.ref
-					IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_044a: ldc.i4.0
-					IL_044b: conv.r8
-					IL_044c: ldstr ""
-					IL_0451: ldc.i4.0
-					IL_0452: ldc.i4.1
-					IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_045d: stloc.s 18
-					IL_045f: ldloc.s 7
-					IL_0461: ldstr "on"
-					IL_0466: ldstr "end"
-					IL_046b: ldloc.s 18
-					IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0472: pop
-					IL_0473: ldnull
-					IL_0474: ret
+					IL_037a: ldloc.s 18
+					IL_037c: ldstr "setEncoding"
+					IL_0381: ldstr "utf8"
+					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_038b: pop
+					IL_038c: ldloc.0
+					IL_038d: ldstr ""
+					IL_0392: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_0397: ldarg.2
+					IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_039d: stloc.s 18
+					IL_039f: ldnull
+					IL_03a0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03ab: ldc.i4.4
+					IL_03ac: newarr [System.Runtime]System.Object
+					IL_03b1: dup
+					IL_03b2: ldc.i4.0
+					IL_03b3: ldarg.0
+					IL_03b4: ldc.i4.0
+					IL_03b5: ldelem.ref
+					IL_03b6: stelem.ref
+					IL_03b7: dup
+					IL_03b8: ldc.i4.1
+					IL_03b9: ldarg.0
+					IL_03ba: ldc.i4.1
+					IL_03bb: ldelem.ref
+					IL_03bc: stelem.ref
+					IL_03bd: dup
+					IL_03be: ldc.i4.2
+					IL_03bf: ldarg.0
+					IL_03c0: ldc.i4.2
+					IL_03c1: ldelem.ref
+					IL_03c2: stelem.ref
+					IL_03c3: dup
+					IL_03c4: ldc.i4.3
+					IL_03c5: ldloc.0
+					IL_03c6: stelem.ref
+					IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03d1: ldc.i4.1
+					IL_03d2: conv.r8
+					IL_03d3: ldstr ""
+					IL_03d8: ldc.i4.0
+					IL_03d9: ldc.i4.1
+					IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_03e4: stloc.s 7
+					IL_03e6: ldloc.s 18
+					IL_03e8: ldstr "on"
+					IL_03ed: ldstr "data"
+					IL_03f2: ldloc.s 7
+					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03f9: pop
+					IL_03fa: ldarg.2
+					IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0400: stloc.s 7
+					IL_0402: ldnull
+					IL_0403: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0409: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_040e: ldc.i4.4
+					IL_040f: newarr [System.Runtime]System.Object
+					IL_0414: dup
+					IL_0415: ldc.i4.0
+					IL_0416: ldarg.0
+					IL_0417: ldc.i4.0
+					IL_0418: ldelem.ref
+					IL_0419: stelem.ref
+					IL_041a: dup
+					IL_041b: ldc.i4.1
+					IL_041c: ldarg.0
+					IL_041d: ldc.i4.1
+					IL_041e: ldelem.ref
+					IL_041f: stelem.ref
+					IL_0420: dup
+					IL_0421: ldc.i4.2
+					IL_0422: ldarg.0
+					IL_0423: ldc.i4.2
+					IL_0424: ldelem.ref
+					IL_0425: stelem.ref
+					IL_0426: dup
+					IL_0427: ldc.i4.3
+					IL_0428: ldloc.0
+					IL_0429: stelem.ref
+					IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0434: ldc.i4.0
+					IL_0435: conv.r8
+					IL_0436: ldstr ""
+					IL_043b: ldc.i4.0
+					IL_043c: ldc.i4.1
+					IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0447: stloc.s 18
+					IL_0449: ldloc.s 7
+					IL_044b: ldstr "on"
+					IL_0450: ldstr "end"
+					IL_0455: ldloc.s 18
+					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_045c: pop
+					IL_045d: ldnull
+					IL_045e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1885,7 +1876,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4637
+						// Method begins at RVA 0x4583
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1905,7 +1896,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4640
+						// Method begins at RVA 0x458c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1928,7 +1919,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x462e
+					// Method begins at RVA 0x457a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1954,7 +1945,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e80
+				// Method begins at RVA 0x3de4
 				// Header size: 12
 				// Code size: 512 (0x200)
 				.maxstack 8
@@ -2199,7 +2190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4625
+				// Method begins at RVA 0x4571
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2295,7 +2286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x467f
+				// Method begins at RVA 0x45cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2362,7 +2353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4691
+					// Method begins at RVA 0x45dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2386,7 +2377,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a3
+						// Method begins at RVA 0x45ef
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2404,7 +2395,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x469a
+					// Method begins at RVA 0x45e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2422,7 +2413,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4688
+				// Method begins at RVA 0x45d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2696,7 +2687,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46b5
+					// Method begins at RVA 0x4601
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2716,7 +2707,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46be
+					// Method begins at RVA 0x460a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2736,7 +2727,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46c7
+					// Method begins at RVA 0x4613
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2756,7 +2747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d0
+					// Method begins at RVA 0x461c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2780,7 +2771,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46e2
+						// Method begins at RVA 0x462e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2800,7 +2791,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46eb
+						// Method begins at RVA 0x4637
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2824,7 +2815,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46fd
+							// Method begins at RVA 0x4649
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2842,7 +2833,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46f4
+						// Method begins at RVA 0x4640
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2862,7 +2853,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4706
+						// Method begins at RVA 0x4652
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2880,7 +2871,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d9
+					// Method begins at RVA 0x4625
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2898,7 +2889,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46ac
+				// Method begins at RVA 0x45f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2928,7 +2919,7 @@
 			)
 			// Method begins at RVA 0x2c24
 			// Header size: 12
-			// Code size: 1118 (0x45e)
+			// Code size: 1096 (0x448)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3110,250 +3101,241 @@
 
 			IL_019e: throw
 
-			IL_019f: ldc.i4.1
-			IL_01a0: newarr [System.Runtime]System.Object
-			IL_01a5: dup
-			IL_01a6: ldc.i4.0
-			IL_01a7: ldarg.0
-			IL_01a8: stelem.ref
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldelem.ref
-			IL_01ab: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_01b0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_01bb: ldnull
-			IL_01bc: ldarg.2
-			IL_01bd: ldloc.s 6
-			IL_01bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_01c4: stloc.s 25
-			IL_01c6: ldloc.s 25
-			IL_01c8: stloc.s 9
-			IL_01ca: ldloc.s 9
-			IL_01cc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01d1: ldc.i4.0
-			IL_01d2: ceq
-			IL_01d4: stloc.s 27
-			IL_01d6: ldloc.s 27
-			IL_01d8: brfalse IL_0231
+			IL_019f: ldarg.0
+			IL_01a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_01a5: ldnull
+			IL_01a6: ldarg.2
+			IL_01a7: ldloc.s 6
+			IL_01a9: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_01ae: stloc.s 25
+			IL_01b0: ldloc.s 25
+			IL_01b2: stloc.s 9
+			IL_01b4: ldloc.s 9
+			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01bb: ldc.i4.0
+			IL_01bc: ceq
+			IL_01be: stloc.s 27
+			IL_01c0: ldloc.s 27
+			IL_01c2: brfalse IL_021b
 
-			IL_01dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
-			IL_01e2: stloc.s 10
-			IL_01e4: ldarg.3
-			IL_01e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ea: stloc.s 24
-			IL_01ec: ldstr "Could not determine tag name for id '"
-			IL_01f1: ldloc.s 24
-			IL_01f3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f8: stloc.s 24
-			IL_01fa: ldloc.s 24
-			IL_01fc: ldstr "'."
-			IL_0201: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0206: stloc.s 24
-			IL_0208: ldloc.s 24
-			IL_020a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_020f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0214: stloc.s 25
-			IL_0216: ldloc.s 25
-			IL_0218: stloc.s 11
-			IL_021a: ldloc.s 11
-			IL_021c: isinst [System.Runtime]System.Exception
-			IL_0221: dup
-			IL_0222: brtrue IL_0230
+			IL_01c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
+			IL_01cc: stloc.s 10
+			IL_01ce: ldarg.3
+			IL_01cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d4: stloc.s 24
+			IL_01d6: ldstr "Could not determine tag name for id '"
+			IL_01db: ldloc.s 24
+			IL_01dd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e2: stloc.s 24
+			IL_01e4: ldloc.s 24
+			IL_01e6: ldstr "'."
+			IL_01eb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f0: stloc.s 24
+			IL_01f2: ldloc.s 24
+			IL_01f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01fe: stloc.s 25
+			IL_0200: ldloc.s 25
+			IL_0202: stloc.s 11
+			IL_0204: ldloc.s 11
+			IL_0206: isinst [System.Runtime]System.Exception
+			IL_020b: dup
+			IL_020c: brtrue IL_021a
 
-			IL_0227: pop
-			IL_0228: ldloc.s 11
-			IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_022f: throw
+			IL_0211: pop
+			IL_0212: ldloc.s 11
+			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0219: throw
 
-			IL_0230: throw
+			IL_021a: throw
 
-			IL_0231: ldnull
-			IL_0232: ldloc.s 9
-			IL_0234: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-			IL_0239: stloc.s 25
-			IL_023b: ldloc.s 25
-			IL_023d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0242: stloc.s 24
-			IL_0244: ldstr "<\\/?"
-			IL_0249: ldloc.s 24
-			IL_024b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0250: stloc.s 24
-			IL_0252: ldloc.s 24
-			IL_0254: ldstr "\\b[^>]*>"
-			IL_0259: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025e: stloc.s 24
-			IL_0260: ldloc.s 24
-			IL_0262: ldstr "gi"
-			IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_026c: stloc.s 28
-			IL_026e: ldloc.s 28
-			IL_0270: stloc.s 12
-			IL_0272: ldloc.s 12
-			IL_0274: ldstr "lastIndex"
-			IL_0279: ldloc.s 6
-			IL_027b: ldc.i4.1
-			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0281: pop
-			IL_0282: ldc.r8 0.0
-			IL_028b: stloc.s 13
-			IL_028d: ldc.r8 1
-			IL_0296: neg
-			IL_0297: box [System.Runtime]System.Double
-			IL_029c: stloc.s 14
-			// loop start (head: IL_029e)
-				IL_029e: ldc.i4.1
-				IL_029f: brfalse IL_03ed
+			IL_021b: ldnull
+			IL_021c: ldloc.s 9
+			IL_021e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_0223: stloc.s 25
+			IL_0225: ldloc.s 25
+			IL_0227: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_022c: stloc.s 24
+			IL_022e: ldstr "<\\/?"
+			IL_0233: ldloc.s 24
+			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
+			IL_023a: stloc.s 24
+			IL_023c: ldloc.s 24
+			IL_023e: ldstr "\\b[^>]*>"
+			IL_0243: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0248: stloc.s 24
+			IL_024a: ldloc.s 24
+			IL_024c: ldstr "gi"
+			IL_0251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0256: stloc.s 28
+			IL_0258: ldloc.s 28
+			IL_025a: stloc.s 12
+			IL_025c: ldloc.s 12
+			IL_025e: ldstr "lastIndex"
+			IL_0263: ldloc.s 6
+			IL_0265: ldc.i4.1
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_026b: pop
+			IL_026c: ldc.r8 0.0
+			IL_0275: stloc.s 13
+			IL_0277: ldc.r8 1
+			IL_0280: neg
+			IL_0281: box [System.Runtime]System.Double
+			IL_0286: stloc.s 14
+			// loop start (head: IL_0288)
+				IL_0288: ldc.i4.1
+				IL_0289: brfalse IL_03d7
 
-				IL_02a4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_02a9: stloc.s 15
-				IL_02ab: ldloc.s 12
-				IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02b2: stloc.s 25
-				IL_02b4: ldloc.s 25
-				IL_02b6: ldstr "exec"
-				IL_02bb: ldarg.2
-				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02c1: stloc.s 25
-				IL_02c3: ldloc.s 25
-				IL_02c5: stloc.s 16
-				IL_02c7: ldloc.s 16
-				IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02ce: ldc.i4.0
-				IL_02cf: ceq
-				IL_02d1: stloc.s 27
-				IL_02d3: ldloc.s 27
-				IL_02d5: brfalse IL_02e6
+				IL_028e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
+				IL_0293: stloc.s 15
+				IL_0295: ldloc.s 12
+				IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_029c: stloc.s 25
+				IL_029e: ldloc.s 25
+				IL_02a0: ldstr "exec"
+				IL_02a5: ldarg.2
+				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02ab: stloc.s 25
+				IL_02ad: ldloc.s 25
+				IL_02af: stloc.s 16
+				IL_02b1: ldloc.s 16
+				IL_02b3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02b8: ldc.i4.0
+				IL_02b9: ceq
+				IL_02bb: stloc.s 27
+				IL_02bd: ldloc.s 27
+				IL_02bf: brfalse IL_02d0
 
-				IL_02da: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
-				IL_02df: stloc.s 17
-				IL_02e1: br IL_03ed
+				IL_02c4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
+				IL_02c9: stloc.s 17
+				IL_02cb: br IL_03d7
 
-				IL_02e6: ldloc.s 16
-				IL_02e8: ldc.r8 0.0
-				IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02f6: stloc.s 18
-				IL_02f8: ldloc.s 14
-				IL_02fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_02ff: stloc.s 26
-				IL_0301: ldloc.s 26
-				IL_0303: ldc.r8 0.0
-				IL_030c: clt
-				IL_030e: brfalse IL_032c
+				IL_02d0: ldloc.s 16
+				IL_02d2: ldc.r8 0.0
+				IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02e0: stloc.s 18
+				IL_02e2: ldloc.s 14
+				IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_02e9: stloc.s 26
+				IL_02eb: ldloc.s 26
+				IL_02ed: ldc.r8 0.0
+				IL_02f6: clt
+				IL_02f8: brfalse IL_0316
 
-				IL_0313: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
-				IL_0318: stloc.s 19
-				IL_031a: ldloc.s 16
-				IL_031c: ldstr "index"
-				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0326: stloc.s 25
-				IL_0328: ldloc.s 25
-				IL_032a: stloc.s 14
+				IL_02fd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
+				IL_0302: stloc.s 19
+				IL_0304: ldloc.s 16
+				IL_0306: ldstr "index"
+				IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0310: stloc.s 25
+				IL_0312: ldloc.s 25
+				IL_0314: stloc.s 14
 
-				IL_032c: ldloc.s 18
-				IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0333: stloc.s 25
-				IL_0335: ldloc.s 25
-				IL_0337: ldstr "startsWith"
-				IL_033c: ldstr "</"
-				IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0346: stloc.s 25
-				IL_0348: ldloc.s 25
-				IL_034a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_034f: stloc.s 27
-				IL_0351: ldloc.s 27
-				IL_0353: brfalse IL_03d3
+				IL_0316: ldloc.s 18
+				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_031d: stloc.s 25
+				IL_031f: ldloc.s 25
+				IL_0321: ldstr "startsWith"
+				IL_0326: ldstr "</"
+				IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0330: stloc.s 25
+				IL_0332: ldloc.s 25
+				IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0339: stloc.s 27
+				IL_033b: ldloc.s 27
+				IL_033d: brfalse IL_03bd
 
-				IL_0358: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
-				IL_035d: stloc.s 20
-				IL_035f: ldloc.s 13
-				IL_0361: ldc.r8 1
-				IL_036a: sub
-				IL_036b: stloc.s 13
-				IL_036d: ldloc.s 13
-				IL_036f: ldc.r8 0.0
-				IL_0378: ceq
-				IL_037a: brfalse IL_03ce
+				IL_0342: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
+				IL_0347: stloc.s 20
+				IL_0349: ldloc.s 13
+				IL_034b: ldc.r8 1
+				IL_0354: sub
+				IL_0355: stloc.s 13
+				IL_0357: ldloc.s 13
+				IL_0359: ldc.r8 0.0
+				IL_0362: ceq
+				IL_0364: brfalse IL_03b8
 
-				IL_037f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
-				IL_0384: stloc.s 21
-				IL_0386: ldarg.2
-				IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_038c: stloc.s 25
-				IL_038e: ldloc.s 25
-				IL_0390: ldstr "substring"
-				IL_0395: ldloc.s 14
-				IL_0397: ldloc.s 12
-				IL_0399: ldstr "lastIndex"
-				IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_03a8: stloc.s 25
-				IL_03aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_03af: dup
-				IL_03b0: ldstr "tagName"
-				IL_03b5: ldloc.s 9
-				IL_03b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03bc: dup
-				IL_03bd: ldstr "html"
-				IL_03c2: ldloc.s 25
-				IL_03c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03c9: stloc.s 29
-				IL_03cb: ldloc.s 29
-				IL_03cd: ret
+				IL_0369: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
+				IL_036e: stloc.s 21
+				IL_0370: ldarg.2
+				IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0376: stloc.s 25
+				IL_0378: ldloc.s 25
+				IL_037a: ldstr "substring"
+				IL_037f: ldloc.s 14
+				IL_0381: ldloc.s 12
+				IL_0383: ldstr "lastIndex"
+				IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0392: stloc.s 25
+				IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0399: dup
+				IL_039a: ldstr "tagName"
+				IL_039f: ldloc.s 9
+				IL_03a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03a6: dup
+				IL_03a7: ldstr "html"
+				IL_03ac: ldloc.s 25
+				IL_03ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03b3: stloc.s 29
+				IL_03b5: ldloc.s 29
+				IL_03b7: ret
 
-				IL_03ce: br IL_03e8
+				IL_03b8: br IL_03d2
 
-				IL_03d3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
-				IL_03d8: stloc.s 22
-				IL_03da: ldloc.s 13
-				IL_03dc: ldc.r8 1
-				IL_03e5: add
-				IL_03e6: stloc.s 13
+				IL_03bd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
+				IL_03c2: stloc.s 22
+				IL_03c4: ldloc.s 13
+				IL_03c6: ldc.r8 1
+				IL_03cf: add
+				IL_03d0: stloc.s 13
 
-				IL_03e8: br IL_029e
+				IL_03d2: br IL_0288
 			// end loop
 
-			IL_03ed: ldloc.s 9
-			IL_03ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03f4: stloc.s 24
-			IL_03f6: ldstr "Could not find a matching closing </"
-			IL_03fb: ldloc.s 24
-			IL_03fd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0402: stloc.s 24
+			IL_03d7: ldloc.s 9
+			IL_03d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03de: stloc.s 24
+			IL_03e0: ldstr "Could not find a matching closing </"
+			IL_03e5: ldloc.s 24
+			IL_03e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03ec: stloc.s 24
+			IL_03ee: ldloc.s 24
+			IL_03f0: ldstr "> for id '"
+			IL_03f5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03fa: stloc.s 24
+			IL_03fc: ldarg.3
+			IL_03fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0402: stloc.s 30
 			IL_0404: ldloc.s 24
-			IL_0406: ldstr "> for id '"
-			IL_040b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0410: stloc.s 24
-			IL_0412: ldarg.3
-			IL_0413: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0418: stloc.s 30
-			IL_041a: ldloc.s 24
-			IL_041c: ldloc.s 30
-			IL_041e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0423: stloc.s 30
-			IL_0425: ldloc.s 30
-			IL_0427: ldstr "'."
-			IL_042c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0431: stloc.s 30
-			IL_0433: ldloc.s 30
-			IL_0435: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_043a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_043f: stloc.s 25
-			IL_0441: ldloc.s 25
-			IL_0443: stloc.s 23
-			IL_0445: ldloc.s 23
-			IL_0447: isinst [System.Runtime]System.Exception
-			IL_044c: dup
-			IL_044d: brtrue IL_045b
+			IL_0406: ldloc.s 30
+			IL_0408: call string [System.Runtime]System.String::Concat(string, string)
+			IL_040d: stloc.s 30
+			IL_040f: ldloc.s 30
+			IL_0411: ldstr "'."
+			IL_0416: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041b: stloc.s 30
+			IL_041d: ldloc.s 30
+			IL_041f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0424: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0429: stloc.s 25
+			IL_042b: ldloc.s 25
+			IL_042d: stloc.s 23
+			IL_042f: ldloc.s 23
+			IL_0431: isinst [System.Runtime]System.Exception
+			IL_0436: dup
+			IL_0437: brtrue IL_0445
 
-			IL_0452: pop
-			IL_0453: ldloc.s 23
-			IL_0455: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_045a: throw
+			IL_043c: pop
+			IL_043d: ldloc.s 23
+			IL_043f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0444: throw
 
-			IL_045b: throw
+			IL_0445: throw
 
-			IL_045c: ldnull
-			IL_045d: ret
+			IL_0446: ldnull
+			IL_0447: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3373,7 +3355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4718
+					// Method begins at RVA 0x4664
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3391,7 +3373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x470f
+				// Method begins at RVA 0x465b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3419,7 +3401,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3090
+			// Method begins at RVA 0x3078
 			// Header size: 12
 			// Code size: 487 (0x1e7)
 			.maxstack 8
@@ -3632,7 +3614,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4721
+				// Method begins at RVA 0x466d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3658,7 +3640,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3284
+			// Method begins at RVA 0x326c
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -3765,7 +3747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4733
+					// Method begins at RVA 0x467f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3785,7 +3767,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x473c
+					// Method begins at RVA 0x4688
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3805,7 +3787,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4745
+					// Method begins at RVA 0x4691
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3829,7 +3811,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4757
+						// Method begins at RVA 0x46a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3849,7 +3831,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4760
+						// Method begins at RVA 0x46ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3867,7 +3849,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x474e
+					// Method begins at RVA 0x469a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3887,7 +3869,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4769
+					// Method begins at RVA 0x46b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3907,7 +3889,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4772
+					// Method begins at RVA 0x46be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3947,7 +3929,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x472a
+				// Method begins at RVA 0x4676
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3971,9 +3953,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3328
+			// Method begins at RVA 0x3310
 			// Header size: 12
-			// Code size: 2889 (0xb49)
+			// Code size: 2757 (0xac5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4183,1099 +4165,1045 @@
 
 			IL_0130: ldloc.0
 			IL_0131: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0136: switch (IL_014b, IL_04ce, IL_0731, IL_08b0)
+			IL_0136: switch (IL_014b, IL_04a2, IL_06d9, IL_0842)
 
 			IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
 			IL_0150: ldstr "argv"
 			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_015a: stloc.s 29
-			IL_015c: ldc.i4.1
-			IL_015d: newarr [System.Runtime]System.Object
-			IL_0162: dup
-			IL_0163: ldc.i4.0
-			IL_0164: ldarg.0
-			IL_0165: ldc.i4.1
-			IL_0166: ldelem.ref
-			IL_0167: stelem.ref
-			IL_0168: ldc.i4.0
-			IL_0169: ldelem.ref
-			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_017a: ldnull
-			IL_017b: ldloc.s 29
-			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0182: stloc.s 29
-			IL_0184: ldloc.s 29
-			IL_0186: stloc.1
-			IL_0187: ldloc.1
-			IL_0188: ldstr "section"
-			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0197: ldc.i4.0
-			IL_0198: ceq
-			IL_019a: stloc.s 30
-			IL_019c: ldloc.s 30
-			IL_019e: brfalse IL_01ec
+			IL_015c: ldarg.0
+			IL_015d: ldc.i4.1
+			IL_015e: ldelem.ref
+			IL_015f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0164: ldnull
+			IL_0165: ldloc.s 29
+			IL_0167: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+			IL_016c: stloc.s 29
+			IL_016e: ldloc.s 29
+			IL_0170: stloc.1
+			IL_0171: ldloc.1
+			IL_0172: ldstr "section"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0181: ldc.i4.0
+			IL_0182: ceq
+			IL_0184: stloc.s 30
+			IL_0186: ldloc.s 30
+			IL_0188: brfalse IL_01d6
 
-			IL_01a3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
-			IL_01a8: stloc.2
-			IL_01a9: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01b8: stloc.s 29
-			IL_01ba: ldloc.s 29
-			IL_01bc: stloc.3
-			IL_01bd: ldloc.0
-			IL_01be: ldc.i4.m1
-			IL_01bf: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01c4: ldloc.0
-			IL_01c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01cf: ldarg.0
-			IL_01d0: ldc.i4.1
-			IL_01d1: newarr [System.Runtime]System.Object
-			IL_01d6: dup
-			IL_01d7: ldc.i4.0
-			IL_01d8: ldloc.3
-			IL_01d9: stelem.ref
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01df: pop
-			IL_01e0: ldloc.0
-			IL_01e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01eb: ret
+			IL_018d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
+			IL_0192: stloc.2
+			IL_0193: ldstr "Missing required --section (e.g. 27.3)."
+			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01a2: stloc.s 29
+			IL_01a4: ldloc.s 29
+			IL_01a6: stloc.3
+			IL_01a7: ldloc.0
+			IL_01a8: ldc.i4.m1
+			IL_01a9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ae: ldloc.0
+			IL_01af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01b9: ldarg.0
+			IL_01ba: ldc.i4.1
+			IL_01bb: newarr [System.Runtime]System.Object
+			IL_01c0: dup
+			IL_01c1: ldc.i4.0
+			IL_01c2: ldloc.3
+			IL_01c3: stelem.ref
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01c9: pop
+			IL_01ca: ldloc.0
+			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01d5: ret
 
-			IL_01ec: ldloc.1
-			IL_01ed: ldstr "outFile"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01fc: ldc.i4.0
-			IL_01fd: ceq
-			IL_01ff: stloc.s 30
-			IL_0201: ldloc.s 30
-			IL_0203: brfalse IL_0254
+			IL_01d6: ldloc.1
+			IL_01d7: ldstr "outFile"
+			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01e6: ldc.i4.0
+			IL_01e7: ceq
+			IL_01e9: stloc.s 30
+			IL_01eb: ldloc.s 30
+			IL_01ed: brfalse IL_023e
 
-			IL_0208: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
-			IL_020d: stloc.s 4
-			IL_020f: ldstr "Missing required --out <output.html>."
-			IL_0214: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_021e: stloc.s 29
-			IL_0220: ldloc.s 29
-			IL_0222: stloc.s 5
-			IL_0224: ldloc.0
-			IL_0225: ldc.i4.m1
-			IL_0226: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_022b: ldloc.0
-			IL_022c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0231: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0236: ldarg.0
-			IL_0237: ldc.i4.1
-			IL_0238: newarr [System.Runtime]System.Object
-			IL_023d: dup
-			IL_023e: ldc.i4.0
-			IL_023f: ldloc.s 5
-			IL_0241: stelem.ref
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0247: pop
-			IL_0248: ldloc.0
-			IL_0249: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_024e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0253: ret
+			IL_01f2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
+			IL_01f7: stloc.s 4
+			IL_01f9: ldstr "Missing required --out <output.html>."
+			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0208: stloc.s 29
+			IL_020a: ldloc.s 29
+			IL_020c: stloc.s 5
+			IL_020e: ldloc.0
+			IL_020f: ldc.i4.m1
+			IL_0210: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0215: ldloc.0
+			IL_0216: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0220: ldarg.0
+			IL_0221: ldc.i4.1
+			IL_0222: newarr [System.Runtime]System.Object
+			IL_0227: dup
+			IL_0228: ldc.i4.0
+			IL_0229: ldloc.s 5
+			IL_022b: stelem.ref
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0231: pop
+			IL_0232: ldloc.0
+			IL_0233: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0238: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_023d: ret
 
-			IL_0254: ldloc.1
-			IL_0255: ldstr "url"
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0264: stloc.s 30
-			IL_0266: ldloc.s 30
-			IL_0268: brfalse IL_0282
+			IL_023e: ldloc.1
+			IL_023f: ldstr "url"
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_024e: stloc.s 30
+			IL_0250: ldloc.s 30
+			IL_0252: brfalse IL_026c
 
-			IL_026d: ldc.r8 1
-			IL_0276: box [System.Runtime]System.Double
-			IL_027b: stloc.s 6
-			IL_027d: br IL_0292
+			IL_0257: ldc.r8 1
+			IL_0260: box [System.Runtime]System.Double
+			IL_0265: stloc.s 6
+			IL_0267: br IL_027c
 
-			IL_0282: ldc.r8 0.0
-			IL_028b: box [System.Runtime]System.Double
-			IL_0290: stloc.s 6
+			IL_026c: ldc.r8 0.0
+			IL_0275: box [System.Runtime]System.Double
+			IL_027a: stloc.s 6
 
-			IL_0292: ldloc.1
-			IL_0293: ldstr "auto"
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02a2: stloc.s 30
-			IL_02a4: ldloc.s 30
-			IL_02a6: brfalse IL_02c0
+			IL_027c: ldloc.1
+			IL_027d: ldstr "auto"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_028c: stloc.s 30
+			IL_028e: ldloc.s 30
+			IL_0290: brfalse IL_02aa
 
-			IL_02ab: ldc.r8 1
-			IL_02b4: box [System.Runtime]System.Double
-			IL_02b9: stloc.s 7
-			IL_02bb: br IL_02d0
+			IL_0295: ldc.r8 1
+			IL_029e: box [System.Runtime]System.Double
+			IL_02a3: stloc.s 7
+			IL_02a5: br IL_02ba
 
-			IL_02c0: ldc.r8 0.0
-			IL_02c9: box [System.Runtime]System.Double
-			IL_02ce: stloc.s 7
+			IL_02aa: ldc.r8 0.0
+			IL_02b3: box [System.Runtime]System.Double
+			IL_02b8: stloc.s 7
 
-			IL_02d0: ldloc.s 6
-			IL_02d2: ldloc.s 7
-			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02d9: stloc.s 31
-			IL_02db: ldloc.s 31
-			IL_02dd: stloc.s 8
-			IL_02df: ldloc.s 8
-			IL_02e1: ldc.r8 1
-			IL_02ea: box [System.Runtime]System.Double
-			IL_02ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02f4: stloc.s 30
-			IL_02f6: ldloc.s 30
-			IL_02f8: brfalse IL_0349
+			IL_02ba: ldloc.s 6
+			IL_02bc: ldloc.s 7
+			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02c3: stloc.s 31
+			IL_02c5: ldloc.s 31
+			IL_02c7: stloc.s 8
+			IL_02c9: ldloc.s 8
+			IL_02cb: ldc.r8 1
+			IL_02d4: box [System.Runtime]System.Double
+			IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02de: stloc.s 30
+			IL_02e0: ldloc.s 30
+			IL_02e2: brfalse IL_0333
 
-			IL_02fd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
-			IL_0302: stloc.s 9
-			IL_0304: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_0309: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_030e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0313: stloc.s 29
-			IL_0315: ldloc.s 29
-			IL_0317: stloc.s 10
-			IL_0319: ldloc.0
-			IL_031a: ldc.i4.m1
-			IL_031b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0320: ldloc.0
-			IL_0321: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0326: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_032b: ldarg.0
-			IL_032c: ldc.i4.1
-			IL_032d: newarr [System.Runtime]System.Object
-			IL_0332: dup
-			IL_0333: ldc.i4.0
-			IL_0334: ldloc.s 10
-			IL_0336: stelem.ref
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_033c: pop
-			IL_033d: ldloc.0
-			IL_033e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0343: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0348: ret
+			IL_02e7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
+			IL_02ec: stloc.s 9
+			IL_02ee: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_02f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_02fd: stloc.s 29
+			IL_02ff: ldloc.s 29
+			IL_0301: stloc.s 10
+			IL_0303: ldloc.0
+			IL_0304: ldc.i4.m1
+			IL_0305: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030a: ldloc.0
+			IL_030b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0310: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0315: ldarg.0
+			IL_0316: ldc.i4.1
+			IL_0317: newarr [System.Runtime]System.Object
+			IL_031c: dup
+			IL_031d: ldc.i4.0
+			IL_031e: ldloc.s 10
+			IL_0320: stelem.ref
+			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0326: pop
+			IL_0327: ldloc.0
+			IL_0328: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_032d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0332: ret
 
-			IL_0349: ldnull
-			IL_034a: stloc.s 11
-			IL_034c: ldloc.1
-			IL_034d: ldstr "id"
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0357: stloc.s 29
-			IL_0359: ldloc.s 29
-			IL_035b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0360: stloc.s 30
-			IL_0362: ldloc.s 30
-			IL_0364: brtrue IL_0375
+			IL_0333: ldnull
+			IL_0334: stloc.s 11
+			IL_0336: ldloc.1
+			IL_0337: ldstr "id"
+			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0341: stloc.s 29
+			IL_0343: ldloc.s 29
+			IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_034a: stloc.s 30
+			IL_034c: ldloc.s 30
+			IL_034e: brtrue IL_035f
 
-			IL_0369: ldstr ""
-			IL_036e: stloc.s 32
-			IL_0370: br IL_0379
+			IL_0353: ldstr ""
+			IL_0358: stloc.s 32
+			IL_035a: br IL_0363
 
-			IL_0375: ldloc.s 29
-			IL_0377: stloc.s 32
+			IL_035f: ldloc.s 29
+			IL_0361: stloc.s 32
 
-			IL_0379: ldloc.s 32
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0380: stloc.s 29
-			IL_0382: ldloc.s 29
-			IL_0384: ldstr "trim"
-			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_038e: stloc.s 29
-			IL_0390: ldloc.s 29
-			IL_0392: stloc.s 12
-			IL_0394: ldstr ""
-			IL_0399: stloc.s 13
-			IL_039b: ldloc.1
-			IL_039c: ldstr "auto"
-			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03ab: stloc.s 30
-			IL_03ad: ldloc.s 30
-			IL_03af: brfalse IL_0796
+			IL_0363: ldloc.s 32
+			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036a: stloc.s 29
+			IL_036c: ldloc.s 29
+			IL_036e: ldstr "trim"
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0378: stloc.s 29
+			IL_037a: ldloc.s 29
+			IL_037c: stloc.s 12
+			IL_037e: ldstr ""
+			IL_0383: stloc.s 13
+			IL_0385: ldloc.1
+			IL_0386: ldstr "auto"
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0395: stloc.s 30
+			IL_0397: ldloc.s 30
+			IL_0399: brfalse IL_073e
 
-			IL_03b4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_03b9: stloc.s 14
-			IL_03bb: ldloc.1
-			IL_03bc: ldstr "indexUrl"
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03cb: stloc.s 29
-			IL_03cd: ldloc.s 29
-			IL_03cf: ldstr "trim"
-			IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03d9: stloc.s 29
-			IL_03db: ldloc.s 29
-			IL_03dd: stloc.s 15
-			IL_03df: ldc.i4.1
-			IL_03e0: newarr [System.Runtime]System.Object
-			IL_03e5: dup
-			IL_03e6: ldc.i4.0
-			IL_03e7: ldarg.0
-			IL_03e8: ldc.i4.1
-			IL_03e9: ldelem.ref
-			IL_03ea: stelem.ref
-			IL_03eb: ldc.i4.0
-			IL_03ec: ldelem.ref
-			IL_03ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03f2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_03f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_03fd: ldnull
-			IL_03fe: ldloc.s 15
-			IL_0400: ldnull
-			IL_0401: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0406: stloc.s 29
-			IL_0408: ldloc.0
-			IL_0409: ldc.i4.1
-			IL_040a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_040f: ldloc.0
-			IL_0410: ldloc.s 29
-			IL_0412: ldarg.0
-			IL_0413: ldc.i4.1
-			IL_0414: ldloc.0
-			IL_0415: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_041a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_041f: ldloc.0
-			IL_0420: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0425: dup
-			IL_0426: ldc.i4.0
-			IL_0427: ldloc.1
+			IL_039e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
+			IL_03a3: stloc.s 14
+			IL_03a5: ldloc.1
+			IL_03a6: ldstr "indexUrl"
+			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b5: stloc.s 29
+			IL_03b7: ldloc.s 29
+			IL_03b9: ldstr "trim"
+			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03c3: stloc.s 29
+			IL_03c5: ldloc.s 29
+			IL_03c7: stloc.s 15
+			IL_03c9: ldarg.0
+			IL_03ca: ldc.i4.1
+			IL_03cb: ldelem.ref
+			IL_03cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03d1: ldnull
+			IL_03d2: ldloc.s 15
+			IL_03d4: ldnull
+			IL_03d5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_03da: stloc.s 29
+			IL_03dc: ldloc.0
+			IL_03dd: ldc.i4.1
+			IL_03de: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03e3: ldloc.0
+			IL_03e4: ldloc.s 29
+			IL_03e6: ldarg.0
+			IL_03e7: ldc.i4.1
+			IL_03e8: ldloc.0
+			IL_03e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03f3: ldloc.0
+			IL_03f4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03f9: dup
+			IL_03fa: ldc.i4.0
+			IL_03fb: ldloc.1
+			IL_03fc: stelem.ref
+			IL_03fd: dup
+			IL_03fe: ldc.i4.1
+			IL_03ff: ldloc.2
+			IL_0400: stelem.ref
+			IL_0401: dup
+			IL_0402: ldc.i4.2
+			IL_0403: ldloc.3
+			IL_0404: stelem.ref
+			IL_0405: dup
+			IL_0406: ldc.i4.3
+			IL_0407: ldloc.s 4
+			IL_0409: stelem.ref
+			IL_040a: dup
+			IL_040b: ldc.i4.4
+			IL_040c: ldloc.s 5
+			IL_040e: stelem.ref
+			IL_040f: dup
+			IL_0410: ldc.i4.5
+			IL_0411: ldloc.s 6
+			IL_0413: stelem.ref
+			IL_0414: dup
+			IL_0415: ldc.i4.6
+			IL_0416: ldloc.s 7
+			IL_0418: stelem.ref
+			IL_0419: dup
+			IL_041a: ldc.i4.7
+			IL_041b: ldloc.s 8
+			IL_041d: stelem.ref
+			IL_041e: dup
+			IL_041f: ldc.i4.8
+			IL_0420: ldloc.s 9
+			IL_0422: stelem.ref
+			IL_0423: dup
+			IL_0424: ldc.i4.s 9
+			IL_0426: ldloc.s 10
 			IL_0428: stelem.ref
 			IL_0429: dup
-			IL_042a: ldc.i4.1
-			IL_042b: ldloc.2
-			IL_042c: stelem.ref
-			IL_042d: dup
-			IL_042e: ldc.i4.2
-			IL_042f: ldloc.3
-			IL_0430: stelem.ref
-			IL_0431: dup
-			IL_0432: ldc.i4.3
-			IL_0433: ldloc.s 4
-			IL_0435: stelem.ref
-			IL_0436: dup
-			IL_0437: ldc.i4.4
-			IL_0438: ldloc.s 5
+			IL_042a: ldc.i4.s 10
+			IL_042c: ldloc.s 11
+			IL_042e: stelem.ref
+			IL_042f: dup
+			IL_0430: ldc.i4.s 11
+			IL_0432: ldloc.s 12
+			IL_0434: stelem.ref
+			IL_0435: dup
+			IL_0436: ldc.i4.s 12
+			IL_0438: ldloc.s 13
 			IL_043a: stelem.ref
 			IL_043b: dup
-			IL_043c: ldc.i4.5
-			IL_043d: ldloc.s 6
-			IL_043f: stelem.ref
-			IL_0440: dup
-			IL_0441: ldc.i4.6
-			IL_0442: ldloc.s 7
-			IL_0444: stelem.ref
-			IL_0445: dup
-			IL_0446: ldc.i4.7
-			IL_0447: ldloc.s 8
-			IL_0449: stelem.ref
-			IL_044a: dup
-			IL_044b: ldc.i4.8
-			IL_044c: ldloc.s 9
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.s 9
-			IL_0452: ldloc.s 10
-			IL_0454: stelem.ref
-			IL_0455: dup
-			IL_0456: ldc.i4.s 10
-			IL_0458: ldloc.s 11
-			IL_045a: stelem.ref
-			IL_045b: dup
-			IL_045c: ldc.i4.s 11
-			IL_045e: ldloc.s 12
-			IL_0460: stelem.ref
-			IL_0461: dup
-			IL_0462: ldc.i4.s 12
-			IL_0464: ldloc.s 13
-			IL_0466: stelem.ref
-			IL_0467: dup
-			IL_0468: ldc.i4.s 13
-			IL_046a: ldloc.s 14
-			IL_046c: stelem.ref
-			IL_046d: dup
-			IL_046e: ldc.i4.s 14
-			IL_0470: ldloc.s 15
-			IL_0472: stelem.ref
-			IL_0473: dup
-			IL_0474: ldc.i4.s 15
-			IL_0476: ldloc.s 16
-			IL_0478: stelem.ref
-			IL_0479: dup
-			IL_047a: ldc.i4.s 16
-			IL_047c: ldloc.s 17
-			IL_047e: stelem.ref
-			IL_047f: dup
-			IL_0480: ldc.i4.s 17
-			IL_0482: ldloc.s 18
-			IL_0484: stelem.ref
-			IL_0485: dup
-			IL_0486: ldc.i4.s 18
-			IL_0488: ldloc.s 19
-			IL_048a: stelem.ref
-			IL_048b: dup
-			IL_048c: ldc.i4.s 19
-			IL_048e: ldloc.s 20
-			IL_0490: stelem.ref
-			IL_0491: dup
-			IL_0492: ldc.i4.s 20
-			IL_0494: ldloc.s 21
-			IL_0496: stelem.ref
-			IL_0497: dup
-			IL_0498: ldc.i4.s 21
-			IL_049a: ldloc.s 22
-			IL_049c: stelem.ref
-			IL_049d: dup
-			IL_049e: ldc.i4.s 22
-			IL_04a0: ldloc.s 23
-			IL_04a2: stelem.ref
-			IL_04a3: dup
-			IL_04a4: ldc.i4.s 23
-			IL_04a6: ldloc.s 24
-			IL_04a8: stelem.ref
-			IL_04a9: dup
-			IL_04aa: ldc.i4.s 24
-			IL_04ac: ldloc.s 25
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.s 25
-			IL_04b2: ldloc.s 26
-			IL_04b4: stelem.ref
-			IL_04b5: dup
-			IL_04b6: ldc.i4.s 26
-			IL_04b8: ldloc.s 27
-			IL_04ba: stelem.ref
-			IL_04bb: dup
-			IL_04bc: ldc.i4.s 27
-			IL_04be: ldloc.s 28
-			IL_04c0: stelem.ref
-			IL_04c1: pop
-			IL_04c2: ldloc.0
-			IL_04c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04c8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04cd: ret
+			IL_043c: ldc.i4.s 13
+			IL_043e: ldloc.s 14
+			IL_0440: stelem.ref
+			IL_0441: dup
+			IL_0442: ldc.i4.s 14
+			IL_0444: ldloc.s 15
+			IL_0446: stelem.ref
+			IL_0447: dup
+			IL_0448: ldc.i4.s 15
+			IL_044a: ldloc.s 16
+			IL_044c: stelem.ref
+			IL_044d: dup
+			IL_044e: ldc.i4.s 16
+			IL_0450: ldloc.s 17
+			IL_0452: stelem.ref
+			IL_0453: dup
+			IL_0454: ldc.i4.s 17
+			IL_0456: ldloc.s 18
+			IL_0458: stelem.ref
+			IL_0459: dup
+			IL_045a: ldc.i4.s 18
+			IL_045c: ldloc.s 19
+			IL_045e: stelem.ref
+			IL_045f: dup
+			IL_0460: ldc.i4.s 19
+			IL_0462: ldloc.s 20
+			IL_0464: stelem.ref
+			IL_0465: dup
+			IL_0466: ldc.i4.s 20
+			IL_0468: ldloc.s 21
+			IL_046a: stelem.ref
+			IL_046b: dup
+			IL_046c: ldc.i4.s 21
+			IL_046e: ldloc.s 22
+			IL_0470: stelem.ref
+			IL_0471: dup
+			IL_0472: ldc.i4.s 22
+			IL_0474: ldloc.s 23
+			IL_0476: stelem.ref
+			IL_0477: dup
+			IL_0478: ldc.i4.s 23
+			IL_047a: ldloc.s 24
+			IL_047c: stelem.ref
+			IL_047d: dup
+			IL_047e: ldc.i4.s 24
+			IL_0480: ldloc.s 25
+			IL_0482: stelem.ref
+			IL_0483: dup
+			IL_0484: ldc.i4.s 25
+			IL_0486: ldloc.s 26
+			IL_0488: stelem.ref
+			IL_0489: dup
+			IL_048a: ldc.i4.s 26
+			IL_048c: ldloc.s 27
+			IL_048e: stelem.ref
+			IL_048f: dup
+			IL_0490: ldc.i4.s 27
+			IL_0492: ldloc.s 28
+			IL_0494: stelem.ref
+			IL_0495: pop
+			IL_0496: ldloc.0
+			IL_0497: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_049c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04a1: ret
 
-			IL_04ce: ldloc.0
-			IL_04cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_04d4: stloc.s 29
-			IL_04d6: ldloc.s 29
-			IL_04d8: stloc.s 16
-			IL_04da: ldloc.1
-			IL_04db: ldstr "section"
-			IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ea: stloc.s 29
-			IL_04ec: ldloc.s 29
-			IL_04ee: ldstr "trim"
-			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_04f8: stloc.s 29
-			IL_04fa: ldc.i4.1
-			IL_04fb: newarr [System.Runtime]System.Object
-			IL_0500: dup
-			IL_0501: ldc.i4.0
-			IL_0502: ldarg.0
-			IL_0503: ldc.i4.1
-			IL_0504: ldelem.ref
-			IL_0505: stelem.ref
-			IL_0506: ldc.i4.0
-			IL_0507: ldelem.ref
-			IL_0508: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_050d: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0513: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0518: ldnull
-			IL_0519: ldloc.s 16
-			IL_051b: ldloc.s 29
-			IL_051d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0522: stloc.s 29
-			IL_0524: ldloc.s 29
-			IL_0526: stloc.s 17
-			IL_0528: ldloc.s 17
-			IL_052a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_052f: ldc.i4.0
-			IL_0530: ceq
-			IL_0532: stloc.s 30
-			IL_0534: ldloc.s 30
-			IL_0536: brfalse IL_05c6
+			IL_04a2: ldloc.0
+			IL_04a3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04a8: stloc.s 29
+			IL_04aa: ldloc.s 29
+			IL_04ac: stloc.s 16
+			IL_04ae: ldloc.1
+			IL_04af: ldstr "section"
+			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04be: stloc.s 29
+			IL_04c0: ldloc.s 29
+			IL_04c2: ldstr "trim"
+			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_04cc: stloc.s 29
+			IL_04ce: ldarg.0
+			IL_04cf: ldc.i4.1
+			IL_04d0: ldelem.ref
+			IL_04d1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04d6: ldnull
+			IL_04d7: ldloc.s 16
+			IL_04d9: ldloc.s 29
+			IL_04db: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_04e0: stloc.s 29
+			IL_04e2: ldloc.s 29
+			IL_04e4: stloc.s 17
+			IL_04e6: ldloc.s 17
+			IL_04e8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04ed: ldc.i4.0
+			IL_04ee: ceq
+			IL_04f0: stloc.s 30
+			IL_04f2: ldloc.s 30
+			IL_04f4: brfalse IL_0584
 
-			IL_053b: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
-			IL_0540: stloc.s 18
-			IL_0542: ldloc.1
-			IL_0543: ldstr "section"
-			IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_054d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0552: stloc.s 33
-			IL_0554: ldstr "Could not find section '"
-			IL_0559: ldloc.s 33
-			IL_055b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0560: stloc.s 33
-			IL_0562: ldloc.s 33
-			IL_0564: ldstr "' in multipage index: "
-			IL_0569: call string [System.Runtime]System.String::Concat(string, string)
-			IL_056e: stloc.s 33
-			IL_0570: ldloc.s 15
-			IL_0572: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0577: stloc.s 34
-			IL_0579: ldloc.s 33
-			IL_057b: ldloc.s 34
-			IL_057d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0582: stloc.s 34
-			IL_0584: ldloc.s 34
-			IL_0586: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_058b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0590: stloc.s 29
-			IL_0592: ldloc.s 29
-			IL_0594: stloc.s 19
-			IL_0596: ldloc.0
-			IL_0597: ldc.i4.m1
-			IL_0598: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_059d: ldloc.0
-			IL_059e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05a8: ldarg.0
-			IL_05a9: ldc.i4.1
-			IL_05aa: newarr [System.Runtime]System.Object
-			IL_05af: dup
-			IL_05b0: ldc.i4.0
-			IL_05b1: ldloc.s 19
-			IL_05b3: stelem.ref
-			IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05b9: pop
-			IL_05ba: ldloc.0
-			IL_05bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05c0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05c5: ret
+			IL_04f9: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
+			IL_04fe: stloc.s 18
+			IL_0500: ldloc.1
+			IL_0501: ldstr "section"
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_050b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0510: stloc.s 33
+			IL_0512: ldstr "Could not find section '"
+			IL_0517: ldloc.s 33
+			IL_0519: call string [System.Runtime]System.String::Concat(string, string)
+			IL_051e: stloc.s 33
+			IL_0520: ldloc.s 33
+			IL_0522: ldstr "' in multipage index: "
+			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
+			IL_052c: stloc.s 33
+			IL_052e: ldloc.s 15
+			IL_0530: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0535: stloc.s 34
+			IL_0537: ldloc.s 33
+			IL_0539: ldloc.s 34
+			IL_053b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0540: stloc.s 34
+			IL_0542: ldloc.s 34
+			IL_0544: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_054e: stloc.s 29
+			IL_0550: ldloc.s 29
+			IL_0552: stloc.s 19
+			IL_0554: ldloc.0
+			IL_0555: ldc.i4.m1
+			IL_0556: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_055b: ldloc.0
+			IL_055c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0561: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0566: ldarg.0
+			IL_0567: ldc.i4.1
+			IL_0568: newarr [System.Runtime]System.Object
+			IL_056d: dup
+			IL_056e: ldc.i4.0
+			IL_056f: ldloc.s 19
+			IL_0571: stelem.ref
+			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0577: pop
+			IL_0578: ldloc.0
+			IL_0579: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_057e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0583: ret
 
-			IL_05c6: ldarg.0
-			IL_05c7: ldc.i4.1
-			IL_05c8: ldelem.ref
-			IL_05c9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05d3: stloc.s 29
-			IL_05d5: ldloc.s 17
-			IL_05d7: ldstr "filePart"
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e1: stloc.s 35
-			IL_05e3: ldloc.s 35
-			IL_05e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05ea: stloc.s 30
-			IL_05ec: ldloc.s 30
-			IL_05ee: brtrue IL_0606
+			IL_0584: ldarg.0
+			IL_0585: ldc.i4.1
+			IL_0586: ldelem.ref
+			IL_0587: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_058c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_0591: stloc.s 29
+			IL_0593: ldloc.s 17
+			IL_0595: ldstr "filePart"
+			IL_059a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_059f: stloc.s 35
+			IL_05a1: ldloc.s 35
+			IL_05a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05a8: stloc.s 30
+			IL_05aa: ldloc.s 30
+			IL_05ac: brtrue IL_05c4
 
-			IL_05f3: ldloc.s 17
-			IL_05f5: ldstr "href"
-			IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ff: stloc.s 36
-			IL_0601: br IL_060a
+			IL_05b1: ldloc.s 17
+			IL_05b3: ldstr "href"
+			IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05bd: stloc.s 36
+			IL_05bf: br IL_05c8
 
-			IL_0606: ldloc.s 35
-			IL_0608: stloc.s 36
+			IL_05c4: ldloc.s 35
+			IL_05c6: stloc.s 36
 
-			IL_060a: ldc.i4.2
-			IL_060b: newarr [System.Runtime]System.Object
-			IL_0610: dup
-			IL_0611: ldc.i4.0
-			IL_0612: ldloc.s 36
-			IL_0614: stelem.ref
-			IL_0615: dup
-			IL_0616: ldc.i4.1
-			IL_0617: ldloc.s 15
-			IL_0619: stelem.ref
-			IL_061a: stloc.s 37
-			IL_061c: ldloc.s 29
-			IL_061e: ldloc.s 37
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0625: stloc.s 29
-			IL_0627: ldloc.s 29
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062e: stloc.s 29
-			IL_0630: ldloc.s 29
-			IL_0632: ldstr "toString"
-			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_063c: stloc.s 29
-			IL_063e: ldloc.s 29
-			IL_0640: stloc.s 20
-			IL_0642: ldc.i4.1
-			IL_0643: newarr [System.Runtime]System.Object
-			IL_0648: dup
-			IL_0649: ldc.i4.0
-			IL_064a: ldarg.0
-			IL_064b: ldc.i4.1
-			IL_064c: ldelem.ref
-			IL_064d: stelem.ref
-			IL_064e: ldc.i4.0
-			IL_064f: ldelem.ref
-			IL_0650: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0655: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_065b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0660: ldnull
-			IL_0661: ldloc.s 20
-			IL_0663: ldnull
-			IL_0664: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0669: stloc.s 29
-			IL_066b: ldloc.0
-			IL_066c: ldc.i4.2
-			IL_066d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0672: ldloc.0
-			IL_0673: ldloc.s 29
-			IL_0675: ldarg.0
-			IL_0676: ldc.i4.2
-			IL_0677: ldloc.0
-			IL_0678: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_067d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0682: ldloc.0
-			IL_0683: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0688: dup
-			IL_0689: ldc.i4.0
-			IL_068a: ldloc.1
-			IL_068b: stelem.ref
-			IL_068c: dup
-			IL_068d: ldc.i4.1
-			IL_068e: ldloc.2
+			IL_05c8: ldc.i4.2
+			IL_05c9: newarr [System.Runtime]System.Object
+			IL_05ce: dup
+			IL_05cf: ldc.i4.0
+			IL_05d0: ldloc.s 36
+			IL_05d2: stelem.ref
+			IL_05d3: dup
+			IL_05d4: ldc.i4.1
+			IL_05d5: ldloc.s 15
+			IL_05d7: stelem.ref
+			IL_05d8: stloc.s 37
+			IL_05da: ldloc.s 29
+			IL_05dc: ldloc.s 37
+			IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_05e3: stloc.s 29
+			IL_05e5: ldloc.s 29
+			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05ec: stloc.s 29
+			IL_05ee: ldloc.s 29
+			IL_05f0: ldstr "toString"
+			IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_05fa: stloc.s 29
+			IL_05fc: ldloc.s 29
+			IL_05fe: stloc.s 20
+			IL_0600: ldarg.0
+			IL_0601: ldc.i4.1
+			IL_0602: ldelem.ref
+			IL_0603: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0608: ldnull
+			IL_0609: ldloc.s 20
+			IL_060b: ldnull
+			IL_060c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0611: stloc.s 29
+			IL_0613: ldloc.0
+			IL_0614: ldc.i4.2
+			IL_0615: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_061a: ldloc.0
+			IL_061b: ldloc.s 29
+			IL_061d: ldarg.0
+			IL_061e: ldc.i4.2
+			IL_061f: ldloc.0
+			IL_0620: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_062a: ldloc.0
+			IL_062b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0630: dup
+			IL_0631: ldc.i4.0
+			IL_0632: ldloc.1
+			IL_0633: stelem.ref
+			IL_0634: dup
+			IL_0635: ldc.i4.1
+			IL_0636: ldloc.2
+			IL_0637: stelem.ref
+			IL_0638: dup
+			IL_0639: ldc.i4.2
+			IL_063a: ldloc.3
+			IL_063b: stelem.ref
+			IL_063c: dup
+			IL_063d: ldc.i4.3
+			IL_063e: ldloc.s 4
+			IL_0640: stelem.ref
+			IL_0641: dup
+			IL_0642: ldc.i4.4
+			IL_0643: ldloc.s 5
+			IL_0645: stelem.ref
+			IL_0646: dup
+			IL_0647: ldc.i4.5
+			IL_0648: ldloc.s 6
+			IL_064a: stelem.ref
+			IL_064b: dup
+			IL_064c: ldc.i4.6
+			IL_064d: ldloc.s 7
+			IL_064f: stelem.ref
+			IL_0650: dup
+			IL_0651: ldc.i4.7
+			IL_0652: ldloc.s 8
+			IL_0654: stelem.ref
+			IL_0655: dup
+			IL_0656: ldc.i4.8
+			IL_0657: ldloc.s 9
+			IL_0659: stelem.ref
+			IL_065a: dup
+			IL_065b: ldc.i4.s 9
+			IL_065d: ldloc.s 10
+			IL_065f: stelem.ref
+			IL_0660: dup
+			IL_0661: ldc.i4.s 10
+			IL_0663: ldloc.s 11
+			IL_0665: stelem.ref
+			IL_0666: dup
+			IL_0667: ldc.i4.s 11
+			IL_0669: ldloc.s 12
+			IL_066b: stelem.ref
+			IL_066c: dup
+			IL_066d: ldc.i4.s 12
+			IL_066f: ldloc.s 13
+			IL_0671: stelem.ref
+			IL_0672: dup
+			IL_0673: ldc.i4.s 13
+			IL_0675: ldloc.s 14
+			IL_0677: stelem.ref
+			IL_0678: dup
+			IL_0679: ldc.i4.s 14
+			IL_067b: ldloc.s 15
+			IL_067d: stelem.ref
+			IL_067e: dup
+			IL_067f: ldc.i4.s 15
+			IL_0681: ldloc.s 16
+			IL_0683: stelem.ref
+			IL_0684: dup
+			IL_0685: ldc.i4.s 16
+			IL_0687: ldloc.s 17
+			IL_0689: stelem.ref
+			IL_068a: dup
+			IL_068b: ldc.i4.s 17
+			IL_068d: ldloc.s 18
 			IL_068f: stelem.ref
 			IL_0690: dup
-			IL_0691: ldc.i4.2
-			IL_0692: ldloc.3
-			IL_0693: stelem.ref
-			IL_0694: dup
-			IL_0695: ldc.i4.3
-			IL_0696: ldloc.s 4
-			IL_0698: stelem.ref
-			IL_0699: dup
-			IL_069a: ldc.i4.4
-			IL_069b: ldloc.s 5
-			IL_069d: stelem.ref
-			IL_069e: dup
-			IL_069f: ldc.i4.5
-			IL_06a0: ldloc.s 6
-			IL_06a2: stelem.ref
-			IL_06a3: dup
-			IL_06a4: ldc.i4.6
-			IL_06a5: ldloc.s 7
+			IL_0691: ldc.i4.s 18
+			IL_0693: ldloc.s 19
+			IL_0695: stelem.ref
+			IL_0696: dup
+			IL_0697: ldc.i4.s 19
+			IL_0699: ldloc.s 20
+			IL_069b: stelem.ref
+			IL_069c: dup
+			IL_069d: ldc.i4.s 20
+			IL_069f: ldloc.s 21
+			IL_06a1: stelem.ref
+			IL_06a2: dup
+			IL_06a3: ldc.i4.s 21
+			IL_06a5: ldloc.s 22
 			IL_06a7: stelem.ref
 			IL_06a8: dup
-			IL_06a9: ldc.i4.7
-			IL_06aa: ldloc.s 8
-			IL_06ac: stelem.ref
-			IL_06ad: dup
-			IL_06ae: ldc.i4.8
-			IL_06af: ldloc.s 9
-			IL_06b1: stelem.ref
-			IL_06b2: dup
-			IL_06b3: ldc.i4.s 9
-			IL_06b5: ldloc.s 10
-			IL_06b7: stelem.ref
-			IL_06b8: dup
-			IL_06b9: ldc.i4.s 10
-			IL_06bb: ldloc.s 11
-			IL_06bd: stelem.ref
-			IL_06be: dup
-			IL_06bf: ldc.i4.s 11
-			IL_06c1: ldloc.s 12
-			IL_06c3: stelem.ref
-			IL_06c4: dup
-			IL_06c5: ldc.i4.s 12
-			IL_06c7: ldloc.s 13
-			IL_06c9: stelem.ref
-			IL_06ca: dup
-			IL_06cb: ldc.i4.s 13
-			IL_06cd: ldloc.s 14
-			IL_06cf: stelem.ref
-			IL_06d0: dup
-			IL_06d1: ldc.i4.s 14
-			IL_06d3: ldloc.s 15
-			IL_06d5: stelem.ref
-			IL_06d6: dup
-			IL_06d7: ldc.i4.s 15
-			IL_06d9: ldloc.s 16
-			IL_06db: stelem.ref
-			IL_06dc: dup
-			IL_06dd: ldc.i4.s 16
-			IL_06df: ldloc.s 17
-			IL_06e1: stelem.ref
-			IL_06e2: dup
-			IL_06e3: ldc.i4.s 17
-			IL_06e5: ldloc.s 18
-			IL_06e7: stelem.ref
-			IL_06e8: dup
-			IL_06e9: ldc.i4.s 18
-			IL_06eb: ldloc.s 19
-			IL_06ed: stelem.ref
-			IL_06ee: dup
-			IL_06ef: ldc.i4.s 19
-			IL_06f1: ldloc.s 20
-			IL_06f3: stelem.ref
-			IL_06f4: dup
-			IL_06f5: ldc.i4.s 20
-			IL_06f7: ldloc.s 21
-			IL_06f9: stelem.ref
-			IL_06fa: dup
-			IL_06fb: ldc.i4.s 21
-			IL_06fd: ldloc.s 22
-			IL_06ff: stelem.ref
-			IL_0700: dup
-			IL_0701: ldc.i4.s 22
-			IL_0703: ldloc.s 23
-			IL_0705: stelem.ref
-			IL_0706: dup
-			IL_0707: ldc.i4.s 23
-			IL_0709: ldloc.s 24
-			IL_070b: stelem.ref
-			IL_070c: dup
-			IL_070d: ldc.i4.s 24
-			IL_070f: ldloc.s 25
-			IL_0711: stelem.ref
-			IL_0712: dup
-			IL_0713: ldc.i4.s 25
-			IL_0715: ldloc.s 26
-			IL_0717: stelem.ref
-			IL_0718: dup
-			IL_0719: ldc.i4.s 26
-			IL_071b: ldloc.s 27
-			IL_071d: stelem.ref
-			IL_071e: dup
-			IL_071f: ldc.i4.s 27
-			IL_0721: ldloc.s 28
-			IL_0723: stelem.ref
-			IL_0724: pop
-			IL_0725: ldloc.0
-			IL_0726: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_072b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0730: ret
+			IL_06a9: ldc.i4.s 22
+			IL_06ab: ldloc.s 23
+			IL_06ad: stelem.ref
+			IL_06ae: dup
+			IL_06af: ldc.i4.s 23
+			IL_06b1: ldloc.s 24
+			IL_06b3: stelem.ref
+			IL_06b4: dup
+			IL_06b5: ldc.i4.s 24
+			IL_06b7: ldloc.s 25
+			IL_06b9: stelem.ref
+			IL_06ba: dup
+			IL_06bb: ldc.i4.s 25
+			IL_06bd: ldloc.s 26
+			IL_06bf: stelem.ref
+			IL_06c0: dup
+			IL_06c1: ldc.i4.s 26
+			IL_06c3: ldloc.s 27
+			IL_06c5: stelem.ref
+			IL_06c6: dup
+			IL_06c7: ldc.i4.s 27
+			IL_06c9: ldloc.s 28
+			IL_06cb: stelem.ref
+			IL_06cc: pop
+			IL_06cd: ldloc.0
+			IL_06ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06d8: ret
 
-			IL_0731: ldloc.0
-			IL_0732: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_0737: stloc.s 29
-			IL_0739: ldloc.s 29
-			IL_073b: stloc.s 11
-			IL_073d: ldloc.s 20
-			IL_073f: stloc.s 29
-			IL_0741: ldloc.s 29
-			IL_0743: stloc.s 13
-			IL_0745: ldloc.s 12
-			IL_0747: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_074c: ldc.i4.0
-			IL_074d: ceq
-			IL_074f: stloc.s 30
-			IL_0751: ldloc.s 30
-			IL_0753: brfalse IL_0791
+			IL_06d9: ldloc.0
+			IL_06da: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_06df: stloc.s 29
+			IL_06e1: ldloc.s 29
+			IL_06e3: stloc.s 11
+			IL_06e5: ldloc.s 20
+			IL_06e7: stloc.s 29
+			IL_06e9: ldloc.s 29
+			IL_06eb: stloc.s 13
+			IL_06ed: ldloc.s 12
+			IL_06ef: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06f4: ldc.i4.0
+			IL_06f5: ceq
+			IL_06f7: stloc.s 30
+			IL_06f9: ldloc.s 30
+			IL_06fb: brfalse IL_0739
 
-			IL_0758: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_075d: stloc.s 21
-			IL_075f: ldloc.s 17
-			IL_0761: ldstr "fragment"
-			IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_076b: stloc.s 29
-			IL_076d: ldloc.s 29
-			IL_076f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0774: stloc.s 30
-			IL_0776: ldloc.s 30
-			IL_0778: brtrue IL_0789
+			IL_0700: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_0705: stloc.s 21
+			IL_0707: ldloc.s 17
+			IL_0709: ldstr "fragment"
+			IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0713: stloc.s 29
+			IL_0715: ldloc.s 29
+			IL_0717: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_071c: stloc.s 30
+			IL_071e: ldloc.s 30
+			IL_0720: brtrue IL_0731
 
-			IL_077d: ldstr ""
-			IL_0782: stloc.s 38
-			IL_0784: br IL_078d
+			IL_0725: ldstr ""
+			IL_072a: stloc.s 38
+			IL_072c: br IL_0735
 
-			IL_0789: ldloc.s 29
-			IL_078b: stloc.s 38
+			IL_0731: ldloc.s 29
+			IL_0733: stloc.s 38
 
-			IL_078d: ldloc.s 38
-			IL_078f: stloc.s 12
+			IL_0735: ldloc.s 38
+			IL_0737: stloc.s 12
 
-			IL_0791: br IL_08c4
+			IL_0739: br IL_0856
 
-			IL_0796: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_079b: stloc.s 22
-			IL_079d: ldloc.1
-			IL_079e: ldstr "url"
-			IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ad: stloc.s 29
-			IL_07af: ldloc.s 29
-			IL_07b1: ldstr "trim"
-			IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_07bb: stloc.s 29
-			IL_07bd: ldloc.s 29
-			IL_07bf: stloc.s 23
-			IL_07c1: ldc.i4.1
-			IL_07c2: newarr [System.Runtime]System.Object
-			IL_07c7: dup
-			IL_07c8: ldc.i4.0
-			IL_07c9: ldarg.0
-			IL_07ca: ldc.i4.1
-			IL_07cb: ldelem.ref
-			IL_07cc: stelem.ref
-			IL_07cd: ldc.i4.0
-			IL_07ce: ldelem.ref
-			IL_07cf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_07d4: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_07da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_07df: ldnull
-			IL_07e0: ldloc.s 23
-			IL_07e2: ldnull
-			IL_07e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_07e8: stloc.s 29
-			IL_07ea: ldloc.0
-			IL_07eb: ldc.i4.3
-			IL_07ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07f1: ldloc.0
-			IL_07f2: ldloc.s 29
-			IL_07f4: ldarg.0
-			IL_07f5: ldc.i4.3
-			IL_07f6: ldloc.0
-			IL_07f7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0801: ldloc.0
-			IL_0802: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0807: dup
-			IL_0808: ldc.i4.0
-			IL_0809: ldloc.1
+			IL_073e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_0743: stloc.s 22
+			IL_0745: ldloc.1
+			IL_0746: ldstr "url"
+			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0755: stloc.s 29
+			IL_0757: ldloc.s 29
+			IL_0759: ldstr "trim"
+			IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0763: stloc.s 29
+			IL_0765: ldloc.s 29
+			IL_0767: stloc.s 23
+			IL_0769: ldarg.0
+			IL_076a: ldc.i4.1
+			IL_076b: ldelem.ref
+			IL_076c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0771: ldnull
+			IL_0772: ldloc.s 23
+			IL_0774: ldnull
+			IL_0775: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_077a: stloc.s 29
+			IL_077c: ldloc.0
+			IL_077d: ldc.i4.3
+			IL_077e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0783: ldloc.0
+			IL_0784: ldloc.s 29
+			IL_0786: ldarg.0
+			IL_0787: ldc.i4.3
+			IL_0788: ldloc.0
+			IL_0789: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_078e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0793: ldloc.0
+			IL_0794: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0799: dup
+			IL_079a: ldc.i4.0
+			IL_079b: ldloc.1
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.1
+			IL_079f: ldloc.2
+			IL_07a0: stelem.ref
+			IL_07a1: dup
+			IL_07a2: ldc.i4.2
+			IL_07a3: ldloc.3
+			IL_07a4: stelem.ref
+			IL_07a5: dup
+			IL_07a6: ldc.i4.3
+			IL_07a7: ldloc.s 4
+			IL_07a9: stelem.ref
+			IL_07aa: dup
+			IL_07ab: ldc.i4.4
+			IL_07ac: ldloc.s 5
+			IL_07ae: stelem.ref
+			IL_07af: dup
+			IL_07b0: ldc.i4.5
+			IL_07b1: ldloc.s 6
+			IL_07b3: stelem.ref
+			IL_07b4: dup
+			IL_07b5: ldc.i4.6
+			IL_07b6: ldloc.s 7
+			IL_07b8: stelem.ref
+			IL_07b9: dup
+			IL_07ba: ldc.i4.7
+			IL_07bb: ldloc.s 8
+			IL_07bd: stelem.ref
+			IL_07be: dup
+			IL_07bf: ldc.i4.8
+			IL_07c0: ldloc.s 9
+			IL_07c2: stelem.ref
+			IL_07c3: dup
+			IL_07c4: ldc.i4.s 9
+			IL_07c6: ldloc.s 10
+			IL_07c8: stelem.ref
+			IL_07c9: dup
+			IL_07ca: ldc.i4.s 10
+			IL_07cc: ldloc.s 11
+			IL_07ce: stelem.ref
+			IL_07cf: dup
+			IL_07d0: ldc.i4.s 11
+			IL_07d2: ldloc.s 12
+			IL_07d4: stelem.ref
+			IL_07d5: dup
+			IL_07d6: ldc.i4.s 12
+			IL_07d8: ldloc.s 13
+			IL_07da: stelem.ref
+			IL_07db: dup
+			IL_07dc: ldc.i4.s 13
+			IL_07de: ldloc.s 14
+			IL_07e0: stelem.ref
+			IL_07e1: dup
+			IL_07e2: ldc.i4.s 14
+			IL_07e4: ldloc.s 15
+			IL_07e6: stelem.ref
+			IL_07e7: dup
+			IL_07e8: ldc.i4.s 15
+			IL_07ea: ldloc.s 16
+			IL_07ec: stelem.ref
+			IL_07ed: dup
+			IL_07ee: ldc.i4.s 16
+			IL_07f0: ldloc.s 17
+			IL_07f2: stelem.ref
+			IL_07f3: dup
+			IL_07f4: ldc.i4.s 17
+			IL_07f6: ldloc.s 18
+			IL_07f8: stelem.ref
+			IL_07f9: dup
+			IL_07fa: ldc.i4.s 18
+			IL_07fc: ldloc.s 19
+			IL_07fe: stelem.ref
+			IL_07ff: dup
+			IL_0800: ldc.i4.s 19
+			IL_0802: ldloc.s 20
+			IL_0804: stelem.ref
+			IL_0805: dup
+			IL_0806: ldc.i4.s 20
+			IL_0808: ldloc.s 21
 			IL_080a: stelem.ref
 			IL_080b: dup
-			IL_080c: ldc.i4.1
-			IL_080d: ldloc.2
-			IL_080e: stelem.ref
-			IL_080f: dup
-			IL_0810: ldc.i4.2
-			IL_0811: ldloc.3
-			IL_0812: stelem.ref
-			IL_0813: dup
-			IL_0814: ldc.i4.3
-			IL_0815: ldloc.s 4
-			IL_0817: stelem.ref
-			IL_0818: dup
-			IL_0819: ldc.i4.4
-			IL_081a: ldloc.s 5
+			IL_080c: ldc.i4.s 21
+			IL_080e: ldloc.s 22
+			IL_0810: stelem.ref
+			IL_0811: dup
+			IL_0812: ldc.i4.s 22
+			IL_0814: ldloc.s 23
+			IL_0816: stelem.ref
+			IL_0817: dup
+			IL_0818: ldc.i4.s 23
+			IL_081a: ldloc.s 24
 			IL_081c: stelem.ref
 			IL_081d: dup
-			IL_081e: ldc.i4.5
-			IL_081f: ldloc.s 6
-			IL_0821: stelem.ref
-			IL_0822: dup
-			IL_0823: ldc.i4.6
-			IL_0824: ldloc.s 7
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.7
-			IL_0829: ldloc.s 8
-			IL_082b: stelem.ref
-			IL_082c: dup
-			IL_082d: ldc.i4.8
-			IL_082e: ldloc.s 9
-			IL_0830: stelem.ref
-			IL_0831: dup
-			IL_0832: ldc.i4.s 9
-			IL_0834: ldloc.s 10
-			IL_0836: stelem.ref
-			IL_0837: dup
-			IL_0838: ldc.i4.s 10
-			IL_083a: ldloc.s 11
-			IL_083c: stelem.ref
-			IL_083d: dup
-			IL_083e: ldc.i4.s 11
-			IL_0840: ldloc.s 12
-			IL_0842: stelem.ref
-			IL_0843: dup
-			IL_0844: ldc.i4.s 12
-			IL_0846: ldloc.s 13
-			IL_0848: stelem.ref
-			IL_0849: dup
-			IL_084a: ldc.i4.s 13
-			IL_084c: ldloc.s 14
-			IL_084e: stelem.ref
-			IL_084f: dup
-			IL_0850: ldc.i4.s 14
-			IL_0852: ldloc.s 15
-			IL_0854: stelem.ref
-			IL_0855: dup
-			IL_0856: ldc.i4.s 15
-			IL_0858: ldloc.s 16
-			IL_085a: stelem.ref
-			IL_085b: dup
-			IL_085c: ldc.i4.s 16
-			IL_085e: ldloc.s 17
-			IL_0860: stelem.ref
-			IL_0861: dup
-			IL_0862: ldc.i4.s 17
-			IL_0864: ldloc.s 18
-			IL_0866: stelem.ref
-			IL_0867: dup
-			IL_0868: ldc.i4.s 18
-			IL_086a: ldloc.s 19
-			IL_086c: stelem.ref
-			IL_086d: dup
-			IL_086e: ldc.i4.s 19
-			IL_0870: ldloc.s 20
-			IL_0872: stelem.ref
-			IL_0873: dup
-			IL_0874: ldc.i4.s 20
-			IL_0876: ldloc.s 21
-			IL_0878: stelem.ref
-			IL_0879: dup
-			IL_087a: ldc.i4.s 21
-			IL_087c: ldloc.s 22
-			IL_087e: stelem.ref
-			IL_087f: dup
-			IL_0880: ldc.i4.s 22
-			IL_0882: ldloc.s 23
-			IL_0884: stelem.ref
-			IL_0885: dup
-			IL_0886: ldc.i4.s 23
-			IL_0888: ldloc.s 24
-			IL_088a: stelem.ref
-			IL_088b: dup
-			IL_088c: ldc.i4.s 24
-			IL_088e: ldloc.s 25
-			IL_0890: stelem.ref
-			IL_0891: dup
-			IL_0892: ldc.i4.s 25
-			IL_0894: ldloc.s 26
-			IL_0896: stelem.ref
-			IL_0897: dup
-			IL_0898: ldc.i4.s 26
-			IL_089a: ldloc.s 27
-			IL_089c: stelem.ref
-			IL_089d: dup
-			IL_089e: ldc.i4.s 27
-			IL_08a0: ldloc.s 28
-			IL_08a2: stelem.ref
-			IL_08a3: pop
-			IL_08a4: ldloc.0
-			IL_08a5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08aa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08af: ret
+			IL_081e: ldc.i4.s 24
+			IL_0820: ldloc.s 25
+			IL_0822: stelem.ref
+			IL_0823: dup
+			IL_0824: ldc.i4.s 25
+			IL_0826: ldloc.s 26
+			IL_0828: stelem.ref
+			IL_0829: dup
+			IL_082a: ldc.i4.s 26
+			IL_082c: ldloc.s 27
+			IL_082e: stelem.ref
+			IL_082f: dup
+			IL_0830: ldc.i4.s 27
+			IL_0832: ldloc.s 28
+			IL_0834: stelem.ref
+			IL_0835: pop
+			IL_0836: ldloc.0
+			IL_0837: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_083c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0841: ret
 
+			IL_0842: ldloc.0
+			IL_0843: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_0848: stloc.s 29
+			IL_084a: ldloc.s 29
+			IL_084c: stloc.s 11
+			IL_084e: ldloc.s 23
+			IL_0850: stloc.s 29
+			IL_0852: ldloc.s 29
+			IL_0854: stloc.s 13
+
+			IL_0856: ldloc.s 12
+			IL_0858: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_085d: ldc.i4.0
+			IL_085e: ceq
+			IL_0860: stloc.s 30
+			IL_0862: ldloc.s 30
+			IL_0864: brfalse IL_08e0
+
+			IL_0869: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_086e: stloc.s 24
+			IL_0870: ldloc.1
+			IL_0871: ldstr "section"
+			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_087b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0880: stloc.s 34
+			IL_0882: ldstr "Could not infer an element id for section '"
+			IL_0887: ldloc.s 34
+			IL_0889: call string [System.Runtime]System.String::Concat(string, string)
+			IL_088e: stloc.s 34
+			IL_0890: ldloc.s 34
+			IL_0892: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0897: call string [System.Runtime]System.String::Concat(string, string)
+			IL_089c: stloc.s 34
+			IL_089e: ldloc.s 34
+			IL_08a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_08aa: stloc.s 29
+			IL_08ac: ldloc.s 29
+			IL_08ae: stloc.s 25
 			IL_08b0: ldloc.0
-			IL_08b1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_08b6: stloc.s 29
-			IL_08b8: ldloc.s 29
-			IL_08ba: stloc.s 11
-			IL_08bc: ldloc.s 23
-			IL_08be: stloc.s 29
-			IL_08c0: ldloc.s 29
-			IL_08c2: stloc.s 13
+			IL_08b1: ldc.i4.m1
+			IL_08b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08b7: ldloc.0
+			IL_08b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_08c2: ldarg.0
+			IL_08c3: ldc.i4.1
+			IL_08c4: newarr [System.Runtime]System.Object
+			IL_08c9: dup
+			IL_08ca: ldc.i4.0
+			IL_08cb: ldloc.s 25
+			IL_08cd: stelem.ref
+			IL_08ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08d3: pop
+			IL_08d4: ldloc.0
+			IL_08d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08df: ret
 
-			IL_08c4: ldloc.s 12
-			IL_08c6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08cb: ldc.i4.0
-			IL_08cc: ceq
-			IL_08ce: stloc.s 30
-			IL_08d0: ldloc.s 30
-			IL_08d2: brfalse IL_094e
-
-			IL_08d7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_08dc: stloc.s 24
-			IL_08de: ldloc.1
-			IL_08df: ldstr "section"
-			IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08ee: stloc.s 34
-			IL_08f0: ldstr "Could not infer an element id for section '"
-			IL_08f5: ldloc.s 34
-			IL_08f7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08fc: stloc.s 34
-			IL_08fe: ldloc.s 34
-			IL_0900: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0905: call string [System.Runtime]System.String::Concat(string, string)
-			IL_090a: stloc.s 34
-			IL_090c: ldloc.s 34
-			IL_090e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0913: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0918: stloc.s 29
-			IL_091a: ldloc.s 29
-			IL_091c: stloc.s 25
-			IL_091e: ldloc.0
-			IL_091f: ldc.i4.m1
-			IL_0920: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0925: ldloc.0
-			IL_0926: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_092b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0930: ldarg.0
-			IL_0931: ldc.i4.1
-			IL_0932: newarr [System.Runtime]System.Object
-			IL_0937: dup
-			IL_0938: ldc.i4.0
-			IL_0939: ldloc.s 25
-			IL_093b: stelem.ref
-			IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0941: pop
-			IL_0942: ldloc.0
-			IL_0943: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0948: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_094d: ret
-
-			IL_094e: ldc.i4.1
-			IL_094f: newarr [System.Runtime]System.Object
-			IL_0954: dup
-			IL_0955: ldc.i4.0
-			IL_0956: ldarg.0
-			IL_0957: ldc.i4.1
-			IL_0958: ldelem.ref
-			IL_0959: stelem.ref
-			IL_095a: ldc.i4.0
-			IL_095b: ldelem.ref
-			IL_095c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0961: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0967: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_096c: ldnull
-			IL_096d: ldloc.s 11
-			IL_096f: ldloc.s 12
-			IL_0971: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0976: stloc.s 29
-			IL_0978: ldloc.s 29
-			IL_097a: stloc.s 26
-			IL_097c: ldarg.0
-			IL_097d: ldc.i4.1
-			IL_097e: ldelem.ref
-			IL_097f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0984: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0989: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_098e: stloc.s 29
-			IL_0990: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_099a: stloc.s 35
-			IL_099c: ldloc.s 35
-			IL_099e: ldstr "cwd"
-			IL_09a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_09a8: stloc.s 35
-			IL_09aa: ldloc.s 29
-			IL_09ac: ldstr "join"
-			IL_09b1: ldloc.s 35
-			IL_09b3: ldloc.1
-			IL_09b4: ldstr "outFile"
-			IL_09b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_09c3: stloc.s 35
-			IL_09c5: ldloc.s 35
-			IL_09c7: stloc.s 27
-			IL_09c9: ldloc.s 26
-			IL_09cb: ldstr "html"
-			IL_09d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09d5: stloc.s 35
-			IL_09d7: ldloc.1
-			IL_09d8: ldstr "section"
-			IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09e7: stloc.s 34
-			IL_09e9: ldstr "ECMA-262 "
-			IL_09ee: ldloc.s 34
-			IL_09f0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09f5: stloc.s 34
-			IL_09f7: ldnull
-			IL_09f8: ldloc.s 35
-			IL_09fa: ldloc.s 34
-			IL_09fc: ldloc.s 13
-			IL_09fe: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-			IL_0a03: stloc.s 35
-			IL_0a05: ldloc.s 35
-			IL_0a07: stloc.s 28
-			IL_0a09: ldarg.0
-			IL_0a0a: ldc.i4.1
-			IL_0a0b: ldelem.ref
-			IL_0a0c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a11: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a1b: stloc.s 35
-			IL_0a1d: ldloc.s 35
-			IL_0a1f: ldstr "writeFileSync"
-			IL_0a24: ldloc.s 27
-			IL_0a26: ldloc.s 28
-			IL_0a28: ldstr "utf8"
-			IL_0a2d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0a32: pop
-			IL_0a33: ldloc.1
-			IL_0a34: ldstr "section"
-			IL_0a39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a3e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a43: stloc.s 34
-			IL_0a45: ldstr "Extracted section "
-			IL_0a4a: ldloc.s 34
-			IL_0a4c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a51: stloc.s 34
-			IL_0a53: ldloc.s 34
-			IL_0a55: ldstr " (id="
-			IL_0a5a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a5f: stloc.s 34
-			IL_0a61: ldloc.s 12
-			IL_0a63: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a68: stloc.s 33
-			IL_0a6a: ldloc.s 34
-			IL_0a6c: ldloc.s 33
-			IL_0a6e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a73: stloc.s 33
-			IL_0a75: ldloc.s 33
-			IL_0a77: ldstr ", tag="
-			IL_0a7c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a81: stloc.s 33
-			IL_0a83: ldloc.s 26
-			IL_0a85: ldstr "tagName"
-			IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a8f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a94: stloc.s 34
-			IL_0a96: ldloc.s 33
-			IL_0a98: ldloc.s 34
-			IL_0a9a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a9f: stloc.s 34
-			IL_0aa1: ldloc.s 34
-			IL_0aa3: ldstr ") -> "
-			IL_0aa8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0aad: stloc.s 34
-			IL_0aaf: ldloc.s 27
-			IL_0ab1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ab6: stloc.s 33
-			IL_0ab8: ldloc.s 34
-			IL_0aba: ldloc.s 33
-			IL_0abc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ac1: stloc.s 33
-			IL_0ac3: ldnull
-			IL_0ac4: ldloc.s 33
-			IL_0ac6: ldloc.s 27
-			IL_0ac8: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0acd: stloc.s 35
-			IL_0acf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ad4: ldloc.s 35
-			IL_0ad6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0adb: pop
-			IL_0adc: ldarg.0
-			IL_0add: ldc.i4.1
-			IL_0ade: ldelem.ref
-			IL_0adf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ae4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0ae9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aee: stloc.s 35
-			IL_0af0: ldloc.s 35
-			IL_0af2: ldstr "readFileSync"
-			IL_0af7: ldloc.s 27
-			IL_0af9: ldstr "utf8"
-			IL_0afe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b03: stloc.s 35
-			IL_0b05: ldnull
-			IL_0b06: ldloc.s 35
-			IL_0b08: ldloc.s 27
-			IL_0b0a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0b0f: stloc.s 35
-			IL_0b11: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b16: ldloc.s 35
-			IL_0b18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b1d: pop
-			IL_0b1e: ldloc.0
-			IL_0b1f: ldc.i4.m1
-			IL_0b20: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b25: ldloc.0
-			IL_0b26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b2b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0b30: ldarg.0
-			IL_0b31: ldc.i4.1
-			IL_0b32: newarr [System.Runtime]System.Object
-			IL_0b37: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0b3c: pop
-			IL_0b3d: ldloc.0
-			IL_0b3e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b43: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0b48: ret
+			IL_08e0: ldarg.0
+			IL_08e1: ldc.i4.1
+			IL_08e2: ldelem.ref
+			IL_08e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08e8: ldnull
+			IL_08e9: ldloc.s 11
+			IL_08eb: ldloc.s 12
+			IL_08ed: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_08f2: stloc.s 29
+			IL_08f4: ldloc.s 29
+			IL_08f6: stloc.s 26
+			IL_08f8: ldarg.0
+			IL_08f9: ldc.i4.1
+			IL_08fa: ldelem.ref
+			IL_08fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0900: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_090a: stloc.s 29
+			IL_090c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0911: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0916: stloc.s 35
+			IL_0918: ldloc.s 35
+			IL_091a: ldstr "cwd"
+			IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0924: stloc.s 35
+			IL_0926: ldloc.s 29
+			IL_0928: ldstr "join"
+			IL_092d: ldloc.s 35
+			IL_092f: ldloc.1
+			IL_0930: ldstr "outFile"
+			IL_0935: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_093f: stloc.s 35
+			IL_0941: ldloc.s 35
+			IL_0943: stloc.s 27
+			IL_0945: ldloc.s 26
+			IL_0947: ldstr "html"
+			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0951: stloc.s 35
+			IL_0953: ldloc.1
+			IL_0954: ldstr "section"
+			IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_095e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0963: stloc.s 34
+			IL_0965: ldstr "ECMA-262 "
+			IL_096a: ldloc.s 34
+			IL_096c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0971: stloc.s 34
+			IL_0973: ldnull
+			IL_0974: ldloc.s 35
+			IL_0976: ldloc.s 34
+			IL_0978: ldloc.s 13
+			IL_097a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_097f: stloc.s 35
+			IL_0981: ldloc.s 35
+			IL_0983: stloc.s 28
+			IL_0985: ldarg.0
+			IL_0986: ldc.i4.1
+			IL_0987: ldelem.ref
+			IL_0988: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_098d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0992: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0997: stloc.s 35
+			IL_0999: ldloc.s 35
+			IL_099b: ldstr "writeFileSync"
+			IL_09a0: ldloc.s 27
+			IL_09a2: ldloc.s 28
+			IL_09a4: ldstr "utf8"
+			IL_09a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_09ae: pop
+			IL_09af: ldloc.1
+			IL_09b0: ldstr "section"
+			IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09bf: stloc.s 34
+			IL_09c1: ldstr "Extracted section "
+			IL_09c6: ldloc.s 34
+			IL_09c8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09cd: stloc.s 34
+			IL_09cf: ldloc.s 34
+			IL_09d1: ldstr " (id="
+			IL_09d6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09db: stloc.s 34
+			IL_09dd: ldloc.s 12
+			IL_09df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09e4: stloc.s 33
+			IL_09e6: ldloc.s 34
+			IL_09e8: ldloc.s 33
+			IL_09ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09ef: stloc.s 33
+			IL_09f1: ldloc.s 33
+			IL_09f3: ldstr ", tag="
+			IL_09f8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09fd: stloc.s 33
+			IL_09ff: ldloc.s 26
+			IL_0a01: ldstr "tagName"
+			IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a10: stloc.s 34
+			IL_0a12: ldloc.s 33
+			IL_0a14: ldloc.s 34
+			IL_0a16: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a1b: stloc.s 34
+			IL_0a1d: ldloc.s 34
+			IL_0a1f: ldstr ") -> "
+			IL_0a24: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a29: stloc.s 34
+			IL_0a2b: ldloc.s 27
+			IL_0a2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a32: stloc.s 33
+			IL_0a34: ldloc.s 34
+			IL_0a36: ldloc.s 33
+			IL_0a38: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a3d: stloc.s 33
+			IL_0a3f: ldnull
+			IL_0a40: ldloc.s 33
+			IL_0a42: ldloc.s 27
+			IL_0a44: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0a49: stloc.s 35
+			IL_0a4b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a50: ldloc.s 35
+			IL_0a52: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a57: pop
+			IL_0a58: ldarg.0
+			IL_0a59: ldc.i4.1
+			IL_0a5a: ldelem.ref
+			IL_0a5b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a60: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a6a: stloc.s 35
+			IL_0a6c: ldloc.s 35
+			IL_0a6e: ldstr "readFileSync"
+			IL_0a73: ldloc.s 27
+			IL_0a75: ldstr "utf8"
+			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a7f: stloc.s 35
+			IL_0a81: ldnull
+			IL_0a82: ldloc.s 35
+			IL_0a84: ldloc.s 27
+			IL_0a86: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0a8b: stloc.s 35
+			IL_0a8d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a92: ldloc.s 35
+			IL_0a94: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a99: pop
+			IL_0a9a: ldloc.0
+			IL_0a9b: ldc.i4.m1
+			IL_0a9c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0aa1: ldloc.0
+			IL_0aa2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0aa7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0aac: ldarg.0
+			IL_0aad: ldc.i4.1
+			IL_0aae: newarr [System.Runtime]System.Object
+			IL_0ab3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0ab8: pop
+			IL_0ab9: ldloc.0
+			IL_0aba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0abf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0ac4: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5315,7 +5243,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x45b9
+			// Method begins at RVA 0x4505
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5581,7 +5509,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x477b
+		// Method begins at RVA 0x46c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+﻿// IL code: Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45a7
+				// Method begins at RVA 0x44f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -192,7 +192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45b0
+				// Method begins at RVA 0x44fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -324,7 +324,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x459e
+			// Method begins at RVA 0x44ea
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -442,7 +442,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45cb
+					// Method begins at RVA 0x4517
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -460,7 +460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45c2
+				// Method begins at RVA 0x450e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -612,7 +612,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45d4
+				// Method begins at RVA 0x4520
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -640,7 +640,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45ef
+						// Method begins at RVA 0x453b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -660,7 +660,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45f8
+						// Method begins at RVA 0x4544
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -680,7 +680,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4601
+						// Method begins at RVA 0x454d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -700,7 +700,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x460a
+						// Method begins at RVA 0x4556
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -720,7 +720,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4613
+						// Method begins at RVA 0x455f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -740,7 +740,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x461c
+						// Method begins at RVA 0x4568
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -758,7 +758,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45e6
+					// Method begins at RVA 0x4532
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +776,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45dd
+				// Method begins at RVA 0x4529
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1130,7 +1130,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x466d
+							// Method begins at RVA 0x45b9
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1155,7 +1155,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4520
+						// Method begins at RVA 0x446c
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1194,7 +1194,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4676
+							// Method begins at RVA 0x45c2
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1218,7 +1218,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4550
+						// Method begins at RVA 0x449c
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1291,7 +1291,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x465b
+								// Method begins at RVA 0x45a7
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1309,7 +1309,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4652
+							// Method begins at RVA 0x459e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1329,7 +1329,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x4664
+							// Method begins at RVA 0x45b0
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1351,7 +1351,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4649
+						// Method begins at RVA 0x4595
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1376,9 +1376,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x409c
+					// Method begins at RVA 0x4000
 					// Header size: 12
-					// Code size: 1141 (0x475)
+					// Code size: 1119 (0x45f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1482,7 +1482,7 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 8
 					IL_00d6: ldloc.s 8
-					IL_00d8: brfalse IL_0274
+					IL_00d8: brfalse IL_025e
 
 					IL_00dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00e2: stloc.3
@@ -1608,262 +1608,253 @@
 					IL_020c: sub
 					IL_020d: box [System.Runtime]System.Double
 					IL_0212: stloc.s 19
-					IL_0214: ldc.i4.1
-					IL_0215: newarr [System.Runtime]System.Object
-					IL_021a: dup
-					IL_021b: ldc.i4.0
-					IL_021c: ldarg.0
-					IL_021d: ldc.i4.0
-					IL_021e: ldelem.ref
-					IL_021f: stelem.ref
-					IL_0220: ldc.i4.0
-					IL_0221: ldelem.ref
-					IL_0222: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_0227: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-					IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-					IL_0232: ldnull
-					IL_0233: ldloc.s 5
-					IL_0235: ldloc.s 19
-					IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-					IL_023c: stloc.s 18
-					IL_023e: ldloc.s 18
-					IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0245: stloc.s 18
-					IL_0247: ldarg.0
-					IL_0248: ldc.i4.2
-					IL_0249: ldelem.ref
-					IL_024a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_024f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_0254: stloc.s 7
-					IL_0256: ldloc.s 18
-					IL_0258: ldstr "then"
-					IL_025d: ldloc.s 7
-					IL_025f: ldarg.0
-					IL_0260: ldc.i4.2
-					IL_0261: ldelem.ref
-					IL_0262: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0267: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0271: pop
-					IL_0272: ldnull
-					IL_0273: ret
+					IL_0214: ldarg.0
+					IL_0215: ldc.i4.0
+					IL_0216: ldelem.ref
+					IL_0217: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_021c: ldnull
+					IL_021d: ldloc.s 5
+					IL_021f: ldloc.s 19
+					IL_0221: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+					IL_0226: stloc.s 18
+					IL_0228: ldloc.s 18
+					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_022f: stloc.s 18
+					IL_0231: ldarg.0
+					IL_0232: ldc.i4.2
+					IL_0233: ldelem.ref
+					IL_0234: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0239: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_023e: stloc.s 7
+					IL_0240: ldloc.s 18
+					IL_0242: ldstr "then"
+					IL_0247: ldloc.s 7
+					IL_0249: ldarg.0
+					IL_024a: ldc.i4.2
+					IL_024b: ldelem.ref
+					IL_024c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0251: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_025b: pop
+					IL_025c: ldnull
+					IL_025d: ret
 
-					IL_0274: ldloc.1
-					IL_0275: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_027a: stloc.s 11
-					IL_027c: ldloc.s 11
-					IL_027e: ldc.r8 200
-					IL_0287: clt
-					IL_0289: stloc.s 8
-					IL_028b: ldloc.s 8
-					IL_028d: box [System.Runtime]System.Boolean
-					IL_0292: stloc.s 12
-					IL_0294: ldloc.s 12
-					IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_029b: stloc.s 8
-					IL_029d: ldloc.s 8
-					IL_029f: brtrue IL_02d0
+					IL_025e: ldloc.1
+					IL_025f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0264: stloc.s 11
+					IL_0266: ldloc.s 11
+					IL_0268: ldc.r8 200
+					IL_0271: clt
+					IL_0273: stloc.s 8
+					IL_0275: ldloc.s 8
+					IL_0277: box [System.Runtime]System.Boolean
+					IL_027c: stloc.s 12
+					IL_027e: ldloc.s 12
+					IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0285: stloc.s 8
+					IL_0287: ldloc.s 8
+					IL_0289: brtrue IL_02ba
 
-					IL_02a4: ldloc.1
-					IL_02a5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_02aa: stloc.s 11
-					IL_02ac: ldloc.s 11
-					IL_02ae: ldc.r8 300
-					IL_02b7: clt
-					IL_02b9: ldc.i4.0
-					IL_02ba: ceq
-					IL_02bc: stloc.s 8
-					IL_02be: ldloc.s 8
-					IL_02c0: box [System.Runtime]System.Boolean
-					IL_02c5: stloc.s 13
-					IL_02c7: ldloc.s 13
-					IL_02c9: stloc.s 20
-					IL_02cb: br IL_02d4
+					IL_028e: ldloc.1
+					IL_028f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0294: stloc.s 11
+					IL_0296: ldloc.s 11
+					IL_0298: ldc.r8 300
+					IL_02a1: clt
+					IL_02a3: ldc.i4.0
+					IL_02a4: ceq
+					IL_02a6: stloc.s 8
+					IL_02a8: ldloc.s 8
+					IL_02aa: box [System.Runtime]System.Boolean
+					IL_02af: stloc.s 13
+					IL_02b1: ldloc.s 13
+					IL_02b3: stloc.s 20
+					IL_02b5: br IL_02be
 
-					IL_02d0: ldloc.s 12
-					IL_02d2: stloc.s 20
+					IL_02ba: ldloc.s 12
+					IL_02bc: stloc.s 20
 
-					IL_02d4: ldloc.s 20
-					IL_02d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02db: stloc.s 8
-					IL_02dd: ldloc.s 8
-					IL_02df: brfalse IL_0388
+					IL_02be: ldloc.s 20
+					IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02c5: stloc.s 8
+					IL_02c7: ldloc.s 8
+					IL_02c9: brfalse IL_0372
 
-					IL_02e4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_02e9: stloc.s 6
-					IL_02eb: ldarg.2
-					IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02f1: stloc.s 7
-					IL_02f3: ldloc.s 7
-					IL_02f5: ldstr "resume"
-					IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02ff: pop
-					IL_0300: ldarg.0
-					IL_0301: ldc.i4.2
-					IL_0302: ldelem.ref
-					IL_0303: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0308: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_030d: stloc.s 7
-					IL_030f: ldc.i4.3
-					IL_0310: newarr [System.Runtime]System.Object
-					IL_0315: dup
-					IL_0316: ldc.i4.0
-					IL_0317: ldarg.0
-					IL_0318: ldc.i4.0
-					IL_0319: ldelem.ref
-					IL_031a: stelem.ref
-					IL_031b: dup
-					IL_031c: ldc.i4.1
-					IL_031d: ldarg.0
-					IL_031e: ldc.i4.1
-					IL_031f: ldelem.ref
-					IL_0320: stelem.ref
-					IL_0321: dup
-					IL_0322: ldc.i4.2
-					IL_0323: ldarg.0
-					IL_0324: ldc.i4.2
-					IL_0325: ldelem.ref
-					IL_0326: stelem.ref
-					IL_0327: stloc.s 16
-					IL_0329: ldloc.1
-					IL_032a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_032f: stloc.s 17
-					IL_0331: ldstr "HTTP "
-					IL_0336: ldloc.s 17
-					IL_0338: call string [System.Runtime]System.String::Concat(string, string)
-					IL_033d: stloc.s 17
-					IL_033f: ldloc.s 17
-					IL_0341: ldstr " fetching "
-					IL_0346: call string [System.Runtime]System.String::Concat(string, string)
-					IL_034b: stloc.s 17
-					IL_034d: ldarg.0
-					IL_034e: ldc.i4.1
-					IL_034f: ldelem.ref
-					IL_0350: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_0355: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_035a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_035f: stloc.s 21
-					IL_0361: ldloc.s 17
-					IL_0363: ldloc.s 21
-					IL_0365: call string [System.Runtime]System.String::Concat(string, string)
-					IL_036a: stloc.s 21
-					IL_036c: ldloc.s 21
-					IL_036e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0373: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_02ce: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_02d3: stloc.s 6
+					IL_02d5: ldarg.2
+					IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02db: stloc.s 7
+					IL_02dd: ldloc.s 7
+					IL_02df: ldstr "resume"
+					IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02e9: pop
+					IL_02ea: ldarg.0
+					IL_02eb: ldc.i4.2
+					IL_02ec: ldelem.ref
+					IL_02ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_02f2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_02f7: stloc.s 7
+					IL_02f9: ldc.i4.3
+					IL_02fa: newarr [System.Runtime]System.Object
+					IL_02ff: dup
+					IL_0300: ldc.i4.0
+					IL_0301: ldarg.0
+					IL_0302: ldc.i4.0
+					IL_0303: ldelem.ref
+					IL_0304: stelem.ref
+					IL_0305: dup
+					IL_0306: ldc.i4.1
+					IL_0307: ldarg.0
+					IL_0308: ldc.i4.1
+					IL_0309: ldelem.ref
+					IL_030a: stelem.ref
+					IL_030b: dup
+					IL_030c: ldc.i4.2
+					IL_030d: ldarg.0
+					IL_030e: ldc.i4.2
+					IL_030f: ldelem.ref
+					IL_0310: stelem.ref
+					IL_0311: stloc.s 16
+					IL_0313: ldloc.1
+					IL_0314: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0319: stloc.s 17
+					IL_031b: ldstr "HTTP "
+					IL_0320: ldloc.s 17
+					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0327: stloc.s 17
+					IL_0329: ldloc.s 17
+					IL_032b: ldstr " fetching "
+					IL_0330: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0335: stloc.s 17
+					IL_0337: ldarg.0
+					IL_0338: ldc.i4.1
+					IL_0339: ldelem.ref
+					IL_033a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_033f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0344: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0349: stloc.s 21
+					IL_034b: ldloc.s 17
+					IL_034d: ldloc.s 21
+					IL_034f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0354: stloc.s 21
+					IL_0356: ldloc.s 21
+					IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0362: stloc.s 18
+					IL_0364: ldloc.s 7
+					IL_0366: ldloc.s 16
+					IL_0368: ldloc.s 18
+					IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_036f: pop
+					IL_0370: ldnull
+					IL_0371: ret
+
+					IL_0372: ldarg.2
+					IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_0378: stloc.s 18
-					IL_037a: ldloc.s 7
-					IL_037c: ldloc.s 16
-					IL_037e: ldloc.s 18
-					IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_0385: pop
-					IL_0386: ldnull
-					IL_0387: ret
-
-					IL_0388: ldarg.2
-					IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_038e: stloc.s 18
-					IL_0390: ldloc.s 18
-					IL_0392: ldstr "setEncoding"
-					IL_0397: ldstr "utf8"
-					IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_03a1: pop
-					IL_03a2: ldloc.0
-					IL_03a3: ldstr ""
-					IL_03a8: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_03ad: ldarg.2
-					IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_03b3: stloc.s 18
-					IL_03b5: ldnull
-					IL_03b6: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_03bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_03c1: ldc.i4.4
-					IL_03c2: newarr [System.Runtime]System.Object
-					IL_03c7: dup
-					IL_03c8: ldc.i4.0
-					IL_03c9: ldarg.0
-					IL_03ca: ldc.i4.0
-					IL_03cb: ldelem.ref
-					IL_03cc: stelem.ref
-					IL_03cd: dup
-					IL_03ce: ldc.i4.1
-					IL_03cf: ldarg.0
-					IL_03d0: ldc.i4.1
-					IL_03d1: ldelem.ref
-					IL_03d2: stelem.ref
-					IL_03d3: dup
-					IL_03d4: ldc.i4.2
-					IL_03d5: ldarg.0
-					IL_03d6: ldc.i4.2
-					IL_03d7: ldelem.ref
-					IL_03d8: stelem.ref
-					IL_03d9: dup
-					IL_03da: ldc.i4.3
-					IL_03db: ldloc.0
-					IL_03dc: stelem.ref
-					IL_03dd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03e7: ldc.i4.1
-					IL_03e8: conv.r8
-					IL_03e9: ldstr ""
-					IL_03ee: ldc.i4.0
-					IL_03ef: ldc.i4.1
-					IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_03fa: stloc.s 7
-					IL_03fc: ldloc.s 18
-					IL_03fe: ldstr "on"
-					IL_0403: ldstr "data"
-					IL_0408: ldloc.s 7
-					IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_040f: pop
-					IL_0410: ldarg.2
-					IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0416: stloc.s 7
-					IL_0418: ldnull
-					IL_0419: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_041f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_0424: ldc.i4.4
-					IL_0425: newarr [System.Runtime]System.Object
-					IL_042a: dup
-					IL_042b: ldc.i4.0
-					IL_042c: ldarg.0
-					IL_042d: ldc.i4.0
-					IL_042e: ldelem.ref
-					IL_042f: stelem.ref
-					IL_0430: dup
-					IL_0431: ldc.i4.1
-					IL_0432: ldarg.0
-					IL_0433: ldc.i4.1
-					IL_0434: ldelem.ref
-					IL_0435: stelem.ref
-					IL_0436: dup
-					IL_0437: ldc.i4.2
-					IL_0438: ldarg.0
-					IL_0439: ldc.i4.2
-					IL_043a: ldelem.ref
-					IL_043b: stelem.ref
-					IL_043c: dup
-					IL_043d: ldc.i4.3
-					IL_043e: ldloc.0
-					IL_043f: stelem.ref
-					IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_044a: ldc.i4.0
-					IL_044b: conv.r8
-					IL_044c: ldstr ""
-					IL_0451: ldc.i4.0
-					IL_0452: ldc.i4.1
-					IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_045d: stloc.s 18
-					IL_045f: ldloc.s 7
-					IL_0461: ldstr "on"
-					IL_0466: ldstr "end"
-					IL_046b: ldloc.s 18
-					IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_0472: pop
-					IL_0473: ldnull
-					IL_0474: ret
+					IL_037a: ldloc.s 18
+					IL_037c: ldstr "setEncoding"
+					IL_0381: ldstr "utf8"
+					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_038b: pop
+					IL_038c: ldloc.0
+					IL_038d: ldstr ""
+					IL_0392: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_0397: ldarg.2
+					IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_039d: stloc.s 18
+					IL_039f: ldnull
+					IL_03a0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03ab: ldc.i4.4
+					IL_03ac: newarr [System.Runtime]System.Object
+					IL_03b1: dup
+					IL_03b2: ldc.i4.0
+					IL_03b3: ldarg.0
+					IL_03b4: ldc.i4.0
+					IL_03b5: ldelem.ref
+					IL_03b6: stelem.ref
+					IL_03b7: dup
+					IL_03b8: ldc.i4.1
+					IL_03b9: ldarg.0
+					IL_03ba: ldc.i4.1
+					IL_03bb: ldelem.ref
+					IL_03bc: stelem.ref
+					IL_03bd: dup
+					IL_03be: ldc.i4.2
+					IL_03bf: ldarg.0
+					IL_03c0: ldc.i4.2
+					IL_03c1: ldelem.ref
+					IL_03c2: stelem.ref
+					IL_03c3: dup
+					IL_03c4: ldc.i4.3
+					IL_03c5: ldloc.0
+					IL_03c6: stelem.ref
+					IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03d1: ldc.i4.1
+					IL_03d2: conv.r8
+					IL_03d3: ldstr ""
+					IL_03d8: ldc.i4.0
+					IL_03d9: ldc.i4.1
+					IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_03e4: stloc.s 7
+					IL_03e6: ldloc.s 18
+					IL_03e8: ldstr "on"
+					IL_03ed: ldstr "data"
+					IL_03f2: ldloc.s 7
+					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_03f9: pop
+					IL_03fa: ldarg.2
+					IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0400: stloc.s 7
+					IL_0402: ldnull
+					IL_0403: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0409: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_040e: ldc.i4.4
+					IL_040f: newarr [System.Runtime]System.Object
+					IL_0414: dup
+					IL_0415: ldc.i4.0
+					IL_0416: ldarg.0
+					IL_0417: ldc.i4.0
+					IL_0418: ldelem.ref
+					IL_0419: stelem.ref
+					IL_041a: dup
+					IL_041b: ldc.i4.1
+					IL_041c: ldarg.0
+					IL_041d: ldc.i4.1
+					IL_041e: ldelem.ref
+					IL_041f: stelem.ref
+					IL_0420: dup
+					IL_0421: ldc.i4.2
+					IL_0422: ldarg.0
+					IL_0423: ldc.i4.2
+					IL_0424: ldelem.ref
+					IL_0425: stelem.ref
+					IL_0426: dup
+					IL_0427: ldc.i4.3
+					IL_0428: ldloc.0
+					IL_0429: stelem.ref
+					IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0434: ldc.i4.0
+					IL_0435: conv.r8
+					IL_0436: ldstr ""
+					IL_043b: ldc.i4.0
+					IL_043c: ldc.i4.1
+					IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0447: stloc.s 18
+					IL_0449: ldloc.s 7
+					IL_044b: ldstr "on"
+					IL_0450: ldstr "end"
+					IL_0455: ldloc.s 18
+					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_045c: pop
+					IL_045d: ldnull
+					IL_045e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1885,7 +1876,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4637
+						// Method begins at RVA 0x4583
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1905,7 +1896,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4640
+						// Method begins at RVA 0x458c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1928,7 +1919,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x462e
+					// Method begins at RVA 0x457a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1954,7 +1945,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e80
+				// Method begins at RVA 0x3de4
 				// Header size: 12
 				// Code size: 512 (0x200)
 				.maxstack 8
@@ -2199,7 +2190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4625
+				// Method begins at RVA 0x4571
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2295,7 +2286,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x467f
+				// Method begins at RVA 0x45cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2362,7 +2353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4691
+					// Method begins at RVA 0x45dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2386,7 +2377,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46a3
+						// Method begins at RVA 0x45ef
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2404,7 +2395,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x469a
+					// Method begins at RVA 0x45e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2422,7 +2413,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4688
+				// Method begins at RVA 0x45d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2696,7 +2687,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46b5
+					// Method begins at RVA 0x4601
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2716,7 +2707,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46be
+					// Method begins at RVA 0x460a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2736,7 +2727,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46c7
+					// Method begins at RVA 0x4613
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2756,7 +2747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d0
+					// Method begins at RVA 0x461c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2780,7 +2771,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46e2
+						// Method begins at RVA 0x462e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2800,7 +2791,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46eb
+						// Method begins at RVA 0x4637
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2824,7 +2815,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x46fd
+							// Method begins at RVA 0x4649
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2842,7 +2833,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46f4
+						// Method begins at RVA 0x4640
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2862,7 +2853,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4706
+						// Method begins at RVA 0x4652
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2880,7 +2871,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46d9
+					// Method begins at RVA 0x4625
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2898,7 +2889,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x46ac
+				// Method begins at RVA 0x45f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2928,7 +2919,7 @@
 			)
 			// Method begins at RVA 0x2c24
 			// Header size: 12
-			// Code size: 1118 (0x45e)
+			// Code size: 1096 (0x448)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -3110,250 +3101,241 @@
 
 			IL_019e: throw
 
-			IL_019f: ldc.i4.1
-			IL_01a0: newarr [System.Runtime]System.Object
-			IL_01a5: dup
-			IL_01a6: ldc.i4.0
-			IL_01a7: ldarg.0
-			IL_01a8: stelem.ref
-			IL_01a9: ldc.i4.0
-			IL_01aa: ldelem.ref
-			IL_01ab: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_01b0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_01b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_01bb: ldnull
-			IL_01bc: ldarg.2
-			IL_01bd: ldloc.s 6
-			IL_01bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_01c4: stloc.s 25
-			IL_01c6: ldloc.s 25
-			IL_01c8: stloc.s 9
-			IL_01ca: ldloc.s 9
-			IL_01cc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01d1: ldc.i4.0
-			IL_01d2: ceq
-			IL_01d4: stloc.s 27
-			IL_01d6: ldloc.s 27
-			IL_01d8: brfalse IL_0231
+			IL_019f: ldarg.0
+			IL_01a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_01a5: ldnull
+			IL_01a6: ldarg.2
+			IL_01a7: ldloc.s 6
+			IL_01a9: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_01ae: stloc.s 25
+			IL_01b0: ldloc.s 25
+			IL_01b2: stloc.s 9
+			IL_01b4: ldloc.s 9
+			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01bb: ldc.i4.0
+			IL_01bc: ceq
+			IL_01be: stloc.s 27
+			IL_01c0: ldloc.s 27
+			IL_01c2: brfalse IL_021b
 
-			IL_01dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
-			IL_01e2: stloc.s 10
-			IL_01e4: ldarg.3
-			IL_01e5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ea: stloc.s 24
-			IL_01ec: ldstr "Could not determine tag name for id '"
-			IL_01f1: ldloc.s 24
-			IL_01f3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f8: stloc.s 24
-			IL_01fa: ldloc.s 24
-			IL_01fc: ldstr "'."
-			IL_0201: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0206: stloc.s 24
-			IL_0208: ldloc.s 24
-			IL_020a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_020f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0214: stloc.s 25
-			IL_0216: ldloc.s 25
-			IL_0218: stloc.s 11
-			IL_021a: ldloc.s 11
-			IL_021c: isinst [System.Runtime]System.Exception
-			IL_0221: dup
-			IL_0222: brtrue IL_0230
+			IL_01c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
+			IL_01cc: stloc.s 10
+			IL_01ce: ldarg.3
+			IL_01cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d4: stloc.s 24
+			IL_01d6: ldstr "Could not determine tag name for id '"
+			IL_01db: ldloc.s 24
+			IL_01dd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e2: stloc.s 24
+			IL_01e4: ldloc.s 24
+			IL_01e6: ldstr "'."
+			IL_01eb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f0: stloc.s 24
+			IL_01f2: ldloc.s 24
+			IL_01f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01fe: stloc.s 25
+			IL_0200: ldloc.s 25
+			IL_0202: stloc.s 11
+			IL_0204: ldloc.s 11
+			IL_0206: isinst [System.Runtime]System.Exception
+			IL_020b: dup
+			IL_020c: brtrue IL_021a
 
-			IL_0227: pop
-			IL_0228: ldloc.s 11
-			IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_022f: throw
+			IL_0211: pop
+			IL_0212: ldloc.s 11
+			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0219: throw
 
-			IL_0230: throw
+			IL_021a: throw
 
-			IL_0231: ldnull
-			IL_0232: ldloc.s 9
-			IL_0234: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-			IL_0239: stloc.s 25
-			IL_023b: ldloc.s 25
-			IL_023d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0242: stloc.s 24
-			IL_0244: ldstr "<\\/?"
-			IL_0249: ldloc.s 24
-			IL_024b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0250: stloc.s 24
-			IL_0252: ldloc.s 24
-			IL_0254: ldstr "\\b[^>]*>"
-			IL_0259: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025e: stloc.s 24
-			IL_0260: ldloc.s 24
-			IL_0262: ldstr "gi"
-			IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_026c: stloc.s 28
-			IL_026e: ldloc.s 28
-			IL_0270: stloc.s 12
-			IL_0272: ldloc.s 12
-			IL_0274: ldstr "lastIndex"
-			IL_0279: ldloc.s 6
-			IL_027b: ldc.i4.1
-			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0281: pop
-			IL_0282: ldc.r8 0.0
-			IL_028b: stloc.s 13
-			IL_028d: ldc.r8 1
-			IL_0296: neg
-			IL_0297: box [System.Runtime]System.Double
-			IL_029c: stloc.s 14
-			// loop start (head: IL_029e)
-				IL_029e: ldc.i4.1
-				IL_029f: brfalse IL_03ed
+			IL_021b: ldnull
+			IL_021c: ldloc.s 9
+			IL_021e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+			IL_0223: stloc.s 25
+			IL_0225: ldloc.s 25
+			IL_0227: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_022c: stloc.s 24
+			IL_022e: ldstr "<\\/?"
+			IL_0233: ldloc.s 24
+			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
+			IL_023a: stloc.s 24
+			IL_023c: ldloc.s 24
+			IL_023e: ldstr "\\b[^>]*>"
+			IL_0243: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0248: stloc.s 24
+			IL_024a: ldloc.s 24
+			IL_024c: ldstr "gi"
+			IL_0251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0256: stloc.s 28
+			IL_0258: ldloc.s 28
+			IL_025a: stloc.s 12
+			IL_025c: ldloc.s 12
+			IL_025e: ldstr "lastIndex"
+			IL_0263: ldloc.s 6
+			IL_0265: ldc.i4.1
+			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_026b: pop
+			IL_026c: ldc.r8 0.0
+			IL_0275: stloc.s 13
+			IL_0277: ldc.r8 1
+			IL_0280: neg
+			IL_0281: box [System.Runtime]System.Double
+			IL_0286: stloc.s 14
+			// loop start (head: IL_0288)
+				IL_0288: ldc.i4.1
+				IL_0289: brfalse IL_03d7
 
-				IL_02a4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_02a9: stloc.s 15
-				IL_02ab: ldloc.s 12
-				IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02b2: stloc.s 25
-				IL_02b4: ldloc.s 25
-				IL_02b6: ldstr "exec"
-				IL_02bb: ldarg.2
-				IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02c1: stloc.s 25
-				IL_02c3: ldloc.s 25
-				IL_02c5: stloc.s 16
-				IL_02c7: ldloc.s 16
-				IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02ce: ldc.i4.0
-				IL_02cf: ceq
-				IL_02d1: stloc.s 27
-				IL_02d3: ldloc.s 27
-				IL_02d5: brfalse IL_02e6
+				IL_028e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
+				IL_0293: stloc.s 15
+				IL_0295: ldloc.s 12
+				IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_029c: stloc.s 25
+				IL_029e: ldloc.s 25
+				IL_02a0: ldstr "exec"
+				IL_02a5: ldarg.2
+				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02ab: stloc.s 25
+				IL_02ad: ldloc.s 25
+				IL_02af: stloc.s 16
+				IL_02b1: ldloc.s 16
+				IL_02b3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02b8: ldc.i4.0
+				IL_02b9: ceq
+				IL_02bb: stloc.s 27
+				IL_02bd: ldloc.s 27
+				IL_02bf: brfalse IL_02d0
 
-				IL_02da: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
-				IL_02df: stloc.s 17
-				IL_02e1: br IL_03ed
+				IL_02c4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
+				IL_02c9: stloc.s 17
+				IL_02cb: br IL_03d7
 
-				IL_02e6: ldloc.s 16
-				IL_02e8: ldc.r8 0.0
-				IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02f6: stloc.s 18
-				IL_02f8: ldloc.s 14
-				IL_02fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_02ff: stloc.s 26
-				IL_0301: ldloc.s 26
-				IL_0303: ldc.r8 0.0
-				IL_030c: clt
-				IL_030e: brfalse IL_032c
+				IL_02d0: ldloc.s 16
+				IL_02d2: ldc.r8 0.0
+				IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02e0: stloc.s 18
+				IL_02e2: ldloc.s 14
+				IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_02e9: stloc.s 26
+				IL_02eb: ldloc.s 26
+				IL_02ed: ldc.r8 0.0
+				IL_02f6: clt
+				IL_02f8: brfalse IL_0316
 
-				IL_0313: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
-				IL_0318: stloc.s 19
-				IL_031a: ldloc.s 16
-				IL_031c: ldstr "index"
-				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0326: stloc.s 25
-				IL_0328: ldloc.s 25
-				IL_032a: stloc.s 14
+				IL_02fd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
+				IL_0302: stloc.s 19
+				IL_0304: ldloc.s 16
+				IL_0306: ldstr "index"
+				IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0310: stloc.s 25
+				IL_0312: ldloc.s 25
+				IL_0314: stloc.s 14
 
-				IL_032c: ldloc.s 18
-				IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0333: stloc.s 25
-				IL_0335: ldloc.s 25
-				IL_0337: ldstr "startsWith"
-				IL_033c: ldstr "</"
-				IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0346: stloc.s 25
-				IL_0348: ldloc.s 25
-				IL_034a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_034f: stloc.s 27
-				IL_0351: ldloc.s 27
-				IL_0353: brfalse IL_03d3
+				IL_0316: ldloc.s 18
+				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_031d: stloc.s 25
+				IL_031f: ldloc.s 25
+				IL_0321: ldstr "startsWith"
+				IL_0326: ldstr "</"
+				IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0330: stloc.s 25
+				IL_0332: ldloc.s 25
+				IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0339: stloc.s 27
+				IL_033b: ldloc.s 27
+				IL_033d: brfalse IL_03bd
 
-				IL_0358: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
-				IL_035d: stloc.s 20
-				IL_035f: ldloc.s 13
-				IL_0361: ldc.r8 1
-				IL_036a: sub
-				IL_036b: stloc.s 13
-				IL_036d: ldloc.s 13
-				IL_036f: ldc.r8 0.0
-				IL_0378: ceq
-				IL_037a: brfalse IL_03ce
+				IL_0342: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
+				IL_0347: stloc.s 20
+				IL_0349: ldloc.s 13
+				IL_034b: ldc.r8 1
+				IL_0354: sub
+				IL_0355: stloc.s 13
+				IL_0357: ldloc.s 13
+				IL_0359: ldc.r8 0.0
+				IL_0362: ceq
+				IL_0364: brfalse IL_03b8
 
-				IL_037f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
-				IL_0384: stloc.s 21
-				IL_0386: ldarg.2
-				IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_038c: stloc.s 25
-				IL_038e: ldloc.s 25
-				IL_0390: ldstr "substring"
-				IL_0395: ldloc.s 14
-				IL_0397: ldloc.s 12
-				IL_0399: ldstr "lastIndex"
-				IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-				IL_03a8: stloc.s 25
-				IL_03aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_03af: dup
-				IL_03b0: ldstr "tagName"
-				IL_03b5: ldloc.s 9
-				IL_03b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03bc: dup
-				IL_03bd: ldstr "html"
-				IL_03c2: ldloc.s 25
-				IL_03c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03c9: stloc.s 29
-				IL_03cb: ldloc.s 29
-				IL_03cd: ret
+				IL_0369: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
+				IL_036e: stloc.s 21
+				IL_0370: ldarg.2
+				IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0376: stloc.s 25
+				IL_0378: ldloc.s 25
+				IL_037a: ldstr "substring"
+				IL_037f: ldloc.s 14
+				IL_0381: ldloc.s 12
+				IL_0383: ldstr "lastIndex"
+				IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0392: stloc.s 25
+				IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0399: dup
+				IL_039a: ldstr "tagName"
+				IL_039f: ldloc.s 9
+				IL_03a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03a6: dup
+				IL_03a7: ldstr "html"
+				IL_03ac: ldloc.s 25
+				IL_03ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03b3: stloc.s 29
+				IL_03b5: ldloc.s 29
+				IL_03b7: ret
 
-				IL_03ce: br IL_03e8
+				IL_03b8: br IL_03d2
 
-				IL_03d3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
-				IL_03d8: stloc.s 22
-				IL_03da: ldloc.s 13
-				IL_03dc: ldc.r8 1
-				IL_03e5: add
-				IL_03e6: stloc.s 13
+				IL_03bd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
+				IL_03c2: stloc.s 22
+				IL_03c4: ldloc.s 13
+				IL_03c6: ldc.r8 1
+				IL_03cf: add
+				IL_03d0: stloc.s 13
 
-				IL_03e8: br IL_029e
+				IL_03d2: br IL_0288
 			// end loop
 
-			IL_03ed: ldloc.s 9
-			IL_03ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03f4: stloc.s 24
-			IL_03f6: ldstr "Could not find a matching closing </"
-			IL_03fb: ldloc.s 24
-			IL_03fd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0402: stloc.s 24
+			IL_03d7: ldloc.s 9
+			IL_03d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03de: stloc.s 24
+			IL_03e0: ldstr "Could not find a matching closing </"
+			IL_03e5: ldloc.s 24
+			IL_03e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03ec: stloc.s 24
+			IL_03ee: ldloc.s 24
+			IL_03f0: ldstr "> for id '"
+			IL_03f5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03fa: stloc.s 24
+			IL_03fc: ldarg.3
+			IL_03fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0402: stloc.s 30
 			IL_0404: ldloc.s 24
-			IL_0406: ldstr "> for id '"
-			IL_040b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0410: stloc.s 24
-			IL_0412: ldarg.3
-			IL_0413: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0418: stloc.s 30
-			IL_041a: ldloc.s 24
-			IL_041c: ldloc.s 30
-			IL_041e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0423: stloc.s 30
-			IL_0425: ldloc.s 30
-			IL_0427: ldstr "'."
-			IL_042c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0431: stloc.s 30
-			IL_0433: ldloc.s 30
-			IL_0435: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_043a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_043f: stloc.s 25
-			IL_0441: ldloc.s 25
-			IL_0443: stloc.s 23
-			IL_0445: ldloc.s 23
-			IL_0447: isinst [System.Runtime]System.Exception
-			IL_044c: dup
-			IL_044d: brtrue IL_045b
+			IL_0406: ldloc.s 30
+			IL_0408: call string [System.Runtime]System.String::Concat(string, string)
+			IL_040d: stloc.s 30
+			IL_040f: ldloc.s 30
+			IL_0411: ldstr "'."
+			IL_0416: call string [System.Runtime]System.String::Concat(string, string)
+			IL_041b: stloc.s 30
+			IL_041d: ldloc.s 30
+			IL_041f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0424: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0429: stloc.s 25
+			IL_042b: ldloc.s 25
+			IL_042d: stloc.s 23
+			IL_042f: ldloc.s 23
+			IL_0431: isinst [System.Runtime]System.Exception
+			IL_0436: dup
+			IL_0437: brtrue IL_0445
 
-			IL_0452: pop
-			IL_0453: ldloc.s 23
-			IL_0455: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_045a: throw
+			IL_043c: pop
+			IL_043d: ldloc.s 23
+			IL_043f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0444: throw
 
-			IL_045b: throw
+			IL_0445: throw
 
-			IL_045c: ldnull
-			IL_045d: ret
+			IL_0446: ldnull
+			IL_0447: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3373,7 +3355,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4718
+					// Method begins at RVA 0x4664
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3391,7 +3373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x470f
+				// Method begins at RVA 0x465b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3419,7 +3401,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3090
+			// Method begins at RVA 0x3078
 			// Header size: 12
 			// Code size: 487 (0x1e7)
 			.maxstack 8
@@ -3632,7 +3614,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4721
+				// Method begins at RVA 0x466d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3658,7 +3640,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3284
+			// Method begins at RVA 0x326c
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -3765,7 +3747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4733
+					// Method begins at RVA 0x467f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3785,7 +3767,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x473c
+					// Method begins at RVA 0x4688
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3805,7 +3787,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4745
+					// Method begins at RVA 0x4691
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3829,7 +3811,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4757
+						// Method begins at RVA 0x46a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3849,7 +3831,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4760
+						// Method begins at RVA 0x46ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3867,7 +3849,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x474e
+					// Method begins at RVA 0x469a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3887,7 +3869,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4769
+					// Method begins at RVA 0x46b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3907,7 +3889,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4772
+					// Method begins at RVA 0x46be
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3947,7 +3929,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x472a
+				// Method begins at RVA 0x4676
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3971,9 +3953,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3328
+			// Method begins at RVA 0x3310
 			// Header size: 12
-			// Code size: 2889 (0xb49)
+			// Code size: 2757 (0xac5)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4183,1099 +4165,1045 @@
 
 			IL_0130: ldloc.0
 			IL_0131: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0136: switch (IL_014b, IL_04ce, IL_0731, IL_08b0)
+			IL_0136: switch (IL_014b, IL_04a2, IL_06d9, IL_0842)
 
 			IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
 			IL_0150: ldstr "argv"
 			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_015a: stloc.s 29
-			IL_015c: ldc.i4.1
-			IL_015d: newarr [System.Runtime]System.Object
-			IL_0162: dup
-			IL_0163: ldc.i4.0
-			IL_0164: ldarg.0
-			IL_0165: ldc.i4.1
-			IL_0166: ldelem.ref
-			IL_0167: stelem.ref
-			IL_0168: ldc.i4.0
-			IL_0169: ldelem.ref
-			IL_016a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_016f: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-			IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_017a: ldnull
-			IL_017b: ldloc.s 29
-			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0182: stloc.s 29
-			IL_0184: ldloc.s 29
-			IL_0186: stloc.1
-			IL_0187: ldloc.1
-			IL_0188: ldstr "section"
-			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0197: ldc.i4.0
-			IL_0198: ceq
-			IL_019a: stloc.s 30
-			IL_019c: ldloc.s 30
-			IL_019e: brfalse IL_01ec
+			IL_015c: ldarg.0
+			IL_015d: ldc.i4.1
+			IL_015e: ldelem.ref
+			IL_015f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0164: ldnull
+			IL_0165: ldloc.s 29
+			IL_0167: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+			IL_016c: stloc.s 29
+			IL_016e: ldloc.s 29
+			IL_0170: stloc.1
+			IL_0171: ldloc.1
+			IL_0172: ldstr "section"
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0181: ldc.i4.0
+			IL_0182: ceq
+			IL_0184: stloc.s 30
+			IL_0186: ldloc.s 30
+			IL_0188: brfalse IL_01d6
 
-			IL_01a3: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
-			IL_01a8: stloc.2
-			IL_01a9: ldstr "Missing required --section (e.g. 27.3)."
-			IL_01ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01b8: stloc.s 29
-			IL_01ba: ldloc.s 29
-			IL_01bc: stloc.3
-			IL_01bd: ldloc.0
-			IL_01be: ldc.i4.m1
-			IL_01bf: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01c4: ldloc.0
-			IL_01c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01cf: ldarg.0
-			IL_01d0: ldc.i4.1
-			IL_01d1: newarr [System.Runtime]System.Object
-			IL_01d6: dup
-			IL_01d7: ldc.i4.0
-			IL_01d8: ldloc.3
-			IL_01d9: stelem.ref
-			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01df: pop
-			IL_01e0: ldloc.0
-			IL_01e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01e6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01eb: ret
+			IL_018d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
+			IL_0192: stloc.2
+			IL_0193: ldstr "Missing required --section (e.g. 27.3)."
+			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01a2: stloc.s 29
+			IL_01a4: ldloc.s 29
+			IL_01a6: stloc.3
+			IL_01a7: ldloc.0
+			IL_01a8: ldc.i4.m1
+			IL_01a9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01ae: ldloc.0
+			IL_01af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01b9: ldarg.0
+			IL_01ba: ldc.i4.1
+			IL_01bb: newarr [System.Runtime]System.Object
+			IL_01c0: dup
+			IL_01c1: ldc.i4.0
+			IL_01c2: ldloc.3
+			IL_01c3: stelem.ref
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01c9: pop
+			IL_01ca: ldloc.0
+			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01d0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01d5: ret
 
-			IL_01ec: ldloc.1
-			IL_01ed: ldstr "outFile"
-			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01fc: ldc.i4.0
-			IL_01fd: ceq
-			IL_01ff: stloc.s 30
-			IL_0201: ldloc.s 30
-			IL_0203: brfalse IL_0254
+			IL_01d6: ldloc.1
+			IL_01d7: ldstr "outFile"
+			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01e6: ldc.i4.0
+			IL_01e7: ceq
+			IL_01e9: stloc.s 30
+			IL_01eb: ldloc.s 30
+			IL_01ed: brfalse IL_023e
 
-			IL_0208: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
-			IL_020d: stloc.s 4
-			IL_020f: ldstr "Missing required --out <output.html>."
-			IL_0214: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_021e: stloc.s 29
-			IL_0220: ldloc.s 29
-			IL_0222: stloc.s 5
-			IL_0224: ldloc.0
-			IL_0225: ldc.i4.m1
-			IL_0226: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_022b: ldloc.0
-			IL_022c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0231: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0236: ldarg.0
-			IL_0237: ldc.i4.1
-			IL_0238: newarr [System.Runtime]System.Object
-			IL_023d: dup
-			IL_023e: ldc.i4.0
-			IL_023f: ldloc.s 5
-			IL_0241: stelem.ref
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0247: pop
-			IL_0248: ldloc.0
-			IL_0249: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_024e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0253: ret
+			IL_01f2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
+			IL_01f7: stloc.s 4
+			IL_01f9: ldstr "Missing required --out <output.html>."
+			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0208: stloc.s 29
+			IL_020a: ldloc.s 29
+			IL_020c: stloc.s 5
+			IL_020e: ldloc.0
+			IL_020f: ldc.i4.m1
+			IL_0210: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0215: ldloc.0
+			IL_0216: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0220: ldarg.0
+			IL_0221: ldc.i4.1
+			IL_0222: newarr [System.Runtime]System.Object
+			IL_0227: dup
+			IL_0228: ldc.i4.0
+			IL_0229: ldloc.s 5
+			IL_022b: stelem.ref
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0231: pop
+			IL_0232: ldloc.0
+			IL_0233: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0238: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_023d: ret
 
-			IL_0254: ldloc.1
-			IL_0255: ldstr "url"
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0264: stloc.s 30
-			IL_0266: ldloc.s 30
-			IL_0268: brfalse IL_0282
+			IL_023e: ldloc.1
+			IL_023f: ldstr "url"
+			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_024e: stloc.s 30
+			IL_0250: ldloc.s 30
+			IL_0252: brfalse IL_026c
 
-			IL_026d: ldc.r8 1
-			IL_0276: box [System.Runtime]System.Double
-			IL_027b: stloc.s 6
-			IL_027d: br IL_0292
+			IL_0257: ldc.r8 1
+			IL_0260: box [System.Runtime]System.Double
+			IL_0265: stloc.s 6
+			IL_0267: br IL_027c
 
-			IL_0282: ldc.r8 0.0
-			IL_028b: box [System.Runtime]System.Double
-			IL_0290: stloc.s 6
+			IL_026c: ldc.r8 0.0
+			IL_0275: box [System.Runtime]System.Double
+			IL_027a: stloc.s 6
 
-			IL_0292: ldloc.1
-			IL_0293: ldstr "auto"
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02a2: stloc.s 30
-			IL_02a4: ldloc.s 30
-			IL_02a6: brfalse IL_02c0
+			IL_027c: ldloc.1
+			IL_027d: ldstr "auto"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_028c: stloc.s 30
+			IL_028e: ldloc.s 30
+			IL_0290: brfalse IL_02aa
 
-			IL_02ab: ldc.r8 1
-			IL_02b4: box [System.Runtime]System.Double
-			IL_02b9: stloc.s 7
-			IL_02bb: br IL_02d0
+			IL_0295: ldc.r8 1
+			IL_029e: box [System.Runtime]System.Double
+			IL_02a3: stloc.s 7
+			IL_02a5: br IL_02ba
 
-			IL_02c0: ldc.r8 0.0
-			IL_02c9: box [System.Runtime]System.Double
-			IL_02ce: stloc.s 7
+			IL_02aa: ldc.r8 0.0
+			IL_02b3: box [System.Runtime]System.Double
+			IL_02b8: stloc.s 7
 
-			IL_02d0: ldloc.s 6
-			IL_02d2: ldloc.s 7
-			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02d9: stloc.s 31
-			IL_02db: ldloc.s 31
-			IL_02dd: stloc.s 8
-			IL_02df: ldloc.s 8
-			IL_02e1: ldc.r8 1
-			IL_02ea: box [System.Runtime]System.Double
-			IL_02ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02f4: stloc.s 30
-			IL_02f6: ldloc.s 30
-			IL_02f8: brfalse IL_0349
+			IL_02ba: ldloc.s 6
+			IL_02bc: ldloc.s 7
+			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02c3: stloc.s 31
+			IL_02c5: ldloc.s 31
+			IL_02c7: stloc.s 8
+			IL_02c9: ldloc.s 8
+			IL_02cb: ldc.r8 1
+			IL_02d4: box [System.Runtime]System.Double
+			IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02de: stloc.s 30
+			IL_02e0: ldloc.s 30
+			IL_02e2: brfalse IL_0333
 
-			IL_02fd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
-			IL_0302: stloc.s 9
-			IL_0304: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_0309: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_030e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0313: stloc.s 29
-			IL_0315: ldloc.s 29
-			IL_0317: stloc.s 10
-			IL_0319: ldloc.0
-			IL_031a: ldc.i4.m1
-			IL_031b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0320: ldloc.0
-			IL_0321: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0326: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_032b: ldarg.0
-			IL_032c: ldc.i4.1
-			IL_032d: newarr [System.Runtime]System.Object
-			IL_0332: dup
-			IL_0333: ldc.i4.0
-			IL_0334: ldloc.s 10
-			IL_0336: stelem.ref
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_033c: pop
-			IL_033d: ldloc.0
-			IL_033e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0343: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0348: ret
+			IL_02e7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
+			IL_02ec: stloc.s 9
+			IL_02ee: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_02f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_02fd: stloc.s 29
+			IL_02ff: ldloc.s 29
+			IL_0301: stloc.s 10
+			IL_0303: ldloc.0
+			IL_0304: ldc.i4.m1
+			IL_0305: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030a: ldloc.0
+			IL_030b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0310: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0315: ldarg.0
+			IL_0316: ldc.i4.1
+			IL_0317: newarr [System.Runtime]System.Object
+			IL_031c: dup
+			IL_031d: ldc.i4.0
+			IL_031e: ldloc.s 10
+			IL_0320: stelem.ref
+			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0326: pop
+			IL_0327: ldloc.0
+			IL_0328: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_032d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0332: ret
 
-			IL_0349: ldnull
-			IL_034a: stloc.s 11
-			IL_034c: ldloc.1
-			IL_034d: ldstr "id"
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0357: stloc.s 29
-			IL_0359: ldloc.s 29
-			IL_035b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0360: stloc.s 30
-			IL_0362: ldloc.s 30
-			IL_0364: brtrue IL_0375
+			IL_0333: ldnull
+			IL_0334: stloc.s 11
+			IL_0336: ldloc.1
+			IL_0337: ldstr "id"
+			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0341: stloc.s 29
+			IL_0343: ldloc.s 29
+			IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_034a: stloc.s 30
+			IL_034c: ldloc.s 30
+			IL_034e: brtrue IL_035f
 
-			IL_0369: ldstr ""
-			IL_036e: stloc.s 32
-			IL_0370: br IL_0379
+			IL_0353: ldstr ""
+			IL_0358: stloc.s 32
+			IL_035a: br IL_0363
 
-			IL_0375: ldloc.s 29
-			IL_0377: stloc.s 32
+			IL_035f: ldloc.s 29
+			IL_0361: stloc.s 32
 
-			IL_0379: ldloc.s 32
-			IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0380: stloc.s 29
-			IL_0382: ldloc.s 29
-			IL_0384: ldstr "trim"
-			IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_038e: stloc.s 29
-			IL_0390: ldloc.s 29
-			IL_0392: stloc.s 12
-			IL_0394: ldstr ""
-			IL_0399: stloc.s 13
-			IL_039b: ldloc.1
-			IL_039c: ldstr "auto"
-			IL_03a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03ab: stloc.s 30
-			IL_03ad: ldloc.s 30
-			IL_03af: brfalse IL_0796
+			IL_0363: ldloc.s 32
+			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_036a: stloc.s 29
+			IL_036c: ldloc.s 29
+			IL_036e: ldstr "trim"
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0378: stloc.s 29
+			IL_037a: ldloc.s 29
+			IL_037c: stloc.s 12
+			IL_037e: ldstr ""
+			IL_0383: stloc.s 13
+			IL_0385: ldloc.1
+			IL_0386: ldstr "auto"
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0395: stloc.s 30
+			IL_0397: ldloc.s 30
+			IL_0399: brfalse IL_073e
 
-			IL_03b4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_03b9: stloc.s 14
-			IL_03bb: ldloc.1
-			IL_03bc: ldstr "indexUrl"
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03cb: stloc.s 29
-			IL_03cd: ldloc.s 29
-			IL_03cf: ldstr "trim"
-			IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03d9: stloc.s 29
-			IL_03db: ldloc.s 29
-			IL_03dd: stloc.s 15
-			IL_03df: ldc.i4.1
-			IL_03e0: newarr [System.Runtime]System.Object
-			IL_03e5: dup
-			IL_03e6: ldc.i4.0
-			IL_03e7: ldarg.0
-			IL_03e8: ldc.i4.1
-			IL_03e9: ldelem.ref
-			IL_03ea: stelem.ref
-			IL_03eb: ldc.i4.0
-			IL_03ec: ldelem.ref
-			IL_03ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03f2: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_03f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_03fd: ldnull
-			IL_03fe: ldloc.s 15
-			IL_0400: ldnull
-			IL_0401: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0406: stloc.s 29
-			IL_0408: ldloc.0
-			IL_0409: ldc.i4.1
-			IL_040a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_040f: ldloc.0
-			IL_0410: ldloc.s 29
-			IL_0412: ldarg.0
-			IL_0413: ldc.i4.1
-			IL_0414: ldloc.0
-			IL_0415: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_041a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_041f: ldloc.0
-			IL_0420: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0425: dup
-			IL_0426: ldc.i4.0
-			IL_0427: ldloc.1
+			IL_039e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
+			IL_03a3: stloc.s 14
+			IL_03a5: ldloc.1
+			IL_03a6: ldstr "indexUrl"
+			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b5: stloc.s 29
+			IL_03b7: ldloc.s 29
+			IL_03b9: ldstr "trim"
+			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03c3: stloc.s 29
+			IL_03c5: ldloc.s 29
+			IL_03c7: stloc.s 15
+			IL_03c9: ldarg.0
+			IL_03ca: ldc.i4.1
+			IL_03cb: ldelem.ref
+			IL_03cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03d1: ldnull
+			IL_03d2: ldloc.s 15
+			IL_03d4: ldnull
+			IL_03d5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_03da: stloc.s 29
+			IL_03dc: ldloc.0
+			IL_03dd: ldc.i4.1
+			IL_03de: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03e3: ldloc.0
+			IL_03e4: ldloc.s 29
+			IL_03e6: ldarg.0
+			IL_03e7: ldc.i4.1
+			IL_03e8: ldloc.0
+			IL_03e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03f3: ldloc.0
+			IL_03f4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_03f9: dup
+			IL_03fa: ldc.i4.0
+			IL_03fb: ldloc.1
+			IL_03fc: stelem.ref
+			IL_03fd: dup
+			IL_03fe: ldc.i4.1
+			IL_03ff: ldloc.2
+			IL_0400: stelem.ref
+			IL_0401: dup
+			IL_0402: ldc.i4.2
+			IL_0403: ldloc.3
+			IL_0404: stelem.ref
+			IL_0405: dup
+			IL_0406: ldc.i4.3
+			IL_0407: ldloc.s 4
+			IL_0409: stelem.ref
+			IL_040a: dup
+			IL_040b: ldc.i4.4
+			IL_040c: ldloc.s 5
+			IL_040e: stelem.ref
+			IL_040f: dup
+			IL_0410: ldc.i4.5
+			IL_0411: ldloc.s 6
+			IL_0413: stelem.ref
+			IL_0414: dup
+			IL_0415: ldc.i4.6
+			IL_0416: ldloc.s 7
+			IL_0418: stelem.ref
+			IL_0419: dup
+			IL_041a: ldc.i4.7
+			IL_041b: ldloc.s 8
+			IL_041d: stelem.ref
+			IL_041e: dup
+			IL_041f: ldc.i4.8
+			IL_0420: ldloc.s 9
+			IL_0422: stelem.ref
+			IL_0423: dup
+			IL_0424: ldc.i4.s 9
+			IL_0426: ldloc.s 10
 			IL_0428: stelem.ref
 			IL_0429: dup
-			IL_042a: ldc.i4.1
-			IL_042b: ldloc.2
-			IL_042c: stelem.ref
-			IL_042d: dup
-			IL_042e: ldc.i4.2
-			IL_042f: ldloc.3
-			IL_0430: stelem.ref
-			IL_0431: dup
-			IL_0432: ldc.i4.3
-			IL_0433: ldloc.s 4
-			IL_0435: stelem.ref
-			IL_0436: dup
-			IL_0437: ldc.i4.4
-			IL_0438: ldloc.s 5
+			IL_042a: ldc.i4.s 10
+			IL_042c: ldloc.s 11
+			IL_042e: stelem.ref
+			IL_042f: dup
+			IL_0430: ldc.i4.s 11
+			IL_0432: ldloc.s 12
+			IL_0434: stelem.ref
+			IL_0435: dup
+			IL_0436: ldc.i4.s 12
+			IL_0438: ldloc.s 13
 			IL_043a: stelem.ref
 			IL_043b: dup
-			IL_043c: ldc.i4.5
-			IL_043d: ldloc.s 6
-			IL_043f: stelem.ref
-			IL_0440: dup
-			IL_0441: ldc.i4.6
-			IL_0442: ldloc.s 7
-			IL_0444: stelem.ref
-			IL_0445: dup
-			IL_0446: ldc.i4.7
-			IL_0447: ldloc.s 8
-			IL_0449: stelem.ref
-			IL_044a: dup
-			IL_044b: ldc.i4.8
-			IL_044c: ldloc.s 9
-			IL_044e: stelem.ref
-			IL_044f: dup
-			IL_0450: ldc.i4.s 9
-			IL_0452: ldloc.s 10
-			IL_0454: stelem.ref
-			IL_0455: dup
-			IL_0456: ldc.i4.s 10
-			IL_0458: ldloc.s 11
-			IL_045a: stelem.ref
-			IL_045b: dup
-			IL_045c: ldc.i4.s 11
-			IL_045e: ldloc.s 12
-			IL_0460: stelem.ref
-			IL_0461: dup
-			IL_0462: ldc.i4.s 12
-			IL_0464: ldloc.s 13
-			IL_0466: stelem.ref
-			IL_0467: dup
-			IL_0468: ldc.i4.s 13
-			IL_046a: ldloc.s 14
-			IL_046c: stelem.ref
-			IL_046d: dup
-			IL_046e: ldc.i4.s 14
-			IL_0470: ldloc.s 15
-			IL_0472: stelem.ref
-			IL_0473: dup
-			IL_0474: ldc.i4.s 15
-			IL_0476: ldloc.s 16
-			IL_0478: stelem.ref
-			IL_0479: dup
-			IL_047a: ldc.i4.s 16
-			IL_047c: ldloc.s 17
-			IL_047e: stelem.ref
-			IL_047f: dup
-			IL_0480: ldc.i4.s 17
-			IL_0482: ldloc.s 18
-			IL_0484: stelem.ref
-			IL_0485: dup
-			IL_0486: ldc.i4.s 18
-			IL_0488: ldloc.s 19
-			IL_048a: stelem.ref
-			IL_048b: dup
-			IL_048c: ldc.i4.s 19
-			IL_048e: ldloc.s 20
-			IL_0490: stelem.ref
-			IL_0491: dup
-			IL_0492: ldc.i4.s 20
-			IL_0494: ldloc.s 21
-			IL_0496: stelem.ref
-			IL_0497: dup
-			IL_0498: ldc.i4.s 21
-			IL_049a: ldloc.s 22
-			IL_049c: stelem.ref
-			IL_049d: dup
-			IL_049e: ldc.i4.s 22
-			IL_04a0: ldloc.s 23
-			IL_04a2: stelem.ref
-			IL_04a3: dup
-			IL_04a4: ldc.i4.s 23
-			IL_04a6: ldloc.s 24
-			IL_04a8: stelem.ref
-			IL_04a9: dup
-			IL_04aa: ldc.i4.s 24
-			IL_04ac: ldloc.s 25
-			IL_04ae: stelem.ref
-			IL_04af: dup
-			IL_04b0: ldc.i4.s 25
-			IL_04b2: ldloc.s 26
-			IL_04b4: stelem.ref
-			IL_04b5: dup
-			IL_04b6: ldc.i4.s 26
-			IL_04b8: ldloc.s 27
-			IL_04ba: stelem.ref
-			IL_04bb: dup
-			IL_04bc: ldc.i4.s 27
-			IL_04be: ldloc.s 28
-			IL_04c0: stelem.ref
-			IL_04c1: pop
-			IL_04c2: ldloc.0
-			IL_04c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04c8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04cd: ret
+			IL_043c: ldc.i4.s 13
+			IL_043e: ldloc.s 14
+			IL_0440: stelem.ref
+			IL_0441: dup
+			IL_0442: ldc.i4.s 14
+			IL_0444: ldloc.s 15
+			IL_0446: stelem.ref
+			IL_0447: dup
+			IL_0448: ldc.i4.s 15
+			IL_044a: ldloc.s 16
+			IL_044c: stelem.ref
+			IL_044d: dup
+			IL_044e: ldc.i4.s 16
+			IL_0450: ldloc.s 17
+			IL_0452: stelem.ref
+			IL_0453: dup
+			IL_0454: ldc.i4.s 17
+			IL_0456: ldloc.s 18
+			IL_0458: stelem.ref
+			IL_0459: dup
+			IL_045a: ldc.i4.s 18
+			IL_045c: ldloc.s 19
+			IL_045e: stelem.ref
+			IL_045f: dup
+			IL_0460: ldc.i4.s 19
+			IL_0462: ldloc.s 20
+			IL_0464: stelem.ref
+			IL_0465: dup
+			IL_0466: ldc.i4.s 20
+			IL_0468: ldloc.s 21
+			IL_046a: stelem.ref
+			IL_046b: dup
+			IL_046c: ldc.i4.s 21
+			IL_046e: ldloc.s 22
+			IL_0470: stelem.ref
+			IL_0471: dup
+			IL_0472: ldc.i4.s 22
+			IL_0474: ldloc.s 23
+			IL_0476: stelem.ref
+			IL_0477: dup
+			IL_0478: ldc.i4.s 23
+			IL_047a: ldloc.s 24
+			IL_047c: stelem.ref
+			IL_047d: dup
+			IL_047e: ldc.i4.s 24
+			IL_0480: ldloc.s 25
+			IL_0482: stelem.ref
+			IL_0483: dup
+			IL_0484: ldc.i4.s 25
+			IL_0486: ldloc.s 26
+			IL_0488: stelem.ref
+			IL_0489: dup
+			IL_048a: ldc.i4.s 26
+			IL_048c: ldloc.s 27
+			IL_048e: stelem.ref
+			IL_048f: dup
+			IL_0490: ldc.i4.s 27
+			IL_0492: ldloc.s 28
+			IL_0494: stelem.ref
+			IL_0495: pop
+			IL_0496: ldloc.0
+			IL_0497: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_049c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04a1: ret
 
-			IL_04ce: ldloc.0
-			IL_04cf: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_04d4: stloc.s 29
-			IL_04d6: ldloc.s 29
-			IL_04d8: stloc.s 16
-			IL_04da: ldloc.1
-			IL_04db: ldstr "section"
-			IL_04e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ea: stloc.s 29
-			IL_04ec: ldloc.s 29
-			IL_04ee: ldstr "trim"
-			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_04f8: stloc.s 29
-			IL_04fa: ldc.i4.1
-			IL_04fb: newarr [System.Runtime]System.Object
-			IL_0500: dup
-			IL_0501: ldc.i4.0
-			IL_0502: ldarg.0
-			IL_0503: ldc.i4.1
-			IL_0504: ldelem.ref
-			IL_0505: stelem.ref
-			IL_0506: ldc.i4.0
-			IL_0507: ldelem.ref
-			IL_0508: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_050d: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0513: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0518: ldnull
-			IL_0519: ldloc.s 16
-			IL_051b: ldloc.s 29
-			IL_051d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0522: stloc.s 29
-			IL_0524: ldloc.s 29
-			IL_0526: stloc.s 17
-			IL_0528: ldloc.s 17
-			IL_052a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_052f: ldc.i4.0
-			IL_0530: ceq
-			IL_0532: stloc.s 30
-			IL_0534: ldloc.s 30
-			IL_0536: brfalse IL_05c6
+			IL_04a2: ldloc.0
+			IL_04a3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04a8: stloc.s 29
+			IL_04aa: ldloc.s 29
+			IL_04ac: stloc.s 16
+			IL_04ae: ldloc.1
+			IL_04af: ldstr "section"
+			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04be: stloc.s 29
+			IL_04c0: ldloc.s 29
+			IL_04c2: ldstr "trim"
+			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_04cc: stloc.s 29
+			IL_04ce: ldarg.0
+			IL_04cf: ldc.i4.1
+			IL_04d0: ldelem.ref
+			IL_04d1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04d6: ldnull
+			IL_04d7: ldloc.s 16
+			IL_04d9: ldloc.s 29
+			IL_04db: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_04e0: stloc.s 29
+			IL_04e2: ldloc.s 29
+			IL_04e4: stloc.s 17
+			IL_04e6: ldloc.s 17
+			IL_04e8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04ed: ldc.i4.0
+			IL_04ee: ceq
+			IL_04f0: stloc.s 30
+			IL_04f2: ldloc.s 30
+			IL_04f4: brfalse IL_0584
 
-			IL_053b: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
-			IL_0540: stloc.s 18
-			IL_0542: ldloc.1
-			IL_0543: ldstr "section"
-			IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_054d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0552: stloc.s 33
-			IL_0554: ldstr "Could not find section '"
-			IL_0559: ldloc.s 33
-			IL_055b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0560: stloc.s 33
-			IL_0562: ldloc.s 33
-			IL_0564: ldstr "' in multipage index: "
-			IL_0569: call string [System.Runtime]System.String::Concat(string, string)
-			IL_056e: stloc.s 33
-			IL_0570: ldloc.s 15
-			IL_0572: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0577: stloc.s 34
-			IL_0579: ldloc.s 33
-			IL_057b: ldloc.s 34
-			IL_057d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0582: stloc.s 34
-			IL_0584: ldloc.s 34
-			IL_0586: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_058b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0590: stloc.s 29
-			IL_0592: ldloc.s 29
-			IL_0594: stloc.s 19
-			IL_0596: ldloc.0
-			IL_0597: ldc.i4.m1
-			IL_0598: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_059d: ldloc.0
-			IL_059e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05a8: ldarg.0
-			IL_05a9: ldc.i4.1
-			IL_05aa: newarr [System.Runtime]System.Object
-			IL_05af: dup
-			IL_05b0: ldc.i4.0
-			IL_05b1: ldloc.s 19
-			IL_05b3: stelem.ref
-			IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05b9: pop
-			IL_05ba: ldloc.0
-			IL_05bb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05c0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05c5: ret
+			IL_04f9: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
+			IL_04fe: stloc.s 18
+			IL_0500: ldloc.1
+			IL_0501: ldstr "section"
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_050b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0510: stloc.s 33
+			IL_0512: ldstr "Could not find section '"
+			IL_0517: ldloc.s 33
+			IL_0519: call string [System.Runtime]System.String::Concat(string, string)
+			IL_051e: stloc.s 33
+			IL_0520: ldloc.s 33
+			IL_0522: ldstr "' in multipage index: "
+			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
+			IL_052c: stloc.s 33
+			IL_052e: ldloc.s 15
+			IL_0530: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0535: stloc.s 34
+			IL_0537: ldloc.s 33
+			IL_0539: ldloc.s 34
+			IL_053b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0540: stloc.s 34
+			IL_0542: ldloc.s 34
+			IL_0544: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_054e: stloc.s 29
+			IL_0550: ldloc.s 29
+			IL_0552: stloc.s 19
+			IL_0554: ldloc.0
+			IL_0555: ldc.i4.m1
+			IL_0556: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_055b: ldloc.0
+			IL_055c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0561: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0566: ldarg.0
+			IL_0567: ldc.i4.1
+			IL_0568: newarr [System.Runtime]System.Object
+			IL_056d: dup
+			IL_056e: ldc.i4.0
+			IL_056f: ldloc.s 19
+			IL_0571: stelem.ref
+			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0577: pop
+			IL_0578: ldloc.0
+			IL_0579: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_057e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0583: ret
 
-			IL_05c6: ldarg.0
-			IL_05c7: ldc.i4.1
-			IL_05c8: ldelem.ref
-			IL_05c9: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05ce: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05d3: stloc.s 29
-			IL_05d5: ldloc.s 17
-			IL_05d7: ldstr "filePart"
-			IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e1: stloc.s 35
-			IL_05e3: ldloc.s 35
-			IL_05e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05ea: stloc.s 30
-			IL_05ec: ldloc.s 30
-			IL_05ee: brtrue IL_0606
+			IL_0584: ldarg.0
+			IL_0585: ldc.i4.1
+			IL_0586: ldelem.ref
+			IL_0587: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_058c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_0591: stloc.s 29
+			IL_0593: ldloc.s 17
+			IL_0595: ldstr "filePart"
+			IL_059a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_059f: stloc.s 35
+			IL_05a1: ldloc.s 35
+			IL_05a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05a8: stloc.s 30
+			IL_05aa: ldloc.s 30
+			IL_05ac: brtrue IL_05c4
 
-			IL_05f3: ldloc.s 17
-			IL_05f5: ldstr "href"
-			IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ff: stloc.s 36
-			IL_0601: br IL_060a
+			IL_05b1: ldloc.s 17
+			IL_05b3: ldstr "href"
+			IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05bd: stloc.s 36
+			IL_05bf: br IL_05c8
 
-			IL_0606: ldloc.s 35
-			IL_0608: stloc.s 36
+			IL_05c4: ldloc.s 35
+			IL_05c6: stloc.s 36
 
-			IL_060a: ldc.i4.2
-			IL_060b: newarr [System.Runtime]System.Object
-			IL_0610: dup
-			IL_0611: ldc.i4.0
-			IL_0612: ldloc.s 36
-			IL_0614: stelem.ref
-			IL_0615: dup
-			IL_0616: ldc.i4.1
-			IL_0617: ldloc.s 15
-			IL_0619: stelem.ref
-			IL_061a: stloc.s 37
-			IL_061c: ldloc.s 29
-			IL_061e: ldloc.s 37
-			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_0625: stloc.s 29
-			IL_0627: ldloc.s 29
-			IL_0629: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_062e: stloc.s 29
-			IL_0630: ldloc.s 29
-			IL_0632: ldstr "toString"
-			IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_063c: stloc.s 29
-			IL_063e: ldloc.s 29
-			IL_0640: stloc.s 20
-			IL_0642: ldc.i4.1
-			IL_0643: newarr [System.Runtime]System.Object
-			IL_0648: dup
-			IL_0649: ldc.i4.0
-			IL_064a: ldarg.0
-			IL_064b: ldc.i4.1
-			IL_064c: ldelem.ref
-			IL_064d: stelem.ref
-			IL_064e: ldc.i4.0
-			IL_064f: ldelem.ref
-			IL_0650: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0655: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_065b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_0660: ldnull
-			IL_0661: ldloc.s 20
-			IL_0663: ldnull
-			IL_0664: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0669: stloc.s 29
-			IL_066b: ldloc.0
-			IL_066c: ldc.i4.2
-			IL_066d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0672: ldloc.0
-			IL_0673: ldloc.s 29
-			IL_0675: ldarg.0
-			IL_0676: ldc.i4.2
-			IL_0677: ldloc.0
-			IL_0678: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_067d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0682: ldloc.0
-			IL_0683: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0688: dup
-			IL_0689: ldc.i4.0
-			IL_068a: ldloc.1
-			IL_068b: stelem.ref
-			IL_068c: dup
-			IL_068d: ldc.i4.1
-			IL_068e: ldloc.2
+			IL_05c8: ldc.i4.2
+			IL_05c9: newarr [System.Runtime]System.Object
+			IL_05ce: dup
+			IL_05cf: ldc.i4.0
+			IL_05d0: ldloc.s 36
+			IL_05d2: stelem.ref
+			IL_05d3: dup
+			IL_05d4: ldc.i4.1
+			IL_05d5: ldloc.s 15
+			IL_05d7: stelem.ref
+			IL_05d8: stloc.s 37
+			IL_05da: ldloc.s 29
+			IL_05dc: ldloc.s 37
+			IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_05e3: stloc.s 29
+			IL_05e5: ldloc.s 29
+			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05ec: stloc.s 29
+			IL_05ee: ldloc.s 29
+			IL_05f0: ldstr "toString"
+			IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_05fa: stloc.s 29
+			IL_05fc: ldloc.s 29
+			IL_05fe: stloc.s 20
+			IL_0600: ldarg.0
+			IL_0601: ldc.i4.1
+			IL_0602: ldelem.ref
+			IL_0603: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0608: ldnull
+			IL_0609: ldloc.s 20
+			IL_060b: ldnull
+			IL_060c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_0611: stloc.s 29
+			IL_0613: ldloc.0
+			IL_0614: ldc.i4.2
+			IL_0615: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_061a: ldloc.0
+			IL_061b: ldloc.s 29
+			IL_061d: ldarg.0
+			IL_061e: ldc.i4.2
+			IL_061f: ldloc.0
+			IL_0620: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_062a: ldloc.0
+			IL_062b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0630: dup
+			IL_0631: ldc.i4.0
+			IL_0632: ldloc.1
+			IL_0633: stelem.ref
+			IL_0634: dup
+			IL_0635: ldc.i4.1
+			IL_0636: ldloc.2
+			IL_0637: stelem.ref
+			IL_0638: dup
+			IL_0639: ldc.i4.2
+			IL_063a: ldloc.3
+			IL_063b: stelem.ref
+			IL_063c: dup
+			IL_063d: ldc.i4.3
+			IL_063e: ldloc.s 4
+			IL_0640: stelem.ref
+			IL_0641: dup
+			IL_0642: ldc.i4.4
+			IL_0643: ldloc.s 5
+			IL_0645: stelem.ref
+			IL_0646: dup
+			IL_0647: ldc.i4.5
+			IL_0648: ldloc.s 6
+			IL_064a: stelem.ref
+			IL_064b: dup
+			IL_064c: ldc.i4.6
+			IL_064d: ldloc.s 7
+			IL_064f: stelem.ref
+			IL_0650: dup
+			IL_0651: ldc.i4.7
+			IL_0652: ldloc.s 8
+			IL_0654: stelem.ref
+			IL_0655: dup
+			IL_0656: ldc.i4.8
+			IL_0657: ldloc.s 9
+			IL_0659: stelem.ref
+			IL_065a: dup
+			IL_065b: ldc.i4.s 9
+			IL_065d: ldloc.s 10
+			IL_065f: stelem.ref
+			IL_0660: dup
+			IL_0661: ldc.i4.s 10
+			IL_0663: ldloc.s 11
+			IL_0665: stelem.ref
+			IL_0666: dup
+			IL_0667: ldc.i4.s 11
+			IL_0669: ldloc.s 12
+			IL_066b: stelem.ref
+			IL_066c: dup
+			IL_066d: ldc.i4.s 12
+			IL_066f: ldloc.s 13
+			IL_0671: stelem.ref
+			IL_0672: dup
+			IL_0673: ldc.i4.s 13
+			IL_0675: ldloc.s 14
+			IL_0677: stelem.ref
+			IL_0678: dup
+			IL_0679: ldc.i4.s 14
+			IL_067b: ldloc.s 15
+			IL_067d: stelem.ref
+			IL_067e: dup
+			IL_067f: ldc.i4.s 15
+			IL_0681: ldloc.s 16
+			IL_0683: stelem.ref
+			IL_0684: dup
+			IL_0685: ldc.i4.s 16
+			IL_0687: ldloc.s 17
+			IL_0689: stelem.ref
+			IL_068a: dup
+			IL_068b: ldc.i4.s 17
+			IL_068d: ldloc.s 18
 			IL_068f: stelem.ref
 			IL_0690: dup
-			IL_0691: ldc.i4.2
-			IL_0692: ldloc.3
-			IL_0693: stelem.ref
-			IL_0694: dup
-			IL_0695: ldc.i4.3
-			IL_0696: ldloc.s 4
-			IL_0698: stelem.ref
-			IL_0699: dup
-			IL_069a: ldc.i4.4
-			IL_069b: ldloc.s 5
-			IL_069d: stelem.ref
-			IL_069e: dup
-			IL_069f: ldc.i4.5
-			IL_06a0: ldloc.s 6
-			IL_06a2: stelem.ref
-			IL_06a3: dup
-			IL_06a4: ldc.i4.6
-			IL_06a5: ldloc.s 7
+			IL_0691: ldc.i4.s 18
+			IL_0693: ldloc.s 19
+			IL_0695: stelem.ref
+			IL_0696: dup
+			IL_0697: ldc.i4.s 19
+			IL_0699: ldloc.s 20
+			IL_069b: stelem.ref
+			IL_069c: dup
+			IL_069d: ldc.i4.s 20
+			IL_069f: ldloc.s 21
+			IL_06a1: stelem.ref
+			IL_06a2: dup
+			IL_06a3: ldc.i4.s 21
+			IL_06a5: ldloc.s 22
 			IL_06a7: stelem.ref
 			IL_06a8: dup
-			IL_06a9: ldc.i4.7
-			IL_06aa: ldloc.s 8
-			IL_06ac: stelem.ref
-			IL_06ad: dup
-			IL_06ae: ldc.i4.8
-			IL_06af: ldloc.s 9
-			IL_06b1: stelem.ref
-			IL_06b2: dup
-			IL_06b3: ldc.i4.s 9
-			IL_06b5: ldloc.s 10
-			IL_06b7: stelem.ref
-			IL_06b8: dup
-			IL_06b9: ldc.i4.s 10
-			IL_06bb: ldloc.s 11
-			IL_06bd: stelem.ref
-			IL_06be: dup
-			IL_06bf: ldc.i4.s 11
-			IL_06c1: ldloc.s 12
-			IL_06c3: stelem.ref
-			IL_06c4: dup
-			IL_06c5: ldc.i4.s 12
-			IL_06c7: ldloc.s 13
-			IL_06c9: stelem.ref
-			IL_06ca: dup
-			IL_06cb: ldc.i4.s 13
-			IL_06cd: ldloc.s 14
-			IL_06cf: stelem.ref
-			IL_06d0: dup
-			IL_06d1: ldc.i4.s 14
-			IL_06d3: ldloc.s 15
-			IL_06d5: stelem.ref
-			IL_06d6: dup
-			IL_06d7: ldc.i4.s 15
-			IL_06d9: ldloc.s 16
-			IL_06db: stelem.ref
-			IL_06dc: dup
-			IL_06dd: ldc.i4.s 16
-			IL_06df: ldloc.s 17
-			IL_06e1: stelem.ref
-			IL_06e2: dup
-			IL_06e3: ldc.i4.s 17
-			IL_06e5: ldloc.s 18
-			IL_06e7: stelem.ref
-			IL_06e8: dup
-			IL_06e9: ldc.i4.s 18
-			IL_06eb: ldloc.s 19
-			IL_06ed: stelem.ref
-			IL_06ee: dup
-			IL_06ef: ldc.i4.s 19
-			IL_06f1: ldloc.s 20
-			IL_06f3: stelem.ref
-			IL_06f4: dup
-			IL_06f5: ldc.i4.s 20
-			IL_06f7: ldloc.s 21
-			IL_06f9: stelem.ref
-			IL_06fa: dup
-			IL_06fb: ldc.i4.s 21
-			IL_06fd: ldloc.s 22
-			IL_06ff: stelem.ref
-			IL_0700: dup
-			IL_0701: ldc.i4.s 22
-			IL_0703: ldloc.s 23
-			IL_0705: stelem.ref
-			IL_0706: dup
-			IL_0707: ldc.i4.s 23
-			IL_0709: ldloc.s 24
-			IL_070b: stelem.ref
-			IL_070c: dup
-			IL_070d: ldc.i4.s 24
-			IL_070f: ldloc.s 25
-			IL_0711: stelem.ref
-			IL_0712: dup
-			IL_0713: ldc.i4.s 25
-			IL_0715: ldloc.s 26
-			IL_0717: stelem.ref
-			IL_0718: dup
-			IL_0719: ldc.i4.s 26
-			IL_071b: ldloc.s 27
-			IL_071d: stelem.ref
-			IL_071e: dup
-			IL_071f: ldc.i4.s 27
-			IL_0721: ldloc.s 28
-			IL_0723: stelem.ref
-			IL_0724: pop
-			IL_0725: ldloc.0
-			IL_0726: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_072b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0730: ret
+			IL_06a9: ldc.i4.s 22
+			IL_06ab: ldloc.s 23
+			IL_06ad: stelem.ref
+			IL_06ae: dup
+			IL_06af: ldc.i4.s 23
+			IL_06b1: ldloc.s 24
+			IL_06b3: stelem.ref
+			IL_06b4: dup
+			IL_06b5: ldc.i4.s 24
+			IL_06b7: ldloc.s 25
+			IL_06b9: stelem.ref
+			IL_06ba: dup
+			IL_06bb: ldc.i4.s 25
+			IL_06bd: ldloc.s 26
+			IL_06bf: stelem.ref
+			IL_06c0: dup
+			IL_06c1: ldc.i4.s 26
+			IL_06c3: ldloc.s 27
+			IL_06c5: stelem.ref
+			IL_06c6: dup
+			IL_06c7: ldc.i4.s 27
+			IL_06c9: ldloc.s 28
+			IL_06cb: stelem.ref
+			IL_06cc: pop
+			IL_06cd: ldloc.0
+			IL_06ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06d8: ret
 
-			IL_0731: ldloc.0
-			IL_0732: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_0737: stloc.s 29
-			IL_0739: ldloc.s 29
-			IL_073b: stloc.s 11
-			IL_073d: ldloc.s 20
-			IL_073f: stloc.s 29
-			IL_0741: ldloc.s 29
-			IL_0743: stloc.s 13
-			IL_0745: ldloc.s 12
-			IL_0747: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_074c: ldc.i4.0
-			IL_074d: ceq
-			IL_074f: stloc.s 30
-			IL_0751: ldloc.s 30
-			IL_0753: brfalse IL_0791
+			IL_06d9: ldloc.0
+			IL_06da: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_06df: stloc.s 29
+			IL_06e1: ldloc.s 29
+			IL_06e3: stloc.s 11
+			IL_06e5: ldloc.s 20
+			IL_06e7: stloc.s 29
+			IL_06e9: ldloc.s 29
+			IL_06eb: stloc.s 13
+			IL_06ed: ldloc.s 12
+			IL_06ef: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06f4: ldc.i4.0
+			IL_06f5: ceq
+			IL_06f7: stloc.s 30
+			IL_06f9: ldloc.s 30
+			IL_06fb: brfalse IL_0739
 
-			IL_0758: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_075d: stloc.s 21
-			IL_075f: ldloc.s 17
-			IL_0761: ldstr "fragment"
-			IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_076b: stloc.s 29
-			IL_076d: ldloc.s 29
-			IL_076f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0774: stloc.s 30
-			IL_0776: ldloc.s 30
-			IL_0778: brtrue IL_0789
+			IL_0700: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_0705: stloc.s 21
+			IL_0707: ldloc.s 17
+			IL_0709: ldstr "fragment"
+			IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0713: stloc.s 29
+			IL_0715: ldloc.s 29
+			IL_0717: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_071c: stloc.s 30
+			IL_071e: ldloc.s 30
+			IL_0720: brtrue IL_0731
 
-			IL_077d: ldstr ""
-			IL_0782: stloc.s 38
-			IL_0784: br IL_078d
+			IL_0725: ldstr ""
+			IL_072a: stloc.s 38
+			IL_072c: br IL_0735
 
-			IL_0789: ldloc.s 29
-			IL_078b: stloc.s 38
+			IL_0731: ldloc.s 29
+			IL_0733: stloc.s 38
 
-			IL_078d: ldloc.s 38
-			IL_078f: stloc.s 12
+			IL_0735: ldloc.s 38
+			IL_0737: stloc.s 12
 
-			IL_0791: br IL_08c4
+			IL_0739: br IL_0856
 
-			IL_0796: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_079b: stloc.s 22
-			IL_079d: ldloc.1
-			IL_079e: ldstr "url"
-			IL_07a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07ad: stloc.s 29
-			IL_07af: ldloc.s 29
-			IL_07b1: ldstr "trim"
-			IL_07b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_07bb: stloc.s 29
-			IL_07bd: ldloc.s 29
-			IL_07bf: stloc.s 23
-			IL_07c1: ldc.i4.1
-			IL_07c2: newarr [System.Runtime]System.Object
-			IL_07c7: dup
-			IL_07c8: ldc.i4.0
-			IL_07c9: ldarg.0
-			IL_07ca: ldc.i4.1
-			IL_07cb: ldelem.ref
-			IL_07cc: stelem.ref
-			IL_07cd: ldc.i4.0
-			IL_07ce: ldelem.ref
-			IL_07cf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_07d4: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_07da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_07df: ldnull
-			IL_07e0: ldloc.s 23
-			IL_07e2: ldnull
-			IL_07e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_07e8: stloc.s 29
-			IL_07ea: ldloc.0
-			IL_07eb: ldc.i4.3
-			IL_07ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_07f1: ldloc.0
-			IL_07f2: ldloc.s 29
-			IL_07f4: ldarg.0
-			IL_07f5: ldc.i4.3
-			IL_07f6: ldloc.0
-			IL_07f7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_07fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0801: ldloc.0
-			IL_0802: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0807: dup
-			IL_0808: ldc.i4.0
-			IL_0809: ldloc.1
+			IL_073e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_0743: stloc.s 22
+			IL_0745: ldloc.1
+			IL_0746: ldstr "url"
+			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0755: stloc.s 29
+			IL_0757: ldloc.s 29
+			IL_0759: ldstr "trim"
+			IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0763: stloc.s 29
+			IL_0765: ldloc.s 29
+			IL_0767: stloc.s 23
+			IL_0769: ldarg.0
+			IL_076a: ldc.i4.1
+			IL_076b: ldelem.ref
+			IL_076c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0771: ldnull
+			IL_0772: ldloc.s 23
+			IL_0774: ldnull
+			IL_0775: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_077a: stloc.s 29
+			IL_077c: ldloc.0
+			IL_077d: ldc.i4.3
+			IL_077e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0783: ldloc.0
+			IL_0784: ldloc.s 29
+			IL_0786: ldarg.0
+			IL_0787: ldc.i4.3
+			IL_0788: ldloc.0
+			IL_0789: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_078e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0793: ldloc.0
+			IL_0794: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0799: dup
+			IL_079a: ldc.i4.0
+			IL_079b: ldloc.1
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.1
+			IL_079f: ldloc.2
+			IL_07a0: stelem.ref
+			IL_07a1: dup
+			IL_07a2: ldc.i4.2
+			IL_07a3: ldloc.3
+			IL_07a4: stelem.ref
+			IL_07a5: dup
+			IL_07a6: ldc.i4.3
+			IL_07a7: ldloc.s 4
+			IL_07a9: stelem.ref
+			IL_07aa: dup
+			IL_07ab: ldc.i4.4
+			IL_07ac: ldloc.s 5
+			IL_07ae: stelem.ref
+			IL_07af: dup
+			IL_07b0: ldc.i4.5
+			IL_07b1: ldloc.s 6
+			IL_07b3: stelem.ref
+			IL_07b4: dup
+			IL_07b5: ldc.i4.6
+			IL_07b6: ldloc.s 7
+			IL_07b8: stelem.ref
+			IL_07b9: dup
+			IL_07ba: ldc.i4.7
+			IL_07bb: ldloc.s 8
+			IL_07bd: stelem.ref
+			IL_07be: dup
+			IL_07bf: ldc.i4.8
+			IL_07c0: ldloc.s 9
+			IL_07c2: stelem.ref
+			IL_07c3: dup
+			IL_07c4: ldc.i4.s 9
+			IL_07c6: ldloc.s 10
+			IL_07c8: stelem.ref
+			IL_07c9: dup
+			IL_07ca: ldc.i4.s 10
+			IL_07cc: ldloc.s 11
+			IL_07ce: stelem.ref
+			IL_07cf: dup
+			IL_07d0: ldc.i4.s 11
+			IL_07d2: ldloc.s 12
+			IL_07d4: stelem.ref
+			IL_07d5: dup
+			IL_07d6: ldc.i4.s 12
+			IL_07d8: ldloc.s 13
+			IL_07da: stelem.ref
+			IL_07db: dup
+			IL_07dc: ldc.i4.s 13
+			IL_07de: ldloc.s 14
+			IL_07e0: stelem.ref
+			IL_07e1: dup
+			IL_07e2: ldc.i4.s 14
+			IL_07e4: ldloc.s 15
+			IL_07e6: stelem.ref
+			IL_07e7: dup
+			IL_07e8: ldc.i4.s 15
+			IL_07ea: ldloc.s 16
+			IL_07ec: stelem.ref
+			IL_07ed: dup
+			IL_07ee: ldc.i4.s 16
+			IL_07f0: ldloc.s 17
+			IL_07f2: stelem.ref
+			IL_07f3: dup
+			IL_07f4: ldc.i4.s 17
+			IL_07f6: ldloc.s 18
+			IL_07f8: stelem.ref
+			IL_07f9: dup
+			IL_07fa: ldc.i4.s 18
+			IL_07fc: ldloc.s 19
+			IL_07fe: stelem.ref
+			IL_07ff: dup
+			IL_0800: ldc.i4.s 19
+			IL_0802: ldloc.s 20
+			IL_0804: stelem.ref
+			IL_0805: dup
+			IL_0806: ldc.i4.s 20
+			IL_0808: ldloc.s 21
 			IL_080a: stelem.ref
 			IL_080b: dup
-			IL_080c: ldc.i4.1
-			IL_080d: ldloc.2
-			IL_080e: stelem.ref
-			IL_080f: dup
-			IL_0810: ldc.i4.2
-			IL_0811: ldloc.3
-			IL_0812: stelem.ref
-			IL_0813: dup
-			IL_0814: ldc.i4.3
-			IL_0815: ldloc.s 4
-			IL_0817: stelem.ref
-			IL_0818: dup
-			IL_0819: ldc.i4.4
-			IL_081a: ldloc.s 5
+			IL_080c: ldc.i4.s 21
+			IL_080e: ldloc.s 22
+			IL_0810: stelem.ref
+			IL_0811: dup
+			IL_0812: ldc.i4.s 22
+			IL_0814: ldloc.s 23
+			IL_0816: stelem.ref
+			IL_0817: dup
+			IL_0818: ldc.i4.s 23
+			IL_081a: ldloc.s 24
 			IL_081c: stelem.ref
 			IL_081d: dup
-			IL_081e: ldc.i4.5
-			IL_081f: ldloc.s 6
-			IL_0821: stelem.ref
-			IL_0822: dup
-			IL_0823: ldc.i4.6
-			IL_0824: ldloc.s 7
-			IL_0826: stelem.ref
-			IL_0827: dup
-			IL_0828: ldc.i4.7
-			IL_0829: ldloc.s 8
-			IL_082b: stelem.ref
-			IL_082c: dup
-			IL_082d: ldc.i4.8
-			IL_082e: ldloc.s 9
-			IL_0830: stelem.ref
-			IL_0831: dup
-			IL_0832: ldc.i4.s 9
-			IL_0834: ldloc.s 10
-			IL_0836: stelem.ref
-			IL_0837: dup
-			IL_0838: ldc.i4.s 10
-			IL_083a: ldloc.s 11
-			IL_083c: stelem.ref
-			IL_083d: dup
-			IL_083e: ldc.i4.s 11
-			IL_0840: ldloc.s 12
-			IL_0842: stelem.ref
-			IL_0843: dup
-			IL_0844: ldc.i4.s 12
-			IL_0846: ldloc.s 13
-			IL_0848: stelem.ref
-			IL_0849: dup
-			IL_084a: ldc.i4.s 13
-			IL_084c: ldloc.s 14
-			IL_084e: stelem.ref
-			IL_084f: dup
-			IL_0850: ldc.i4.s 14
-			IL_0852: ldloc.s 15
-			IL_0854: stelem.ref
-			IL_0855: dup
-			IL_0856: ldc.i4.s 15
-			IL_0858: ldloc.s 16
-			IL_085a: stelem.ref
-			IL_085b: dup
-			IL_085c: ldc.i4.s 16
-			IL_085e: ldloc.s 17
-			IL_0860: stelem.ref
-			IL_0861: dup
-			IL_0862: ldc.i4.s 17
-			IL_0864: ldloc.s 18
-			IL_0866: stelem.ref
-			IL_0867: dup
-			IL_0868: ldc.i4.s 18
-			IL_086a: ldloc.s 19
-			IL_086c: stelem.ref
-			IL_086d: dup
-			IL_086e: ldc.i4.s 19
-			IL_0870: ldloc.s 20
-			IL_0872: stelem.ref
-			IL_0873: dup
-			IL_0874: ldc.i4.s 20
-			IL_0876: ldloc.s 21
-			IL_0878: stelem.ref
-			IL_0879: dup
-			IL_087a: ldc.i4.s 21
-			IL_087c: ldloc.s 22
-			IL_087e: stelem.ref
-			IL_087f: dup
-			IL_0880: ldc.i4.s 22
-			IL_0882: ldloc.s 23
-			IL_0884: stelem.ref
-			IL_0885: dup
-			IL_0886: ldc.i4.s 23
-			IL_0888: ldloc.s 24
-			IL_088a: stelem.ref
-			IL_088b: dup
-			IL_088c: ldc.i4.s 24
-			IL_088e: ldloc.s 25
-			IL_0890: stelem.ref
-			IL_0891: dup
-			IL_0892: ldc.i4.s 25
-			IL_0894: ldloc.s 26
-			IL_0896: stelem.ref
-			IL_0897: dup
-			IL_0898: ldc.i4.s 26
-			IL_089a: ldloc.s 27
-			IL_089c: stelem.ref
-			IL_089d: dup
-			IL_089e: ldc.i4.s 27
-			IL_08a0: ldloc.s 28
-			IL_08a2: stelem.ref
-			IL_08a3: pop
-			IL_08a4: ldloc.0
-			IL_08a5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08aa: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08af: ret
+			IL_081e: ldc.i4.s 24
+			IL_0820: ldloc.s 25
+			IL_0822: stelem.ref
+			IL_0823: dup
+			IL_0824: ldc.i4.s 25
+			IL_0826: ldloc.s 26
+			IL_0828: stelem.ref
+			IL_0829: dup
+			IL_082a: ldc.i4.s 26
+			IL_082c: ldloc.s 27
+			IL_082e: stelem.ref
+			IL_082f: dup
+			IL_0830: ldc.i4.s 27
+			IL_0832: ldloc.s 28
+			IL_0834: stelem.ref
+			IL_0835: pop
+			IL_0836: ldloc.0
+			IL_0837: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_083c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0841: ret
 
+			IL_0842: ldloc.0
+			IL_0843: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_0848: stloc.s 29
+			IL_084a: ldloc.s 29
+			IL_084c: stloc.s 11
+			IL_084e: ldloc.s 23
+			IL_0850: stloc.s 29
+			IL_0852: ldloc.s 29
+			IL_0854: stloc.s 13
+
+			IL_0856: ldloc.s 12
+			IL_0858: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_085d: ldc.i4.0
+			IL_085e: ceq
+			IL_0860: stloc.s 30
+			IL_0862: ldloc.s 30
+			IL_0864: brfalse IL_08e0
+
+			IL_0869: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_086e: stloc.s 24
+			IL_0870: ldloc.1
+			IL_0871: ldstr "section"
+			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_087b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0880: stloc.s 34
+			IL_0882: ldstr "Could not infer an element id for section '"
+			IL_0887: ldloc.s 34
+			IL_0889: call string [System.Runtime]System.String::Concat(string, string)
+			IL_088e: stloc.s 34
+			IL_0890: ldloc.s 34
+			IL_0892: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0897: call string [System.Runtime]System.String::Concat(string, string)
+			IL_089c: stloc.s 34
+			IL_089e: ldloc.s 34
+			IL_08a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_08aa: stloc.s 29
+			IL_08ac: ldloc.s 29
+			IL_08ae: stloc.s 25
 			IL_08b0: ldloc.0
-			IL_08b1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_08b6: stloc.s 29
-			IL_08b8: ldloc.s 29
-			IL_08ba: stloc.s 11
-			IL_08bc: ldloc.s 23
-			IL_08be: stloc.s 29
-			IL_08c0: ldloc.s 29
-			IL_08c2: stloc.s 13
+			IL_08b1: ldc.i4.m1
+			IL_08b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08b7: ldloc.0
+			IL_08b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_08c2: ldarg.0
+			IL_08c3: ldc.i4.1
+			IL_08c4: newarr [System.Runtime]System.Object
+			IL_08c9: dup
+			IL_08ca: ldc.i4.0
+			IL_08cb: ldloc.s 25
+			IL_08cd: stelem.ref
+			IL_08ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_08d3: pop
+			IL_08d4: ldloc.0
+			IL_08d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_08da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_08df: ret
 
-			IL_08c4: ldloc.s 12
-			IL_08c6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_08cb: ldc.i4.0
-			IL_08cc: ceq
-			IL_08ce: stloc.s 30
-			IL_08d0: ldloc.s 30
-			IL_08d2: brfalse IL_094e
-
-			IL_08d7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_08dc: stloc.s 24
-			IL_08de: ldloc.1
-			IL_08df: ldstr "section"
-			IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08ee: stloc.s 34
-			IL_08f0: ldstr "Could not infer an element id for section '"
-			IL_08f5: ldloc.s 34
-			IL_08f7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_08fc: stloc.s 34
-			IL_08fe: ldloc.s 34
-			IL_0900: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0905: call string [System.Runtime]System.String::Concat(string, string)
-			IL_090a: stloc.s 34
-			IL_090c: ldloc.s 34
-			IL_090e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0913: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0918: stloc.s 29
-			IL_091a: ldloc.s 29
-			IL_091c: stloc.s 25
-			IL_091e: ldloc.0
-			IL_091f: ldc.i4.m1
-			IL_0920: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0925: ldloc.0
-			IL_0926: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_092b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0930: ldarg.0
-			IL_0931: ldc.i4.1
-			IL_0932: newarr [System.Runtime]System.Object
-			IL_0937: dup
-			IL_0938: ldc.i4.0
-			IL_0939: ldloc.s 25
-			IL_093b: stelem.ref
-			IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0941: pop
-			IL_0942: ldloc.0
-			IL_0943: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0948: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_094d: ret
-
-			IL_094e: ldc.i4.1
-			IL_094f: newarr [System.Runtime]System.Object
-			IL_0954: dup
-			IL_0955: ldc.i4.0
-			IL_0956: ldarg.0
-			IL_0957: ldc.i4.1
-			IL_0958: ldelem.ref
-			IL_0959: stelem.ref
-			IL_095a: ldc.i4.0
-			IL_095b: ldelem.ref
-			IL_095c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0961: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0967: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-			IL_096c: ldnull
-			IL_096d: ldloc.s 11
-			IL_096f: ldloc.s 12
-			IL_0971: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-			IL_0976: stloc.s 29
-			IL_0978: ldloc.s 29
-			IL_097a: stloc.s 26
-			IL_097c: ldarg.0
-			IL_097d: ldc.i4.1
-			IL_097e: ldelem.ref
-			IL_097f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0984: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0989: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_098e: stloc.s 29
-			IL_0990: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_099a: stloc.s 35
-			IL_099c: ldloc.s 35
-			IL_099e: ldstr "cwd"
-			IL_09a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_09a8: stloc.s 35
-			IL_09aa: ldloc.s 29
-			IL_09ac: ldstr "join"
-			IL_09b1: ldloc.s 35
-			IL_09b3: ldloc.1
-			IL_09b4: ldstr "outFile"
-			IL_09b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_09c3: stloc.s 35
-			IL_09c5: ldloc.s 35
-			IL_09c7: stloc.s 27
-			IL_09c9: ldloc.s 26
-			IL_09cb: ldstr "html"
-			IL_09d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09d5: stloc.s 35
-			IL_09d7: ldloc.1
-			IL_09d8: ldstr "section"
-			IL_09dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09e7: stloc.s 34
-			IL_09e9: ldstr "ECMA-262 "
-			IL_09ee: ldloc.s 34
-			IL_09f0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09f5: stloc.s 34
-			IL_09f7: ldnull
-			IL_09f8: ldloc.s 35
-			IL_09fa: ldloc.s 34
-			IL_09fc: ldloc.s 13
-			IL_09fe: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-			IL_0a03: stloc.s 35
-			IL_0a05: ldloc.s 35
-			IL_0a07: stloc.s 28
-			IL_0a09: ldarg.0
-			IL_0a0a: ldc.i4.1
-			IL_0a0b: ldelem.ref
-			IL_0a0c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a11: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a16: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a1b: stloc.s 35
-			IL_0a1d: ldloc.s 35
-			IL_0a1f: ldstr "writeFileSync"
-			IL_0a24: ldloc.s 27
-			IL_0a26: ldloc.s 28
-			IL_0a28: ldstr "utf8"
-			IL_0a2d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0a32: pop
-			IL_0a33: ldloc.1
-			IL_0a34: ldstr "section"
-			IL_0a39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a3e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a43: stloc.s 34
-			IL_0a45: ldstr "Extracted section "
-			IL_0a4a: ldloc.s 34
-			IL_0a4c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a51: stloc.s 34
-			IL_0a53: ldloc.s 34
-			IL_0a55: ldstr " (id="
-			IL_0a5a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a5f: stloc.s 34
-			IL_0a61: ldloc.s 12
-			IL_0a63: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a68: stloc.s 33
-			IL_0a6a: ldloc.s 34
-			IL_0a6c: ldloc.s 33
-			IL_0a6e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a73: stloc.s 33
-			IL_0a75: ldloc.s 33
-			IL_0a77: ldstr ", tag="
-			IL_0a7c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a81: stloc.s 33
-			IL_0a83: ldloc.s 26
-			IL_0a85: ldstr "tagName"
-			IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a8f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a94: stloc.s 34
-			IL_0a96: ldloc.s 33
-			IL_0a98: ldloc.s 34
-			IL_0a9a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a9f: stloc.s 34
-			IL_0aa1: ldloc.s 34
-			IL_0aa3: ldstr ") -> "
-			IL_0aa8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0aad: stloc.s 34
-			IL_0aaf: ldloc.s 27
-			IL_0ab1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ab6: stloc.s 33
-			IL_0ab8: ldloc.s 34
-			IL_0aba: ldloc.s 33
-			IL_0abc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ac1: stloc.s 33
-			IL_0ac3: ldnull
-			IL_0ac4: ldloc.s 33
-			IL_0ac6: ldloc.s 27
-			IL_0ac8: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0acd: stloc.s 35
-			IL_0acf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ad4: ldloc.s 35
-			IL_0ad6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0adb: pop
-			IL_0adc: ldarg.0
-			IL_0add: ldc.i4.1
-			IL_0ade: ldelem.ref
-			IL_0adf: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0ae4: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0ae9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0aee: stloc.s 35
-			IL_0af0: ldloc.s 35
-			IL_0af2: ldstr "readFileSync"
-			IL_0af7: ldloc.s 27
-			IL_0af9: ldstr "utf8"
-			IL_0afe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0b03: stloc.s 35
-			IL_0b05: ldnull
-			IL_0b06: ldloc.s 35
-			IL_0b08: ldloc.s 27
-			IL_0b0a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0b0f: stloc.s 35
-			IL_0b11: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b16: ldloc.s 35
-			IL_0b18: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b1d: pop
-			IL_0b1e: ldloc.0
-			IL_0b1f: ldc.i4.m1
-			IL_0b20: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b25: ldloc.0
-			IL_0b26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b2b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0b30: ldarg.0
-			IL_0b31: ldc.i4.1
-			IL_0b32: newarr [System.Runtime]System.Object
-			IL_0b37: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0b3c: pop
-			IL_0b3d: ldloc.0
-			IL_0b3e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0b43: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0b48: ret
+			IL_08e0: ldarg.0
+			IL_08e1: ldc.i4.1
+			IL_08e2: ldelem.ref
+			IL_08e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08e8: ldnull
+			IL_08e9: ldloc.s 11
+			IL_08eb: ldloc.s 12
+			IL_08ed: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+			IL_08f2: stloc.s 29
+			IL_08f4: ldloc.s 29
+			IL_08f6: stloc.s 26
+			IL_08f8: ldarg.0
+			IL_08f9: ldc.i4.1
+			IL_08fa: ldelem.ref
+			IL_08fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0900: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_090a: stloc.s 29
+			IL_090c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0911: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0916: stloc.s 35
+			IL_0918: ldloc.s 35
+			IL_091a: ldstr "cwd"
+			IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0924: stloc.s 35
+			IL_0926: ldloc.s 29
+			IL_0928: ldstr "join"
+			IL_092d: ldloc.s 35
+			IL_092f: ldloc.1
+			IL_0930: ldstr "outFile"
+			IL_0935: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_093f: stloc.s 35
+			IL_0941: ldloc.s 35
+			IL_0943: stloc.s 27
+			IL_0945: ldloc.s 26
+			IL_0947: ldstr "html"
+			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0951: stloc.s 35
+			IL_0953: ldloc.1
+			IL_0954: ldstr "section"
+			IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_095e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0963: stloc.s 34
+			IL_0965: ldstr "ECMA-262 "
+			IL_096a: ldloc.s 34
+			IL_096c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0971: stloc.s 34
+			IL_0973: ldnull
+			IL_0974: ldloc.s 35
+			IL_0976: ldloc.s 34
+			IL_0978: ldloc.s 13
+			IL_097a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+			IL_097f: stloc.s 35
+			IL_0981: ldloc.s 35
+			IL_0983: stloc.s 28
+			IL_0985: ldarg.0
+			IL_0986: ldc.i4.1
+			IL_0987: ldelem.ref
+			IL_0988: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_098d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0992: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0997: stloc.s 35
+			IL_0999: ldloc.s 35
+			IL_099b: ldstr "writeFileSync"
+			IL_09a0: ldloc.s 27
+			IL_09a2: ldloc.s 28
+			IL_09a4: ldstr "utf8"
+			IL_09a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_09ae: pop
+			IL_09af: ldloc.1
+			IL_09b0: ldstr "section"
+			IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09bf: stloc.s 34
+			IL_09c1: ldstr "Extracted section "
+			IL_09c6: ldloc.s 34
+			IL_09c8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09cd: stloc.s 34
+			IL_09cf: ldloc.s 34
+			IL_09d1: ldstr " (id="
+			IL_09d6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09db: stloc.s 34
+			IL_09dd: ldloc.s 12
+			IL_09df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09e4: stloc.s 33
+			IL_09e6: ldloc.s 34
+			IL_09e8: ldloc.s 33
+			IL_09ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09ef: stloc.s 33
+			IL_09f1: ldloc.s 33
+			IL_09f3: ldstr ", tag="
+			IL_09f8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09fd: stloc.s 33
+			IL_09ff: ldloc.s 26
+			IL_0a01: ldstr "tagName"
+			IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a0b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a10: stloc.s 34
+			IL_0a12: ldloc.s 33
+			IL_0a14: ldloc.s 34
+			IL_0a16: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a1b: stloc.s 34
+			IL_0a1d: ldloc.s 34
+			IL_0a1f: ldstr ") -> "
+			IL_0a24: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a29: stloc.s 34
+			IL_0a2b: ldloc.s 27
+			IL_0a2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a32: stloc.s 33
+			IL_0a34: ldloc.s 34
+			IL_0a36: ldloc.s 33
+			IL_0a38: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a3d: stloc.s 33
+			IL_0a3f: ldnull
+			IL_0a40: ldloc.s 33
+			IL_0a42: ldloc.s 27
+			IL_0a44: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0a49: stloc.s 35
+			IL_0a4b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a50: ldloc.s 35
+			IL_0a52: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a57: pop
+			IL_0a58: ldarg.0
+			IL_0a59: ldc.i4.1
+			IL_0a5a: ldelem.ref
+			IL_0a5b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a60: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a6a: stloc.s 35
+			IL_0a6c: ldloc.s 35
+			IL_0a6e: ldstr "readFileSync"
+			IL_0a73: ldloc.s 27
+			IL_0a75: ldstr "utf8"
+			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0a7f: stloc.s 35
+			IL_0a81: ldnull
+			IL_0a82: ldloc.s 35
+			IL_0a84: ldloc.s 27
+			IL_0a86: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+			IL_0a8b: stloc.s 35
+			IL_0a8d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a92: ldloc.s 35
+			IL_0a94: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a99: pop
+			IL_0a9a: ldloc.0
+			IL_0a9b: ldc.i4.m1
+			IL_0a9c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0aa1: ldloc.0
+			IL_0aa2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0aa7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0aac: ldarg.0
+			IL_0aad: ldc.i4.1
+			IL_0aae: newarr [System.Runtime]System.Object
+			IL_0ab3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0ab8: pop
+			IL_0ab9: ldloc.0
+			IL_0aba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0abf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0ac4: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5315,7 +5243,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x45b9
+			// Method begins at RVA 0x4505
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5581,7 +5509,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x477b
+		// Method begins at RVA 0x46c7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Compile_Scripts_GenerateNodeSupportMd
+﻿// IL code: Compile_Scripts_GenerateNodeSupportMd
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x368a
+				// Method begins at RVA 0x35c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x22c8
+			// Method begins at RVA 0x22b4
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3693
+				// Method begins at RVA 0x35cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,7 +107,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22fc
+			// Method begins at RVA 0x22e8
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -157,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x369c
+				// Method begins at RVA 0x35d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -181,7 +181,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2340
+			// Method begins at RVA 0x232c
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36a5
+				// Method begins at RVA 0x35dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -249,7 +249,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x237c
+			// Method begins at RVA 0x2368
 			// Header size: 12
 			// Code size: 122 (0x7a)
 			.maxstack 8
@@ -331,7 +331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36ae
+				// Method begins at RVA 0x35e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,7 +358,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2404
+			// Method begins at RVA 0x23f0
 			// Header size: 12
 			// Code size: 253 (0xfd)
 			.maxstack 8
@@ -490,7 +490,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36c0
+					// Method begins at RVA 0x35f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -515,7 +515,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3658
+				// Method begins at RVA 0x3590
 				// Header size: 12
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -548,7 +548,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36b7
+				// Method begins at RVA 0x35ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -575,7 +575,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2510
+			// Method begins at RVA 0x24fc
 			// Header size: 12
 			// Code size: 158 (0x9e)
 			.maxstack 8
@@ -664,7 +664,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c9
+				// Method begins at RVA 0x3601
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -688,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36db
+					// Method begins at RVA 0x3613
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -706,7 +706,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36d2
+				// Method begins at RVA 0x360a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -733,7 +733,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x25bc
+			// Method begins at RVA 0x25a8
 			// Header size: 12
 			// Code size: 613 (0x265)
 			.maxstack 8
@@ -1010,7 +1010,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36e4
+				// Method begins at RVA 0x361c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1034,7 +1034,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36f6
+					// Method begins at RVA 0x362e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1058,7 +1058,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3708
+						// Method begins at RVA 0x3640
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1076,7 +1076,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x36ff
+					// Method begins at RVA 0x3637
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1094,7 +1094,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36ed
+				// Method begins at RVA 0x3625
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1121,7 +1121,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x284c
+			// Method begins at RVA 0x2838
 			// Header size: 12
 			// Code size: 722 (0x2d2)
 			.maxstack 8
@@ -1456,7 +1456,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3711
+				// Method begins at RVA 0x3649
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1484,7 +1484,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x372c
+						// Method begins at RVA 0x3664
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1504,7 +1504,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3735
+						// Method begins at RVA 0x366d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1524,7 +1524,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x373e
+						// Method begins at RVA 0x3676
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1542,7 +1542,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3723
+					// Method begins at RVA 0x365b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1560,7 +1560,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x371a
+				// Method begins at RVA 0x3652
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1587,9 +1587,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2b60
+			// Method begins at RVA 0x2b4c
 			// Header size: 12
-			// Code size: 781 (0x30d)
+			// Code size: 715 (0x2cb)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1659,7 +1659,7 @@
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0068: stloc.s 12
 					IL_006a: ldloc.s 12
-					IL_006c: brtrue IL_02da
+					IL_006c: brtrue IL_0298
 
 					IL_0071: ldloc.s 11
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -1733,7 +1733,7 @@
 					IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_014d: stloc.s 12
 					IL_014f: ldloc.s 12
-					IL_0151: brfalse IL_01a6
+					IL_0151: brfalse IL_0190
 
 					IL_0156: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L77C26::.ctor()
 					IL_015b: stloc.s 6
@@ -1745,175 +1745,148 @@
 					IL_016b: ldstr "implementation"
 					IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0175: stloc.s 11
-					IL_0177: ldc.i4.1
-					IL_0178: newarr [System.Runtime]System.Object
-					IL_017d: dup
-					IL_017e: ldc.i4.0
-					IL_017f: ldarg.0
-					IL_0180: stelem.ref
-					IL_0181: ldc.i4.0
-					IL_0182: ldelem.ref
-					IL_0183: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_0188: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_018e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_0193: ldnull
-					IL_0194: ldloc.s 11
-					IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_019b: stloc.s 11
-					IL_019d: ldloc.0
-					IL_019e: ldloc.s 11
-					IL_01a0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01a5: pop
+					IL_0177: ldarg.0
+					IL_0178: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_017d: ldnull
+					IL_017e: ldloc.s 11
+					IL_0180: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_0185: stloc.s 11
+					IL_0187: ldloc.0
+					IL_0188: ldloc.s 11
+					IL_018a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_018f: pop
 
-					IL_01a6: ldloc.0
-					IL_01a7: ldstr ""
-					IL_01ac: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01b1: pop
-					IL_01b2: ldloc.s 4
-					IL_01b4: ldstr "apis"
-					IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01be: stloc.s 11
-					IL_01c0: ldloc.s 11
-					IL_01c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01c7: stloc.s 12
-					IL_01c9: ldloc.s 12
-					IL_01cb: brtrue IL_01dd
+					IL_0190: ldloc.0
+					IL_0191: ldstr ""
+					IL_0196: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_019b: pop
+					IL_019c: ldloc.s 4
+					IL_019e: ldstr "apis"
+					IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01a8: stloc.s 11
+					IL_01aa: ldloc.s 11
+					IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01b1: stloc.s 12
+					IL_01b3: ldloc.s 12
+					IL_01b5: brtrue IL_01c7
 
-					IL_01d0: ldc.i4.0
-					IL_01d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_01d6: stloc.s 17
-					IL_01d8: br IL_01e1
+					IL_01ba: ldc.i4.0
+					IL_01bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01c0: stloc.s 17
+					IL_01c2: br IL_01cb
 
-					IL_01dd: ldloc.s 11
-					IL_01df: stloc.s 17
+					IL_01c7: ldloc.s 11
+					IL_01c9: stloc.s 17
 
-					IL_01e1: ldc.i4.1
-					IL_01e2: newarr [System.Runtime]System.Object
-					IL_01e7: dup
-					IL_01e8: ldc.i4.0
-					IL_01e9: ldarg.0
-					IL_01ea: stelem.ref
-					IL_01eb: ldc.i4.0
-					IL_01ec: ldelem.ref
-					IL_01ed: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_01f2: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_01f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_01fd: ldnull
-					IL_01fe: ldloc.s 17
-					IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_0205: stloc.s 11
-					IL_0207: ldloc.s 11
-					IL_0209: stloc.s 7
-					IL_020b: ldloc.s 7
-					IL_020d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0212: stloc.s 12
-					IL_0214: ldloc.s 12
-					IL_0216: brfalse IL_0237
+					IL_01cb: ldarg.0
+					IL_01cc: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_01d1: ldnull
+					IL_01d2: ldloc.s 17
+					IL_01d4: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_01d9: stloc.s 11
+					IL_01db: ldloc.s 11
+					IL_01dd: stloc.s 7
+					IL_01df: ldloc.s 7
+					IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01e6: stloc.s 12
+					IL_01e8: ldloc.s 12
+					IL_01ea: brfalse IL_020b
 
-					IL_021b: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L83C15::.ctor()
-					IL_0220: stloc.s 8
-					IL_0222: ldloc.0
-					IL_0223: ldloc.s 7
-					IL_0225: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_022a: pop
-					IL_022b: ldloc.0
-					IL_022c: ldstr ""
-					IL_0231: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0236: pop
+					IL_01ef: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L83C15::.ctor()
+					IL_01f4: stloc.s 8
+					IL_01f6: ldloc.0
+					IL_01f7: ldloc.s 7
+					IL_01f9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01fe: pop
+					IL_01ff: ldloc.0
+					IL_0200: ldstr ""
+					IL_0205: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_020a: pop
 
-					IL_0237: ldloc.s 4
-					IL_0239: ldstr "apis"
-					IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0243: stloc.s 11
-					IL_0245: ldloc.s 11
-					IL_0247: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_024c: stloc.s 12
-					IL_024e: ldloc.s 12
-					IL_0250: brtrue IL_0262
+					IL_020b: ldloc.s 4
+					IL_020d: ldstr "apis"
+					IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0217: stloc.s 11
+					IL_0219: ldloc.s 11
+					IL_021b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0220: stloc.s 12
+					IL_0222: ldloc.s 12
+					IL_0224: brtrue IL_0236
 
-					IL_0255: ldc.i4.0
-					IL_0256: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_025b: stloc.s 18
-					IL_025d: br IL_0266
+					IL_0229: ldc.i4.0
+					IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_022f: stloc.s 18
+					IL_0231: br IL_023a
 
-					IL_0262: ldloc.s 11
-					IL_0264: stloc.s 18
+					IL_0236: ldloc.s 11
+					IL_0238: stloc.s 18
 
-					IL_0266: ldc.i4.1
-					IL_0267: newarr [System.Runtime]System.Object
-					IL_026c: dup
-					IL_026d: ldc.i4.0
-					IL_026e: ldarg.0
-					IL_026f: stelem.ref
-					IL_0270: ldc.i4.0
-					IL_0271: ldelem.ref
-					IL_0272: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_0277: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_027d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_0282: ldnull
-					IL_0283: ldloc.s 18
-					IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_028a: stloc.s 11
-					IL_028c: ldloc.s 11
-					IL_028e: stloc.s 9
-					IL_0290: ldloc.s 9
-					IL_0292: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0297: stloc.s 12
-					IL_0299: ldloc.s 12
-					IL_029b: brfalse IL_02c8
+					IL_023a: ldarg.0
+					IL_023b: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_0240: ldnull
+					IL_0241: ldloc.s 18
+					IL_0243: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_0248: stloc.s 11
+					IL_024a: ldloc.s 11
+					IL_024c: stloc.s 9
+					IL_024e: ldloc.s 9
+					IL_0250: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0255: stloc.s 12
+					IL_0257: ldloc.s 12
+					IL_0259: brfalse IL_0286
 
-					IL_02a0: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L88C15::.ctor()
-					IL_02a5: stloc.s 10
-					IL_02a7: ldloc.0
-					IL_02a8: ldstr "Tests:"
-					IL_02ad: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02b2: pop
-					IL_02b3: ldloc.0
-					IL_02b4: ldloc.s 9
-					IL_02b6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02bb: pop
-					IL_02bc: ldloc.0
-					IL_02bd: ldstr ""
-					IL_02c2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_02c7: pop
+					IL_025e: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L88C15::.ctor()
+					IL_0263: stloc.s 10
+					IL_0265: ldloc.0
+					IL_0266: ldstr "Tests:"
+					IL_026b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0270: pop
+					IL_0271: ldloc.0
+					IL_0272: ldloc.s 9
+					IL_0274: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0279: pop
+					IL_027a: ldloc.0
+					IL_027b: ldstr ""
+					IL_0280: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0285: pop
 
-					IL_02c8: br IL_0059
+					IL_0286: br IL_0059
 				// end loop
-				IL_02cd: ldloc.1
-				IL_02ce: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_02d3: ldc.i4.1
-				IL_02d4: stloc.3
-				IL_02d5: leave IL_02f4
+				IL_028b: ldloc.1
+				IL_028c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0291: ldc.i4.1
+				IL_0292: stloc.3
+				IL_0293: leave IL_02b2
 
-				IL_02da: ldc.i4.1
-				IL_02db: stloc.2
-				IL_02dc: leave IL_02f4
+				IL_0298: ldc.i4.1
+				IL_0299: stloc.2
+				IL_029a: leave IL_02b2
 			} // end .try
 			finally
 			{
-				IL_02e1: ldloc.2
-				IL_02e2: brtrue IL_02f3
+				IL_029f: ldloc.2
+				IL_02a0: brtrue IL_02b1
 
-				IL_02e7: ldloc.3
-				IL_02e8: brtrue IL_02f3
+				IL_02a5: ldloc.3
+				IL_02a6: brtrue IL_02b1
 
-				IL_02ed: ldloc.1
-				IL_02ee: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_02ab: ldloc.1
+				IL_02ac: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_02f3: endfinally
+				IL_02b1: endfinally
 			} // end handler
 
-			IL_02f4: ldloc.0
-			IL_02f5: ldc.i4.1
-			IL_02f6: newarr [System.Runtime]System.Object
-			IL_02fb: dup
-			IL_02fc: ldc.i4.0
-			IL_02fd: ldstr "\n"
-			IL_0302: stelem.ref
-			IL_0303: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0308: stloc.s 16
-			IL_030a: ldloc.s 16
-			IL_030c: ret
+			IL_02b2: ldloc.0
+			IL_02b3: ldc.i4.1
+			IL_02b4: newarr [System.Runtime]System.Object
+			IL_02b9: dup
+			IL_02ba: ldc.i4.0
+			IL_02bb: ldstr "\n"
+			IL_02c0: stelem.ref
+			IL_02c1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_02c6: stloc.s 16
+			IL_02c8: ldloc.s 16
+			IL_02ca: ret
 		} // end of method renderModules::__js_call__
 
 	} // end of class renderModules
@@ -1929,7 +1902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3747
+				// Method begins at RVA 0x367f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1957,7 +1930,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3762
+						// Method begins at RVA 0x369a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1977,7 +1950,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x376b
+						// Method begins at RVA 0x36a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1997,7 +1970,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3774
+						// Method begins at RVA 0x36ac
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2021,7 +1994,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3786
+							// Method begins at RVA 0x36be
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2039,7 +2012,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x377d
+						// Method begins at RVA 0x36b5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2057,7 +2030,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3759
+					// Method begins at RVA 0x3691
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2075,7 +2048,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3750
+				// Method begins at RVA 0x3688
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2102,9 +2075,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2e98
+			// Method begins at RVA 0x2e40
 			// Header size: 12
-			// Code size: 1014 (0x3f6)
+			// Code size: 992 (0x3e0)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2180,7 +2153,7 @@
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0068: stloc.s 19
 					IL_006a: ldloc.s 19
-					IL_006c: brtrue IL_03c3
+					IL_006c: brtrue IL_03ad
 
 					IL_0071: ldloc.s 18
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -2254,7 +2227,7 @@
 					IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_014d: stloc.s 19
 					IL_014f: ldloc.s 19
-					IL_0151: brfalse IL_01a6
+					IL_0151: brfalse IL_0190
 
 					IL_0156: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L104C26::.ctor()
 					IL_015b: stloc.s 6
@@ -2266,254 +2239,245 @@
 					IL_016b: ldstr "implementation"
 					IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 					IL_0175: stloc.s 18
-					IL_0177: ldc.i4.1
-					IL_0178: newarr [System.Runtime]System.Object
-					IL_017d: dup
-					IL_017e: ldc.i4.0
-					IL_017f: ldarg.0
-					IL_0180: stelem.ref
-					IL_0181: ldc.i4.0
-					IL_0182: ldelem.ref
-					IL_0183: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_0188: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_018e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-					IL_0193: ldnull
-					IL_0194: ldloc.s 18
-					IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-					IL_019b: stloc.s 18
-					IL_019d: ldloc.0
-					IL_019e: ldloc.s 18
-					IL_01a0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01a5: pop
+					IL_0177: ldarg.0
+					IL_0178: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+					IL_017d: ldnull
+					IL_017e: ldloc.s 18
+					IL_0180: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+					IL_0185: stloc.s 18
+					IL_0187: ldloc.0
+					IL_0188: ldloc.s 18
+					IL_018a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_018f: pop
 
-					IL_01a6: ldloc.s 4
-					IL_01a8: ldstr "notes"
-					IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01b7: stloc.s 19
-					IL_01b9: ldloc.s 19
-					IL_01bb: brfalse IL_01e6
+					IL_0190: ldloc.s 4
+					IL_0192: ldstr "notes"
+					IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_019c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01a1: stloc.s 19
+					IL_01a3: ldloc.s 19
+					IL_01a5: brfalse IL_01d0
 
-					IL_01c0: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L108C17::.ctor()
-					IL_01c5: stloc.s 7
-					IL_01c7: ldloc.0
-					IL_01c8: ldstr "Notes:"
-					IL_01cd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01d2: pop
-					IL_01d3: ldloc.0
-					IL_01d4: ldloc.s 4
-					IL_01d6: ldstr "notes"
-					IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01e0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01e5: pop
+					IL_01aa: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L108C17::.ctor()
+					IL_01af: stloc.s 7
+					IL_01b1: ldloc.0
+					IL_01b2: ldstr "Notes:"
+					IL_01b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01bc: pop
+					IL_01bd: ldloc.0
+					IL_01be: ldloc.s 4
+					IL_01c0: ldstr "notes"
+					IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01ca: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01cf: pop
 
-					IL_01e6: ldloc.s 4
-					IL_01e8: ldstr "tests"
-					IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01f2: stloc.s 18
-					IL_01f4: ldloc.s 18
-					IL_01f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01fb: stloc.s 19
-					IL_01fd: ldloc.s 19
-					IL_01ff: brfalse IL_0221
+					IL_01d0: ldloc.s 4
+					IL_01d2: ldstr "tests"
+					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01dc: stloc.s 18
+					IL_01de: ldloc.s 18
+					IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01e5: stloc.s 19
+					IL_01e7: ldloc.s 19
+					IL_01e9: brfalse IL_020b
 
-					IL_0204: ldloc.s 4
-					IL_0206: ldstr "tests"
-					IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0210: ldstr "length"
-					IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_021a: stloc.s 24
-					IL_021c: br IL_0225
+					IL_01ee: ldloc.s 4
+					IL_01f0: ldstr "tests"
+					IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01fa: ldstr "length"
+					IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0204: stloc.s 24
+					IL_0206: br IL_020f
 
-					IL_0221: ldloc.s 18
-					IL_0223: stloc.s 24
+					IL_020b: ldloc.s 18
+					IL_020d: stloc.s 24
 
-					IL_0225: ldloc.s 24
-					IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_022c: stloc.s 19
-					IL_022e: ldloc.s 19
-					IL_0230: brfalse IL_03a5
+					IL_020f: ldloc.s 24
+					IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0216: stloc.s 19
+					IL_0218: ldloc.s 19
+					IL_021a: brfalse IL_038f
 
-					IL_0235: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L112C35::.ctor()
-					IL_023a: stloc.s 8
-					IL_023c: ldloc.0
-					IL_023d: ldstr "Tests:"
-					IL_0242: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0247: pop
-					IL_0248: ldloc.s 4
-					IL_024a: ldstr "tests"
-					IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-					IL_0259: stloc.s 9
-					IL_025b: ldc.i4.0
-					IL_025c: stloc.s 10
-					IL_025e: ldc.i4.0
-					IL_025f: stloc.s 11
+					IL_021f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L112C35::.ctor()
+					IL_0224: stloc.s 8
+					IL_0226: ldloc.0
+					IL_0227: ldstr "Tests:"
+					IL_022c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0231: pop
+					IL_0232: ldloc.s 4
+					IL_0234: ldstr "tests"
+					IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_023e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+					IL_0243: stloc.s 9
+					IL_0245: ldc.i4.0
+					IL_0246: stloc.s 10
+					IL_0248: ldc.i4.0
+					IL_0249: stloc.s 11
 					.try
 					{
-						// loop start (head: IL_0261)
-							IL_0261: ldloc.s 9
-							IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-							IL_0268: stloc.s 18
-							IL_026a: ldloc.s 18
-							IL_026c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-							IL_0271: stloc.s 19
-							IL_0273: ldloc.s 19
-							IL_0275: brtrue IL_0387
+						// loop start (head: IL_024b)
+							IL_024b: ldloc.s 9
+							IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+							IL_0252: stloc.s 18
+							IL_0254: ldloc.s 18
+							IL_0256: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+							IL_025b: stloc.s 19
+							IL_025d: ldloc.s 19
+							IL_025f: brtrue IL_0371
 
-							IL_027a: ldloc.s 18
-							IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-							IL_0281: stloc.s 18
-							IL_0283: ldloc.s 18
-							IL_0285: stloc.s 12
-							IL_0287: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31::.ctor()
-							IL_028c: stloc.s 13
-							IL_028e: ldloc.s 12
-							IL_0290: ldstr "name"
-							IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_029a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_029f: stloc.s 19
-							IL_02a1: ldloc.s 19
-							IL_02a3: brfalse IL_02c9
+							IL_0264: ldloc.s 18
+							IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+							IL_026b: stloc.s 18
+							IL_026d: ldloc.s 18
+							IL_026f: stloc.s 12
+							IL_0271: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31::.ctor()
+							IL_0276: stloc.s 13
+							IL_0278: ldloc.s 12
+							IL_027a: ldstr "name"
+							IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0284: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_0289: stloc.s 19
+							IL_028b: ldloc.s 19
+							IL_028d: brfalse IL_02b3
 
-							IL_02a8: ldloc.s 12
-							IL_02aa: ldstr "name"
-							IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02b4: stloc.s 18
-							IL_02b6: ldnull
-							IL_02b7: ldloc.s 18
-							IL_02b9: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-							IL_02be: stloc.s 18
-							IL_02c0: ldloc.s 18
-							IL_02c2: stloc.s 14
-							IL_02c4: br IL_02d0
+							IL_0292: ldloc.s 12
+							IL_0294: ldstr "name"
+							IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_029e: stloc.s 18
+							IL_02a0: ldnull
+							IL_02a1: ldloc.s 18
+							IL_02a3: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+							IL_02a8: stloc.s 18
+							IL_02aa: ldloc.s 18
+							IL_02ac: stloc.s 14
+							IL_02ae: br IL_02ba
 
-							IL_02c9: ldstr ""
-							IL_02ce: stloc.s 14
+							IL_02b3: ldstr ""
+							IL_02b8: stloc.s 14
 
-							IL_02d0: ldloc.s 14
-							IL_02d2: stloc.s 15
-							IL_02d4: ldloc.s 12
-							IL_02d6: ldstr "file"
-							IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_02e5: stloc.s 19
-							IL_02e7: ldloc.s 19
-							IL_02e9: brfalse IL_0334
+							IL_02ba: ldloc.s 14
+							IL_02bc: stloc.s 15
+							IL_02be: ldloc.s 12
+							IL_02c0: ldstr "file"
+							IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_02cf: stloc.s 19
+							IL_02d1: ldloc.s 19
+							IL_02d3: brfalse IL_031e
 
-							IL_02ee: ldloc.s 12
-							IL_02f0: ldstr "file"
-							IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02fa: stloc.s 18
-							IL_02fc: ldnull
-							IL_02fd: ldloc.s 18
-							IL_02ff: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-							IL_0304: stloc.s 18
-							IL_0306: ldloc.s 18
-							IL_0308: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_030d: stloc.s 23
-							IL_030f: ldstr " ("
-							IL_0314: ldloc.s 23
-							IL_0316: call string [System.Runtime]System.String::Concat(string, string)
-							IL_031b: stloc.s 23
-							IL_031d: ldloc.s 23
-							IL_031f: ldstr ")"
-							IL_0324: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0329: stloc.s 23
-							IL_032b: ldloc.s 23
-							IL_032d: stloc.s 16
-							IL_032f: br IL_033b
+							IL_02d8: ldloc.s 12
+							IL_02da: ldstr "file"
+							IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02e4: stloc.s 18
+							IL_02e6: ldnull
+							IL_02e7: ldloc.s 18
+							IL_02e9: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+							IL_02ee: stloc.s 18
+							IL_02f0: ldloc.s 18
+							IL_02f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_02f7: stloc.s 23
+							IL_02f9: ldstr " ("
+							IL_02fe: ldloc.s 23
+							IL_0300: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0305: stloc.s 23
+							IL_0307: ldloc.s 23
+							IL_0309: ldstr ")"
+							IL_030e: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0313: stloc.s 23
+							IL_0315: ldloc.s 23
+							IL_0317: stloc.s 16
+							IL_0319: br IL_0325
 
-							IL_0334: ldstr ""
-							IL_0339: stloc.s 16
+							IL_031e: ldstr ""
+							IL_0323: stloc.s 16
 
-							IL_033b: ldloc.s 16
-							IL_033d: stloc.s 17
-							IL_033f: ldloc.s 15
-							IL_0341: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0346: stloc.s 23
-							IL_0348: ldstr "- "
-							IL_034d: ldloc.s 23
-							IL_034f: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0354: stloc.s 23
-							IL_0356: ldloc.s 17
-							IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_035d: stloc.s 22
-							IL_035f: ldloc.s 23
-							IL_0361: ldloc.s 22
-							IL_0363: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0368: stloc.s 22
-							IL_036a: ldloc.0
-							IL_036b: ldloc.s 22
-							IL_036d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_0372: pop
-							IL_0373: br IL_0261
+							IL_0325: ldloc.s 16
+							IL_0327: stloc.s 17
+							IL_0329: ldloc.s 15
+							IL_032b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0330: stloc.s 23
+							IL_0332: ldstr "- "
+							IL_0337: ldloc.s 23
+							IL_0339: call string [System.Runtime]System.String::Concat(string, string)
+							IL_033e: stloc.s 23
+							IL_0340: ldloc.s 17
+							IL_0342: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0347: stloc.s 22
+							IL_0349: ldloc.s 23
+							IL_034b: ldloc.s 22
+							IL_034d: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0352: stloc.s 22
+							IL_0354: ldloc.0
+							IL_0355: ldloc.s 22
+							IL_0357: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_035c: pop
+							IL_035d: br IL_024b
 						// end loop
-						IL_0378: ldloc.s 9
-						IL_037a: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-						IL_037f: ldc.i4.1
-						IL_0380: stloc.s 11
-						IL_0382: leave IL_03a5
+						IL_0362: ldloc.s 9
+						IL_0364: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+						IL_0369: ldc.i4.1
+						IL_036a: stloc.s 11
+						IL_036c: leave IL_038f
 
-						IL_0387: ldc.i4.1
-						IL_0388: stloc.s 10
-						IL_038a: leave IL_03a5
+						IL_0371: ldc.i4.1
+						IL_0372: stloc.s 10
+						IL_0374: leave IL_038f
 					} // end .try
 					finally
 					{
-						IL_038f: ldloc.s 10
-						IL_0391: brtrue IL_03a4
+						IL_0379: ldloc.s 10
+						IL_037b: brtrue IL_038e
 
-						IL_0396: ldloc.s 11
-						IL_0398: brtrue IL_03a4
+						IL_0380: ldloc.s 11
+						IL_0382: brtrue IL_038e
 
-						IL_039d: ldloc.s 9
-						IL_039f: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+						IL_0387: ldloc.s 9
+						IL_0389: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-						IL_03a4: endfinally
+						IL_038e: endfinally
 					} // end handler
 
-					IL_03a5: ldloc.0
-					IL_03a6: ldstr ""
-					IL_03ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_03b0: pop
-					IL_03b1: br IL_0059
+					IL_038f: ldloc.0
+					IL_0390: ldstr ""
+					IL_0395: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_039a: pop
+					IL_039b: br IL_0059
 				// end loop
-				IL_03b6: ldloc.1
-				IL_03b7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_03bc: ldc.i4.1
-				IL_03bd: stloc.3
-				IL_03be: leave IL_03dd
+				IL_03a0: ldloc.1
+				IL_03a1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_03a6: ldc.i4.1
+				IL_03a7: stloc.3
+				IL_03a8: leave IL_03c7
 
-				IL_03c3: ldc.i4.1
-				IL_03c4: stloc.2
-				IL_03c5: leave IL_03dd
+				IL_03ad: ldc.i4.1
+				IL_03ae: stloc.2
+				IL_03af: leave IL_03c7
 			} // end .try
 			finally
 			{
-				IL_03ca: ldloc.2
-				IL_03cb: brtrue IL_03dc
+				IL_03b4: ldloc.2
+				IL_03b5: brtrue IL_03c6
 
-				IL_03d0: ldloc.3
-				IL_03d1: brtrue IL_03dc
+				IL_03ba: ldloc.3
+				IL_03bb: brtrue IL_03c6
 
-				IL_03d6: ldloc.1
-				IL_03d7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_03c0: ldloc.1
+				IL_03c1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_03dc: endfinally
+				IL_03c6: endfinally
 			} // end handler
 
-			IL_03dd: ldloc.0
-			IL_03de: ldc.i4.1
-			IL_03df: newarr [System.Runtime]System.Object
-			IL_03e4: dup
-			IL_03e5: ldc.i4.0
-			IL_03e6: ldstr "\n"
-			IL_03eb: stelem.ref
-			IL_03ec: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_03f1: stloc.s 22
-			IL_03f3: ldloc.s 22
-			IL_03f5: ret
+			IL_03c7: ldloc.0
+			IL_03c8: ldc.i4.1
+			IL_03c9: newarr [System.Runtime]System.Object
+			IL_03ce: dup
+			IL_03cf: ldc.i4.0
+			IL_03d0: ldstr "\n"
+			IL_03d5: stelem.ref
+			IL_03d6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03db: stloc.s 22
+			IL_03dd: ldloc.s 22
+			IL_03df: ret
 		} // end of method renderGlobals::__js_call__
 
 	} // end of class renderGlobals
@@ -2529,7 +2493,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x378f
+				// Method begins at RVA 0x36c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2549,7 +2513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3798
+				// Method begins at RVA 0x36d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2573,7 +2537,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32d0
+			// Method begins at RVA 0x3260
 			// Header size: 12
 			// Code size: 278 (0x116)
 			.maxstack 8
@@ -2726,7 +2690,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37a1
+				// Method begins at RVA 0x36d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2752,9 +2716,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x3404
+			// Method begins at RVA 0x3394
 			// Header size: 12
-			// Code size: 584 (0x248)
+			// Code size: 496 (0x1f0)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2847,158 +2811,122 @@
 			IL_00b0: stloc.s 8
 			IL_00b2: ldloc.s 8
 			IL_00b4: stloc.2
-			IL_00b5: ldc.i4.1
-			IL_00b6: newarr [System.Runtime]System.Object
-			IL_00bb: dup
-			IL_00bc: ldc.i4.0
-			IL_00bd: ldarg.0
-			IL_00be: stelem.ref
-			IL_00bf: ldc.i4.0
-			IL_00c0: ldelem.ref
-			IL_00c1: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_00c6: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_00cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00d1: ldnull
-			IL_00d2: ldloc.1
-			IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_00d8: stloc.s 8
-			IL_00da: ldloc.s 8
-			IL_00dc: stloc.3
-			IL_00dd: ldc.i4.0
-			IL_00de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00e3: stloc.s 4
-			IL_00e5: ldc.i4.1
-			IL_00e6: newarr [System.Runtime]System.Object
-			IL_00eb: dup
-			IL_00ec: ldc.i4.0
-			IL_00ed: ldarg.0
-			IL_00ee: stelem.ref
-			IL_00ef: ldc.i4.0
-			IL_00f0: ldelem.ref
-			IL_00f1: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_00f6: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_00fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0101: ldnull
-			IL_0102: ldloc.3
-			IL_0103: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0108: stloc.s 8
-			IL_010a: ldloc.s 4
-			IL_010c: ldloc.s 8
-			IL_010e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0113: pop
-			IL_0114: ldc.i4.1
-			IL_0115: newarr [System.Runtime]System.Object
-			IL_011a: dup
-			IL_011b: ldc.i4.0
-			IL_011c: ldarg.0
-			IL_011d: stelem.ref
-			IL_011e: ldc.i4.0
-			IL_011f: ldelem.ref
-			IL_0120: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_0125: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0130: ldnull
-			IL_0131: ldloc.3
-			IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0137: stloc.s 8
-			IL_0139: ldloc.s 4
-			IL_013b: ldloc.s 8
-			IL_013d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0142: pop
+			IL_00b5: ldarg.0
+			IL_00b6: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00bb: ldnull
+			IL_00bc: ldloc.1
+			IL_00bd: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00c2: stloc.s 8
+			IL_00c4: ldloc.s 8
+			IL_00c6: stloc.3
+			IL_00c7: ldc.i4.0
+			IL_00c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00cd: stloc.s 4
+			IL_00cf: ldarg.0
+			IL_00d0: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00d5: ldnull
+			IL_00d6: ldloc.3
+			IL_00d7: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00dc: stloc.s 8
+			IL_00de: ldloc.s 4
+			IL_00e0: ldloc.s 8
+			IL_00e2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00e7: pop
+			IL_00e8: ldarg.0
+			IL_00e9: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_00ee: ldnull
+			IL_00ef: ldloc.3
+			IL_00f0: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_00f5: stloc.s 8
+			IL_00f7: ldloc.s 4
+			IL_00f9: ldloc.s 8
+			IL_00fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0100: pop
+			IL_0101: ldarg.0
+			IL_0102: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+			IL_0107: ldnull
+			IL_0108: ldloc.3
+			IL_0109: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+			IL_010e: stloc.s 8
+			IL_0110: ldloc.s 4
+			IL_0112: ldloc.s 8
+			IL_0114: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0119: pop
+			IL_011a: ldnull
+			IL_011b: ldloc.3
+			IL_011c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
+			IL_0121: stloc.s 8
+			IL_0123: ldloc.s 8
+			IL_0125: stloc.s 5
+			IL_0127: ldloc.s 5
+			IL_0129: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_012e: stloc.s 10
+			IL_0130: ldloc.s 10
+			IL_0132: brfalse IL_0141
+
+			IL_0137: ldloc.s 4
+			IL_0139: ldloc.s 5
+			IL_013b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0140: pop
+
+			IL_0141: ldloc.s 4
 			IL_0143: ldc.i4.1
 			IL_0144: newarr [System.Runtime]System.Object
 			IL_0149: dup
 			IL_014a: ldc.i4.0
-			IL_014b: ldarg.0
-			IL_014c: stelem.ref
-			IL_014d: ldc.i4.0
-			IL_014e: ldelem.ref
-			IL_014f: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_0154: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_015f: ldnull
-			IL_0160: ldloc.3
-			IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-			IL_0166: stloc.s 8
-			IL_0168: ldloc.s 4
-			IL_016a: ldloc.s 8
-			IL_016c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0171: pop
-			IL_0172: ldnull
-			IL_0173: ldloc.3
-			IL_0174: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
-			IL_0179: stloc.s 8
-			IL_017b: ldloc.s 8
-			IL_017d: stloc.s 5
-			IL_017f: ldloc.s 5
-			IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0186: stloc.s 10
-			IL_0188: ldloc.s 10
-			IL_018a: brfalse IL_0199
-
-			IL_018f: ldloc.s 4
-			IL_0191: ldloc.s 5
-			IL_0193: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0198: pop
-
-			IL_0199: ldloc.s 4
-			IL_019b: ldc.i4.1
-			IL_019c: newarr [System.Runtime]System.Object
-			IL_01a1: dup
-			IL_01a2: ldc.i4.0
-			IL_01a3: ldstr "\n\n"
-			IL_01a8: stelem.ref
-			IL_01a9: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01ae: stloc.s 11
-			IL_01b0: ldloc.s 11
-			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b7: stloc.s 8
-			IL_01b9: ldstr "\\r?\\n"
-			IL_01be: ldstr "g"
-			IL_01c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_01c8: stloc.s 12
+			IL_014b: ldstr "\n\n"
+			IL_0150: stelem.ref
+			IL_0151: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0156: stloc.s 11
+			IL_0158: ldloc.s 11
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015f: stloc.s 8
+			IL_0161: ldstr "\\r?\\n"
+			IL_0166: ldstr "g"
+			IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0170: stloc.s 12
+			IL_0172: ldloc.s 8
+			IL_0174: ldstr "replace"
+			IL_0179: ldloc.s 12
+			IL_017b: ldstr "\n"
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0185: stloc.s 8
+			IL_0187: ldloc.s 8
+			IL_0189: stloc.s 6
+			IL_018b: ldarg.0
+			IL_018c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0196: stloc.s 8
+			IL_0198: ldloc.s 8
+			IL_019a: ldstr "writeFileSync"
+			IL_019f: ldloc.2
+			IL_01a0: ldloc.s 6
+			IL_01a2: ldstr "utf8"
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01ac: pop
+			IL_01ad: ldarg.0
+			IL_01ae: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01b8: stloc.s 8
+			IL_01ba: ldloc.s 8
+			IL_01bc: ldstr "relative"
+			IL_01c1: ldloc.0
+			IL_01c2: ldloc.2
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01c8: stloc.s 8
 			IL_01ca: ldloc.s 8
-			IL_01cc: ldstr "replace"
-			IL_01d1: ldloc.s 12
-			IL_01d3: ldstr "\n"
-			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01dd: stloc.s 8
-			IL_01df: ldloc.s 8
-			IL_01e1: stloc.s 6
-			IL_01e3: ldarg.0
-			IL_01e4: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ee: stloc.s 8
-			IL_01f0: ldloc.s 8
-			IL_01f2: ldstr "writeFileSync"
-			IL_01f7: ldloc.2
-			IL_01f8: ldloc.s 6
-			IL_01fa: ldstr "utf8"
-			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0204: pop
-			IL_0205: ldarg.0
-			IL_0206: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0210: stloc.s 8
-			IL_0212: ldloc.s 8
-			IL_0214: ldstr "relative"
-			IL_0219: ldloc.0
-			IL_021a: ldloc.2
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0220: stloc.s 8
-			IL_0222: ldloc.s 8
-			IL_0224: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0229: stloc.s 11
-			IL_022b: ldstr "Wrote "
-			IL_0230: ldloc.s 11
-			IL_0232: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0237: stloc.s 11
-			IL_0239: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_023e: ldloc.s 11
-			IL_0240: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0245: pop
-			IL_0246: ldnull
-			IL_0247: ret
+			IL_01cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d1: stloc.s 11
+			IL_01d3: ldstr "Wrote "
+			IL_01d8: ldloc.s 11
+			IL_01da: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01df: stloc.s 11
+			IL_01e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01e6: ldloc.s 11
+			IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ed: pop
+			IL_01ee: ldnull
+			IL_01ef: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -3041,7 +2969,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3681
+			// Method begins at RVA 0x35b9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3067,7 +2995,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 619 (0x26b)
+		// Code size: 597 (0x255)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope,
@@ -3313,21 +3241,12 @@
 		IL_0240: ldloc.0
 		IL_0241: ldloc.2
 		IL_0242: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-		IL_0247: ldc.i4.1
-		IL_0248: newarr [System.Runtime]System.Object
-		IL_024d: dup
-		IL_024e: ldc.i4.0
-		IL_024f: ldloc.0
-		IL_0250: stelem.ref
-		IL_0251: ldc.i4.0
-		IL_0252: ldelem.ref
-		IL_0253: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0258: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
-		IL_025e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0263: ldnull
-		IL_0264: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0269: pop
-		IL_026a: ret
+		IL_0247: ldloc.0
+		IL_0248: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+		IL_024d: ldnull
+		IL_024e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
+		IL_0253: pop
+		IL_0254: ret
 	} // end of method Compile_Scripts_GenerateNodeSupportMd::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_GenerateNodeSupportMd
@@ -3339,7 +3258,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x37aa
+		// Method begins at RVA 0x36e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Iterator_Helper_Cleanup
+﻿// IL code: Iterator_Helper_Cleanup
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3086
+					// Method begins at RVA 0x301a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bae
+				// Method begins at RVA 0x2b42
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -76,7 +76,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3098
+						// Method begins at RVA 0x302c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -100,7 +100,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2e4c
+					// Method begins at RVA 0x2de0
 					// Header size: 12
 					// Code size: 131 (0x83)
 					.maxstack 8
@@ -171,7 +171,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30a1
+						// Method begins at RVA 0x3035
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -195,7 +195,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2edc
+					// Method begins at RVA 0x2e70
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -238,7 +238,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x308f
+					// Method begins at RVA 0x3023
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -262,7 +262,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bc0
+				// Method begins at RVA 0x2b54
 				// Header size: 12
 				// Code size: 154 (0x9a)
 				.maxstack 8
@@ -365,7 +365,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x307d
+				// Method begins at RVA 0x3011
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -392,7 +392,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2900
+			// Method begins at RVA 0x2894
 			// Header size: 12
 			// Code size: 176 (0xb0)
 			.maxstack 8
@@ -495,7 +495,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30aa
+				// Method begins at RVA 0x303e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -519,7 +519,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29bc
+			// Method begins at RVA 0x2950
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -548,7 +548,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30b3
+				// Method begins at RVA 0x3047
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -572,7 +572,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29c0
+			// Method begins at RVA 0x2954
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -623,7 +623,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30ce
+				// Method begins at RVA 0x3062
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -647,7 +647,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29f8
+			// Method begins at RVA 0x298c
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -703,7 +703,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3104
+							// Method begins at RVA 0x3098
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30fb
+						// Method begins at RVA 0x308f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -745,7 +745,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f28
+					// Method begins at RVA 0x2ebc
 					// Header size: 12
 					// Code size: 110 (0x6e)
 					.maxstack 8
@@ -809,7 +809,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x310d
+						// Method begins at RVA 0x30a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -833,7 +833,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fa4
+					// Method begins at RVA 0x2f38
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -876,7 +876,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f2
+					// Method begins at RVA 0x3086
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -900,7 +900,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c68
+				// Method begins at RVA 0x2bfc
 				// Header size: 12
 				// Code size: 146 (0x92)
 				.maxstack 8
@@ -1001,7 +1001,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e9
+				// Method begins at RVA 0x307d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1028,7 +1028,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2a30
+			// Method begins at RVA 0x29c4
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1097,7 +1097,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3116
+				// Method begins at RVA 0x30aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1121,7 +1121,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a90
+			// Method begins at RVA 0x2a24
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1173,7 +1173,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3143
+						// Method begins at RVA 0x30d7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1191,7 +1191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x313a
+					// Method begins at RVA 0x30ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1215,7 +1215,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d08
+				// Method begins at RVA 0x2c9c
 				// Header size: 12
 				// Code size: 106 (0x6a)
 				.maxstack 8
@@ -1275,7 +1275,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x314c
+					// Method begins at RVA 0x30e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1299,7 +1299,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d80
+				// Method begins at RVA 0x2d14
 				// Header size: 12
 				// Code size: 64 (0x40)
 				.maxstack 8
@@ -1342,7 +1342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3131
+				// Method begins at RVA 0x30c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1368,7 +1368,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2ac8
+			// Method begins at RVA 0x2a5c
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -1458,7 +1458,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3167
+						// Method begins at RVA 0x30fb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1481,7 +1481,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2ff0
+					// Method begins at RVA 0x2f84
 					// Header size: 12
 					// Code size: 41 (0x29)
 					.maxstack 8
@@ -1525,7 +1525,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3170
+						// Method begins at RVA 0x3104
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1549,7 +1549,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3028
+					// Method begins at RVA 0x2fbc
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -1585,7 +1585,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x315e
+					// Method begins at RVA 0x30f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1609,7 +1609,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2dcc
+				// Method begins at RVA 0x2d60
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -1689,7 +1689,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3155
+				// Method begins at RVA 0x30e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1716,7 +1716,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2b58
+			// Method begins at RVA 0x2aec
 			// Header size: 12
 			// Code size: 74 (0x4a)
 			.maxstack 8
@@ -1788,7 +1788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30bc
+				// Method begins at RVA 0x3050
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1808,7 +1808,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c5
+				// Method begins at RVA 0x3059
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1828,7 +1828,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30d7
+				// Method begins at RVA 0x306b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1848,7 +1848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e0
+				// Method begins at RVA 0x3074
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1868,7 +1868,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x311f
+				// Method begins at RVA 0x30b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1888,7 +1888,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3128
+				// Method begins at RVA 0x30bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1908,7 +1908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3179
+				// Method begins at RVA 0x310d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1928,7 +1928,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3182
+				// Method begins at RVA 0x3116
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1952,7 +1952,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3074
+			// Method begins at RVA 0x3008
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1978,7 +1978,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2159 (0x86f)
+		// Code size: 2049 (0x801)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
@@ -2044,734 +2044,689 @@
 		IL_0030: stloc.s 35
 		IL_0032: ldloc.s 35
 		IL_0034: stloc.1
-		IL_0035: ldc.i4.1
-		IL_0036: newarr [System.Runtime]System.Object
-		IL_003b: dup
-		IL_003c: ldc.i4.0
-		IL_003d: ldloc.0
-		IL_003e: stelem.ref
-		IL_003f: ldc.i4.0
-		IL_0040: ldelem.ref
-		IL_0041: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0046: ldftn object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0051: ldnull
-		IL_0052: ldc.r8 2
-		IL_005b: box [System.Runtime]System.Double
-		IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0065: stloc.s 35
-		IL_0067: ldloc.s 35
-		IL_0069: stloc.2
-		IL_006a: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0074: stloc.s 35
-		IL_0076: ldloc.s 35
-		IL_0078: ldstr "from"
-		IL_007d: ldloc.2
-		IL_007e: ldstr "iterable"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_008d: stloc.s 35
-		IL_008f: ldloc.s 35
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0096: stloc.s 35
-		IL_0098: ldnull
-		IL_0099: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56::__js_call__(object, object)
-		IL_009f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00a4: ldc.i4.1
-		IL_00a5: newarr [System.Runtime]System.Object
-		IL_00aa: dup
-		IL_00ab: ldc.i4.0
-		IL_00ac: ldloc.0
-		IL_00ad: stelem.ref
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00b8: ldc.i4.1
-		IL_00b9: conv.r8
-		IL_00ba: ldstr ""
-		IL_00bf: ldc.i4.0
-		IL_00c0: ldc.i4.1
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00cb: stloc.s 36
-		IL_00cd: ldloc.s 35
-		IL_00cf: ldstr "map"
-		IL_00d4: ldloc.s 36
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00db: stloc.s 36
-		IL_00dd: ldloc.s 36
-		IL_00df: stloc.3
-		IL_00e0: ldloc.3
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e6: stloc.s 36
-		IL_00e8: ldloc.s 36
-		IL_00ea: ldstr "next"
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00f4: pop
-		IL_00f5: ldloc.3
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fb: stloc.s 36
-		IL_00fd: ldloc.s 36
-		IL_00ff: ldstr "next"
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0109: pop
-		IL_010a: ldloc.3
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0110: stloc.s 36
-		IL_0112: ldloc.s 36
-		IL_0114: ldstr "next"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_011e: stloc.s 36
-		IL_0120: ldloc.s 36
-		IL_0122: ldstr "done"
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012c: stloc.s 36
-		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0133: ldloc.s 36
-		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013a: pop
-		IL_013b: ldloc.2
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0141: stloc.s 36
-		IL_0143: ldloc.s 36
-		IL_0145: ldstr "getClosed"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_014f: stloc.s 36
-		IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0156: ldloc.s 36
-		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015d: pop
-		IL_015e: ldc.i4.1
-		IL_015f: newarr [System.Runtime]System.Object
-		IL_0164: dup
-		IL_0165: ldc.i4.0
-		IL_0166: ldloc.0
-		IL_0167: stelem.ref
-		IL_0168: ldc.i4.0
-		IL_0169: ldelem.ref
-		IL_016a: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_016f: ldftn object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_017a: ldnull
-		IL_017b: ldc.r8 2
-		IL_0184: box [System.Runtime]System.Double
-		IL_0189: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_018e: stloc.s 36
-		IL_0190: ldloc.s 36
-		IL_0192: stloc.s 4
-		IL_0194: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_019e: stloc.s 36
-		IL_01a0: ldloc.s 36
-		IL_01a2: ldstr "from"
-		IL_01a7: ldloc.s 4
-		IL_01a9: ldstr "iterable"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01b8: stloc.s 36
-		IL_01ba: ldloc.s 36
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c1: stloc.s 36
-		IL_01c3: ldnull
-		IL_01c4: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68::__js_call__(object, object)
-		IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01cf: ldc.i4.1
-		IL_01d0: newarr [System.Runtime]System.Object
-		IL_01d5: dup
-		IL_01d6: ldc.i4.0
-		IL_01d7: ldloc.0
-		IL_01d8: stelem.ref
-		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01e3: ldc.i4.1
-		IL_01e4: conv.r8
-		IL_01e5: ldstr ""
-		IL_01ea: ldc.i4.0
-		IL_01eb: ldc.i4.1
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01f6: stloc.s 35
-		IL_01f8: ldloc.s 36
-		IL_01fa: ldstr "map"
-		IL_01ff: ldloc.s 35
-		IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0206: stloc.s 35
-		IL_0208: ldloc.s 35
-		IL_020a: stloc.s 5
+		IL_0035: ldloc.0
+		IL_0036: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_003b: ldnull
+		IL_003c: ldc.r8 2
+		IL_0045: box [System.Runtime]System.Double
+		IL_004a: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_004f: stloc.s 35
+		IL_0051: ldloc.s 35
+		IL_0053: stloc.2
+		IL_0054: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005e: stloc.s 35
+		IL_0060: ldloc.s 35
+		IL_0062: ldstr "from"
+		IL_0067: ldloc.2
+		IL_0068: ldstr "iterable"
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0077: stloc.s 35
+		IL_0079: ldloc.s 35
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0080: stloc.s 35
+		IL_0082: ldnull
+		IL_0083: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56::__js_call__(object, object)
+		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_008e: ldc.i4.1
+		IL_008f: newarr [System.Runtime]System.Object
+		IL_0094: dup
+		IL_0095: ldc.i4.0
+		IL_0096: ldloc.0
+		IL_0097: stelem.ref
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00a2: ldc.i4.1
+		IL_00a3: conv.r8
+		IL_00a4: ldstr ""
+		IL_00a9: ldc.i4.0
+		IL_00aa: ldc.i4.1
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_00b5: stloc.s 36
+		IL_00b7: ldloc.s 35
+		IL_00b9: ldstr "map"
+		IL_00be: ldloc.s 36
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c5: stloc.s 36
+		IL_00c7: ldloc.s 36
+		IL_00c9: stloc.3
+		IL_00ca: ldloc.3
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: stloc.s 36
+		IL_00d2: ldloc.s 36
+		IL_00d4: ldstr "next"
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00de: pop
+		IL_00df: ldloc.3
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e5: stloc.s 36
+		IL_00e7: ldloc.s 36
+		IL_00e9: ldstr "next"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00f3: pop
+		IL_00f4: ldloc.3
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fa: stloc.s 36
+		IL_00fc: ldloc.s 36
+		IL_00fe: ldstr "next"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0108: stloc.s 36
+		IL_010a: ldloc.s 36
+		IL_010c: ldstr "done"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0116: stloc.s 36
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011d: ldloc.s 36
+		IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0124: pop
+		IL_0125: ldloc.2
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012b: stloc.s 36
+		IL_012d: ldloc.s 36
+		IL_012f: ldstr "getClosed"
+		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0139: stloc.s 36
+		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0140: ldloc.s 36
+		IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0147: pop
+		IL_0148: ldloc.0
+		IL_0149: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_014e: ldnull
+		IL_014f: ldc.r8 2
+		IL_0158: box [System.Runtime]System.Double
+		IL_015d: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_0162: stloc.s 36
+		IL_0164: ldloc.s 36
+		IL_0166: stloc.s 4
+		IL_0168: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0172: stloc.s 36
+		IL_0174: ldloc.s 36
+		IL_0176: ldstr "from"
+		IL_017b: ldloc.s 4
+		IL_017d: ldstr "iterable"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_018c: stloc.s 36
+		IL_018e: ldloc.s 36
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0195: stloc.s 36
+		IL_0197: ldnull
+		IL_0198: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68::__js_call__(object, object)
+		IL_019e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01a3: ldc.i4.1
+		IL_01a4: newarr [System.Runtime]System.Object
+		IL_01a9: dup
+		IL_01aa: ldc.i4.0
+		IL_01ab: ldloc.0
+		IL_01ac: stelem.ref
+		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01b7: ldc.i4.1
+		IL_01b8: conv.r8
+		IL_01b9: ldstr ""
+		IL_01be: ldc.i4.0
+		IL_01bf: ldc.i4.1
+		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_01ca: stloc.s 35
+		IL_01cc: ldloc.s 36
+		IL_01ce: ldstr "map"
+		IL_01d3: ldloc.s 35
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01da: stloc.s 35
+		IL_01dc: ldloc.s 35
+		IL_01de: stloc.s 5
 		.try
 		{
-			IL_020c: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L38C4::.ctor()
-			IL_0211: stloc.s 6
-			IL_0213: ldloc.s 5
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021a: stloc.s 35
-			IL_021c: ldloc.s 35
-			IL_021e: ldstr "next"
-			IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0228: pop
-			IL_0229: leave IL_0270
+			IL_01e0: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L38C4::.ctor()
+			IL_01e5: stloc.s 6
+			IL_01e7: ldloc.s 5
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ee: stloc.s 35
+			IL_01f0: ldloc.s 35
+			IL_01f2: ldstr "next"
+			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01fc: pop
+			IL_01fd: leave IL_0244
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_022e: stloc.s 7
-			IL_0230: ldloc.s 7
-			IL_0232: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0237: dup
-			IL_0238: brtrue IL_024e
+			IL_0202: stloc.s 7
+			IL_0204: ldloc.s 7
+			IL_0206: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_020b: dup
+			IL_020c: brtrue IL_0222
 
-			IL_023d: pop
-			IL_023e: ldloc.s 7
-			IL_0240: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0245: dup
-			IL_0246: brtrue IL_025a
+			IL_0211: pop
+			IL_0212: ldloc.s 7
+			IL_0214: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0219: dup
+			IL_021a: brtrue IL_022e
 
-			IL_024b: pop
-			IL_024c: rethrow
+			IL_021f: pop
+			IL_0220: rethrow
 
-			IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0253: stloc.s 8
-			IL_0255: br IL_025c
+			IL_0222: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0227: stloc.s 8
+			IL_0229: br IL_0230
 
-			IL_025a: stloc.s 8
+			IL_022e: stloc.s 8
 
-			IL_025c: ldloc.s 8
-			IL_025e: stloc.s 35
-			IL_0260: ldloc.s 35
-			IL_0262: stloc.s 9
-			IL_0264: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L40C16::.ctor()
-			IL_0269: stloc.s 10
-			IL_026b: leave IL_0270
+			IL_0230: ldloc.s 8
+			IL_0232: stloc.s 35
+			IL_0234: ldloc.s 35
+			IL_0236: stloc.s 9
+			IL_0238: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L40C16::.ctor()
+			IL_023d: stloc.s 10
+			IL_023f: leave IL_0244
 		} // end handler
 
-		IL_0270: ldloc.s 4
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0277: stloc.s 35
-		IL_0279: ldloc.s 35
-		IL_027b: ldstr "getClosed"
-		IL_0280: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0285: stloc.s 35
-		IL_0287: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_028c: ldloc.s 35
-		IL_028e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0293: pop
-		IL_0294: ldc.i4.1
-		IL_0295: newarr [System.Runtime]System.Object
-		IL_029a: dup
-		IL_029b: ldc.i4.0
-		IL_029c: ldloc.0
-		IL_029d: stelem.ref
-		IL_029e: ldc.i4.0
-		IL_029f: ldelem.ref
-		IL_02a0: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_02a5: ldftn object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_02ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02b0: ldnull
-		IL_02b1: ldc.r8 2
-		IL_02ba: box [System.Runtime]System.Double
-		IL_02bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_02c4: stloc.s 35
-		IL_02c6: ldloc.s 35
-		IL_02c8: stloc.s 11
-		IL_02ca: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d4: stloc.s 35
-		IL_02d6: ldloc.s 35
-		IL_02d8: ldstr "from"
-		IL_02dd: ldloc.s 11
-		IL_02df: ldstr "iterable"
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02ee: stloc.s 35
-		IL_02f0: ldloc.s 35
-		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02f7: stloc.s 35
-		IL_02f9: ldnull
-		IL_02fa: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77::__js_call__(object, object)
-		IL_0300: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0305: ldc.i4.1
-		IL_0306: newarr [System.Runtime]System.Object
-		IL_030b: dup
-		IL_030c: ldc.i4.0
-		IL_030d: ldloc.0
-		IL_030e: stelem.ref
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0319: ldc.i4.1
-		IL_031a: conv.r8
-		IL_031b: ldstr ""
-		IL_0320: ldc.i4.0
-		IL_0321: ldc.i4.1
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_032c: stloc.s 36
-		IL_032e: ldloc.s 35
-		IL_0330: ldstr "filter"
-		IL_0335: ldloc.s 36
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_033c: stloc.s 36
-		IL_033e: ldloc.s 36
-		IL_0340: stloc.s 12
+		IL_0244: ldloc.s 4
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024b: stloc.s 35
+		IL_024d: ldloc.s 35
+		IL_024f: ldstr "getClosed"
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0259: stloc.s 35
+		IL_025b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0260: ldloc.s 35
+		IL_0262: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0267: pop
+		IL_0268: ldloc.0
+		IL_0269: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_026e: ldnull
+		IL_026f: ldc.r8 2
+		IL_0278: box [System.Runtime]System.Double
+		IL_027d: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_0282: stloc.s 35
+		IL_0284: ldloc.s 35
+		IL_0286: stloc.s 11
+		IL_0288: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0292: stloc.s 35
+		IL_0294: ldloc.s 35
+		IL_0296: ldstr "from"
+		IL_029b: ldloc.s 11
+		IL_029d: ldstr "iterable"
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02ac: stloc.s 35
+		IL_02ae: ldloc.s 35
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b5: stloc.s 35
+		IL_02b7: ldnull
+		IL_02b8: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77::__js_call__(object, object)
+		IL_02be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02c3: ldc.i4.1
+		IL_02c4: newarr [System.Runtime]System.Object
+		IL_02c9: dup
+		IL_02ca: ldc.i4.0
+		IL_02cb: ldloc.0
+		IL_02cc: stelem.ref
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02d7: ldc.i4.1
+		IL_02d8: conv.r8
+		IL_02d9: ldstr ""
+		IL_02de: ldc.i4.0
+		IL_02df: ldc.i4.1
+		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_02ea: stloc.s 36
+		IL_02ec: ldloc.s 35
+		IL_02ee: ldstr "filter"
+		IL_02f3: ldloc.s 36
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02fa: stloc.s 36
+		IL_02fc: ldloc.s 36
+		IL_02fe: stloc.s 12
 		.try
 		{
-			IL_0342: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L48C4::.ctor()
-			IL_0347: stloc.s 13
-			IL_0349: ldloc.s 12
-			IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0350: stloc.s 36
-			IL_0352: ldloc.s 36
-			IL_0354: ldstr "next"
-			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_035e: pop
-			IL_035f: leave IL_03a6
+			IL_0300: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L48C4::.ctor()
+			IL_0305: stloc.s 13
+			IL_0307: ldloc.s 12
+			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_030e: stloc.s 36
+			IL_0310: ldloc.s 36
+			IL_0312: ldstr "next"
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_031c: pop
+			IL_031d: leave IL_0364
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0364: stloc.s 14
-			IL_0366: ldloc.s 14
-			IL_0368: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_036d: dup
-			IL_036e: brtrue IL_0384
+			IL_0322: stloc.s 14
+			IL_0324: ldloc.s 14
+			IL_0326: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_032b: dup
+			IL_032c: brtrue IL_0342
 
-			IL_0373: pop
-			IL_0374: ldloc.s 14
-			IL_0376: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_037b: dup
-			IL_037c: brtrue IL_0390
+			IL_0331: pop
+			IL_0332: ldloc.s 14
+			IL_0334: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0339: dup
+			IL_033a: brtrue IL_034e
 
-			IL_0381: pop
-			IL_0382: rethrow
+			IL_033f: pop
+			IL_0340: rethrow
 
-			IL_0384: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0389: stloc.s 15
-			IL_038b: br IL_0392
+			IL_0342: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0347: stloc.s 15
+			IL_0349: br IL_0350
 
-			IL_0390: stloc.s 15
+			IL_034e: stloc.s 15
 
-			IL_0392: ldloc.s 15
-			IL_0394: stloc.s 36
-			IL_0396: ldloc.s 36
-			IL_0398: stloc.s 16
-			IL_039a: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L50C16::.ctor()
-			IL_039f: stloc.s 17
-			IL_03a1: leave IL_03a6
+			IL_0350: ldloc.s 15
+			IL_0352: stloc.s 36
+			IL_0354: ldloc.s 36
+			IL_0356: stloc.s 16
+			IL_0358: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L50C16::.ctor()
+			IL_035d: stloc.s 17
+			IL_035f: leave IL_0364
 		} // end handler
 
-		IL_03a6: ldloc.s 11
-		IL_03a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03ad: stloc.s 36
-		IL_03af: ldloc.s 36
-		IL_03b1: ldstr "getClosed"
-		IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_03bb: stloc.s 36
-		IL_03bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c2: ldloc.s 36
-		IL_03c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03c9: pop
-		IL_03ca: ldc.i4.1
-		IL_03cb: newarr [System.Runtime]System.Object
-		IL_03d0: dup
-		IL_03d1: ldc.i4.0
-		IL_03d2: ldloc.0
-		IL_03d3: stelem.ref
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldelem.ref
-		IL_03d6: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_03db: ldftn object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_03e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_03e6: ldnull
-		IL_03e7: ldc.r8 3
-		IL_03f0: box [System.Runtime]System.Double
-		IL_03f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_03fa: stloc.s 36
-		IL_03fc: ldloc.s 36
-		IL_03fe: stloc.s 18
-		IL_0400: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040a: stloc.s 36
-		IL_040c: ldloc.s 36
-		IL_040e: ldstr "from"
-		IL_0413: ldloc.s 18
-		IL_0415: ldstr "iterable"
-		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0424: stloc.s 36
-		IL_0426: ldloc.s 36
-		IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_042d: stloc.s 36
-		IL_042f: ldloc.s 36
-		IL_0431: ldstr "take"
-		IL_0436: ldc.r8 0.0
-		IL_043f: box [System.Runtime]System.Double
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0449: stloc.s 36
-		IL_044b: ldloc.s 36
-		IL_044d: stloc.s 19
-		IL_044f: ldloc.s 19
-		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0456: stloc.s 36
-		IL_0458: ldloc.s 36
-		IL_045a: ldstr "next"
-		IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0464: stloc.s 36
-		IL_0466: ldloc.s 36
-		IL_0468: ldstr "done"
-		IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0472: stloc.s 36
-		IL_0474: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0479: ldloc.s 36
-		IL_047b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0480: pop
-		IL_0481: ldloc.s 18
-		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0488: stloc.s 36
-		IL_048a: ldloc.s 36
-		IL_048c: ldstr "getClosed"
-		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0496: stloc.s 36
-		IL_0498: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_049d: ldloc.s 36
-		IL_049f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04a4: pop
-		IL_04a5: ldloc.0
-		IL_04a6: ldc.r8 0.0
-		IL_04af: box [System.Runtime]System.Double
-		IL_04b4: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_04b9: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04c3: stloc.s 36
-		IL_04c5: ldloc.s 36
-		IL_04c7: ldstr "from"
-		IL_04cc: ldc.i4.1
-		IL_04cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_04d2: dup
-		IL_04d3: ldc.r8 1
-		IL_04dc: box [System.Runtime]System.Double
-		IL_04e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04eb: stloc.s 36
-		IL_04ed: ldloc.s 36
-		IL_04ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04f4: stloc.s 36
-		IL_04f6: ldc.i4.1
-		IL_04f7: newarr [System.Runtime]System.Object
-		IL_04fc: dup
-		IL_04fd: ldc.i4.0
-		IL_04fe: ldloc.0
-		IL_04ff: stelem.ref
-		IL_0500: ldc.i4.0
-		IL_0501: ldelem.ref
-		IL_0502: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0507: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_050d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0512: ldc.i4.1
-		IL_0513: newarr [System.Runtime]System.Object
-		IL_0518: dup
-		IL_0519: ldc.i4.0
-		IL_051a: ldloc.0
-		IL_051b: stelem.ref
-		IL_051c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0526: ldc.i4.1
-		IL_0527: conv.r8
-		IL_0528: ldstr ""
-		IL_052d: ldc.i4.0
-		IL_052e: ldc.i4.1
-		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0539: stloc.s 35
-		IL_053b: ldloc.s 36
-		IL_053d: ldstr "flatMap"
-		IL_0542: ldloc.s 35
-		IL_0544: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0549: stloc.s 35
-		IL_054b: ldloc.s 35
-		IL_054d: stloc.s 20
-		IL_054f: ldloc.s 20
-		IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0556: stloc.s 35
-		IL_0558: ldloc.s 35
-		IL_055a: ldstr "next"
-		IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0564: pop
-		IL_0565: ldloc.s 20
-		IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_056c: stloc.s 35
-		IL_056e: ldloc.s 35
-		IL_0570: ldstr "next"
-		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0364: ldloc.s 11
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_036b: stloc.s 36
+		IL_036d: ldloc.s 36
+		IL_036f: ldstr "getClosed"
+		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0379: stloc.s 36
+		IL_037b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0380: ldloc.s 36
+		IL_0382: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0387: pop
+		IL_0388: ldloc.0
+		IL_0389: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_038e: ldnull
+		IL_038f: ldc.r8 3
+		IL_0398: box [System.Runtime]System.Double
+		IL_039d: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_03a2: stloc.s 36
+		IL_03a4: ldloc.s 36
+		IL_03a6: stloc.s 18
+		IL_03a8: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03b2: stloc.s 36
+		IL_03b4: ldloc.s 36
+		IL_03b6: ldstr "from"
+		IL_03bb: ldloc.s 18
+		IL_03bd: ldstr "iterable"
+		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03cc: stloc.s 36
+		IL_03ce: ldloc.s 36
+		IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d5: stloc.s 36
+		IL_03d7: ldloc.s 36
+		IL_03d9: ldstr "take"
+		IL_03de: ldc.r8 0.0
+		IL_03e7: box [System.Runtime]System.Double
+		IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03f1: stloc.s 36
+		IL_03f3: ldloc.s 36
+		IL_03f5: stloc.s 19
+		IL_03f7: ldloc.s 19
+		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03fe: stloc.s 36
+		IL_0400: ldloc.s 36
+		IL_0402: ldstr "next"
+		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_040c: stloc.s 36
+		IL_040e: ldloc.s 36
+		IL_0410: ldstr "done"
+		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041a: stloc.s 36
+		IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0421: ldloc.s 36
+		IL_0423: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0428: pop
+		IL_0429: ldloc.s 18
+		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0430: stloc.s 36
+		IL_0432: ldloc.s 36
+		IL_0434: ldstr "getClosed"
+		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_043e: stloc.s 36
+		IL_0440: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0445: ldloc.s 36
+		IL_0447: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_044c: pop
+		IL_044d: ldloc.0
+		IL_044e: ldc.r8 0.0
+		IL_0457: box [System.Runtime]System.Double
+		IL_045c: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_0461: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046b: stloc.s 36
+		IL_046d: ldloc.s 36
+		IL_046f: ldstr "from"
+		IL_0474: ldc.i4.1
+		IL_0475: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_047a: dup
+		IL_047b: ldc.r8 1
+		IL_0484: box [System.Runtime]System.Double
+		IL_0489: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0493: stloc.s 36
+		IL_0495: ldloc.s 36
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_049c: stloc.s 36
+		IL_049e: ldc.i4.1
+		IL_049f: newarr [System.Runtime]System.Object
+		IL_04a4: dup
+		IL_04a5: ldc.i4.0
+		IL_04a6: ldloc.0
+		IL_04a7: stelem.ref
+		IL_04a8: ldc.i4.0
+		IL_04a9: ldelem.ref
+		IL_04aa: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_04af: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_04b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_04ba: ldc.i4.1
+		IL_04bb: newarr [System.Runtime]System.Object
+		IL_04c0: dup
+		IL_04c1: ldc.i4.0
+		IL_04c2: ldloc.0
+		IL_04c3: stelem.ref
+		IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_04ce: ldc.i4.1
+		IL_04cf: conv.r8
+		IL_04d0: ldstr ""
+		IL_04d5: ldc.i4.0
+		IL_04d6: ldc.i4.1
+		IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_04e1: stloc.s 35
+		IL_04e3: ldloc.s 36
+		IL_04e5: ldstr "flatMap"
+		IL_04ea: ldloc.s 35
+		IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04f1: stloc.s 35
+		IL_04f3: ldloc.s 35
+		IL_04f5: stloc.s 20
+		IL_04f7: ldloc.s 20
+		IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04fe: stloc.s 35
+		IL_0500: ldloc.s 35
+		IL_0502: ldstr "next"
+		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_050c: pop
+		IL_050d: ldloc.s 20
+		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0514: stloc.s 35
+		IL_0516: ldloc.s 35
+		IL_0518: ldstr "next"
+		IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0522: stloc.s 35
+		IL_0524: ldloc.s 35
+		IL_0526: ldstr "done"
+		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0530: stloc.s 35
+		IL_0532: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0537: ldloc.s 35
+		IL_0539: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_053e: pop
+		IL_053f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0544: ldloc.0
+		IL_0545: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_054a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_054f: pop
+		IL_0550: ldloc.0
+		IL_0551: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0556: ldnull
+		IL_0557: ldc.r8 2
+		IL_0560: box [System.Runtime]System.Double
+		IL_0565: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_056a: stloc.s 35
+		IL_056c: ldloc.s 35
+		IL_056e: stloc.s 21
+		IL_0570: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 		IL_057a: stloc.s 35
 		IL_057c: ldloc.s 35
-		IL_057e: ldstr "done"
-		IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0588: stloc.s 35
-		IL_058a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058f: ldloc.s 35
-		IL_0591: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0596: pop
-		IL_0597: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_059c: ldloc.0
-		IL_059d: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_05a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05a7: pop
-		IL_05a8: ldc.i4.1
-		IL_05a9: newarr [System.Runtime]System.Object
-		IL_05ae: dup
-		IL_05af: ldc.i4.0
-		IL_05b0: ldloc.0
-		IL_05b1: stelem.ref
+		IL_057e: ldstr "from"
+		IL_0583: ldloc.s 21
+		IL_0585: ldstr "iterable"
+		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0594: stloc.s 35
+		IL_0596: ldloc.s 35
+		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_059d: stloc.s 35
+		IL_059f: ldnull
+		IL_05a0: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74::__js_call__(object, object)
+		IL_05a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_05ab: ldc.i4.1
+		IL_05ac: newarr [System.Runtime]System.Object
+		IL_05b1: dup
 		IL_05b2: ldc.i4.0
-		IL_05b3: ldelem.ref
-		IL_05b4: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_05b9: ldftn object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_05bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_05c4: ldnull
-		IL_05c5: ldc.r8 2
-		IL_05ce: box [System.Runtime]System.Double
-		IL_05d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_05d8: stloc.s 35
-		IL_05da: ldloc.s 35
-		IL_05dc: stloc.s 21
-		IL_05de: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05e8: stloc.s 35
-		IL_05ea: ldloc.s 35
-		IL_05ec: ldstr "from"
-		IL_05f1: ldloc.s 21
-		IL_05f3: ldstr "iterable"
-		IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0602: stloc.s 35
-		IL_0604: ldloc.s 35
-		IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_060b: stloc.s 35
-		IL_060d: ldnull
-		IL_060e: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74::__js_call__(object, object)
-		IL_0614: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0619: ldc.i4.1
-		IL_061a: newarr [System.Runtime]System.Object
-		IL_061f: dup
-		IL_0620: ldc.i4.0
-		IL_0621: ldloc.0
-		IL_0622: stelem.ref
-		IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_062d: ldc.i4.1
-		IL_062e: conv.r8
-		IL_062f: ldstr ""
-		IL_0634: ldc.i4.0
-		IL_0635: ldc.i4.1
-		IL_0636: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_063b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0640: stloc.s 36
-		IL_0642: ldloc.s 35
-		IL_0644: ldstr "flatMap"
-		IL_0649: ldloc.s 36
-		IL_064b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0650: stloc.s 36
-		IL_0652: ldloc.s 36
-		IL_0654: stloc.s 22
+		IL_05b3: ldloc.0
+		IL_05b4: stelem.ref
+		IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_05bf: ldc.i4.1
+		IL_05c0: conv.r8
+		IL_05c1: ldstr ""
+		IL_05c6: ldc.i4.0
+		IL_05c7: ldc.i4.1
+		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_05d2: stloc.s 36
+		IL_05d4: ldloc.s 35
+		IL_05d6: ldstr "flatMap"
+		IL_05db: ldloc.s 36
+		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05e2: stloc.s 36
+		IL_05e4: ldloc.s 36
+		IL_05e6: stloc.s 22
 		.try
 		{
-			IL_0656: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L87C4::.ctor()
-			IL_065b: stloc.s 23
-			IL_065d: ldloc.s 22
-			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0664: stloc.s 36
-			IL_0666: ldloc.s 36
-			IL_0668: ldstr "next"
-			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0672: pop
-			IL_0673: leave IL_06ba
+			IL_05e8: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L87C4::.ctor()
+			IL_05ed: stloc.s 23
+			IL_05ef: ldloc.s 22
+			IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05f6: stloc.s 36
+			IL_05f8: ldloc.s 36
+			IL_05fa: ldstr "next"
+			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0604: pop
+			IL_0605: leave IL_064c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0678: stloc.s 24
-			IL_067a: ldloc.s 24
-			IL_067c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0681: dup
-			IL_0682: brtrue IL_0698
+			IL_060a: stloc.s 24
+			IL_060c: ldloc.s 24
+			IL_060e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0613: dup
+			IL_0614: brtrue IL_062a
 
-			IL_0687: pop
-			IL_0688: ldloc.s 24
-			IL_068a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_068f: dup
-			IL_0690: brtrue IL_06a4
+			IL_0619: pop
+			IL_061a: ldloc.s 24
+			IL_061c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0621: dup
+			IL_0622: brtrue IL_0636
 
-			IL_0695: pop
-			IL_0696: rethrow
+			IL_0627: pop
+			IL_0628: rethrow
 
-			IL_0698: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_069d: stloc.s 25
-			IL_069f: br IL_06a6
+			IL_062a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_062f: stloc.s 25
+			IL_0631: br IL_0638
 
-			IL_06a4: stloc.s 25
+			IL_0636: stloc.s 25
 
-			IL_06a6: ldloc.s 25
-			IL_06a8: stloc.s 36
-			IL_06aa: ldloc.s 36
-			IL_06ac: stloc.s 26
-			IL_06ae: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L89C16::.ctor()
-			IL_06b3: stloc.s 27
-			IL_06b5: leave IL_06ba
+			IL_0638: ldloc.s 25
+			IL_063a: stloc.s 36
+			IL_063c: ldloc.s 36
+			IL_063e: stloc.s 26
+			IL_0640: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L89C16::.ctor()
+			IL_0645: stloc.s 27
+			IL_0647: leave IL_064c
 		} // end handler
 
-		IL_06ba: ldloc.s 21
-		IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06c1: stloc.s 36
-		IL_06c3: ldloc.s 36
-		IL_06c5: ldstr "getClosed"
-		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_06cf: stloc.s 36
-		IL_06d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06d6: ldloc.s 36
-		IL_06d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06dd: pop
-		IL_06de: ldloc.0
-		IL_06df: ldc.r8 0.0
-		IL_06e8: box [System.Runtime]System.Double
-		IL_06ed: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_06f2: ldloc.0
-		IL_06f3: ldc.r8 0.0
-		IL_06fc: box [System.Runtime]System.Double
-		IL_0701: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0706: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_070b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0710: stloc.s 36
-		IL_0712: ldstr "iterator"
-		IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_071c: stloc.s 35
-		IL_071e: ldc.i4.1
-		IL_071f: newarr [System.Runtime]System.Object
-		IL_0724: dup
-		IL_0725: ldc.i4.0
-		IL_0726: ldloc.0
-		IL_0727: stelem.ref
-		IL_0728: ldc.i4.0
-		IL_0729: ldelem.ref
-		IL_072a: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_072f: ldftn object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
-		IL_0735: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_073a: ldc.i4.0
-		IL_073b: conv.r8
-		IL_073c: ldstr ""
-		IL_0741: ldc.i4.0
-		IL_0742: ldc.i4.1
-		IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0748: stloc.s 37
-		IL_074a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_074f: stloc.s 38
-		IL_0751: ldloc.s 38
-		IL_0753: ldloc.s 35
-		IL_0755: ldloc.s 37
-		IL_0757: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_075c: pop
-		IL_075d: ldloc.s 36
-		IL_075f: ldstr "from"
-		IL_0764: ldloc.s 38
-		IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_076b: stloc.s 36
-		IL_076d: ldloc.s 36
-		IL_076f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0774: stloc.s 36
-		IL_0776: ldc.i4.1
-		IL_0777: newarr [System.Runtime]System.Object
-		IL_077c: dup
-		IL_077d: ldc.i4.0
-		IL_077e: ldloc.0
-		IL_077f: stelem.ref
-		IL_0780: ldc.i4.0
-		IL_0781: ldelem.ref
-		IL_0782: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0787: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_078d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0792: ldc.i4.1
-		IL_0793: newarr [System.Runtime]System.Object
-		IL_0798: dup
-		IL_0799: ldc.i4.0
-		IL_079a: ldloc.0
-		IL_079b: stelem.ref
-		IL_079c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_07a1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_07a6: ldc.i4.1
-		IL_07a7: conv.r8
-		IL_07a8: ldstr ""
-		IL_07ad: ldc.i4.0
-		IL_07ae: ldc.i4.1
-		IL_07af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_07b9: stloc.s 37
-		IL_07bb: ldloc.s 36
-		IL_07bd: ldstr "flatMap"
-		IL_07c2: ldloc.s 37
-		IL_07c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_07c9: stloc.s 37
-		IL_07cb: ldloc.s 37
-		IL_07cd: stloc.s 28
+		IL_064c: ldloc.s 21
+		IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0653: stloc.s 36
+		IL_0655: ldloc.s 36
+		IL_0657: ldstr "getClosed"
+		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0661: stloc.s 36
+		IL_0663: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0668: ldloc.s 36
+		IL_066a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_066f: pop
+		IL_0670: ldloc.0
+		IL_0671: ldc.r8 0.0
+		IL_067a: box [System.Runtime]System.Double
+		IL_067f: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_0684: ldloc.0
+		IL_0685: ldc.r8 0.0
+		IL_068e: box [System.Runtime]System.Double
+		IL_0693: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0698: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_069d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06a2: stloc.s 36
+		IL_06a4: ldstr "iterator"
+		IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_06ae: stloc.s 35
+		IL_06b0: ldc.i4.1
+		IL_06b1: newarr [System.Runtime]System.Object
+		IL_06b6: dup
+		IL_06b7: ldc.i4.0
+		IL_06b8: ldloc.0
+		IL_06b9: stelem.ref
+		IL_06ba: ldc.i4.0
+		IL_06bb: ldelem.ref
+		IL_06bc: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_06c1: ldftn object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
+		IL_06c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_06cc: ldc.i4.0
+		IL_06cd: conv.r8
+		IL_06ce: ldstr ""
+		IL_06d3: ldc.i4.0
+		IL_06d4: ldc.i4.1
+		IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_06da: stloc.s 37
+		IL_06dc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06e1: stloc.s 38
+		IL_06e3: ldloc.s 38
+		IL_06e5: ldloc.s 35
+		IL_06e7: ldloc.s 37
+		IL_06e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_06ee: pop
+		IL_06ef: ldloc.s 36
+		IL_06f1: ldstr "from"
+		IL_06f6: ldloc.s 38
+		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_06fd: stloc.s 36
+		IL_06ff: ldloc.s 36
+		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0706: stloc.s 36
+		IL_0708: ldc.i4.1
+		IL_0709: newarr [System.Runtime]System.Object
+		IL_070e: dup
+		IL_070f: ldc.i4.0
+		IL_0710: ldloc.0
+		IL_0711: stelem.ref
+		IL_0712: ldc.i4.0
+		IL_0713: ldelem.ref
+		IL_0714: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0719: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_071f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0724: ldc.i4.1
+		IL_0725: newarr [System.Runtime]System.Object
+		IL_072a: dup
+		IL_072b: ldc.i4.0
+		IL_072c: ldloc.0
+		IL_072d: stelem.ref
+		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0738: ldc.i4.1
+		IL_0739: conv.r8
+		IL_073a: ldstr ""
+		IL_073f: ldc.i4.0
+		IL_0740: ldc.i4.1
+		IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_074b: stloc.s 37
+		IL_074d: ldloc.s 36
+		IL_074f: ldstr "flatMap"
+		IL_0754: ldloc.s 37
+		IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_075b: stloc.s 37
+		IL_075d: ldloc.s 37
+		IL_075f: stloc.s 28
 		.try
 		{
-			IL_07cf: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L126C4::.ctor()
-			IL_07d4: stloc.s 29
-			IL_07d6: ldloc.s 28
-			IL_07d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07dd: stloc.s 37
-			IL_07df: ldloc.s 37
-			IL_07e1: ldstr "next"
-			IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_07eb: pop
-			IL_07ec: ldloc.s 28
-			IL_07ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07f3: stloc.s 37
-			IL_07f5: ldloc.s 37
-			IL_07f7: ldstr "next"
-			IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0801: pop
-			IL_0802: leave IL_0849
+			IL_0761: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L126C4::.ctor()
+			IL_0766: stloc.s 29
+			IL_0768: ldloc.s 28
+			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_076f: stloc.s 37
+			IL_0771: ldloc.s 37
+			IL_0773: ldstr "next"
+			IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_077d: pop
+			IL_077e: ldloc.s 28
+			IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0785: stloc.s 37
+			IL_0787: ldloc.s 37
+			IL_0789: ldstr "next"
+			IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0793: pop
+			IL_0794: leave IL_07db
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0807: stloc.s 30
-			IL_0809: ldloc.s 30
-			IL_080b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0810: dup
-			IL_0811: brtrue IL_0827
+			IL_0799: stloc.s 30
+			IL_079b: ldloc.s 30
+			IL_079d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07a2: dup
+			IL_07a3: brtrue IL_07b9
 
-			IL_0816: pop
-			IL_0817: ldloc.s 30
-			IL_0819: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_081e: dup
-			IL_081f: brtrue IL_0833
+			IL_07a8: pop
+			IL_07a9: ldloc.s 30
+			IL_07ab: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07b0: dup
+			IL_07b1: brtrue IL_07c5
 
-			IL_0824: pop
-			IL_0825: rethrow
+			IL_07b6: pop
+			IL_07b7: rethrow
 
-			IL_0827: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_082c: stloc.s 31
-			IL_082e: br IL_0835
+			IL_07b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07be: stloc.s 31
+			IL_07c0: br IL_07c7
 
-			IL_0833: stloc.s 31
+			IL_07c5: stloc.s 31
 
-			IL_0835: ldloc.s 31
-			IL_0837: stloc.s 37
-			IL_0839: ldloc.s 37
-			IL_083b: stloc.s 32
-			IL_083d: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L129C16::.ctor()
-			IL_0842: stloc.s 33
-			IL_0844: leave IL_0849
+			IL_07c7: ldloc.s 31
+			IL_07c9: stloc.s 37
+			IL_07cb: ldloc.s 37
+			IL_07cd: stloc.s 32
+			IL_07cf: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L129C16::.ctor()
+			IL_07d4: stloc.s 33
+			IL_07d6: leave IL_07db
 		} // end handler
 
-		IL_0849: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_084e: ldloc.0
-		IL_084f: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0854: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0859: pop
-		IL_085a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_085f: ldloc.0
-		IL_0860: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0865: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_086a: pop
-		IL_086b: ldnull
-		IL_086c: stloc.s 34
-		IL_086e: ret
+		IL_07db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07e0: ldloc.0
+		IL_07e1: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_07e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07eb: pop
+		IL_07ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07f1: ldloc.0
+		IL_07f2: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_07f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07fc: pop
+		IL_07fd: ldnull
+		IL_07fe: stloc.s 34
+		IL_0800: ret
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup
@@ -2783,7 +2738,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x318b
+		// Method begins at RVA 0x311f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
+﻿// IL code: Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -2934,10 +2934,11 @@
 		IL_05d3: stloc.s 5
 		IL_05d5: ldloc.s 5
 		IL_05d7: stloc.s 4
-		IL_05d9: ldloc.s 4
-		IL_05db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05d9: ldloc.0
+		IL_05da: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_05df: ldnull
 		IL_05e0: ldloc.1
-		IL_05e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_05e1: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
 		IL_05e6: pop
 		IL_05e7: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Require_ChildProcess_Fork_Silent
+﻿// IL code: Require_ChildProcess_Fork_Silent
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x290c
+					// Method begins at RVA 0x28e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2694
+				// Method begins at RVA 0x2680
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -100,7 +100,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2915
+					// Method begins at RVA 0x28e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -125,7 +125,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26c4
+				// Method begins at RVA 0x26b0
 				// Header size: 12
 				// Code size: 36 (0x24)
 				.maxstack 8
@@ -171,7 +171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x291e
+					// Method begins at RVA 0x28f2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x26f4
+				// Method begins at RVA 0x26e0
 				// Header size: 12
 				// Code size: 82 (0x52)
 				.maxstack 8
@@ -252,7 +252,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2927
+					// Method begins at RVA 0x28fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -277,9 +277,9 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2754
+				// Method begins at RVA 0x2740
 				// Header size: 12
-				// Code size: 222 (0xde)
+				// Code size: 200 (0xc8)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -351,24 +351,15 @@
 				IL_00b0: ldloc.3
 				IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 				IL_00b6: pop
-				IL_00b7: ldc.i4.1
-				IL_00b8: newarr [System.Runtime]System.Object
-				IL_00bd: dup
-				IL_00be: ldc.i4.0
-				IL_00bf: ldarg.0
-				IL_00c0: ldc.i4.0
-				IL_00c1: ldelem.ref
-				IL_00c2: stelem.ref
-				IL_00c3: ldc.i4.0
-				IL_00c4: ldelem.ref
-				IL_00c5: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-				IL_00ca: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-				IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_00d5: ldnull
-				IL_00d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-				IL_00db: pop
-				IL_00dc: ldnull
-				IL_00dd: ret
+				IL_00b7: ldarg.0
+				IL_00b8: ldc.i4.0
+				IL_00b9: ldelem.ref
+				IL_00ba: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+				IL_00bf: ldnull
+				IL_00c0: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+				IL_00c5: pop
+				IL_00c6: ldnull
+				IL_00c7: ret
 			} // end of method ArrowFunction_L31C23::__js_call__
 
 		} // end of class ArrowFunction_L31C23
@@ -391,7 +382,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2903
+				// Method begins at RVA 0x28d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -417,7 +408,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2234
+			// Method begins at RVA 0x2220
 			// Header size: 12
 			// Code size: 698 (0x2ba)
 			.maxstack 8
@@ -692,7 +683,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2939
+					// Method begins at RVA 0x290d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -717,7 +708,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2840
+				// Method begins at RVA 0x2814
 				// Header size: 12
 				// Code size: 82 (0x52)
 				.maxstack 8
@@ -773,7 +764,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2942
+					// Method begins at RVA 0x2916
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +788,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x289e
+				// Method begins at RVA 0x2872
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -827,7 +818,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2930
+				// Method begins at RVA 0x2904
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -853,7 +844,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x24fc
+			// Method begins at RVA 0x24e8
 			// Header size: 12
 			// Code size: 396 (0x18c)
 			.maxstack 8
@@ -1024,7 +1015,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28fa
+				// Method begins at RVA 0x28ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1047,7 +1038,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28f1
+			// Method begins at RVA 0x28c5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1073,7 +1064,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 180 (0xb4)
+		// Code size: 158 (0x9e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Silent/Scope,
@@ -1142,21 +1133,12 @@
 		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 		IL_008f: pop
 
-		IL_0090: ldc.i4.1
-		IL_0091: newarr [System.Runtime]System.Object
-		IL_0096: dup
-		IL_0097: ldc.i4.0
-		IL_0098: ldloc.0
-		IL_0099: stelem.ref
-		IL_009a: ldc.i4.0
-		IL_009b: ldelem.ref
-		IL_009c: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-		IL_00a1: ldftn object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-		IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ac: ldnull
-		IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00b2: pop
-		IL_00b3: ret
+		IL_0090: ldloc.0
+		IL_0091: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+		IL_0096: ldnull
+		IL_0097: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+		IL_009c: pop
+		IL_009d: ret
 	} // end of method Require_ChildProcess_Fork_Silent::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Silent
@@ -1184,7 +1166,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2966
+					// Method begins at RVA 0x293a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1205,7 +1187,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x295d
+				// Method begins at RVA 0x2931
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1229,7 +1211,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28b4
+			// Method begins at RVA 0x2888
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -1273,7 +1255,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2954
+				// Method begins at RVA 0x2928
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1291,7 +1273,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x294b
+			// Method begins at RVA 0x291f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1315,7 +1297,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2110
+		// Method begins at RVA 0x20fc
 		// Header size: 12
 		// Code size: 279 (0x117)
 		.maxstack 8
@@ -1427,7 +1409,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x296f
+		// Method begins at RVA 0x2943
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Require_Path_Join_NestedFunction
+﻿// IL code: Require_Path_Join_NestedFunction
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212d
+				// Method begins at RVA 0x2119
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20fc
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -86,7 +86,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2110
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -112,7 +112,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 159 (0x9f)
+		// Code size: 137 (0x89)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Join_NestedFunction/Scope,
@@ -150,38 +150,29 @@
 		IL_003f: ldloc.0
 		IL_0040: ldloc.3
 		IL_0041: stfld object Modules.Require_Path_Join_NestedFunction/Scope::path
-		IL_0046: ldc.i4.1
-		IL_0047: newarr [System.Runtime]System.Object
-		IL_004c: dup
-		IL_004d: ldc.i4.0
-		IL_004e: ldloc.0
-		IL_004f: stelem.ref
-		IL_0050: ldc.i4.0
-		IL_0051: ldelem.ref
-		IL_0052: castclass Modules.Require_Path_Join_NestedFunction/Scope
-		IL_0057: ldftn object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, object, object)
-		IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0062: ldnull
-		IL_0063: ldstr "a"
-		IL_0068: ldstr "b"
-		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0072: stloc.3
-		IL_0073: ldloc.3
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0046: ldloc.0
+		IL_0047: castclass Modules.Require_Path_Join_NestedFunction/Scope
+		IL_004c: ldnull
+		IL_004d: ldstr "a"
+		IL_0052: ldstr "b"
+		IL_0057: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, object, object)
+		IL_005c: stloc.3
+		IL_005d: ldloc.3
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0063: stloc.3
+		IL_0064: ldloc.3
+		IL_0065: ldstr "replace"
+		IL_006a: ldstr "\\"
+		IL_006f: ldstr "/"
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 		IL_0079: stloc.3
 		IL_007a: ldloc.3
-		IL_007b: ldstr "replace"
-		IL_0080: ldstr "\\"
-		IL_0085: ldstr "/"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_008f: stloc.3
-		IL_0090: ldloc.3
-		IL_0091: stloc.2
-		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0097: ldloc.2
-		IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009d: pop
-		IL_009e: ret
+		IL_007b: stloc.2
+		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0081: ldloc.2
+		IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0087: pop
+		IL_0088: ret
 	} // end of method Require_Path_Join_NestedFunction::__js_module_init__
 
 } // end of class Modules.Require_Path_Join_NestedFunction
@@ -193,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2136
+		// Method begins at RVA 0x2122
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Stream_Helper_Signal_Requires_AbortSignal
+﻿// IL code: Stream_Helper_Signal_Requires_AbortSignal
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29bb
+					// Method begins at RVA 0x2937
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29a0
+				// Method begins at RVA 0x291c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b2
+				// Method begins at RVA 0x292e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -155,7 +155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c4
+				// Method begins at RVA 0x2940
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -228,7 +228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29df
+					// Method begins at RVA 0x295b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -251,7 +251,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29a3
+				// Method begins at RVA 0x291f
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -273,7 +273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29fa
+					// Method begins at RVA 0x2976
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -296,7 +296,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29a6
+				// Method begins at RVA 0x2922
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -333,7 +333,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29d6
+					// Method begins at RVA 0x2952
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29e8
+					// Method begins at RVA 0x2964
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -373,7 +373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29f1
+					// Method begins at RVA 0x296d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -393,7 +393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a03
+					// Method begins at RVA 0x297f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -413,7 +413,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a0c
+					// Method begins at RVA 0x2988
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -433,7 +433,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a15
+					// Method begins at RVA 0x2991
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -453,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a1e
+					// Method begins at RVA 0x299a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -473,7 +473,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a27
+					// Method begins at RVA 0x29a3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -501,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29cd
+				// Method begins at RVA 0x2949
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -527,7 +527,7 @@
 			)
 			// Method begins at RVA 0x21d8
 			// Header size: 12
-			// Code size: 1950 (0x79e)
+			// Code size: 1818 (0x71a)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
@@ -690,7 +690,7 @@
 
 			IL_00ff: ldloc.0
 			IL_0100: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0105: switch (IL_011e, IL_04f5, IL_04d9, IL_06e8, IL_06cc)
+			IL_0105: switch (IL_011e, IL_049d, IL_0481, IL_0664, IL_0648)
 			.try
 			{
 				IL_011e: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L17C6::.ctor()
@@ -702,674 +702,620 @@
 				IL_012c: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
 				IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0136: stloc.s 20
-				IL_0138: ldc.i4.1
-				IL_0139: newarr [System.Runtime]System.Object
-				IL_013e: dup
-				IL_013f: ldc.i4.0
-				IL_0140: ldarg.0
-				IL_0141: ldc.i4.1
-				IL_0142: ldelem.ref
-				IL_0143: stelem.ref
-				IL_0144: ldc.i4.0
-				IL_0145: ldelem.ref
-				IL_0146: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_014b: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0156: ldnull
-				IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-				IL_015c: stloc.s 21
-				IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0163: dup
-				IL_0164: ldstr "signal"
-				IL_0169: ldc.i4.0
-				IL_016a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_016f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0174: stloc.s 22
-				IL_0176: ldnull
-				IL_0177: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-				IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_0182: ldc.i4.0
-				IL_0183: conv.r8
-				IL_0184: ldstr ""
-				IL_0189: ldc.i4.0
-				IL_018a: ldc.i4.1
-				IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_0190: stloc.s 23
-				IL_0192: ldloc.s 20
-				IL_0194: ldstr "finished"
-				IL_0199: ldloc.s 21
-				IL_019b: ldloc.s 22
-				IL_019d: ldloc.s 23
-				IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_01a4: pop
-				IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_01aa: ldstr "callback-finished:ok"
-				IL_01af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_01b4: pop
-				IL_01b5: leave IL_0255
+				IL_0138: ldarg.0
+				IL_0139: ldc.i4.1
+				IL_013a: ldelem.ref
+				IL_013b: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0140: ldnull
+				IL_0141: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0146: stloc.s 21
+				IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_014d: dup
+				IL_014e: ldstr "signal"
+				IL_0153: ldc.i4.0
+				IL_0154: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0159: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_015e: stloc.s 22
+				IL_0160: ldnull
+				IL_0161: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+				IL_0167: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_016c: ldc.i4.0
+				IL_016d: conv.r8
+				IL_016e: ldstr ""
+				IL_0173: ldc.i4.0
+				IL_0174: ldc.i4.1
+				IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_017a: stloc.s 23
+				IL_017c: ldloc.s 20
+				IL_017e: ldstr "finished"
+				IL_0183: ldloc.s 21
+				IL_0185: ldloc.s 22
+				IL_0187: ldloc.s 23
+				IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_018e: pop
+				IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0194: ldstr "callback-finished:ok"
+				IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_019e: pop
+				IL_019f: leave IL_023f
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_01ba: stloc.2
-				IL_01bb: ldloc.2
-				IL_01bc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_01c1: dup
-				IL_01c2: brtrue IL_01d7
+				IL_01a4: stloc.2
+				IL_01a5: ldloc.2
+				IL_01a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_01ab: dup
+				IL_01ac: brtrue IL_01c1
 
-				IL_01c7: pop
-				IL_01c8: ldloc.2
-				IL_01c9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_01ce: dup
-				IL_01cf: brtrue IL_01e2
+				IL_01b1: pop
+				IL_01b2: ldloc.2
+				IL_01b3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_01b8: dup
+				IL_01b9: brtrue IL_01cc
 
-				IL_01d4: pop
-				IL_01d5: rethrow
+				IL_01be: pop
+				IL_01bf: rethrow
 
-				IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_01dc: stloc.3
-				IL_01dd: br IL_01e3
+				IL_01c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_01c6: stloc.3
+				IL_01c7: br IL_01cd
 
-				IL_01e2: stloc.3
+				IL_01cc: stloc.3
 
-				IL_01e3: ldloc.3
-				IL_01e4: stloc.s 23
-				IL_01e6: ldloc.s 23
-				IL_01e8: stloc.s 4
-				IL_01ea: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
-				IL_01ef: stloc.s 5
-				IL_01f1: ldstr "callback-finished:"
-				IL_01f6: ldloc.s 4
-				IL_01f8: ldstr "name"
-				IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0207: stloc.s 24
-				IL_0209: ldloc.s 24
-				IL_020b: ldstr ":"
-				IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0215: stloc.s 24
-				IL_0217: ldloc.s 24
-				IL_0219: ldloc.s 4
-				IL_021b: ldstr "code"
-				IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_022a: stloc.s 24
-				IL_022c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0231: ldloc.s 24
-				IL_0233: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0238: pop
-				IL_0239: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_023e: ldloc.s 4
-				IL_0240: ldstr "message"
-				IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_024a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_024f: pop
-				IL_0250: leave IL_0255
+				IL_01cd: ldloc.3
+				IL_01ce: stloc.s 23
+				IL_01d0: ldloc.s 23
+				IL_01d2: stloc.s 4
+				IL_01d4: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
+				IL_01d9: stloc.s 5
+				IL_01db: ldstr "callback-finished:"
+				IL_01e0: ldloc.s 4
+				IL_01e2: ldstr "name"
+				IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01f1: stloc.s 24
+				IL_01f3: ldloc.s 24
+				IL_01f5: ldstr ":"
+				IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_01ff: stloc.s 24
+				IL_0201: ldloc.s 24
+				IL_0203: ldloc.s 4
+				IL_0205: ldstr "code"
+				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0214: stloc.s 24
+				IL_0216: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_021b: ldloc.s 24
+				IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0222: pop
+				IL_0223: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0228: ldloc.s 4
+				IL_022a: ldstr "message"
+				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0234: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0239: pop
+				IL_023a: leave IL_023f
 			} // end handler
 			.try
 			{
-				IL_0255: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
-				IL_025a: stloc.s 6
-				IL_025c: ldarg.0
-				IL_025d: ldc.i4.1
-				IL_025e: ldelem.ref
-				IL_025f: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0264: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_026e: stloc.s 23
-				IL_0270: ldc.i4.1
-				IL_0271: newarr [System.Runtime]System.Object
-				IL_0276: dup
-				IL_0277: ldc.i4.0
-				IL_0278: ldarg.0
-				IL_0279: ldc.i4.1
-				IL_027a: ldelem.ref
-				IL_027b: stelem.ref
-				IL_027c: ldc.i4.0
-				IL_027d: ldelem.ref
-				IL_027e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0283: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_0289: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_028e: ldnull
-				IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-				IL_0294: stloc.s 21
-				IL_0296: ldc.i4.1
-				IL_0297: newarr [System.Runtime]System.Object
-				IL_029c: dup
+				IL_023f: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
+				IL_0244: stloc.s 6
+				IL_0246: ldarg.0
+				IL_0247: ldc.i4.1
+				IL_0248: ldelem.ref
+				IL_0249: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_024e: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0258: stloc.s 23
+				IL_025a: ldarg.0
+				IL_025b: ldc.i4.1
+				IL_025c: ldelem.ref
+				IL_025d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0262: ldnull
+				IL_0263: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0268: stloc.s 21
+				IL_026a: ldarg.0
+				IL_026b: ldc.i4.1
+				IL_026c: ldelem.ref
+				IL_026d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0272: ldnull
+				IL_0273: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0278: stloc.s 20
+				IL_027a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_027f: dup
+				IL_0280: ldstr "signal"
+				IL_0285: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_028a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_028f: stloc.s 22
+				IL_0291: ldnull
+				IL_0292: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+				IL_0298: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 				IL_029d: ldc.i4.0
-				IL_029e: ldarg.0
-				IL_029f: ldc.i4.1
-				IL_02a0: ldelem.ref
-				IL_02a1: stelem.ref
-				IL_02a2: ldc.i4.0
-				IL_02a3: ldelem.ref
-				IL_02a4: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_02a9: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_02af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_02b4: ldnull
-				IL_02b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-				IL_02ba: stloc.s 20
-				IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_02c1: dup
-				IL_02c2: ldstr "signal"
-				IL_02c7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_02cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_02d1: stloc.s 22
-				IL_02d3: ldnull
-				IL_02d4: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-				IL_02da: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_02df: ldc.i4.0
-				IL_02e0: conv.r8
-				IL_02e1: ldstr ""
-				IL_02e6: ldc.i4.0
-				IL_02e7: ldc.i4.1
-				IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_02ed: stloc.s 25
-				IL_02ef: ldc.i4.4
-				IL_02f0: newarr [System.Runtime]System.Object
-				IL_02f5: dup
-				IL_02f6: ldc.i4.0
-				IL_02f7: ldloc.s 21
-				IL_02f9: stelem.ref
-				IL_02fa: dup
-				IL_02fb: ldc.i4.1
-				IL_02fc: ldloc.s 20
-				IL_02fe: stelem.ref
-				IL_02ff: dup
-				IL_0300: ldc.i4.2
-				IL_0301: ldloc.s 22
-				IL_0303: stelem.ref
-				IL_0304: dup
-				IL_0305: ldc.i4.3
-				IL_0306: ldloc.s 25
-				IL_0308: stelem.ref
-				IL_0309: stloc.s 26
-				IL_030b: ldloc.s 23
-				IL_030d: ldstr "pipeline"
-				IL_0312: ldloc.s 26
-				IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_0319: pop
-				IL_031a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_031f: ldstr "callback-pipeline:ok"
-				IL_0324: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0329: pop
-				IL_032a: leave IL_03d0
+				IL_029e: conv.r8
+				IL_029f: ldstr ""
+				IL_02a4: ldc.i4.0
+				IL_02a5: ldc.i4.1
+				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_02ab: stloc.s 25
+				IL_02ad: ldc.i4.4
+				IL_02ae: newarr [System.Runtime]System.Object
+				IL_02b3: dup
+				IL_02b4: ldc.i4.0
+				IL_02b5: ldloc.s 21
+				IL_02b7: stelem.ref
+				IL_02b8: dup
+				IL_02b9: ldc.i4.1
+				IL_02ba: ldloc.s 20
+				IL_02bc: stelem.ref
+				IL_02bd: dup
+				IL_02be: ldc.i4.2
+				IL_02bf: ldloc.s 22
+				IL_02c1: stelem.ref
+				IL_02c2: dup
+				IL_02c3: ldc.i4.3
+				IL_02c4: ldloc.s 25
+				IL_02c6: stelem.ref
+				IL_02c7: stloc.s 26
+				IL_02c9: ldloc.s 23
+				IL_02cb: ldstr "pipeline"
+				IL_02d0: ldloc.s 26
+				IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_02d7: pop
+				IL_02d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_02dd: ldstr "callback-pipeline:ok"
+				IL_02e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_02e7: pop
+				IL_02e8: leave IL_038e
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_032f: stloc.s 7
-				IL_0331: ldloc.s 7
-				IL_0333: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0338: dup
-				IL_0339: brtrue IL_034f
+				IL_02ed: stloc.s 7
+				IL_02ef: ldloc.s 7
+				IL_02f1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_02f6: dup
+				IL_02f7: brtrue IL_030d
 
-				IL_033e: pop
-				IL_033f: ldloc.s 7
-				IL_0341: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0346: dup
-				IL_0347: brtrue IL_035b
+				IL_02fc: pop
+				IL_02fd: ldloc.s 7
+				IL_02ff: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0304: dup
+				IL_0305: brtrue IL_0319
 
-				IL_034c: pop
-				IL_034d: rethrow
+				IL_030a: pop
+				IL_030b: rethrow
 
-				IL_034f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0354: stloc.s 8
-				IL_0356: br IL_035d
+				IL_030d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0312: stloc.s 8
+				IL_0314: br IL_031b
 
-				IL_035b: stloc.s 8
+				IL_0319: stloc.s 8
 
-				IL_035d: ldloc.s 8
-				IL_035f: stloc.s 23
-				IL_0361: ldloc.s 23
-				IL_0363: stloc.s 9
-				IL_0365: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
-				IL_036a: stloc.s 10
-				IL_036c: ldstr "callback-pipeline:"
-				IL_0371: ldloc.s 9
-				IL_0373: ldstr "name"
-				IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0382: stloc.s 24
-				IL_0384: ldloc.s 24
-				IL_0386: ldstr ":"
-				IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0390: stloc.s 24
-				IL_0392: ldloc.s 24
-				IL_0394: ldloc.s 9
-				IL_0396: ldstr "code"
-				IL_039b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_03a5: stloc.s 24
-				IL_03a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_03ac: ldloc.s 24
-				IL_03ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_03b3: pop
-				IL_03b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_03b9: ldloc.s 9
-				IL_03bb: ldstr "message"
-				IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_03ca: pop
-				IL_03cb: leave IL_03d0
+				IL_031b: ldloc.s 8
+				IL_031d: stloc.s 23
+				IL_031f: ldloc.s 23
+				IL_0321: stloc.s 9
+				IL_0323: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
+				IL_0328: stloc.s 10
+				IL_032a: ldstr "callback-pipeline:"
+				IL_032f: ldloc.s 9
+				IL_0331: ldstr "name"
+				IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0340: stloc.s 24
+				IL_0342: ldloc.s 24
+				IL_0344: ldstr ":"
+				IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_034e: stloc.s 24
+				IL_0350: ldloc.s 24
+				IL_0352: ldloc.s 9
+				IL_0354: ldstr "code"
+				IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0363: stloc.s 24
+				IL_0365: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_036a: ldloc.s 24
+				IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0371: pop
+				IL_0372: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0377: ldloc.s 9
+				IL_0379: ldstr "message"
+				IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0383: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0388: pop
+				IL_0389: leave IL_038e
 			} // end handler
 
-			IL_03d0: ldloc.0
-			IL_03d1: ldc.i4.0
-			IL_03d2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03d7: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_03dc: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
-			IL_03e1: stloc.s 11
-			IL_03e3: ldarg.0
-			IL_03e4: ldc.i4.1
-			IL_03e5: ldelem.ref
-			IL_03e6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_03eb: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03f5: stloc.s 23
-			IL_03f7: ldc.i4.1
-			IL_03f8: newarr [System.Runtime]System.Object
-			IL_03fd: dup
-			IL_03fe: ldc.i4.0
-			IL_03ff: ldarg.0
-			IL_0400: ldc.i4.1
-			IL_0401: ldelem.ref
-			IL_0402: stelem.ref
-			IL_0403: ldc.i4.0
-			IL_0404: ldelem.ref
-			IL_0405: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_040a: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_0410: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0415: ldnull
-			IL_0416: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_041b: stloc.s 25
-			IL_041d: ldloc.s 23
-			IL_041f: ldstr "finished"
-			IL_0424: ldloc.s 25
-			IL_0426: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_042b: dup
-			IL_042c: ldstr "signal"
-			IL_0431: ldc.i4.0
-			IL_0432: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0437: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_043c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0441: stloc.s 25
-			IL_0443: ldloc.0
-			IL_0444: ldc.i4.2
-			IL_0445: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_044a: ldloc.0
-			IL_044b: ldloc.s 25
-			IL_044d: ldarg.0
-			IL_044e: ldc.i4.1
-			IL_044f: ldloc.0
-			IL_0450: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0455: ldc.i4.1
-			IL_0456: ldstr "_pendingException"
-			IL_045b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0460: ldloc.0
-			IL_0461: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0466: dup
-			IL_0467: ldc.i4.0
-			IL_0468: ldloc.1
-			IL_0469: stelem.ref
-			IL_046a: dup
-			IL_046b: ldc.i4.1
-			IL_046c: ldloc.2
+			IL_038e: ldloc.0
+			IL_038f: ldc.i4.0
+			IL_0390: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0395: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_039a: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
+			IL_039f: stloc.s 11
+			IL_03a1: ldarg.0
+			IL_03a2: ldc.i4.1
+			IL_03a3: ldelem.ref
+			IL_03a4: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_03a9: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03b3: stloc.s 23
+			IL_03b5: ldarg.0
+			IL_03b6: ldc.i4.1
+			IL_03b7: ldelem.ref
+			IL_03b8: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_03bd: ldnull
+			IL_03be: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_03c3: stloc.s 25
+			IL_03c5: ldloc.s 23
+			IL_03c7: ldstr "finished"
+			IL_03cc: ldloc.s 25
+			IL_03ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03d3: dup
+			IL_03d4: ldstr "signal"
+			IL_03d9: ldc.i4.0
+			IL_03da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_03e9: stloc.s 25
+			IL_03eb: ldloc.0
+			IL_03ec: ldc.i4.2
+			IL_03ed: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03f2: ldloc.0
+			IL_03f3: ldloc.s 25
+			IL_03f5: ldarg.0
+			IL_03f6: ldc.i4.1
+			IL_03f7: ldloc.0
+			IL_03f8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03fd: ldc.i4.1
+			IL_03fe: ldstr "_pendingException"
+			IL_0403: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0408: ldloc.0
+			IL_0409: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_040e: dup
+			IL_040f: ldc.i4.0
+			IL_0410: ldloc.1
+			IL_0411: stelem.ref
+			IL_0412: dup
+			IL_0413: ldc.i4.1
+			IL_0414: ldloc.2
+			IL_0415: stelem.ref
+			IL_0416: dup
+			IL_0417: ldc.i4.2
+			IL_0418: ldloc.3
+			IL_0419: stelem.ref
+			IL_041a: dup
+			IL_041b: ldc.i4.3
+			IL_041c: ldloc.s 4
+			IL_041e: stelem.ref
+			IL_041f: dup
+			IL_0420: ldc.i4.4
+			IL_0421: ldloc.s 5
+			IL_0423: stelem.ref
+			IL_0424: dup
+			IL_0425: ldc.i4.5
+			IL_0426: ldloc.s 6
+			IL_0428: stelem.ref
+			IL_0429: dup
+			IL_042a: ldc.i4.6
+			IL_042b: ldloc.s 7
+			IL_042d: stelem.ref
+			IL_042e: dup
+			IL_042f: ldc.i4.7
+			IL_0430: ldloc.s 8
+			IL_0432: stelem.ref
+			IL_0433: dup
+			IL_0434: ldc.i4.8
+			IL_0435: ldloc.s 9
+			IL_0437: stelem.ref
+			IL_0438: dup
+			IL_0439: ldc.i4.s 9
+			IL_043b: ldloc.s 10
+			IL_043d: stelem.ref
+			IL_043e: dup
+			IL_043f: ldc.i4.s 10
+			IL_0441: ldloc.s 11
+			IL_0443: stelem.ref
+			IL_0444: dup
+			IL_0445: ldc.i4.s 11
+			IL_0447: ldloc.s 12
+			IL_0449: stelem.ref
+			IL_044a: dup
+			IL_044b: ldc.i4.s 12
+			IL_044d: ldloc.s 13
+			IL_044f: stelem.ref
+			IL_0450: dup
+			IL_0451: ldc.i4.s 13
+			IL_0453: ldloc.s 14
+			IL_0455: stelem.ref
+			IL_0456: dup
+			IL_0457: ldc.i4.s 14
+			IL_0459: ldloc.s 15
+			IL_045b: stelem.ref
+			IL_045c: dup
+			IL_045d: ldc.i4.s 15
+			IL_045f: ldloc.s 16
+			IL_0461: stelem.ref
+			IL_0462: dup
+			IL_0463: ldc.i4.s 16
+			IL_0465: ldloc.s 17
+			IL_0467: stelem.ref
+			IL_0468: dup
+			IL_0469: ldc.i4.s 17
+			IL_046b: ldloc.s 18
 			IL_046d: stelem.ref
 			IL_046e: dup
-			IL_046f: ldc.i4.2
-			IL_0470: ldloc.3
-			IL_0471: stelem.ref
-			IL_0472: dup
-			IL_0473: ldc.i4.3
-			IL_0474: ldloc.s 4
-			IL_0476: stelem.ref
-			IL_0477: dup
-			IL_0478: ldc.i4.4
-			IL_0479: ldloc.s 5
-			IL_047b: stelem.ref
-			IL_047c: dup
-			IL_047d: ldc.i4.5
-			IL_047e: ldloc.s 6
-			IL_0480: stelem.ref
-			IL_0481: dup
-			IL_0482: ldc.i4.6
-			IL_0483: ldloc.s 7
-			IL_0485: stelem.ref
-			IL_0486: dup
-			IL_0487: ldc.i4.7
-			IL_0488: ldloc.s 8
-			IL_048a: stelem.ref
-			IL_048b: dup
-			IL_048c: ldc.i4.8
-			IL_048d: ldloc.s 9
-			IL_048f: stelem.ref
-			IL_0490: dup
-			IL_0491: ldc.i4.s 9
-			IL_0493: ldloc.s 10
-			IL_0495: stelem.ref
-			IL_0496: dup
-			IL_0497: ldc.i4.s 10
-			IL_0499: ldloc.s 11
-			IL_049b: stelem.ref
-			IL_049c: dup
-			IL_049d: ldc.i4.s 11
-			IL_049f: ldloc.s 12
-			IL_04a1: stelem.ref
-			IL_04a2: dup
-			IL_04a3: ldc.i4.s 12
-			IL_04a5: ldloc.s 13
-			IL_04a7: stelem.ref
-			IL_04a8: dup
-			IL_04a9: ldc.i4.s 13
-			IL_04ab: ldloc.s 14
-			IL_04ad: stelem.ref
-			IL_04ae: dup
-			IL_04af: ldc.i4.s 14
-			IL_04b1: ldloc.s 15
-			IL_04b3: stelem.ref
-			IL_04b4: dup
-			IL_04b5: ldc.i4.s 15
-			IL_04b7: ldloc.s 16
-			IL_04b9: stelem.ref
-			IL_04ba: dup
-			IL_04bb: ldc.i4.s 16
-			IL_04bd: ldloc.s 17
-			IL_04bf: stelem.ref
-			IL_04c0: dup
-			IL_04c1: ldc.i4.s 17
-			IL_04c3: ldloc.s 18
-			IL_04c5: stelem.ref
-			IL_04c6: dup
-			IL_04c7: ldc.i4.s 18
-			IL_04c9: ldloc.s 19
-			IL_04cb: stelem.ref
-			IL_04cc: pop
-			IL_04cd: ldloc.0
-			IL_04ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_04d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04d8: ret
+			IL_046f: ldc.i4.s 18
+			IL_0471: ldloc.s 19
+			IL_0473: stelem.ref
+			IL_0474: pop
+			IL_0475: ldloc.0
+			IL_0476: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_047b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0480: ret
 
-			IL_04d9: ldloc.0
-			IL_04da: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
-			IL_04df: pop
-			IL_04e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04e5: ldstr "promise-finished:ok"
-			IL_04ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04ef: pop
-			IL_04f0: br IL_0578
+			IL_0481: ldloc.0
+			IL_0482: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_0487: pop
+			IL_0488: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_048d: ldstr "promise-finished:ok"
+			IL_0492: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0497: pop
+			IL_0498: br IL_0520
 
-			IL_04f5: ldloc.0
-			IL_04f6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04fb: stloc.s 25
-			IL_04fd: ldloc.0
-			IL_04fe: ldc.i4.0
-			IL_04ff: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0504: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0509: ldloc.s 25
-			IL_050b: stloc.s 12
-			IL_050d: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
-			IL_0512: stloc.s 13
-			IL_0514: ldstr "promise-finished:"
-			IL_0519: ldloc.s 12
-			IL_051b: ldstr "name"
-			IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0525: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_052a: stloc.s 24
-			IL_052c: ldloc.s 24
-			IL_052e: ldstr ":"
-			IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0538: stloc.s 24
-			IL_053a: ldloc.s 24
-			IL_053c: ldloc.s 12
-			IL_053e: ldstr "code"
-			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_054d: stloc.s 24
-			IL_054f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0554: ldloc.s 24
-			IL_0556: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_055b: pop
-			IL_055c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0561: ldloc.s 12
-			IL_0563: ldstr "message"
-			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_056d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0572: pop
-			IL_0573: br IL_0578
+			IL_049d: ldloc.0
+			IL_049e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04a3: stloc.s 25
+			IL_04a5: ldloc.0
+			IL_04a6: ldc.i4.0
+			IL_04a7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04ac: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04b1: ldloc.s 25
+			IL_04b3: stloc.s 12
+			IL_04b5: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
+			IL_04ba: stloc.s 13
+			IL_04bc: ldstr "promise-finished:"
+			IL_04c1: ldloc.s 12
+			IL_04c3: ldstr "name"
+			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04d2: stloc.s 24
+			IL_04d4: ldloc.s 24
+			IL_04d6: ldstr ":"
+			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04e0: stloc.s 24
+			IL_04e2: ldloc.s 24
+			IL_04e4: ldloc.s 12
+			IL_04e6: ldstr "code"
+			IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04f5: stloc.s 24
+			IL_04f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04fc: ldloc.s 24
+			IL_04fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0503: pop
+			IL_0504: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0509: ldloc.s 12
+			IL_050b: ldstr "message"
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0515: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_051a: pop
+			IL_051b: br IL_0520
 
-			IL_0578: ldloc.0
-			IL_0579: ldc.i4.0
-			IL_057a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_057f: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0584: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
-			IL_0589: stloc.s 14
-			IL_058b: ldc.i4.1
-			IL_058c: newarr [System.Runtime]System.Object
-			IL_0591: dup
-			IL_0592: ldc.i4.0
-			IL_0593: ldarg.0
-			IL_0594: ldc.i4.1
-			IL_0595: ldelem.ref
-			IL_0596: stelem.ref
-			IL_0597: ldc.i4.0
-			IL_0598: ldelem.ref
-			IL_0599: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_059e: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_05a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_05a9: ldnull
-			IL_05aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_05af: stloc.s 25
-			IL_05b1: ldloc.s 25
-			IL_05b3: stloc.s 15
-			IL_05b5: ldarg.0
-			IL_05b6: ldc.i4.1
-			IL_05b7: ldelem.ref
-			IL_05b8: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_05bd: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05c7: stloc.s 25
-			IL_05c9: ldc.i4.1
-			IL_05ca: newarr [System.Runtime]System.Object
-			IL_05cf: dup
-			IL_05d0: ldc.i4.0
-			IL_05d1: ldarg.0
-			IL_05d2: ldc.i4.1
-			IL_05d3: ldelem.ref
-			IL_05d4: stelem.ref
-			IL_05d5: ldc.i4.0
-			IL_05d6: ldelem.ref
-			IL_05d7: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_05dc: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_05e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_05e7: ldnull
-			IL_05e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_05ed: stloc.s 23
-			IL_05ef: ldloc.s 25
-			IL_05f1: ldstr "pipeline"
-			IL_05f6: ldloc.s 15
-			IL_05f8: ldloc.s 23
-			IL_05fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0520: ldloc.0
+			IL_0521: ldc.i4.0
+			IL_0522: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0527: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_052c: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
+			IL_0531: stloc.s 14
+			IL_0533: ldarg.0
+			IL_0534: ldc.i4.1
+			IL_0535: ldelem.ref
+			IL_0536: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_053b: ldnull
+			IL_053c: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_0541: stloc.s 25
+			IL_0543: ldloc.s 25
+			IL_0545: stloc.s 15
+			IL_0547: ldarg.0
+			IL_0548: ldc.i4.1
+			IL_0549: ldelem.ref
+			IL_054a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_054f: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0559: stloc.s 25
+			IL_055b: ldarg.0
+			IL_055c: ldc.i4.1
+			IL_055d: ldelem.ref
+			IL_055e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_0563: ldnull
+			IL_0564: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+			IL_0569: stloc.s 23
+			IL_056b: ldloc.s 25
+			IL_056d: ldstr "pipeline"
+			IL_0572: ldloc.s 15
+			IL_0574: ldloc.s 23
+			IL_0576: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_057b: dup
+			IL_057c: ldstr "signal"
+			IL_0581: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0586: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0590: stloc.s 23
+			IL_0592: ldloc.s 23
+			IL_0594: stloc.s 16
+			IL_0596: ldloc.s 15
+			IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_059d: stloc.s 23
+			IL_059f: ldloc.s 23
+			IL_05a1: ldstr "push"
+			IL_05a6: ldc.i4.0
+			IL_05a7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_05b1: pop
+			IL_05b2: ldloc.0
+			IL_05b3: ldc.i4.4
+			IL_05b4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_05b9: ldloc.0
+			IL_05ba: ldloc.s 16
+			IL_05bc: ldarg.0
+			IL_05bd: ldc.i4.2
+			IL_05be: ldloc.0
+			IL_05bf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_05c4: ldc.i4.3
+			IL_05c5: ldstr "_pendingException"
+			IL_05ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_05cf: ldloc.0
+			IL_05d0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_05d5: dup
+			IL_05d6: ldc.i4.0
+			IL_05d7: ldloc.1
+			IL_05d8: stelem.ref
+			IL_05d9: dup
+			IL_05da: ldc.i4.1
+			IL_05db: ldloc.2
+			IL_05dc: stelem.ref
+			IL_05dd: dup
+			IL_05de: ldc.i4.2
+			IL_05df: ldloc.3
+			IL_05e0: stelem.ref
+			IL_05e1: dup
+			IL_05e2: ldc.i4.3
+			IL_05e3: ldloc.s 4
+			IL_05e5: stelem.ref
+			IL_05e6: dup
+			IL_05e7: ldc.i4.4
+			IL_05e8: ldloc.s 5
+			IL_05ea: stelem.ref
+			IL_05eb: dup
+			IL_05ec: ldc.i4.5
+			IL_05ed: ldloc.s 6
+			IL_05ef: stelem.ref
+			IL_05f0: dup
+			IL_05f1: ldc.i4.6
+			IL_05f2: ldloc.s 7
+			IL_05f4: stelem.ref
+			IL_05f5: dup
+			IL_05f6: ldc.i4.7
+			IL_05f7: ldloc.s 8
+			IL_05f9: stelem.ref
+			IL_05fa: dup
+			IL_05fb: ldc.i4.8
+			IL_05fc: ldloc.s 9
+			IL_05fe: stelem.ref
 			IL_05ff: dup
-			IL_0600: ldstr "signal"
-			IL_0605: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_060a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0614: stloc.s 23
-			IL_0616: ldloc.s 23
-			IL_0618: stloc.s 16
-			IL_061a: ldloc.s 15
-			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0621: stloc.s 23
-			IL_0623: ldloc.s 23
-			IL_0625: ldstr "push"
-			IL_062a: ldc.i4.0
-			IL_062b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0635: pop
-			IL_0636: ldloc.0
-			IL_0637: ldc.i4.4
-			IL_0638: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_063d: ldloc.0
-			IL_063e: ldloc.s 16
-			IL_0640: ldarg.0
-			IL_0641: ldc.i4.2
-			IL_0642: ldloc.0
-			IL_0643: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0648: ldc.i4.3
-			IL_0649: ldstr "_pendingException"
-			IL_064e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0653: ldloc.0
-			IL_0654: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0659: dup
-			IL_065a: ldc.i4.0
-			IL_065b: ldloc.1
-			IL_065c: stelem.ref
-			IL_065d: dup
-			IL_065e: ldc.i4.1
-			IL_065f: ldloc.2
-			IL_0660: stelem.ref
-			IL_0661: dup
-			IL_0662: ldc.i4.2
-			IL_0663: ldloc.3
-			IL_0664: stelem.ref
-			IL_0665: dup
-			IL_0666: ldc.i4.3
-			IL_0667: ldloc.s 4
-			IL_0669: stelem.ref
-			IL_066a: dup
-			IL_066b: ldc.i4.4
-			IL_066c: ldloc.s 5
-			IL_066e: stelem.ref
-			IL_066f: dup
-			IL_0670: ldc.i4.5
-			IL_0671: ldloc.s 6
-			IL_0673: stelem.ref
-			IL_0674: dup
-			IL_0675: ldc.i4.6
-			IL_0676: ldloc.s 7
-			IL_0678: stelem.ref
-			IL_0679: dup
-			IL_067a: ldc.i4.7
-			IL_067b: ldloc.s 8
-			IL_067d: stelem.ref
-			IL_067e: dup
-			IL_067f: ldc.i4.8
-			IL_0680: ldloc.s 9
-			IL_0682: stelem.ref
-			IL_0683: dup
-			IL_0684: ldc.i4.s 9
-			IL_0686: ldloc.s 10
-			IL_0688: stelem.ref
-			IL_0689: dup
-			IL_068a: ldc.i4.s 10
-			IL_068c: ldloc.s 11
-			IL_068e: stelem.ref
-			IL_068f: dup
-			IL_0690: ldc.i4.s 11
-			IL_0692: ldloc.s 12
-			IL_0694: stelem.ref
-			IL_0695: dup
-			IL_0696: ldc.i4.s 12
-			IL_0698: ldloc.s 13
-			IL_069a: stelem.ref
-			IL_069b: dup
-			IL_069c: ldc.i4.s 13
-			IL_069e: ldloc.s 14
-			IL_06a0: stelem.ref
-			IL_06a1: dup
-			IL_06a2: ldc.i4.s 14
-			IL_06a4: ldloc.s 15
-			IL_06a6: stelem.ref
-			IL_06a7: dup
-			IL_06a8: ldc.i4.s 15
-			IL_06aa: ldloc.s 16
-			IL_06ac: stelem.ref
-			IL_06ad: dup
-			IL_06ae: ldc.i4.s 16
-			IL_06b0: ldloc.s 17
-			IL_06b2: stelem.ref
-			IL_06b3: dup
-			IL_06b4: ldc.i4.s 17
-			IL_06b6: ldloc.s 18
-			IL_06b8: stelem.ref
-			IL_06b9: dup
-			IL_06ba: ldc.i4.s 18
-			IL_06bc: ldloc.s 19
-			IL_06be: stelem.ref
-			IL_06bf: pop
-			IL_06c0: ldloc.0
-			IL_06c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06c6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06cb: ret
+			IL_0600: ldc.i4.s 9
+			IL_0602: ldloc.s 10
+			IL_0604: stelem.ref
+			IL_0605: dup
+			IL_0606: ldc.i4.s 10
+			IL_0608: ldloc.s 11
+			IL_060a: stelem.ref
+			IL_060b: dup
+			IL_060c: ldc.i4.s 11
+			IL_060e: ldloc.s 12
+			IL_0610: stelem.ref
+			IL_0611: dup
+			IL_0612: ldc.i4.s 12
+			IL_0614: ldloc.s 13
+			IL_0616: stelem.ref
+			IL_0617: dup
+			IL_0618: ldc.i4.s 13
+			IL_061a: ldloc.s 14
+			IL_061c: stelem.ref
+			IL_061d: dup
+			IL_061e: ldc.i4.s 14
+			IL_0620: ldloc.s 15
+			IL_0622: stelem.ref
+			IL_0623: dup
+			IL_0624: ldc.i4.s 15
+			IL_0626: ldloc.s 16
+			IL_0628: stelem.ref
+			IL_0629: dup
+			IL_062a: ldc.i4.s 16
+			IL_062c: ldloc.s 17
+			IL_062e: stelem.ref
+			IL_062f: dup
+			IL_0630: ldc.i4.s 17
+			IL_0632: ldloc.s 18
+			IL_0634: stelem.ref
+			IL_0635: dup
+			IL_0636: ldc.i4.s 18
+			IL_0638: ldloc.s 19
+			IL_063a: stelem.ref
+			IL_063b: pop
+			IL_063c: ldloc.0
+			IL_063d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0642: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0647: ret
 
-			IL_06cc: ldloc.0
-			IL_06cd: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_06d2: pop
-			IL_06d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06d8: ldstr "promise-pipeline:ok"
-			IL_06dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06e2: pop
-			IL_06e3: br IL_076b
+			IL_0648: ldloc.0
+			IL_0649: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_064e: pop
+			IL_064f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0654: ldstr "promise-pipeline:ok"
+			IL_0659: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_065e: pop
+			IL_065f: br IL_06e7
 
-			IL_06e8: ldloc.0
-			IL_06e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_06ee: stloc.s 23
-			IL_06f0: ldloc.0
-			IL_06f1: ldc.i4.0
-			IL_06f2: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_06f7: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_06fc: ldloc.s 23
-			IL_06fe: stloc.s 17
-			IL_0700: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
-			IL_0705: stloc.s 18
-			IL_0707: ldstr "promise-pipeline:"
-			IL_070c: ldloc.s 17
-			IL_070e: ldstr "name"
-			IL_0713: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0718: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_071d: stloc.s 24
-			IL_071f: ldloc.s 24
-			IL_0721: ldstr ":"
-			IL_0726: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_072b: stloc.s 24
-			IL_072d: ldloc.s 24
-			IL_072f: ldloc.s 17
-			IL_0731: ldstr "code"
-			IL_0736: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0740: stloc.s 24
-			IL_0742: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0747: ldloc.s 24
-			IL_0749: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_074e: pop
-			IL_074f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0754: ldloc.s 17
-			IL_0756: ldstr "message"
-			IL_075b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0760: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0765: pop
-			IL_0766: br IL_076b
+			IL_0664: ldloc.0
+			IL_0665: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_066a: stloc.s 23
+			IL_066c: ldloc.0
+			IL_066d: ldc.i4.0
+			IL_066e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0673: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0678: ldloc.s 23
+			IL_067a: stloc.s 17
+			IL_067c: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
+			IL_0681: stloc.s 18
+			IL_0683: ldstr "promise-pipeline:"
+			IL_0688: ldloc.s 17
+			IL_068a: ldstr "name"
+			IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0699: stloc.s 24
+			IL_069b: ldloc.s 24
+			IL_069d: ldstr ":"
+			IL_06a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06a7: stloc.s 24
+			IL_06a9: ldloc.s 24
+			IL_06ab: ldloc.s 17
+			IL_06ad: ldstr "code"
+			IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06bc: stloc.s 24
+			IL_06be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06c3: ldloc.s 24
+			IL_06c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06ca: pop
+			IL_06cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06d0: ldloc.s 17
+			IL_06d2: ldstr "message"
+			IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06e1: pop
+			IL_06e2: br IL_06e7
 
-			IL_076b: ldnull
-			IL_076c: stloc.s 19
-			IL_076e: ldloc.0
-			IL_076f: ldc.i4.m1
-			IL_0770: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0775: ldloc.0
-			IL_0776: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_077b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0780: ldarg.0
-			IL_0781: ldc.i4.1
-			IL_0782: newarr [System.Runtime]System.Object
-			IL_0787: dup
-			IL_0788: ldc.i4.0
-			IL_0789: ldloc.s 19
-			IL_078b: stelem.ref
-			IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0791: pop
-			IL_0792: ldloc.0
-			IL_0793: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0798: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_079d: ret
+			IL_06e7: ldnull
+			IL_06e8: stloc.s 19
+			IL_06ea: ldloc.0
+			IL_06eb: ldc.i4.m1
+			IL_06ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06f1: ldloc.0
+			IL_06f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06fc: ldarg.0
+			IL_06fd: ldc.i4.1
+			IL_06fe: newarr [System.Runtime]System.Object
+			IL_0703: dup
+			IL_0704: ldc.i4.0
+			IL_0705: ldloc.s 19
+			IL_0707: stelem.ref
+			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_070d: pop
+			IL_070e: ldloc.0
+			IL_070f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0714: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0719: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1399,7 +1345,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29a9
+			// Method begins at RVA 0x2925
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1529,7 +1475,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a30
+		// Method begins at RVA 0x29ac
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TimersPromises_Abort_RejectsSupportedOneShotApis
+﻿// IL code: TimersPromises_Abort_RejectsSupportedOneShotApis
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2594
+						// Method begins at RVA 0x256c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x258b
+					// Method begins at RVA 0x2563
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2428
+				// Method begins at RVA 0x2400
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25a6
+						// Method begins at RVA 0x257e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x259d
+					// Method begins at RVA 0x2575
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2460
+				// Method begins at RVA 0x2438
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25b8
+						// Method begins at RVA 0x2590
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25af
+					// Method begins at RVA 0x2587
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -279,7 +279,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24e4
+				// Method begins at RVA 0x24bc
 				// Header size: 12
 				// Code size: 107 (0x6b)
 				.maxstack 8
@@ -348,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2582
+				// Method begins at RVA 0x255a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -374,7 +374,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2200
+			// Method begins at RVA 0x21ec
 			// Header size: 12
 			// Code size: 186 (0xba)
 			.maxstack 8
@@ -471,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25c1
+				// Method begins at RVA 0x2599
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -495,7 +495,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22c8
+			// Method begins at RVA 0x22b4
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -535,7 +535,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ca
+				// Method begins at RVA 0x25a2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -558,7 +558,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2318
+			// Method begins at RVA 0x2304
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -584,7 +584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d3
+				// Method begins at RVA 0x25ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -611,7 +611,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x232b
+			// Method begins at RVA 0x2317
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -641,7 +641,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25e5
+					// Method begins at RVA 0x25bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -664,7 +664,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x255b
+				// Method begins at RVA 0x2533
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -690,7 +690,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ee
+					// Method begins at RVA 0x25c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -715,7 +715,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x256e
+				// Method begins at RVA 0x2546
 				// Header size: 1
 				// Code size: 10 (0xa)
 				.maxstack 8
@@ -737,7 +737,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25dc
+				// Method begins at RVA 0x25b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,9 +763,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2338
+			// Method begins at RVA 0x2324
 			// Header size: 12
-			// Code size: 227 (0xe3)
+			// Code size: 205 (0xcd)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope,
@@ -776,92 +776,83 @@
 
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: ldc.i4.0
-			IL_0011: ldelem.ref
-			IL_0012: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-			IL_0017: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-			IL_001d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0022: ldnull
-			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_0028: stloc.2
-			IL_0029: ldloc.2
-			IL_002a: stloc.1
-			IL_002b: ldloc.1
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0031: stloc.2
-			IL_0032: ldloc.2
-			IL_0033: ldstr "abort"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_003d: pop
-			IL_003e: ldarg.0
-			IL_003f: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0049: stloc.2
-			IL_004a: ldloc.2
-			IL_004b: ldstr "setImmediate"
-			IL_0050: ldstr "immediate-value"
-			IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_005a: dup
-			IL_005b: ldstr "signal"
-			IL_0060: ldloc.1
-			IL_0061: ldstr "signal"
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0075: stloc.2
-			IL_0076: ldloc.2
-			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007c: stloc.2
-			IL_007d: ldnull
-			IL_007e: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
-			IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0089: ldc.i4.0
-			IL_008a: conv.r8
-			IL_008b: ldstr ""
-			IL_0090: ldc.i4.0
-			IL_0091: ldc.i4.1
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0097: stloc.3
-			IL_0098: ldloc.2
-			IL_0099: ldstr "then"
-			IL_009e: ldloc.3
-			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00a4: stloc.3
-			IL_00a5: ldloc.3
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ab: stloc.3
-			IL_00ac: ldc.i4.2
-			IL_00ad: newarr [System.Runtime]System.Object
-			IL_00b2: dup
-			IL_00b3: ldc.i4.0
-			IL_00b4: ldarg.0
-			IL_00b5: stelem.ref
-			IL_00b6: dup
+			IL_0006: ldarg.0
+			IL_0007: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+			IL_000c: ldnull
+			IL_000d: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+			IL_0012: stloc.2
+			IL_0013: ldloc.2
+			IL_0014: stloc.1
+			IL_0015: ldloc.1
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001b: stloc.2
+			IL_001c: ldloc.2
+			IL_001d: ldstr "abort"
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0027: pop
+			IL_0028: ldarg.0
+			IL_0029: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0033: stloc.2
+			IL_0034: ldloc.2
+			IL_0035: ldstr "setImmediate"
+			IL_003a: ldstr "immediate-value"
+			IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0044: dup
+			IL_0045: ldstr "signal"
+			IL_004a: ldloc.1
+			IL_004b: ldstr "signal"
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_005f: stloc.2
+			IL_0060: ldloc.2
+			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0066: stloc.2
+			IL_0067: ldnull
+			IL_0068: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
+			IL_006e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0073: ldc.i4.0
+			IL_0074: conv.r8
+			IL_0075: ldstr ""
+			IL_007a: ldc.i4.0
+			IL_007b: ldc.i4.1
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0081: stloc.3
+			IL_0082: ldloc.2
+			IL_0083: ldstr "then"
+			IL_0088: ldloc.3
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_008e: stloc.3
+			IL_008f: ldloc.3
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0095: stloc.3
+			IL_0096: ldc.i4.2
+			IL_0097: newarr [System.Runtime]System.Object
+			IL_009c: dup
+			IL_009d: ldc.i4.0
+			IL_009e: ldarg.0
+			IL_009f: stelem.ref
+			IL_00a0: dup
+			IL_00a1: ldc.i4.1
+			IL_00a2: ldloc.0
+			IL_00a3: stelem.ref
+			IL_00a4: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
+			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00af: ldc.i4.1
+			IL_00b0: conv.r8
+			IL_00b1: ldstr ""
+			IL_00b6: ldc.i4.0
 			IL_00b7: ldc.i4.1
-			IL_00b8: ldloc.0
-			IL_00b9: stelem.ref
-			IL_00ba: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
-			IL_00c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00c5: ldc.i4.1
-			IL_00c6: conv.r8
-			IL_00c7: ldstr ""
-			IL_00cc: ldc.i4.0
-			IL_00cd: ldc.i4.1
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00d3: stloc.2
-			IL_00d4: ldloc.3
-			IL_00d5: ldstr "catch"
-			IL_00da: ldloc.2
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00e0: stloc.2
-			IL_00e1: ldloc.2
-			IL_00e2: ret
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00bd: stloc.2
+			IL_00be: ldloc.3
+			IL_00bf: ldstr "catch"
+			IL_00c4: ldloc.2
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ca: stloc.2
+			IL_00cb: ldloc.2
+			IL_00cc: ret
 		} // end of method FunctionExpression_L48C8::__js_call__
 
 	} // end of class FunctionExpression_L48C8
@@ -887,7 +878,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2579
+			// Method begins at RVA 0x2551
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -913,7 +904,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 419 (0x1a3)
+		// Code size: 397 (0x18d)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope,
@@ -966,120 +957,111 @@
 		IL_0066: ldloc.0
 		IL_0067: ldloc.3
 		IL_0068: stfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-		IL_006d: ldc.i4.1
-		IL_006e: newarr [System.Runtime]System.Object
-		IL_0073: dup
-		IL_0074: ldc.i4.0
-		IL_0075: ldloc.0
-		IL_0076: stelem.ref
-		IL_0077: ldc.i4.0
-		IL_0078: ldelem.ref
-		IL_0079: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_007e: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_0084: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0089: ldnull
-		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_008f: stloc.3
-		IL_0090: ldloc.3
-		IL_0091: stloc.1
-		IL_0092: ldloc.0
-		IL_0093: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_009d: stloc.3
-		IL_009e: ldloc.3
-		IL_009f: ldstr "setTimeout"
-		IL_00a4: ldc.r8 0.0
-		IL_00ad: box [System.Runtime]System.Double
-		IL_00b2: ldstr "timeout-value"
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00bc: dup
-		IL_00bd: ldstr "signal"
-		IL_00c2: ldloc.1
-		IL_00c3: ldstr "signal"
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00d7: stloc.3
-		IL_00d8: ldloc.3
-		IL_00d9: stloc.2
-		IL_00da: ldloc.1
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e0: stloc.3
-		IL_00e1: ldloc.3
-		IL_00e2: ldstr "abort"
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00ec: pop
-		IL_00ed: ldloc.2
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f3: stloc.3
-		IL_00f4: ldnull
-		IL_00f5: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
-		IL_00fb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0100: ldc.i4.0
-		IL_0101: conv.r8
-		IL_0102: ldstr ""
-		IL_0107: ldc.i4.0
-		IL_0108: ldc.i4.1
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_010e: stloc.s 4
-		IL_0110: ldloc.3
-		IL_0111: ldstr "then"
-		IL_0116: ldloc.s 4
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_011d: stloc.s 4
-		IL_011f: ldloc.s 4
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0126: stloc.s 4
-		IL_0128: ldc.i4.1
-		IL_0129: newarr [System.Runtime]System.Object
-		IL_012e: dup
-		IL_012f: ldc.i4.0
-		IL_0130: ldloc.0
-		IL_0131: stelem.ref
-		IL_0132: ldc.i4.0
-		IL_0133: ldelem.ref
-		IL_0134: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0139: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
-		IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0144: ldc.i4.1
-		IL_0145: conv.r8
-		IL_0146: ldstr ""
-		IL_014b: ldc.i4.0
-		IL_014c: ldc.i4.1
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0152: stloc.3
-		IL_0153: ldloc.s 4
-		IL_0155: ldstr "catch"
-		IL_015a: ldloc.3
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0160: stloc.3
-		IL_0161: ldloc.3
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0167: stloc.3
-		IL_0168: ldc.i4.1
-		IL_0169: newarr [System.Runtime]System.Object
-		IL_016e: dup
-		IL_016f: ldc.i4.0
-		IL_0170: ldloc.0
-		IL_0171: stelem.ref
-		IL_0172: ldc.i4.0
-		IL_0173: ldelem.ref
-		IL_0174: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0179: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_017f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0184: ldc.i4.0
-		IL_0185: conv.r8
-		IL_0186: ldstr ""
-		IL_018b: ldc.i4.0
-		IL_018c: ldc.i4.1
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0192: stloc.s 4
-		IL_0194: ldloc.3
-		IL_0195: ldstr "then"
-		IL_019a: ldloc.s 4
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a1: pop
-		IL_01a2: ret
+		IL_006d: ldloc.0
+		IL_006e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0073: ldnull
+		IL_0074: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+		IL_0079: stloc.3
+		IL_007a: ldloc.3
+		IL_007b: stloc.1
+		IL_007c: ldloc.0
+		IL_007d: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0087: stloc.3
+		IL_0088: ldloc.3
+		IL_0089: ldstr "setTimeout"
+		IL_008e: ldc.r8 0.0
+		IL_0097: box [System.Runtime]System.Double
+		IL_009c: ldstr "timeout-value"
+		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a6: dup
+		IL_00a7: ldstr "signal"
+		IL_00ac: ldloc.1
+		IL_00ad: ldstr "signal"
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00c1: stloc.3
+		IL_00c2: ldloc.3
+		IL_00c3: stloc.2
+		IL_00c4: ldloc.1
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ca: stloc.3
+		IL_00cb: ldloc.3
+		IL_00cc: ldstr "abort"
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00d6: pop
+		IL_00d7: ldloc.2
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00dd: stloc.3
+		IL_00de: ldnull
+		IL_00df: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
+		IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ea: ldc.i4.0
+		IL_00eb: conv.r8
+		IL_00ec: ldstr ""
+		IL_00f1: ldc.i4.0
+		IL_00f2: ldc.i4.1
+		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00f8: stloc.s 4
+		IL_00fa: ldloc.3
+		IL_00fb: ldstr "then"
+		IL_0100: ldloc.s 4
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0107: stloc.s 4
+		IL_0109: ldloc.s 4
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0110: stloc.s 4
+		IL_0112: ldc.i4.1
+		IL_0113: newarr [System.Runtime]System.Object
+		IL_0118: dup
+		IL_0119: ldc.i4.0
+		IL_011a: ldloc.0
+		IL_011b: stelem.ref
+		IL_011c: ldc.i4.0
+		IL_011d: ldelem.ref
+		IL_011e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0123: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
+		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_012e: ldc.i4.1
+		IL_012f: conv.r8
+		IL_0130: ldstr ""
+		IL_0135: ldc.i4.0
+		IL_0136: ldc.i4.1
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_013c: stloc.3
+		IL_013d: ldloc.s 4
+		IL_013f: ldstr "catch"
+		IL_0144: ldloc.3
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_014a: stloc.3
+		IL_014b: ldloc.3
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0151: stloc.3
+		IL_0152: ldc.i4.1
+		IL_0153: newarr [System.Runtime]System.Object
+		IL_0158: dup
+		IL_0159: ldc.i4.0
+		IL_015a: ldloc.0
+		IL_015b: stelem.ref
+		IL_015c: ldc.i4.0
+		IL_015d: ldelem.ref
+		IL_015e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0163: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+		IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016e: ldc.i4.0
+		IL_016f: conv.r8
+		IL_0170: ldstr ""
+		IL_0175: ldc.i4.0
+		IL_0176: ldc.i4.1
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_017c: stloc.s 4
+		IL_017e: ldloc.3
+		IL_017f: ldstr "then"
+		IL_0184: ldloc.s 4
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_018b: pop
+		IL_018c: ret
 	} // end of method TimersPromises_Abort_RejectsSupportedOneShotApis::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis
@@ -1091,7 +1073,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25f7
+		// Method begins at RVA 0x25cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TimersPromises_SetInterval_Abort_RejectsActiveIterator
+﻿// IL code: TimersPromises_SetInterval_Abort_RejectsActiveIterator
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2697
+						// Method begins at RVA 0x2683
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x268e
+					// Method begins at RVA 0x267a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x248c
+				// Method begins at RVA 0x2478
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26a9
+						// Method begins at RVA 0x2695
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26a0
+					// Method begins at RVA 0x268c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24c4
+				// Method begins at RVA 0x24b0
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26bb
+						// Method begins at RVA 0x26a7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b2
+					// Method begins at RVA 0x269e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -280,7 +280,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2548
+				// Method begins at RVA 0x2534
 				// Header size: 12
 				// Code size: 133 (0x85)
 				.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2685
+				// Method begins at RVA 0x2671
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -491,7 +491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26cd
+					// Method begins at RVA 0x26b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -514,7 +514,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25d9
+				// Method begins at RVA 0x25c5
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -540,7 +540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26d6
+					// Method begins at RVA 0x26c2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -564,7 +564,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25ec
+				// Method begins at RVA 0x25d8
 				// Header size: 12
 				// Code size: 132 (0x84)
 				.maxstack 8
@@ -631,7 +631,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26c4
+				// Method begins at RVA 0x26b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -657,7 +657,7 @@
 			)
 			// Method begins at RVA 0x21b8
 			// Header size: 12
-			// Code size: 712 (0x2c8)
+			// Code size: 690 (0x2b2)
 			.maxstack 9
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -730,227 +730,218 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_008e, IL_015b, IL_01cd)
+			IL_007d: switch (IL_008e, IL_0145, IL_01b7)
 
-			IL_008e: ldc.i4.1
-			IL_008f: newarr [System.Runtime]System.Object
-			IL_0094: dup
-			IL_0095: ldc.i4.0
-			IL_0096: ldarg.0
-			IL_0097: ldc.i4.1
-			IL_0098: ldelem.ref
-			IL_0099: stelem.ref
-			IL_009a: ldc.i4.0
-			IL_009b: ldelem.ref
-			IL_009c: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_00a1: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_00ac: ldnull
-			IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_00b2: stloc.s 5
-			IL_00b4: ldloc.s 5
-			IL_00b6: stloc.1
-			IL_00b7: ldarg.0
-			IL_00b8: ldc.i4.1
-			IL_00b9: ldelem.ref
-			IL_00ba: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_00bf: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c9: stloc.s 5
-			IL_00cb: ldloc.s 5
-			IL_00cd: ldstr "setInterval"
-			IL_00d2: ldc.r8 0.0
-			IL_00db: box [System.Runtime]System.Double
-			IL_00e0: ldstr "tick"
-			IL_00e5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00ea: dup
-			IL_00eb: ldstr "signal"
-			IL_00f0: ldloc.1
-			IL_00f1: ldstr "signal"
-			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00fb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0105: stloc.s 5
-			IL_0107: ldloc.s 5
-			IL_0109: stloc.2
-			IL_010a: ldloc.2
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: stloc.s 5
+			IL_008e: ldarg.0
+			IL_008f: ldc.i4.1
+			IL_0090: ldelem.ref
+			IL_0091: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
+			IL_0096: ldnull
+			IL_0097: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
+			IL_009c: stloc.s 5
+			IL_009e: ldloc.s 5
+			IL_00a0: stloc.1
+			IL_00a1: ldarg.0
+			IL_00a2: ldc.i4.1
+			IL_00a3: ldelem.ref
+			IL_00a4: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
+			IL_00a9: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
+			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b3: stloc.s 5
+			IL_00b5: ldloc.s 5
+			IL_00b7: ldstr "setInterval"
+			IL_00bc: ldc.r8 0.0
+			IL_00c5: box [System.Runtime]System.Double
+			IL_00ca: ldstr "tick"
+			IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00d4: dup
+			IL_00d5: ldstr "signal"
+			IL_00da: ldloc.1
+			IL_00db: ldstr "signal"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00ef: stloc.s 5
+			IL_00f1: ldloc.s 5
+			IL_00f3: stloc.2
+			IL_00f4: ldloc.2
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fa: stloc.s 5
+			IL_00fc: ldloc.s 5
+			IL_00fe: ldstr "next"
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0108: stloc.s 5
+			IL_010a: ldloc.0
+			IL_010b: ldc.i4.1
+			IL_010c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0111: ldloc.0
 			IL_0112: ldloc.s 5
-			IL_0114: ldstr "next"
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_011e: stloc.s 5
-			IL_0120: ldloc.0
-			IL_0121: ldc.i4.1
-			IL_0122: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0127: ldloc.0
-			IL_0128: ldloc.s 5
-			IL_012a: ldarg.0
-			IL_012b: ldc.i4.1
-			IL_012c: ldloc.0
-			IL_012d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0132: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0137: ldloc.0
-			IL_0138: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_013d: dup
-			IL_013e: ldc.i4.0
-			IL_013f: ldloc.1
-			IL_0140: stelem.ref
-			IL_0141: dup
-			IL_0142: ldc.i4.1
-			IL_0143: ldloc.2
-			IL_0144: stelem.ref
-			IL_0145: dup
-			IL_0146: ldc.i4.2
-			IL_0147: ldloc.3
-			IL_0148: stelem.ref
-			IL_0149: dup
-			IL_014a: ldc.i4.3
-			IL_014b: ldloc.s 4
-			IL_014d: stelem.ref
-			IL_014e: pop
-			IL_014f: ldloc.0
-			IL_0150: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0155: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_015a: ret
+			IL_0114: ldarg.0
+			IL_0115: ldc.i4.1
+			IL_0116: ldloc.0
+			IL_0117: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0121: ldloc.0
+			IL_0122: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0127: dup
+			IL_0128: ldc.i4.0
+			IL_0129: ldloc.1
+			IL_012a: stelem.ref
+			IL_012b: dup
+			IL_012c: ldc.i4.1
+			IL_012d: ldloc.2
+			IL_012e: stelem.ref
+			IL_012f: dup
+			IL_0130: ldc.i4.2
+			IL_0131: ldloc.3
+			IL_0132: stelem.ref
+			IL_0133: dup
+			IL_0134: ldc.i4.3
+			IL_0135: ldloc.s 4
+			IL_0137: stelem.ref
+			IL_0138: pop
+			IL_0139: ldloc.0
+			IL_013a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_013f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0144: ret
 
-			IL_015b: ldloc.0
-			IL_015c: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
-			IL_0161: stloc.s 5
-			IL_0163: ldloc.s 5
-			IL_0165: stloc.3
-			IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_016b: ldloc.3
-			IL_016c: ldstr "value"
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0176: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_017b: pop
-			IL_017c: ldloc.2
-			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0182: stloc.s 5
+			IL_0145: ldloc.0
+			IL_0146: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
+			IL_014b: stloc.s 5
+			IL_014d: ldloc.s 5
+			IL_014f: stloc.3
+			IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0155: ldloc.3
+			IL_0156: ldstr "value"
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0165: pop
+			IL_0166: ldloc.2
+			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016c: stloc.s 5
+			IL_016e: ldloc.s 5
+			IL_0170: ldstr "next"
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_017a: stloc.s 5
+			IL_017c: ldloc.0
+			IL_017d: ldc.i4.2
+			IL_017e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0183: ldloc.0
 			IL_0184: ldloc.s 5
-			IL_0186: ldstr "next"
-			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0190: stloc.s 5
-			IL_0192: ldloc.0
-			IL_0193: ldc.i4.2
-			IL_0194: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0199: ldloc.0
-			IL_019a: ldloc.s 5
-			IL_019c: ldarg.0
-			IL_019d: ldc.i4.2
-			IL_019e: ldloc.0
-			IL_019f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01a9: ldloc.0
-			IL_01aa: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01af: dup
-			IL_01b0: ldc.i4.0
-			IL_01b1: ldloc.1
-			IL_01b2: stelem.ref
-			IL_01b3: dup
-			IL_01b4: ldc.i4.1
-			IL_01b5: ldloc.2
-			IL_01b6: stelem.ref
-			IL_01b7: dup
-			IL_01b8: ldc.i4.2
-			IL_01b9: ldloc.3
-			IL_01ba: stelem.ref
-			IL_01bb: dup
-			IL_01bc: ldc.i4.3
-			IL_01bd: ldloc.s 4
-			IL_01bf: stelem.ref
-			IL_01c0: pop
-			IL_01c1: ldloc.0
-			IL_01c2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01c7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01cc: ret
+			IL_0186: ldarg.0
+			IL_0187: ldc.i4.2
+			IL_0188: ldloc.0
+			IL_0189: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_018e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0193: ldloc.0
+			IL_0194: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0199: dup
+			IL_019a: ldc.i4.0
+			IL_019b: ldloc.1
+			IL_019c: stelem.ref
+			IL_019d: dup
+			IL_019e: ldc.i4.1
+			IL_019f: ldloc.2
+			IL_01a0: stelem.ref
+			IL_01a1: dup
+			IL_01a2: ldc.i4.2
+			IL_01a3: ldloc.3
+			IL_01a4: stelem.ref
+			IL_01a5: dup
+			IL_01a6: ldc.i4.3
+			IL_01a7: ldloc.s 4
+			IL_01a9: stelem.ref
+			IL_01aa: pop
+			IL_01ab: ldloc.0
+			IL_01ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01b6: ret
 
-			IL_01cd: ldloc.0
-			IL_01ce: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
-			IL_01d3: stloc.s 5
-			IL_01d5: ldloc.s 5
-			IL_01d7: stloc.s 4
-			IL_01d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01de: ldloc.s 4
-			IL_01e0: ldstr "value"
-			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01ef: pop
-			IL_01f0: ldloc.1
-			IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f6: stloc.s 5
-			IL_01f8: ldstr "boom-reason"
-			IL_01fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0202: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0207: stloc.s 6
-			IL_0209: ldloc.s 5
-			IL_020b: ldstr "abort"
-			IL_0210: ldloc.s 6
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0217: pop
-			IL_0218: ldloc.2
-			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021e: stloc.s 6
-			IL_0220: ldloc.s 6
-			IL_0222: ldstr "next"
-			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_022c: stloc.s 6
-			IL_022e: ldloc.s 6
-			IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0235: stloc.s 6
-			IL_0237: ldnull
-			IL_0238: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-			IL_023e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0243: ldc.i4.0
-			IL_0244: conv.r8
-			IL_0245: ldstr ""
-			IL_024a: ldc.i4.0
-			IL_024b: ldc.i4.1
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0251: stloc.s 5
-			IL_0253: ldloc.s 6
-			IL_0255: ldstr "then"
-			IL_025a: ldloc.s 5
-			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0261: stloc.s 5
-			IL_0263: ldloc.s 5
-			IL_0265: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_026a: stloc.s 5
-			IL_026c: ldnull
-			IL_026d: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-			IL_0273: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0278: ldc.i4.1
-			IL_0279: conv.r8
-			IL_027a: ldstr ""
-			IL_027f: ldc.i4.0
-			IL_0280: ldc.i4.1
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0286: stloc.s 6
-			IL_0288: ldloc.s 5
-			IL_028a: ldstr "catch"
-			IL_028f: ldloc.s 6
-			IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0296: stloc.s 6
-			IL_0298: ldloc.0
-			IL_0299: ldc.i4.m1
-			IL_029a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_029f: ldloc.0
-			IL_02a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02aa: ldarg.0
-			IL_02ab: ldc.i4.1
-			IL_02ac: newarr [System.Runtime]System.Object
-			IL_02b1: dup
-			IL_02b2: ldc.i4.0
-			IL_02b3: ldloc.s 6
-			IL_02b5: stelem.ref
-			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02bb: pop
-			IL_02bc: ldloc.0
-			IL_02bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c7: ret
+			IL_01b7: ldloc.0
+			IL_01b8: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
+			IL_01bd: stloc.s 5
+			IL_01bf: ldloc.s 5
+			IL_01c1: stloc.s 4
+			IL_01c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01c8: ldloc.s 4
+			IL_01ca: ldstr "value"
+			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01d9: pop
+			IL_01da: ldloc.1
+			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01e0: stloc.s 5
+			IL_01e2: ldstr "boom-reason"
+			IL_01e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01f1: stloc.s 6
+			IL_01f3: ldloc.s 5
+			IL_01f5: ldstr "abort"
+			IL_01fa: ldloc.s 6
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0201: pop
+			IL_0202: ldloc.2
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0208: stloc.s 6
+			IL_020a: ldloc.s 6
+			IL_020c: ldstr "next"
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0216: stloc.s 6
+			IL_0218: ldloc.s 6
+			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_021f: stloc.s 6
+			IL_0221: ldnull
+			IL_0222: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+			IL_0228: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_022d: ldc.i4.0
+			IL_022e: conv.r8
+			IL_022f: ldstr ""
+			IL_0234: ldc.i4.0
+			IL_0235: ldc.i4.1
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_023b: stloc.s 5
+			IL_023d: ldloc.s 6
+			IL_023f: ldstr "then"
+			IL_0244: ldloc.s 5
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_024b: stloc.s 5
+			IL_024d: ldloc.s 5
+			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0254: stloc.s 5
+			IL_0256: ldnull
+			IL_0257: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+			IL_025d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0262: ldc.i4.1
+			IL_0263: conv.r8
+			IL_0264: ldstr ""
+			IL_0269: ldc.i4.0
+			IL_026a: ldc.i4.1
+			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0270: stloc.s 6
+			IL_0272: ldloc.s 5
+			IL_0274: ldstr "catch"
+			IL_0279: ldloc.s 6
+			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0280: stloc.s 6
+			IL_0282: ldloc.0
+			IL_0283: ldc.i4.m1
+			IL_0284: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0289: ldloc.0
+			IL_028a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0294: ldarg.0
+			IL_0295: ldc.i4.1
+			IL_0296: newarr [System.Runtime]System.Object
+			IL_029b: dup
+			IL_029c: ldc.i4.0
+			IL_029d: ldloc.s 6
+			IL_029f: stelem.ref
+			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02a5: pop
+			IL_02a6: ldloc.0
+			IL_02a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02b1: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -975,7 +966,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x267c
+			// Method begins at RVA 0x2668
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1077,7 +1068,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26df
+		// Method begins at RVA 0x26cb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ObjectLiteral_ComputedKey_EvaluationOrder
+﻿// IL code: ObjectLiteral_ComputedKey_EvaluationOrder
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x226f
+				// Method begins at RVA 0x222f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21c8
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -77,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2278
+				// Method begins at RVA 0x2238
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21b4
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -137,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2281
+				// Method begins at RVA 0x2241
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -163,7 +163,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2228
+			// Method begins at RVA 0x21e8
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -207,7 +207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2266
+			// Method begins at RVA 0x2226
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -233,7 +233,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 363 (0x16b)
+		// Code size: 297 (0x129)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope,
@@ -311,79 +311,52 @@
 		IL_0093: ldloc.0
 		IL_0094: ldstr ""
 		IL_0099: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-		IL_009e: ldc.i4.1
-		IL_009f: newarr [System.Runtime]System.Object
-		IL_00a4: dup
-		IL_00a5: ldc.i4.0
-		IL_00a6: ldloc.0
-		IL_00a7: stelem.ref
-		IL_00a8: ldc.i4.0
-		IL_00a9: ldelem.ref
-		IL_00aa: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_00af: ldftn object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_00b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ba: ldnull
-		IL_00bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00c0: stloc.s 5
-		IL_00c2: ldc.i4.1
-		IL_00c3: newarr [System.Runtime]System.Object
-		IL_00c8: dup
-		IL_00c9: ldc.i4.0
-		IL_00ca: ldloc.0
-		IL_00cb: stelem.ref
-		IL_00cc: ldc.i4.0
-		IL_00cd: ldelem.ref
+		IL_009e: ldloc.0
+		IL_009f: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
+		IL_00a4: ldnull
+		IL_00a5: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+		IL_00aa: stloc.s 5
+		IL_00ac: ldloc.0
+		IL_00ad: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
+		IL_00b2: ldnull
+		IL_00b3: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+		IL_00b8: stloc.s 6
+		IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00bf: stloc.s 7
+		IL_00c1: ldloc.s 7
+		IL_00c3: ldloc.s 5
+		IL_00c5: ldloc.s 6
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_00cc: pop
+		IL_00cd: ldloc.0
 		IL_00ce: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_00d3: ldftn object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00de: ldnull
-		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00e4: stloc.s 6
-		IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00eb: stloc.s 7
-		IL_00ed: ldloc.s 7
-		IL_00ef: ldloc.s 5
-		IL_00f1: ldloc.s 6
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_00f8: pop
-		IL_00f9: ldc.i4.1
-		IL_00fa: newarr [System.Runtime]System.Object
-		IL_00ff: dup
-		IL_0100: ldc.i4.0
-		IL_0101: ldloc.0
-		IL_0102: stelem.ref
-		IL_0103: ldc.i4.0
-		IL_0104: ldelem.ref
-		IL_0105: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_010a: ldftn object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_0110: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0115: ldnull
-		IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_011b: stloc.s 6
-		IL_011d: ldloc.s 7
-		IL_011f: ldloc.s 6
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SpreadIntoObjectLiteral(object, object)
-		IL_0126: pop
-		IL_0127: ldloc.s 7
-		IL_0129: stloc.s 4
-		IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0130: ldloc.0
-		IL_0131: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-		IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013b: pop
-		IL_013c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0141: ldloc.s 4
-		IL_0143: ldstr "k"
-		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0152: pop
-		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0158: ldloc.s 4
-		IL_015a: ldstr "a"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0169: pop
-		IL_016a: ret
+		IL_00d3: ldnull
+		IL_00d4: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+		IL_00d9: stloc.s 6
+		IL_00db: ldloc.s 7
+		IL_00dd: ldloc.s 6
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SpreadIntoObjectLiteral(object, object)
+		IL_00e4: pop
+		IL_00e5: ldloc.s 7
+		IL_00e7: stloc.s 4
+		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ee: ldloc.0
+		IL_00ef: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
+		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f9: pop
+		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ff: ldloc.s 4
+		IL_0101: ldstr "k"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0110: pop
+		IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0116: ldloc.s 4
+		IL_0118: ldstr "a"
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0127: pop
+		IL_0128: ret
 	} // end of method ObjectLiteral_ComputedKey_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ComputedKey_EvaluationOrder
@@ -395,7 +368,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x228a
+		// Method begins at RVA 0x224a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ObjectLiteral_InlinePropertyInit
+﻿// IL code: ObjectLiteral_InlinePropertyInit
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2185
+				// Method begins at RVA 0x216f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2143
+			// Method begins at RVA 0x212d
 			// Header size: 1
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217c
+			// Method begins at RVA 0x2166
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,7 +105,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 231 (0xe7)
+		// Code size: 209 (0xd1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InlinePropertyInit/Scope,
@@ -163,25 +163,16 @@
 		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_00b6: pop
-		IL_00b7: ldc.i4.1
-		IL_00b8: newarr [System.Runtime]System.Object
-		IL_00bd: dup
-		IL_00be: ldc.i4.0
-		IL_00bf: ldloc.0
-		IL_00c0: stelem.ref
-		IL_00c1: ldc.i4.0
-		IL_00c2: ldelem.ref
-		IL_00c3: castclass Modules.ObjectLiteral_InlinePropertyInit/Scope
-		IL_00c8: ldftn object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
-		IL_00ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00d3: ldnull
-		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00d9: stloc.2
-		IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00df: ldloc.2
-		IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e5: pop
-		IL_00e6: ret
+		IL_00b7: ldloc.0
+		IL_00b8: castclass Modules.ObjectLiteral_InlinePropertyInit/Scope
+		IL_00bd: ldnull
+		IL_00be: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
+		IL_00c3: stloc.2
+		IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c9: ldloc.2
+		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00cf: pop
+		IL_00d0: ret
 	} // end of method ObjectLiteral_InlinePropertyInit::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InlinePropertyInit
@@ -193,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218e
+		// Method begins at RVA 0x2178
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Proxy_Revocable_ThrowsAfterRevoke
+﻿// IL code: Proxy_Revocable_ThrowsAfterRevoke
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x281f
+					// Method begins at RVA 0x275b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2828
+					// Method begins at RVA 0x2764
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2816
+				// Method begins at RVA 0x2752
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2530
+			// Method begins at RVA 0x246c
 			// Header size: 12
 			// Code size: 181 (0xb5)
 			.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2831
+				// Method begins at RVA 0x276d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -223,7 +223,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2604
+			// Method begins at RVA 0x2540
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -247,7 +247,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x283a
+				// Method begins at RVA 0x2776
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -273,7 +273,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x260d
+			// Method begins at RVA 0x2549
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -302,7 +302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2843
+				// Method begins at RVA 0x277f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -328,7 +328,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x261f
+			// Method begins at RVA 0x255b
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -355,7 +355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x284c
+				// Method begins at RVA 0x2788
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -381,7 +381,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x263b
+			// Method begins at RVA 0x2577
 			// Header size: 1
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -412,7 +412,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2855
+				// Method begins at RVA 0x2791
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -438,7 +438,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2668
+			// Method begins at RVA 0x25a4
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -474,7 +474,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x285e
+				// Method begins at RVA 0x279a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -500,7 +500,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2698
+			// Method begins at RVA 0x25d4
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -536,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2867
+				// Method begins at RVA 0x27a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -562,7 +562,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x26c8
+			// Method begins at RVA 0x2604
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -601,7 +601,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2870
+				// Method begins at RVA 0x27ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -627,7 +627,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2704
+			// Method begins at RVA 0x2640
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -658,7 +658,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2879
+				// Method begins at RVA 0x27b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -684,7 +684,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2728
+			// Method begins at RVA 0x2664
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -719,7 +719,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2882
+				// Method begins at RVA 0x27be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -743,7 +743,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2754
+			// Method begins at RVA 0x2690
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -772,7 +772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x288b
+				// Method begins at RVA 0x27c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -798,7 +798,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2774
+			// Method begins at RVA 0x26b0
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -839,7 +839,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2894
+				// Method begins at RVA 0x27d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -863,7 +863,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27a8
+			// Method begins at RVA 0x26e4
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -899,7 +899,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x289d
+				// Method begins at RVA 0x27d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -925,7 +925,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x27d0
+			// Method begins at RVA 0x270c
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -976,7 +976,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x280d
+			// Method begins at RVA 0x2749
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1002,7 +1002,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1236 (0x4d4)
+		// Code size: 1038 (0x40e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope,
@@ -1129,345 +1129,264 @@
 		IL_0159: ldc.i4.1
 		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_015f: stloc.s 4
-		IL_0161: ldc.i4.1
-		IL_0162: newarr [System.Runtime]System.Object
-		IL_0167: dup
-		IL_0168: ldc.i4.0
-		IL_0169: ldloc.0
-		IL_016a: stelem.ref
-		IL_016b: ldc.i4.0
-		IL_016c: ldelem.ref
-		IL_016d: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0172: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_017d: ldnull
-		IL_017e: ldstr "get"
-		IL_0183: ldloc.s 4
-		IL_0185: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_018a: pop
-		IL_018b: ldc.i4.1
-		IL_018c: newarr [System.Runtime]System.Object
-		IL_0191: dup
-		IL_0192: ldc.i4.0
-		IL_0193: ldloc.0
-		IL_0194: stelem.ref
-		IL_0195: ldc.i4.0
-		IL_0196: ldelem.ref
-		IL_0197: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_019c: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_01a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01a7: ldc.i4.0
-		IL_01a8: conv.r8
-		IL_01a9: ldstr ""
-		IL_01ae: ldc.i4.0
-		IL_01af: ldc.i4.1
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01b5: stloc.s 4
-		IL_01b7: ldc.i4.1
-		IL_01b8: newarr [System.Runtime]System.Object
-		IL_01bd: dup
-		IL_01be: ldc.i4.0
-		IL_01bf: ldloc.0
-		IL_01c0: stelem.ref
-		IL_01c1: ldc.i4.0
-		IL_01c2: ldelem.ref
-		IL_01c3: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01c8: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01d3: ldnull
-		IL_01d4: ldstr "set"
-		IL_01d9: ldloc.s 4
-		IL_01db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01e0: pop
-		IL_01e1: ldc.i4.1
-		IL_01e2: newarr [System.Runtime]System.Object
-		IL_01e7: dup
-		IL_01e8: ldc.i4.0
-		IL_01e9: ldloc.0
-		IL_01ea: stelem.ref
-		IL_01eb: ldc.i4.0
-		IL_01ec: ldelem.ref
-		IL_01ed: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01f2: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_01f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01fd: ldc.i4.0
-		IL_01fe: conv.r8
-		IL_01ff: ldstr ""
-		IL_0204: ldc.i4.0
-		IL_0205: ldc.i4.1
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_020b: stloc.s 4
-		IL_020d: ldc.i4.1
-		IL_020e: newarr [System.Runtime]System.Object
-		IL_0213: dup
-		IL_0214: ldc.i4.0
-		IL_0215: ldloc.0
-		IL_0216: stelem.ref
-		IL_0217: ldc.i4.0
-		IL_0218: ldelem.ref
-		IL_0219: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_021e: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0224: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0229: ldnull
-		IL_022a: ldstr "has"
-		IL_022f: ldloc.s 4
-		IL_0231: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0236: pop
-		IL_0237: ldc.i4.1
-		IL_0238: newarr [System.Runtime]System.Object
-		IL_023d: dup
-		IL_023e: ldc.i4.0
-		IL_023f: ldloc.0
-		IL_0240: stelem.ref
-		IL_0241: ldc.i4.0
-		IL_0242: ldelem.ref
-		IL_0243: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0248: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_024e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0253: ldc.i4.0
-		IL_0254: conv.r8
-		IL_0255: ldstr ""
-		IL_025a: ldc.i4.0
-		IL_025b: ldc.i4.1
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0261: stloc.s 4
-		IL_0263: ldc.i4.1
-		IL_0264: newarr [System.Runtime]System.Object
-		IL_0269: dup
-		IL_026a: ldc.i4.0
-		IL_026b: ldloc.0
-		IL_026c: stelem.ref
-		IL_026d: ldc.i4.0
-		IL_026e: ldelem.ref
-		IL_026f: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0274: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_027f: ldnull
-		IL_0280: ldstr "delete"
-		IL_0285: ldloc.s 4
-		IL_0287: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_028c: pop
-		IL_028d: ldc.i4.1
-		IL_028e: newarr [System.Runtime]System.Object
-		IL_0293: dup
-		IL_0294: ldc.i4.0
-		IL_0295: ldloc.0
-		IL_0296: stelem.ref
-		IL_0297: ldc.i4.0
-		IL_0298: ldelem.ref
-		IL_0299: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_029e: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_02a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02a9: ldc.i4.0
-		IL_02aa: conv.r8
-		IL_02ab: ldstr ""
-		IL_02b0: ldc.i4.0
-		IL_02b1: ldc.i4.1
-		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02b7: stloc.s 4
-		IL_02b9: ldc.i4.1
-		IL_02ba: newarr [System.Runtime]System.Object
-		IL_02bf: dup
-		IL_02c0: ldc.i4.0
-		IL_02c1: ldloc.0
-		IL_02c2: stelem.ref
-		IL_02c3: ldc.i4.0
-		IL_02c4: ldelem.ref
-		IL_02c5: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02ca: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_02d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_02d5: ldnull
-		IL_02d6: ldstr "keys"
-		IL_02db: ldloc.s 4
-		IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_02e2: pop
-		IL_02e3: ldc.i4.1
-		IL_02e4: newarr [System.Runtime]System.Object
-		IL_02e9: dup
-		IL_02ea: ldc.i4.0
-		IL_02eb: ldloc.0
-		IL_02ec: stelem.ref
-		IL_02ed: ldc.i4.0
-		IL_02ee: ldelem.ref
-		IL_02ef: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02f4: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_02fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02ff: ldc.i4.0
-		IL_0300: conv.r8
-		IL_0301: ldstr ""
-		IL_0306: ldc.i4.0
-		IL_0307: ldc.i4.1
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_030d: stloc.s 4
-		IL_030f: ldc.i4.1
-		IL_0310: newarr [System.Runtime]System.Object
-		IL_0315: dup
-		IL_0316: ldc.i4.0
-		IL_0317: ldloc.0
-		IL_0318: stelem.ref
-		IL_0319: ldc.i4.0
-		IL_031a: ldelem.ref
-		IL_031b: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0320: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0326: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_032b: ldnull
-		IL_032c: ldstr "getPrototypeOf"
-		IL_0331: ldloc.s 4
-		IL_0333: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0338: pop
-		IL_0339: ldc.i4.1
-		IL_033a: newarr [System.Runtime]System.Object
-		IL_033f: dup
-		IL_0340: ldc.i4.0
-		IL_0341: ldloc.0
-		IL_0342: stelem.ref
-		IL_0343: ldc.i4.0
-		IL_0344: ldelem.ref
-		IL_0345: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_034a: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0350: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0355: ldc.i4.0
-		IL_0356: conv.r8
-		IL_0357: ldstr ""
-		IL_035c: ldc.i4.0
-		IL_035d: ldc.i4.1
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0363: stloc.s 4
+		IL_0161: ldloc.0
+		IL_0162: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0167: ldnull
+		IL_0168: ldstr "get"
+		IL_016d: ldloc.s 4
+		IL_016f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_0174: pop
+		IL_0175: ldc.i4.1
+		IL_0176: newarr [System.Runtime]System.Object
+		IL_017b: dup
+		IL_017c: ldc.i4.0
+		IL_017d: ldloc.0
+		IL_017e: stelem.ref
+		IL_017f: ldc.i4.0
+		IL_0180: ldelem.ref
+		IL_0181: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0186: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_018c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0191: ldc.i4.0
+		IL_0192: conv.r8
+		IL_0193: ldstr ""
+		IL_0198: ldc.i4.0
+		IL_0199: ldc.i4.1
+		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_019f: stloc.s 4
+		IL_01a1: ldloc.0
+		IL_01a2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_01a7: ldnull
+		IL_01a8: ldstr "set"
+		IL_01ad: ldloc.s 4
+		IL_01af: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_01b4: pop
+		IL_01b5: ldc.i4.1
+		IL_01b6: newarr [System.Runtime]System.Object
+		IL_01bb: dup
+		IL_01bc: ldc.i4.0
+		IL_01bd: ldloc.0
+		IL_01be: stelem.ref
+		IL_01bf: ldc.i4.0
+		IL_01c0: ldelem.ref
+		IL_01c1: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_01c6: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_01cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01d1: ldc.i4.0
+		IL_01d2: conv.r8
+		IL_01d3: ldstr ""
+		IL_01d8: ldc.i4.0
+		IL_01d9: ldc.i4.1
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01df: stloc.s 4
+		IL_01e1: ldloc.0
+		IL_01e2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_01e7: ldnull
+		IL_01e8: ldstr "has"
+		IL_01ed: ldloc.s 4
+		IL_01ef: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_01f4: pop
+		IL_01f5: ldc.i4.1
+		IL_01f6: newarr [System.Runtime]System.Object
+		IL_01fb: dup
+		IL_01fc: ldc.i4.0
+		IL_01fd: ldloc.0
+		IL_01fe: stelem.ref
+		IL_01ff: ldc.i4.0
+		IL_0200: ldelem.ref
+		IL_0201: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0206: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_020c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0211: ldc.i4.0
+		IL_0212: conv.r8
+		IL_0213: ldstr ""
+		IL_0218: ldc.i4.0
+		IL_0219: ldc.i4.1
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_021f: stloc.s 4
+		IL_0221: ldloc.0
+		IL_0222: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0227: ldnull
+		IL_0228: ldstr "delete"
+		IL_022d: ldloc.s 4
+		IL_022f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_0234: pop
+		IL_0235: ldc.i4.1
+		IL_0236: newarr [System.Runtime]System.Object
+		IL_023b: dup
+		IL_023c: ldc.i4.0
+		IL_023d: ldloc.0
+		IL_023e: stelem.ref
+		IL_023f: ldc.i4.0
+		IL_0240: ldelem.ref
+		IL_0241: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0246: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_024c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0251: ldc.i4.0
+		IL_0252: conv.r8
+		IL_0253: ldstr ""
+		IL_0258: ldc.i4.0
+		IL_0259: ldc.i4.1
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_025f: stloc.s 4
+		IL_0261: ldloc.0
+		IL_0262: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0267: ldnull
+		IL_0268: ldstr "keys"
+		IL_026d: ldloc.s 4
+		IL_026f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_0274: pop
+		IL_0275: ldc.i4.1
+		IL_0276: newarr [System.Runtime]System.Object
+		IL_027b: dup
+		IL_027c: ldc.i4.0
+		IL_027d: ldloc.0
+		IL_027e: stelem.ref
+		IL_027f: ldc.i4.0
+		IL_0280: ldelem.ref
+		IL_0281: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0286: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_028c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0291: ldc.i4.0
+		IL_0292: conv.r8
+		IL_0293: ldstr ""
+		IL_0298: ldc.i4.0
+		IL_0299: ldc.i4.1
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_029f: stloc.s 4
+		IL_02a1: ldloc.0
+		IL_02a2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02a7: ldnull
+		IL_02a8: ldstr "getPrototypeOf"
+		IL_02ad: ldloc.s 4
+		IL_02af: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_02b4: pop
+		IL_02b5: ldc.i4.1
+		IL_02b6: newarr [System.Runtime]System.Object
+		IL_02bb: dup
+		IL_02bc: ldc.i4.0
+		IL_02bd: ldloc.0
+		IL_02be: stelem.ref
+		IL_02bf: ldc.i4.0
+		IL_02c0: ldelem.ref
+		IL_02c1: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02c6: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_02cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02d1: ldc.i4.0
+		IL_02d2: conv.r8
+		IL_02d3: ldstr ""
+		IL_02d8: ldc.i4.0
+		IL_02d9: ldc.i4.1
+		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02df: stloc.s 4
+		IL_02e1: ldloc.0
+		IL_02e2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02e7: ldnull
+		IL_02e8: ldstr "setPrototypeOf"
+		IL_02ed: ldloc.s 4
+		IL_02ef: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_02f4: pop
+		IL_02f5: ldnull
+		IL_02f6: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
+		IL_02fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0301: ldc.i4.1
+		IL_0302: conv.r8
+		IL_0303: ldstr ""
+		IL_0308: ldc.i4.0
+		IL_0309: ldc.i4.1
+		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_030f: stloc.s 4
+		IL_0311: ldloc.s 4
+		IL_0313: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
+		IL_031d: stloc.s 4
+		IL_031f: ldloc.0
+		IL_0320: ldloc.s 4
+		IL_0322: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_0327: ldloc.0
+		IL_0328: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0332: stloc.s 4
+		IL_0334: ldloc.s 4
+		IL_0336: ldstr "revoke"
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0340: pop
+		IL_0341: ldc.i4.1
+		IL_0342: newarr [System.Runtime]System.Object
+		IL_0347: dup
+		IL_0348: ldc.i4.0
+		IL_0349: ldloc.0
+		IL_034a: stelem.ref
+		IL_034b: ldc.i4.0
+		IL_034c: ldelem.ref
+		IL_034d: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0352: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0358: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_035d: ldc.i4.0
+		IL_035e: conv.r8
+		IL_035f: ldstr ""
+		IL_0364: ldc.i4.0
 		IL_0365: ldc.i4.1
-		IL_0366: newarr [System.Runtime]System.Object
-		IL_036b: dup
-		IL_036c: ldc.i4.0
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_036b: stloc.s 4
 		IL_036d: ldloc.0
-		IL_036e: stelem.ref
-		IL_036f: ldc.i4.0
-		IL_0370: ldelem.ref
-		IL_0371: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0376: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_037c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
+		IL_036e: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0373: ldnull
+		IL_0374: ldstr "call"
+		IL_0379: ldloc.s 4
+		IL_037b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_0380: pop
 		IL_0381: ldnull
-		IL_0382: ldstr "setPrototypeOf"
-		IL_0387: ldloc.s 4
-		IL_0389: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_038e: pop
-		IL_038f: ldnull
-		IL_0390: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
-		IL_0396: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_039b: ldc.i4.1
-		IL_039c: conv.r8
-		IL_039d: ldstr ""
-		IL_03a2: ldc.i4.0
-		IL_03a3: ldc.i4.1
-		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0382: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
+		IL_0388: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_038d: ldc.i4.1
+		IL_038e: conv.r8
+		IL_038f: ldstr "C"
+		IL_0394: ldc.i4.1
+		IL_0395: ldc.i4.1
+		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_039b: stloc.s 4
+		IL_039d: ldloc.s 4
+		IL_039f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
 		IL_03a9: stloc.s 4
-		IL_03ab: ldloc.s 4
-		IL_03ad: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03b2: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_03b7: stloc.s 4
-		IL_03b9: ldloc.0
-		IL_03ba: ldloc.s 4
-		IL_03bc: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_03c1: ldloc.0
-		IL_03c2: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03cc: stloc.s 4
-		IL_03ce: ldloc.s 4
-		IL_03d0: ldstr "revoke"
-		IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_03da: pop
-		IL_03db: ldc.i4.1
-		IL_03dc: newarr [System.Runtime]System.Object
-		IL_03e1: dup
-		IL_03e2: ldc.i4.0
-		IL_03e3: ldloc.0
-		IL_03e4: stelem.ref
-		IL_03e5: ldc.i4.0
-		IL_03e6: ldelem.ref
-		IL_03e7: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_03ec: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_03f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_03f7: ldc.i4.0
-		IL_03f8: conv.r8
-		IL_03f9: ldstr ""
-		IL_03fe: ldc.i4.0
-		IL_03ff: ldc.i4.1
-		IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0405: stloc.s 4
-		IL_0407: ldc.i4.1
-		IL_0408: newarr [System.Runtime]System.Object
-		IL_040d: dup
-		IL_040e: ldc.i4.0
-		IL_040f: ldloc.0
-		IL_0410: stelem.ref
-		IL_0411: ldc.i4.0
-		IL_0412: ldelem.ref
-		IL_0413: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0418: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_041e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0423: ldnull
-		IL_0424: ldstr "call"
-		IL_0429: ldloc.s 4
-		IL_042b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0430: pop
-		IL_0431: ldnull
-		IL_0432: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
-		IL_0438: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_043d: ldc.i4.1
-		IL_043e: conv.r8
-		IL_043f: ldstr "C"
-		IL_0444: ldc.i4.1
-		IL_0445: ldc.i4.1
-		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_044b: stloc.s 4
-		IL_044d: ldloc.s 4
-		IL_044f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_0459: stloc.s 4
-		IL_045b: ldloc.0
-		IL_045c: ldloc.s 4
-		IL_045e: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_0463: ldloc.0
-		IL_0464: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046e: stloc.s 4
-		IL_0470: ldloc.s 4
-		IL_0472: ldstr "revoke"
-		IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_047c: pop
-		IL_047d: ldc.i4.1
-		IL_047e: newarr [System.Runtime]System.Object
-		IL_0483: dup
-		IL_0484: ldc.i4.0
-		IL_0485: ldloc.0
-		IL_0486: stelem.ref
-		IL_0487: ldc.i4.0
-		IL_0488: ldelem.ref
-		IL_0489: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_048e: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0494: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0499: ldc.i4.0
-		IL_049a: conv.r8
-		IL_049b: ldstr ""
-		IL_04a0: ldc.i4.0
-		IL_04a1: ldc.i4.1
-		IL_04a2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04a7: stloc.s 4
-		IL_04a9: ldc.i4.1
-		IL_04aa: newarr [System.Runtime]System.Object
-		IL_04af: dup
-		IL_04b0: ldc.i4.0
-		IL_04b1: ldloc.0
-		IL_04b2: stelem.ref
-		IL_04b3: ldc.i4.0
-		IL_04b4: ldelem.ref
-		IL_04b5: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_04ba: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_04c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_04c5: ldnull
-		IL_04c6: ldstr "construct"
-		IL_04cb: ldloc.s 4
-		IL_04cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_04d2: pop
-		IL_04d3: ret
+		IL_03ab: ldloc.0
+		IL_03ac: ldloc.s 4
+		IL_03ae: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_03b3: ldloc.0
+		IL_03b4: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03be: stloc.s 4
+		IL_03c0: ldloc.s 4
+		IL_03c2: ldstr "revoke"
+		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_03cc: pop
+		IL_03cd: ldc.i4.1
+		IL_03ce: newarr [System.Runtime]System.Object
+		IL_03d3: dup
+		IL_03d4: ldc.i4.0
+		IL_03d5: ldloc.0
+		IL_03d6: stelem.ref
+		IL_03d7: ldc.i4.0
+		IL_03d8: ldelem.ref
+		IL_03d9: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_03de: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_03e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_03e9: ldc.i4.0
+		IL_03ea: conv.r8
+		IL_03eb: ldstr ""
+		IL_03f0: ldc.i4.0
+		IL_03f1: ldc.i4.1
+		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03f7: stloc.s 4
+		IL_03f9: ldloc.0
+		IL_03fa: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_03ff: ldnull
+		IL_0400: ldstr "construct"
+		IL_0405: ldloc.s 4
+		IL_0407: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
+		IL_040c: pop
+		IL_040d: ret
 	} // end of method Proxy_Revocable_ThrowsAfterRevoke::__js_module_init__
 
 } // end of class Modules.Proxy_Revocable_ThrowsAfterRevoke
@@ -1479,7 +1398,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x28a6
+		// Method begins at RVA 0x27e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Proxy_Validation_EdgeCases
+﻿// IL code: Proxy_Validation_EdgeCases
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a90
+					// Method begins at RVA 0x29b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a99
+					// Method begins at RVA 0x29bd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a87
+				// Method begins at RVA 0x29ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2714
+			// Method begins at RVA 0x2638
 			// Header size: 12
 			// Code size: 181 (0xb5)
 			.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aa2
+				// Method begins at RVA 0x29c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27e8
+			// Method begins at RVA 0x270c
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -251,7 +251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aab
+				// Method begins at RVA 0x29cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2810
+			// Method begins at RVA 0x2734
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -307,7 +307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab4
+				// Method begins at RVA 0x29d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -330,7 +330,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x283c
+			// Method begins at RVA 0x2760
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -360,7 +360,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2abd
+				// Method begins at RVA 0x29e1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -383,7 +383,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2864
+			// Method begins at RVA 0x2788
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -416,7 +416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac6
+				// Method begins at RVA 0x29ea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -439,7 +439,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x288d
+			// Method begins at RVA 0x27b1
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -461,7 +461,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2acf
+				// Method begins at RVA 0x29f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -487,7 +487,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2894
+			// Method begins at RVA 0x27b8
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -522,7 +522,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad8
+				// Method begins at RVA 0x29fc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -548,7 +548,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28b8
+			// Method begins at RVA 0x27dc
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -574,7 +574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae1
+				// Method begins at RVA 0x2a05
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -600,7 +600,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28cc
+			// Method begins at RVA 0x27f0
 			// Header size: 12
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -638,7 +638,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aea
+				// Method begins at RVA 0x2a0e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28ec
+			// Method begins at RVA 0x2810
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -691,7 +691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af3
+				// Method begins at RVA 0x2a17
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -714,7 +714,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2902
+			// Method begins at RVA 0x2826
 			// Header size: 1
 			// Code size: 15 (0xf)
 			.maxstack 8
@@ -737,7 +737,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2afc
+				// Method begins at RVA 0x2a20
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2914
+			// Method begins at RVA 0x2838
 			// Header size: 12
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -794,7 +794,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b05
+				// Method begins at RVA 0x2a29
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -817,7 +817,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2934
+			// Method begins at RVA 0x2858
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -840,7 +840,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b0e
+				// Method begins at RVA 0x2a32
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -863,7 +863,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x293c
+			// Method begins at RVA 0x2860
 			// Header size: 1
 			// Code size: 15 (0xf)
 			.maxstack 8
@@ -886,7 +886,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b17
+				// Method begins at RVA 0x2a3b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -912,7 +912,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x294c
+			// Method begins at RVA 0x2870
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -941,7 +941,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b20
+				// Method begins at RVA 0x2a44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -967,7 +967,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2966
+			// Method begins at RVA 0x288a
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -1001,7 +1001,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b29
+				// Method begins at RVA 0x2a4d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1027,7 +1027,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x29a4
+			// Method begins at RVA 0x28c8
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -1070,7 +1070,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b32
+				// Method begins at RVA 0x2a56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1093,7 +1093,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29f3
+			// Method begins at RVA 0x2917
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1115,7 +1115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b3b
+				// Method begins at RVA 0x2a5f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1141,7 +1141,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x29fc
+			// Method begins at RVA 0x2920
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1178,7 +1178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b44
+				// Method begins at RVA 0x2a68
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1201,7 +1201,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a2e
+			// Method begins at RVA 0x2952
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -1228,7 +1228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b4d
+				// Method begins at RVA 0x2a71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1254,7 +1254,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2a4c
+			// Method begins at RVA 0x2970
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1314,7 +1314,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a7e
+			// Method begins at RVA 0x29a2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1340,7 +1340,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1720 (0x6b8)
+		// Code size: 1500 (0x5dc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Validation_EdgeCases/Scope,
@@ -1390,336 +1390,331 @@
 		IL_004e: ldc.i4.1
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0054: stloc.s 5
-		IL_0056: ldc.i4.1
-		IL_0057: newarr [System.Runtime]System.Object
-		IL_005c: dup
-		IL_005d: ldc.i4.0
-		IL_005e: ldloc.0
-		IL_005f: stelem.ref
-		IL_0060: ldc.i4.0
-		IL_0061: ldelem.ref
-		IL_0062: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0067: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0072: ldnull
-		IL_0073: ldstr "proxy-target"
-		IL_0078: ldloc.s 5
-		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_007f: pop
-		IL_0080: ldnull
-		IL_0081: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
-		IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_008c: ldc.i4.0
-		IL_008d: conv.r8
-		IL_008e: ldstr ""
-		IL_0093: ldc.i4.0
-		IL_0094: ldc.i4.1
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_009a: stloc.s 5
-		IL_009c: ldc.i4.1
-		IL_009d: newarr [System.Runtime]System.Object
-		IL_00a2: dup
-		IL_00a3: ldc.i4.0
-		IL_00a4: ldloc.0
-		IL_00a5: stelem.ref
+		IL_0056: ldloc.0
+		IL_0057: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_005c: ldnull
+		IL_005d: ldstr "proxy-target"
+		IL_0062: ldloc.s 5
+		IL_0064: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_0069: pop
+		IL_006a: ldnull
+		IL_006b: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
+		IL_0071: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0076: ldc.i4.0
+		IL_0077: conv.r8
+		IL_0078: ldstr ""
+		IL_007d: ldc.i4.0
+		IL_007e: ldc.i4.1
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0084: stloc.s 5
+		IL_0086: ldloc.0
+		IL_0087: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_008c: ldnull
+		IL_008d: ldstr "proxy-handler"
+		IL_0092: ldloc.s 5
+		IL_0094: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_0099: pop
+		IL_009a: ldnull
+		IL_009b: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
+		IL_00a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_00a6: ldc.i4.0
-		IL_00a7: ldelem.ref
-		IL_00a8: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_00ad: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_00b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00b8: ldnull
-		IL_00b9: ldstr "proxy-handler"
-		IL_00be: ldloc.s 5
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_00c5: pop
-		IL_00c6: ldnull
-		IL_00c7: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
-		IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00d2: ldc.i4.0
-		IL_00d3: conv.r8
-		IL_00d4: ldstr ""
-		IL_00d9: ldc.i4.0
-		IL_00da: ldc.i4.1
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00e0: stloc.s 5
-		IL_00e2: ldc.i4.1
-		IL_00e3: newarr [System.Runtime]System.Object
-		IL_00e8: dup
-		IL_00e9: ldc.i4.0
-		IL_00ea: ldloc.0
-		IL_00eb: stelem.ref
-		IL_00ec: ldc.i4.0
-		IL_00ed: ldelem.ref
-		IL_00ee: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_00f3: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00fe: ldnull
-		IL_00ff: ldstr "revocable-target"
-		IL_0104: ldloc.s 5
-		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_010b: pop
-		IL_010c: ldnull
-		IL_010d: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
-		IL_0113: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0118: ldc.i4.0
-		IL_0119: conv.r8
-		IL_011a: ldstr ""
-		IL_011f: ldc.i4.0
-		IL_0120: ldc.i4.1
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0126: stloc.s 5
-		IL_0128: ldc.i4.1
-		IL_0129: newarr [System.Runtime]System.Object
-		IL_012e: dup
-		IL_012f: ldc.i4.0
-		IL_0130: ldloc.0
-		IL_0131: stelem.ref
-		IL_0132: ldc.i4.0
-		IL_0133: ldelem.ref
-		IL_0134: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0139: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0144: ldnull
-		IL_0145: ldstr "revocable-handler"
-		IL_014a: ldloc.s 5
-		IL_014c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0151: pop
-		IL_0152: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0157: stloc.s 6
-		IL_0159: ldnull
-		IL_015a: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
-		IL_0160: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0165: ldc.i4.0
-		IL_0166: conv.r8
-		IL_0167: ldstr ""
-		IL_016c: ldc.i4.0
-		IL_016d: ldc.i4.1
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0173: stloc.s 5
-		IL_0175: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_017a: dup
-		IL_017b: ldstr "apply"
-		IL_0180: ldloc.s 5
-		IL_0182: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0187: stloc.s 7
-		IL_0189: ldloc.s 6
-		IL_018b: ldloc.s 7
-		IL_018d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0192: stloc.s 8
-		IL_0194: ldloc.0
-		IL_0195: ldloc.s 8
-		IL_0197: stfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
-		IL_019c: ldc.i4.1
-		IL_019d: newarr [System.Runtime]System.Object
-		IL_01a2: dup
-		IL_01a3: ldc.i4.0
-		IL_01a4: ldloc.0
-		IL_01a5: stelem.ref
-		IL_01a6: ldc.i4.0
-		IL_01a7: ldelem.ref
-		IL_01a8: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_01ad: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_01b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01b8: ldc.i4.0
-		IL_01b9: conv.r8
-		IL_01ba: ldstr ""
-		IL_01bf: ldc.i4.0
-		IL_01c0: ldc.i4.1
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01c6: stloc.s 5
-		IL_01c8: ldc.i4.1
-		IL_01c9: newarr [System.Runtime]System.Object
-		IL_01ce: dup
-		IL_01cf: ldc.i4.0
-		IL_01d0: ldloc.0
-		IL_01d1: stelem.ref
-		IL_01d2: ldc.i4.0
-		IL_01d3: ldelem.ref
-		IL_01d4: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_01d9: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_01df: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_01e4: ldnull
-		IL_01e5: ldstr "apply-noncallable"
-		IL_01ea: ldloc.s 5
-		IL_01ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_01f1: pop
-		IL_01f2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01f7: stloc.s 7
-		IL_01f9: ldc.i4.1
-		IL_01fa: newarr [System.Runtime]System.Object
-		IL_01ff: dup
-		IL_0200: ldc.i4.0
-		IL_0201: ldloc.0
-		IL_0202: stelem.ref
-		IL_0203: ldc.i4.0
-		IL_0204: ldelem.ref
-		IL_0205: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_020a: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0210: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0215: ldc.i4.0
-		IL_0216: conv.r8
-		IL_0217: ldstr ""
-		IL_021c: ldc.i4.0
-		IL_021d: ldc.i4.1
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0223: stloc.s 5
-		IL_0225: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_022a: dup
-		IL_022b: ldstr "construct"
-		IL_0230: ldloc.s 5
-		IL_0232: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0237: stloc.s 6
-		IL_0239: ldloc.s 7
-		IL_023b: ldloc.s 6
-		IL_023d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0242: stloc.s 8
-		IL_0244: ldloc.0
-		IL_0245: ldloc.s 8
-		IL_0247: stfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
-		IL_024c: ldc.i4.1
-		IL_024d: newarr [System.Runtime]System.Object
-		IL_0252: dup
-		IL_0253: ldc.i4.0
-		IL_0254: ldloc.0
-		IL_0255: stelem.ref
-		IL_0256: ldc.i4.0
-		IL_0257: ldelem.ref
-		IL_0258: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_025d: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0268: ldc.i4.0
-		IL_0269: conv.r8
-		IL_026a: ldstr ""
-		IL_026f: ldc.i4.0
-		IL_0270: ldc.i4.1
-		IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0276: stloc.s 5
-		IL_0278: ldc.i4.1
-		IL_0279: newarr [System.Runtime]System.Object
-		IL_027e: dup
-		IL_027f: ldc.i4.0
-		IL_0280: ldloc.0
-		IL_0281: stelem.ref
-		IL_0282: ldc.i4.0
-		IL_0283: ldelem.ref
-		IL_0284: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0289: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_028f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0294: ldnull
-		IL_0295: ldstr "construct-nonconstructible"
-		IL_029a: ldloc.s 5
-		IL_029c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_02a1: pop
-		IL_02a2: ldnull
-		IL_02a3: ldftn object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
-		IL_02a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02ae: ldc.i4.0
-		IL_02af: conv.r8
-		IL_02b0: ldstr "Base"
-		IL_02b5: ldc.i4.1
-		IL_02b6: ldc.i4.1
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02bc: stloc.s 5
-		IL_02be: ldnull
-		IL_02bf: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
-		IL_02c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02ca: ldc.i4.0
-		IL_02cb: conv.r8
-		IL_02cc: ldstr ""
-		IL_02d1: ldc.i4.0
-		IL_02d2: ldc.i4.1
-		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02d8: stloc.s 9
-		IL_02da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02df: dup
-		IL_02e0: ldstr "construct"
-		IL_02e5: ldloc.s 9
-		IL_02e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02ec: stloc.s 6
-		IL_02ee: ldloc.s 5
-		IL_02f0: ldloc.s 6
-		IL_02f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_02f7: stloc.s 8
-		IL_02f9: ldloc.0
-		IL_02fa: ldloc.s 8
-		IL_02fc: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
-		IL_0301: ldc.i4.1
-		IL_0302: newarr [System.Runtime]System.Object
-		IL_0307: dup
-		IL_0308: ldc.i4.0
-		IL_0309: ldloc.0
-		IL_030a: stelem.ref
-		IL_030b: ldc.i4.0
-		IL_030c: ldelem.ref
-		IL_030d: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0312: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0318: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_031d: ldc.i4.0
-		IL_031e: conv.r8
-		IL_031f: ldstr ""
-		IL_0324: ldc.i4.0
-		IL_0325: ldc.i4.1
-		IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_032b: stloc.s 5
-		IL_032d: ldc.i4.1
-		IL_032e: newarr [System.Runtime]System.Object
-		IL_0333: dup
-		IL_0334: ldc.i4.0
-		IL_0335: ldloc.0
-		IL_0336: stelem.ref
-		IL_0337: ldc.i4.0
-		IL_0338: ldelem.ref
-		IL_0339: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_033e: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0344: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0349: ldnull
-		IL_034a: ldstr "construct-primitive-result"
-		IL_034f: ldloc.s 5
-		IL_0351: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0356: pop
-		IL_0357: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_035c: stloc.s 6
-		IL_035e: ldnull
-		IL_035f: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
-		IL_0365: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_036a: ldc.i4.0
-		IL_036b: conv.r8
-		IL_036c: ldstr ""
-		IL_0371: ldc.i4.0
-		IL_0372: ldc.i4.1
-		IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0378: stloc.s 5
-		IL_037a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00a7: conv.r8
+		IL_00a8: ldstr ""
+		IL_00ad: ldc.i4.0
+		IL_00ae: ldc.i4.1
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00b4: stloc.s 5
+		IL_00b6: ldloc.0
+		IL_00b7: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_00bc: ldnull
+		IL_00bd: ldstr "revocable-target"
+		IL_00c2: ldloc.s 5
+		IL_00c4: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_00c9: pop
+		IL_00ca: ldnull
+		IL_00cb: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
+		IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00d6: ldc.i4.0
+		IL_00d7: conv.r8
+		IL_00d8: ldstr ""
+		IL_00dd: ldc.i4.0
+		IL_00de: ldc.i4.1
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00e4: stloc.s 5
+		IL_00e6: ldloc.0
+		IL_00e7: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_00ec: ldnull
+		IL_00ed: ldstr "revocable-handler"
+		IL_00f2: ldloc.s 5
+		IL_00f4: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_00f9: pop
+		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00ff: stloc.s 6
+		IL_0101: ldnull
+		IL_0102: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
+		IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_010d: ldc.i4.0
+		IL_010e: conv.r8
+		IL_010f: ldstr ""
+		IL_0114: ldc.i4.0
+		IL_0115: ldc.i4.1
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_011b: stloc.s 5
+		IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0122: dup
+		IL_0123: ldstr "apply"
+		IL_0128: ldloc.s 5
+		IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_012f: stloc.s 7
+		IL_0131: ldloc.s 6
+		IL_0133: ldloc.s 7
+		IL_0135: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_013a: stloc.s 8
+		IL_013c: ldloc.0
+		IL_013d: ldloc.s 8
+		IL_013f: stfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
+		IL_0144: ldc.i4.1
+		IL_0145: newarr [System.Runtime]System.Object
+		IL_014a: dup
+		IL_014b: ldc.i4.0
+		IL_014c: ldloc.0
+		IL_014d: stelem.ref
+		IL_014e: ldc.i4.0
+		IL_014f: ldelem.ref
+		IL_0150: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0155: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_015b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0160: ldc.i4.0
+		IL_0161: conv.r8
+		IL_0162: ldstr ""
+		IL_0167: ldc.i4.0
+		IL_0168: ldc.i4.1
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_016e: stloc.s 5
+		IL_0170: ldloc.0
+		IL_0171: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0176: ldnull
+		IL_0177: ldstr "apply-noncallable"
+		IL_017c: ldloc.s 5
+		IL_017e: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_0183: pop
+		IL_0184: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0189: stloc.s 7
+		IL_018b: ldc.i4.1
+		IL_018c: newarr [System.Runtime]System.Object
+		IL_0191: dup
+		IL_0192: ldc.i4.0
+		IL_0193: ldloc.0
+		IL_0194: stelem.ref
+		IL_0195: ldc.i4.0
+		IL_0196: ldelem.ref
+		IL_0197: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_019c: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_01a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01a7: ldc.i4.0
+		IL_01a8: conv.r8
+		IL_01a9: ldstr ""
+		IL_01ae: ldc.i4.0
+		IL_01af: ldc.i4.1
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01b5: stloc.s 5
+		IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01bc: dup
+		IL_01bd: ldstr "construct"
+		IL_01c2: ldloc.s 5
+		IL_01c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01c9: stloc.s 6
+		IL_01cb: ldloc.s 7
+		IL_01cd: ldloc.s 6
+		IL_01cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_01d4: stloc.s 8
+		IL_01d6: ldloc.0
+		IL_01d7: ldloc.s 8
+		IL_01d9: stfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
+		IL_01de: ldc.i4.1
+		IL_01df: newarr [System.Runtime]System.Object
+		IL_01e4: dup
+		IL_01e5: ldc.i4.0
+		IL_01e6: ldloc.0
+		IL_01e7: stelem.ref
+		IL_01e8: ldc.i4.0
+		IL_01e9: ldelem.ref
+		IL_01ea: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_01ef: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_01f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01fa: ldc.i4.0
+		IL_01fb: conv.r8
+		IL_01fc: ldstr ""
+		IL_0201: ldc.i4.0
+		IL_0202: ldc.i4.1
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0208: stloc.s 5
+		IL_020a: ldloc.0
+		IL_020b: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0210: ldnull
+		IL_0211: ldstr "construct-nonconstructible"
+		IL_0216: ldloc.s 5
+		IL_0218: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_021d: pop
+		IL_021e: ldnull
+		IL_021f: ldftn object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
+		IL_0225: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_022a: ldc.i4.0
+		IL_022b: conv.r8
+		IL_022c: ldstr "Base"
+		IL_0231: ldc.i4.1
+		IL_0232: ldc.i4.1
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0238: stloc.s 5
+		IL_023a: ldnull
+		IL_023b: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
+		IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0246: ldc.i4.0
+		IL_0247: conv.r8
+		IL_0248: ldstr ""
+		IL_024d: ldc.i4.0
+		IL_024e: ldc.i4.1
+		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0254: stloc.s 9
+		IL_0256: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_025b: dup
+		IL_025c: ldstr "construct"
+		IL_0261: ldloc.s 9
+		IL_0263: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0268: stloc.s 6
+		IL_026a: ldloc.s 5
+		IL_026c: ldloc.s 6
+		IL_026e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0273: stloc.s 8
+		IL_0275: ldloc.0
+		IL_0276: ldloc.s 8
+		IL_0278: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
+		IL_027d: ldc.i4.1
+		IL_027e: newarr [System.Runtime]System.Object
+		IL_0283: dup
+		IL_0284: ldc.i4.0
+		IL_0285: ldloc.0
+		IL_0286: stelem.ref
+		IL_0287: ldc.i4.0
+		IL_0288: ldelem.ref
+		IL_0289: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_028e: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_0294: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0299: ldc.i4.0
+		IL_029a: conv.r8
+		IL_029b: ldstr ""
+		IL_02a0: ldc.i4.0
+		IL_02a1: ldc.i4.1
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02a7: stloc.s 5
+		IL_02a9: ldloc.0
+		IL_02aa: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_02af: ldnull
+		IL_02b0: ldstr "construct-primitive-result"
+		IL_02b5: ldloc.s 5
+		IL_02b7: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_02bc: pop
+		IL_02bd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02c2: stloc.s 6
+		IL_02c4: ldnull
+		IL_02c5: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
+		IL_02cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02d0: ldc.i4.0
+		IL_02d1: conv.r8
+		IL_02d2: ldstr ""
+		IL_02d7: ldc.i4.0
+		IL_02d8: ldc.i4.1
+		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02de: stloc.s 5
+		IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02e5: dup
+		IL_02e6: ldstr "getPrototypeOf"
+		IL_02eb: ldloc.s 5
+		IL_02ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_02f2: stloc.s 7
+		IL_02f4: ldloc.s 6
+		IL_02f6: ldloc.s 7
+		IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_02fd: stloc.s 8
+		IL_02ff: ldloc.s 8
+		IL_0301: stloc.2
+		IL_0302: ldloc.2
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_0308: stloc.s 5
+		IL_030a: ldloc.s 5
+		IL_030c: ldc.i4.0
+		IL_030d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0312: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0317: stloc.s 10
+		IL_0319: ldloc.s 10
+		IL_031b: box [System.Runtime]System.Boolean
+		IL_0320: stloc.s 11
+		IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0327: ldloc.s 11
+		IL_0329: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_032e: pop
+		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0334: stloc.s 7
+		IL_0336: ldnull
+		IL_0337: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
+		IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0342: ldc.i4.0
+		IL_0343: conv.r8
+		IL_0344: ldstr ""
+		IL_0349: ldc.i4.0
+		IL_034a: ldc.i4.1
+		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0350: stloc.s 5
+		IL_0352: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0357: dup
+		IL_0358: ldstr "getPrototypeOf"
+		IL_035d: ldloc.s 5
+		IL_035f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0364: stloc.s 6
+		IL_0366: ldloc.s 7
+		IL_0368: ldloc.s 6
+		IL_036a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_036f: stloc.s 8
+		IL_0371: ldloc.0
+		IL_0372: ldloc.s 8
+		IL_0374: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
+		IL_0379: ldc.i4.1
+		IL_037a: newarr [System.Runtime]System.Object
 		IL_037f: dup
-		IL_0380: ldstr "getPrototypeOf"
-		IL_0385: ldloc.s 5
-		IL_0387: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_038c: stloc.s 7
-		IL_038e: ldloc.s 6
-		IL_0390: ldloc.s 7
-		IL_0392: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0397: stloc.s 8
-		IL_0399: ldloc.s 8
-		IL_039b: stloc.2
-		IL_039c: ldloc.2
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_03a2: stloc.s 5
-		IL_03a4: ldloc.s 5
-		IL_03a6: ldc.i4.0
-		IL_03a7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_03ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03b1: stloc.s 10
-		IL_03b3: ldloc.s 10
-		IL_03b5: box [System.Runtime]System.Boolean
-		IL_03ba: stloc.s 11
-		IL_03bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c1: ldloc.s 11
-		IL_03c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03c8: pop
-		IL_03c9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03ce: stloc.s 7
-		IL_03d0: ldnull
-		IL_03d1: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
+		IL_0380: ldc.i4.0
+		IL_0381: ldloc.0
+		IL_0382: stelem.ref
+		IL_0383: ldc.i4.0
+		IL_0384: ldelem.ref
+		IL_0385: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_038a: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0395: ldc.i4.0
+		IL_0396: conv.r8
+		IL_0397: ldstr ""
+		IL_039c: ldc.i4.0
+		IL_039d: ldc.i4.1
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03a3: stloc.s 5
+		IL_03a5: ldloc.0
+		IL_03a6: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_03ab: ldnull
+		IL_03ac: ldstr "getPrototypeOf-primitive"
+		IL_03b1: ldloc.s 5
+		IL_03b3: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_03b8: pop
+		IL_03b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03be: stloc.s 6
+		IL_03c0: ldc.i4.1
+		IL_03c1: newarr [System.Runtime]System.Object
+		IL_03c6: dup
+		IL_03c7: ldc.i4.0
+		IL_03c8: ldloc.0
+		IL_03c9: stelem.ref
+		IL_03ca: ldc.i4.0
+		IL_03cb: ldelem.ref
+		IL_03cc: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_03d1: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 		IL_03d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_03dc: ldc.i4.0
 		IL_03dd: conv.r8
@@ -1730,264 +1725,179 @@
 		IL_03ea: stloc.s 5
 		IL_03ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_03f1: dup
-		IL_03f2: ldstr "getPrototypeOf"
+		IL_03f2: ldstr "ownKeys"
 		IL_03f7: ldloc.s 5
 		IL_03f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03fe: stloc.s 6
-		IL_0400: ldloc.s 7
-		IL_0402: ldloc.s 6
+		IL_03fe: stloc.s 7
+		IL_0400: ldloc.s 6
+		IL_0402: ldloc.s 7
 		IL_0404: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
 		IL_0409: stloc.s 8
-		IL_040b: ldloc.0
-		IL_040c: ldloc.s 8
-		IL_040e: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
-		IL_0413: ldc.i4.1
-		IL_0414: newarr [System.Runtime]System.Object
-		IL_0419: dup
-		IL_041a: ldc.i4.0
-		IL_041b: ldloc.0
-		IL_041c: stelem.ref
-		IL_041d: ldc.i4.0
-		IL_041e: ldelem.ref
-		IL_041f: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0424: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_042a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_042f: ldc.i4.0
-		IL_0430: conv.r8
-		IL_0431: ldstr ""
-		IL_0436: ldc.i4.0
-		IL_0437: ldc.i4.1
-		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_043d: stloc.s 5
-		IL_043f: ldc.i4.1
-		IL_0440: newarr [System.Runtime]System.Object
-		IL_0445: dup
-		IL_0446: ldc.i4.0
-		IL_0447: ldloc.0
-		IL_0448: stelem.ref
-		IL_0449: ldc.i4.0
-		IL_044a: ldelem.ref
-		IL_044b: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0450: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0456: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_045b: ldnull
-		IL_045c: ldstr "getPrototypeOf-primitive"
-		IL_0461: ldloc.s 5
-		IL_0463: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0468: pop
-		IL_0469: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_046e: stloc.s 6
-		IL_0470: ldc.i4.1
-		IL_0471: newarr [System.Runtime]System.Object
-		IL_0476: dup
-		IL_0477: ldc.i4.0
-		IL_0478: ldloc.0
-		IL_0479: stelem.ref
-		IL_047a: ldc.i4.0
-		IL_047b: ldelem.ref
-		IL_047c: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0481: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0487: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_048c: ldc.i4.0
-		IL_048d: conv.r8
-		IL_048e: ldstr ""
-		IL_0493: ldc.i4.0
-		IL_0494: ldc.i4.1
-		IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_049a: stloc.s 5
-		IL_049c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04a1: dup
-		IL_04a2: ldstr "ownKeys"
+		IL_040b: ldloc.s 8
+		IL_040d: stloc.3
+		IL_040e: ldloc.3
+		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0414: stloc.s 5
+		IL_0416: ldloc.s 5
+		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_041d: stloc.s 5
+		IL_041f: ldloc.s 5
+		IL_0421: ldstr "join"
+		IL_0426: ldstr ","
+		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0430: stloc.s 5
+		IL_0432: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0437: ldloc.s 5
+		IL_0439: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_043e: pop
+		IL_043f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0444: stloc.s 7
+		IL_0446: ldc.i4.1
+		IL_0447: newarr [System.Runtime]System.Object
+		IL_044c: dup
+		IL_044d: ldc.i4.0
+		IL_044e: ldloc.0
+		IL_044f: stelem.ref
+		IL_0450: ldc.i4.0
+		IL_0451: ldelem.ref
+		IL_0452: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0457: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_045d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0462: ldc.i4.0
+		IL_0463: conv.r8
+		IL_0464: ldstr ""
+		IL_0469: ldc.i4.0
+		IL_046a: ldc.i4.1
+		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0470: stloc.s 5
+		IL_0472: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0477: dup
+		IL_0478: ldstr "ownKeys"
+		IL_047d: ldloc.s 5
+		IL_047f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0484: stloc.s 6
+		IL_0486: ldloc.s 7
+		IL_0488: ldloc.s 6
+		IL_048a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_048f: stloc.s 8
+		IL_0491: ldloc.s 8
+		IL_0493: stloc.s 4
+		IL_0495: ldloc.s 4
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_049c: stloc.s 5
+		IL_049e: ldloc.s 5
+		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a5: stloc.s 5
 		IL_04a7: ldloc.s 5
-		IL_04a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04ae: stloc.s 7
-		IL_04b0: ldloc.s 6
-		IL_04b2: ldloc.s 7
-		IL_04b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_04b9: stloc.s 8
-		IL_04bb: ldloc.s 8
-		IL_04bd: stloc.3
-		IL_04be: ldloc.3
-		IL_04bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_04c4: stloc.s 5
-		IL_04c6: ldloc.s 5
-		IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04cd: stloc.s 5
-		IL_04cf: ldloc.s 5
-		IL_04d1: ldstr "join"
-		IL_04d6: ldstr ","
-		IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04e0: stloc.s 5
-		IL_04e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04e7: ldloc.s 5
-		IL_04e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04ee: pop
-		IL_04ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04f4: stloc.s 7
-		IL_04f6: ldc.i4.1
-		IL_04f7: newarr [System.Runtime]System.Object
-		IL_04fc: dup
-		IL_04fd: ldc.i4.0
-		IL_04fe: ldloc.0
-		IL_04ff: stelem.ref
-		IL_0500: ldc.i4.0
-		IL_0501: ldelem.ref
-		IL_0502: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0507: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_050d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0512: ldc.i4.0
-		IL_0513: conv.r8
-		IL_0514: ldstr ""
-		IL_0519: ldc.i4.0
-		IL_051a: ldc.i4.1
-		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0520: stloc.s 5
-		IL_0522: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0527: dup
-		IL_0528: ldstr "ownKeys"
-		IL_052d: ldloc.s 5
-		IL_052f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0534: stloc.s 6
-		IL_0536: ldloc.s 7
-		IL_0538: ldloc.s 6
-		IL_053a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_053f: stloc.s 8
-		IL_0541: ldloc.s 8
-		IL_0543: stloc.s 4
-		IL_0545: ldloc.s 4
-		IL_0547: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_054c: stloc.s 5
-		IL_054e: ldloc.s 5
-		IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0555: stloc.s 5
-		IL_0557: ldloc.s 5
-		IL_0559: ldstr "join"
-		IL_055e: ldstr ","
-		IL_0563: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0568: stloc.s 5
-		IL_056a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_056f: ldloc.s 5
-		IL_0571: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0576: pop
-		IL_0577: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_057c: stloc.s 6
-		IL_057e: ldnull
-		IL_057f: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
-		IL_0585: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_058a: ldc.i4.0
-		IL_058b: conv.r8
-		IL_058c: ldstr ""
-		IL_0591: ldc.i4.0
-		IL_0592: ldc.i4.1
-		IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0598: stloc.s 5
-		IL_059a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_059f: dup
-		IL_05a0: ldstr "ownKeys"
-		IL_05a5: ldloc.s 5
-		IL_05a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_05ac: stloc.s 7
-		IL_05ae: ldloc.s 6
-		IL_05b0: ldloc.s 7
-		IL_05b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_05b7: stloc.s 8
-		IL_05b9: ldloc.0
-		IL_05ba: ldloc.s 8
-		IL_05bc: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
-		IL_05c1: ldc.i4.1
-		IL_05c2: newarr [System.Runtime]System.Object
-		IL_05c7: dup
-		IL_05c8: ldc.i4.0
-		IL_05c9: ldloc.0
-		IL_05ca: stelem.ref
-		IL_05cb: ldc.i4.0
-		IL_05cc: ldelem.ref
-		IL_05cd: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_05d2: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_05d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_05dd: ldc.i4.0
-		IL_05de: conv.r8
-		IL_05df: ldstr ""
-		IL_05e4: ldc.i4.0
-		IL_05e5: ldc.i4.1
-		IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05eb: stloc.s 5
-		IL_05ed: ldc.i4.1
-		IL_05ee: newarr [System.Runtime]System.Object
-		IL_05f3: dup
-		IL_05f4: ldc.i4.0
-		IL_05f5: ldloc.0
-		IL_05f6: stelem.ref
-		IL_05f7: ldc.i4.0
-		IL_05f8: ldelem.ref
-		IL_05f9: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_05fe: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0604: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0609: ldnull
-		IL_060a: ldstr "ownKeys-primitive"
-		IL_060f: ldloc.s 5
-		IL_0611: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0616: pop
-		IL_0617: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_061c: stloc.s 7
-		IL_061e: ldnull
-		IL_061f: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
-		IL_0625: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_062a: ldc.i4.0
-		IL_062b: conv.r8
-		IL_062c: ldstr ""
-		IL_0631: ldc.i4.0
-		IL_0632: ldc.i4.1
-		IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0638: stloc.s 5
-		IL_063a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_063f: dup
-		IL_0640: ldstr "ownKeys"
-		IL_0645: ldloc.s 5
-		IL_0647: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_064c: stloc.s 6
-		IL_064e: ldloc.s 7
-		IL_0650: ldloc.s 6
-		IL_0652: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0657: stloc.s 8
-		IL_0659: ldloc.0
-		IL_065a: ldloc.s 8
-		IL_065c: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
-		IL_0661: ldc.i4.1
-		IL_0662: newarr [System.Runtime]System.Object
-		IL_0667: dup
-		IL_0668: ldc.i4.0
-		IL_0669: ldloc.0
-		IL_066a: stelem.ref
-		IL_066b: ldc.i4.0
-		IL_066c: ldelem.ref
-		IL_066d: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0672: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0678: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_067d: ldc.i4.0
-		IL_067e: conv.r8
-		IL_067f: ldstr ""
-		IL_0684: ldc.i4.0
-		IL_0685: ldc.i4.1
-		IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_068b: stloc.s 5
-		IL_068d: ldc.i4.1
-		IL_068e: newarr [System.Runtime]System.Object
-		IL_0693: dup
-		IL_0694: ldc.i4.0
-		IL_0695: ldloc.0
-		IL_0696: stelem.ref
-		IL_0697: ldc.i4.0
-		IL_0698: ldelem.ref
-		IL_0699: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_069e: ldftn object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_06a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_06a9: ldnull
-		IL_06aa: ldstr "ownKeys-entry"
-		IL_06af: ldloc.s 5
-		IL_06b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_06b6: pop
-		IL_06b7: ret
+		IL_04a9: ldstr "join"
+		IL_04ae: ldstr ","
+		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04b8: stloc.s 5
+		IL_04ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04bf: ldloc.s 5
+		IL_04c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04c6: pop
+		IL_04c7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04cc: stloc.s 6
+		IL_04ce: ldnull
+		IL_04cf: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
+		IL_04d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_04da: ldc.i4.0
+		IL_04db: conv.r8
+		IL_04dc: ldstr ""
+		IL_04e1: ldc.i4.0
+		IL_04e2: ldc.i4.1
+		IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04e8: stloc.s 5
+		IL_04ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04ef: dup
+		IL_04f0: ldstr "ownKeys"
+		IL_04f5: ldloc.s 5
+		IL_04f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_04fc: stloc.s 7
+		IL_04fe: ldloc.s 6
+		IL_0500: ldloc.s 7
+		IL_0502: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0507: stloc.s 8
+		IL_0509: ldloc.0
+		IL_050a: ldloc.s 8
+		IL_050c: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
+		IL_0511: ldc.i4.1
+		IL_0512: newarr [System.Runtime]System.Object
+		IL_0517: dup
+		IL_0518: ldc.i4.0
+		IL_0519: ldloc.0
+		IL_051a: stelem.ref
+		IL_051b: ldc.i4.0
+		IL_051c: ldelem.ref
+		IL_051d: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0522: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_0528: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_052d: ldc.i4.0
+		IL_052e: conv.r8
+		IL_052f: ldstr ""
+		IL_0534: ldc.i4.0
+		IL_0535: ldc.i4.1
+		IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_053b: stloc.s 5
+		IL_053d: ldloc.0
+		IL_053e: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0543: ldnull
+		IL_0544: ldstr "ownKeys-primitive"
+		IL_0549: ldloc.s 5
+		IL_054b: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_0550: pop
+		IL_0551: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0556: stloc.s 7
+		IL_0558: ldnull
+		IL_0559: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
+		IL_055f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0564: ldc.i4.0
+		IL_0565: conv.r8
+		IL_0566: ldstr ""
+		IL_056b: ldc.i4.0
+		IL_056c: ldc.i4.1
+		IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0572: stloc.s 5
+		IL_0574: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0579: dup
+		IL_057a: ldstr "ownKeys"
+		IL_057f: ldloc.s 5
+		IL_0581: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0586: stloc.s 6
+		IL_0588: ldloc.s 7
+		IL_058a: ldloc.s 6
+		IL_058c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0591: stloc.s 8
+		IL_0593: ldloc.0
+		IL_0594: ldloc.s 8
+		IL_0596: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
+		IL_059b: ldc.i4.1
+		IL_059c: newarr [System.Runtime]System.Object
+		IL_05a1: dup
+		IL_05a2: ldc.i4.0
+		IL_05a3: ldloc.0
+		IL_05a4: stelem.ref
+		IL_05a5: ldc.i4.0
+		IL_05a6: ldelem.ref
+		IL_05a7: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_05ac: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_05b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_05b7: ldc.i4.0
+		IL_05b8: conv.r8
+		IL_05b9: ldstr ""
+		IL_05be: ldc.i4.0
+		IL_05bf: ldc.i4.1
+		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_05c5: stloc.s 5
+		IL_05c7: ldloc.0
+		IL_05c8: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_05cd: ldnull
+		IL_05ce: ldstr "ownKeys-entry"
+		IL_05d3: ldloc.s 5
+		IL_05d5: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
+		IL_05da: pop
+		IL_05db: ret
 	} // end of method Proxy_Validation_EdgeCases::__js_module_init__
 
 } // end of class Modules.Proxy_Validation_EdgeCases
@@ -1999,7 +1909,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b56
+		// Method begins at RVA 0x2a7a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: String_Repeat_Basic
+﻿// IL code: String_Repeat_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22fe
+					// Method begins at RVA 0x227a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2307
+					// Method begins at RVA 0x2283
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f5
+				// Method begins at RVA 0x2271
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x2154
 			// Header size: 12
 			// Code size: 247 (0xf7)
 			.maxstack 8
@@ -230,7 +230,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22ec
+			// Method begins at RVA 0x2268
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -256,7 +256,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 379 (0x17b)
+		// Code size: 247 (0xf7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Repeat_Basic/Scope,
@@ -287,112 +287,58 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.String_Repeat_Basic/Scope
-		IL_0044: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: ldstr "ab"
-		IL_0055: ldc.r8 3
-		IL_005e: box [System.Runtime]System.Double
-		IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0068: pop
-		IL_0069: ldc.i4.1
-		IL_006a: newarr [System.Runtime]System.Object
-		IL_006f: dup
-		IL_0070: ldc.i4.0
-		IL_0071: ldloc.0
-		IL_0072: stelem.ref
-		IL_0073: ldc.i4.0
-		IL_0074: ldelem.ref
-		IL_0075: castclass Modules.String_Repeat_Basic/Scope
-		IL_007a: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_0080: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0085: ldnull
-		IL_0086: ldstr "x"
-		IL_008b: ldc.r8 0.0
-		IL_0094: box [System.Runtime]System.Double
-		IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_009e: pop
-		IL_009f: ldc.i4.1
-		IL_00a0: newarr [System.Runtime]System.Object
-		IL_00a5: dup
-		IL_00a6: ldc.i4.0
-		IL_00a7: ldloc.0
-		IL_00a8: stelem.ref
-		IL_00a9: ldc.i4.0
-		IL_00aa: ldelem.ref
-		IL_00ab: castclass Modules.String_Repeat_Basic/Scope
-		IL_00b0: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00bb: ldnull
-		IL_00bc: ldstr "x"
-		IL_00c1: ldc.r8 1
-		IL_00ca: box [System.Runtime]System.Double
-		IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_00d4: pop
-		IL_00d5: ldc.i4.1
-		IL_00d6: newarr [System.Runtime]System.Object
-		IL_00db: dup
-		IL_00dc: ldc.i4.0
-		IL_00dd: ldloc.0
-		IL_00de: stelem.ref
-		IL_00df: ldc.i4.0
-		IL_00e0: ldelem.ref
-		IL_00e1: castclass Modules.String_Repeat_Basic/Scope
-		IL_00e6: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_00ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00f1: ldnull
-		IL_00f2: ldstr "x"
-		IL_00f7: ldc.r8 2.9
-		IL_0100: box [System.Runtime]System.Double
-		IL_0105: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_010a: pop
-		IL_010b: ldc.r8 1
-		IL_0114: neg
-		IL_0115: box [System.Runtime]System.Double
-		IL_011a: stloc.3
-		IL_011b: ldc.i4.1
-		IL_011c: newarr [System.Runtime]System.Object
-		IL_0121: dup
-		IL_0122: ldc.i4.0
-		IL_0123: ldloc.0
-		IL_0124: stelem.ref
-		IL_0125: ldc.i4.0
-		IL_0126: ldelem.ref
-		IL_0127: castclass Modules.String_Repeat_Basic/Scope
-		IL_012c: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0137: ldnull
-		IL_0138: ldstr "x"
-		IL_013d: ldloc.3
-		IL_013e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0143: pop
-		IL_0144: ldc.i4.1
-		IL_0145: newarr [System.Runtime]System.Object
-		IL_014a: dup
-		IL_014b: ldc.i4.0
-		IL_014c: ldloc.0
-		IL_014d: stelem.ref
-		IL_014e: ldc.i4.0
-		IL_014f: ldelem.ref
-		IL_0150: castclass Modules.String_Repeat_Basic/Scope
-		IL_0155: ldftn object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_015b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0160: ldnull
-		IL_0161: ldstr "x"
-		IL_0166: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_016f: box [System.Runtime]System.Double
-		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::Invoke(object, object, object)
-		IL_0179: pop
-		IL_017a: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.String_Repeat_Basic/Scope
+		IL_0039: ldnull
+		IL_003a: ldstr "ab"
+		IL_003f: ldc.r8 3
+		IL_0048: box [System.Runtime]System.Double
+		IL_004d: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
+		IL_0052: pop
+		IL_0053: ldloc.0
+		IL_0054: castclass Modules.String_Repeat_Basic/Scope
+		IL_0059: ldnull
+		IL_005a: ldstr "x"
+		IL_005f: ldc.r8 0.0
+		IL_0068: box [System.Runtime]System.Double
+		IL_006d: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
+		IL_0072: pop
+		IL_0073: ldloc.0
+		IL_0074: castclass Modules.String_Repeat_Basic/Scope
+		IL_0079: ldnull
+		IL_007a: ldstr "x"
+		IL_007f: ldc.r8 1
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
+		IL_0092: pop
+		IL_0093: ldloc.0
+		IL_0094: castclass Modules.String_Repeat_Basic/Scope
+		IL_0099: ldnull
+		IL_009a: ldstr "x"
+		IL_009f: ldc.r8 2.9
+		IL_00a8: box [System.Runtime]System.Double
+		IL_00ad: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
+		IL_00b2: pop
+		IL_00b3: ldc.r8 1
+		IL_00bc: neg
+		IL_00bd: box [System.Runtime]System.Double
+		IL_00c2: stloc.3
+		IL_00c3: ldloc.0
+		IL_00c4: castclass Modules.String_Repeat_Basic/Scope
+		IL_00c9: ldnull
+		IL_00ca: ldstr "x"
+		IL_00cf: ldloc.3
+		IL_00d0: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
+		IL_00d5: pop
+		IL_00d6: ldloc.0
+		IL_00d7: castclass Modules.String_Repeat_Basic/Scope
+		IL_00dc: ldnull
+		IL_00dd: ldstr "x"
+		IL_00e2: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_00eb: box [System.Runtime]System.Double
+		IL_00f0: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
+		IL_00f5: pop
+		IL_00f6: ret
 	} // end of method String_Repeat_Basic::__js_module_init__
 
 } // end of class Modules.String_Repeat_Basic
@@ -404,7 +350,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2310
+		// Method begins at RVA 0x228c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -1,4 +1,4 @@
-// IL code: String_StartsWith_NestedParam
+﻿// IL code: String_StartsWith_NestedParam
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2168
+					// Method begins at RVA 0x2154
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2128
+				// Method begins at RVA 0x2114
 				// Header size: 12
 				// Code size: 34 (0x22)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x215f
+				// Method begins at RVA 0x214b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20c4
+			// Method begins at RVA 0x20b0
 			// Header size: 12
 			// Code size: 85 (0x55)
 			.maxstack 8
@@ -187,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2156
+			// Method begins at RVA 0x2142
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -213,7 +213,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 104 (0x68)
+		// Code size: 82 (0x52)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_NestedParam/Scope,
@@ -243,26 +243,17 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.String_StartsWith_NestedParam/Scope
-		IL_0044: ldftn object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: ldstr "abc"
-		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_005a: stloc.2
-		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0060: ldloc.2
-		IL_0061: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0066: pop
-		IL_0067: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.String_StartsWith_NestedParam/Scope
+		IL_0039: ldnull
+		IL_003a: ldstr "abc"
+		IL_003f: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
+		IL_0044: stloc.2
+		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004a: ldloc.2
+		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0050: pop
+		IL_0051: ret
 	} // end of method String_StartsWith_NestedParam::__js_module_init__
 
 } // end of class Modules.String_StartsWith_NestedParam
@@ -274,7 +265,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2171
+		// Method begins at RVA 0x215d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
@@ -1,4 +1,4 @@
-// IL code: String_TaggedTemplate_EvaluationOrder
+﻿// IL code: String_TaggedTemplate_EvaluationOrder
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x2202
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a0
+			// Method begins at RVA 0x2174
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2237
+				// Method begins at RVA 0x220b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -101,7 +101,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21ac
 			// Header size: 12
 			// Code size: 65 (0x41)
 			.maxstack 8
@@ -153,7 +153,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2225
+			// Method begins at RVA 0x21f9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -179,7 +179,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 324 (0x144)
+		// Code size: 280 (0x118)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_EvaluationOrder/Scope,
@@ -267,67 +267,49 @@
 		IL_00af: ldloc.s 6
 		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateTemplateObject(object, object, object)
 		IL_00b6: stloc.s 7
-		IL_00b8: ldc.i4.1
-		IL_00b9: newarr [System.Runtime]System.Object
-		IL_00be: dup
-		IL_00bf: ldc.i4.0
-		IL_00c0: ldloc.0
-		IL_00c1: stelem.ref
-		IL_00c2: ldc.i4.0
-		IL_00c3: ldelem.ref
-		IL_00c4: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
-		IL_00c9: ldftn object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
-		IL_00cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00d4: ldnull
-		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00da: stloc.s 4
-		IL_00dc: ldloc.s 4
-		IL_00de: stloc.s 8
-		IL_00e0: ldc.i4.1
-		IL_00e1: newarr [System.Runtime]System.Object
-		IL_00e6: dup
-		IL_00e7: ldc.i4.0
-		IL_00e8: ldloc.0
-		IL_00e9: stelem.ref
-		IL_00ea: ldc.i4.0
-		IL_00eb: ldelem.ref
-		IL_00ec: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
-		IL_00f1: ldftn object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
-		IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00fc: ldnull
-		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0102: stloc.s 4
-		IL_0104: ldloc.s 4
-		IL_0106: stloc.s 9
-		IL_0108: ldc.i4.3
-		IL_0109: newarr [System.Runtime]System.Object
-		IL_010e: dup
-		IL_010f: ldc.i4.0
-		IL_0110: ldloc.s 7
-		IL_0112: stelem.ref
-		IL_0113: dup
-		IL_0114: ldc.i4.1
-		IL_0115: ldloc.s 8
-		IL_0117: stelem.ref
-		IL_0118: dup
-		IL_0119: ldc.i4.2
-		IL_011a: ldloc.s 9
-		IL_011c: stelem.ref
-		IL_011d: stloc.s 6
-		IL_011f: ldloc.1
-		IL_0120: ldc.i4.0
-		IL_0121: newarr [System.Runtime]System.Object
-		IL_0126: ldloc.s 6
-		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_012d: stloc.s 4
-		IL_012f: ldloc.s 4
-		IL_0131: stloc.3
-		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0137: ldstr "final result:"
-		IL_013c: ldloc.3
-		IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0142: pop
-		IL_0143: ret
+		IL_00b8: ldloc.0
+		IL_00b9: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
+		IL_00be: ldnull
+		IL_00bf: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
+		IL_00c4: stloc.s 4
+		IL_00c6: ldloc.s 4
+		IL_00c8: stloc.s 8
+		IL_00ca: ldloc.0
+		IL_00cb: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
+		IL_00d0: ldnull
+		IL_00d1: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
+		IL_00d6: stloc.s 4
+		IL_00d8: ldloc.s 4
+		IL_00da: stloc.s 9
+		IL_00dc: ldc.i4.3
+		IL_00dd: newarr [System.Runtime]System.Object
+		IL_00e2: dup
+		IL_00e3: ldc.i4.0
+		IL_00e4: ldloc.s 7
+		IL_00e6: stelem.ref
+		IL_00e7: dup
+		IL_00e8: ldc.i4.1
+		IL_00e9: ldloc.s 8
+		IL_00eb: stelem.ref
+		IL_00ec: dup
+		IL_00ed: ldc.i4.2
+		IL_00ee: ldloc.s 9
+		IL_00f0: stelem.ref
+		IL_00f1: stloc.s 6
+		IL_00f3: ldloc.1
+		IL_00f4: ldc.i4.0
+		IL_00f5: newarr [System.Runtime]System.Object
+		IL_00fa: ldloc.s 6
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0101: stloc.s 4
+		IL_0103: ldloc.s 4
+		IL_0105: stloc.3
+		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010b: ldstr "final result:"
+		IL_0110: ldloc.3
+		IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0116: pop
+		IL_0117: ret
 	} // end of method String_TaggedTemplate_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.String_TaggedTemplate_EvaluationOrder
@@ -339,7 +321,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2240
+		// Method begins at RVA 0x2214
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -1,4 +1,4 @@
-// IL code: UnaryOperator_MinusMinusPostfix
+﻿// IL code: UnaryOperator_MinusMinusPostfix
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2436
+				// Method begins at RVA 0x23de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ae
+			// Method begins at RVA 0x2256
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243f
+				// Method begins at RVA 0x23e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22d4
+			// Method begins at RVA 0x227c
 			// Header size: 12
 			// Code size: 104 (0x68)
 			.maxstack 8
@@ -181,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2448
+				// Method begins at RVA 0x23f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -208,7 +208,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -261,7 +261,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2451
+				// Method begins at RVA 0x23f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -287,7 +287,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2390
+			// Method begins at RVA 0x2338
 			// Header size: 12
 			// Code size: 76 (0x4c)
 			.maxstack 8
@@ -344,7 +344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245a
+				// Method begins at RVA 0x2402
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -371,7 +371,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23e8
+			// Method begins at RVA 0x2390
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -446,7 +446,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x242d
+			// Method begins at RVA 0x23d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -472,7 +472,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 594 (0x252)
+		// Code size: 506 (0x1fa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix/Scope,
@@ -619,103 +619,67 @@
 		IL_013a: ldc.r8 3
 		IL_0143: box [System.Runtime]System.Double
 		IL_0148: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldloc.0
-		IL_0156: stelem.ref
-		IL_0157: ldc.i4.0
-		IL_0158: ldelem.ref
-		IL_0159: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_015e: ldftn object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0169: ldnull
-		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_016f: pop
-		IL_0170: ldc.i4.1
-		IL_0171: newarr [System.Runtime]System.Object
-		IL_0176: dup
-		IL_0177: ldc.i4.0
-		IL_0178: ldloc.0
-		IL_0179: stelem.ref
-		IL_017a: ldc.i4.0
-		IL_017b: ldelem.ref
-		IL_017c: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0181: ldftn object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
-		IL_0187: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_018c: ldnull
-		IL_018d: ldc.r8 3
-		IL_0196: box [System.Runtime]System.Double
-		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_01a0: pop
-		IL_01a1: ldstr "3"
-		IL_01a6: stloc.s 9
-		IL_01a8: ldloc.s 9
-		IL_01aa: stloc.s 12
-		IL_01ac: ldloc.s 12
-		IL_01ae: stloc.s 6
-		IL_01b0: ldloc.s 9
-		IL_01b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01b7: stloc.s 13
-		IL_01b9: ldloc.s 13
-		IL_01bb: box [System.Runtime]System.Double
-		IL_01c0: stloc.s 11
-		IL_01c2: ldloc.s 13
-		IL_01c4: ldc.r8 1
-		IL_01cd: sub
-		IL_01ce: stloc.s 13
-		IL_01d0: ldloc.s 13
-		IL_01d2: box [System.Runtime]System.Double
-		IL_01d7: stloc.s 14
-		IL_01d9: ldloc.s 14
-		IL_01db: stloc.s 9
-		IL_01dd: ldloc.s 11
-		IL_01df: stloc.s 7
-		IL_01e1: ldloc.s 9
-		IL_01e3: stloc.s 11
-		IL_01e5: ldloc.s 11
-		IL_01e7: stloc.s 8
-		IL_01e9: ldnull
-		IL_01ea: ldstr "global-string"
-		IL_01ef: ldloc.s 6
-		IL_01f1: ldloc.s 7
-		IL_01f3: ldloc.s 8
-		IL_01f5: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_01fa: pop
-		IL_01fb: ldloc.0
-		IL_01fc: ldstr "3"
-		IL_0201: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
-		IL_0206: ldc.i4.1
-		IL_0207: newarr [System.Runtime]System.Object
-		IL_020c: dup
-		IL_020d: ldc.i4.0
-		IL_020e: ldloc.0
-		IL_020f: stelem.ref
-		IL_0210: ldc.i4.0
-		IL_0211: ldelem.ref
-		IL_0212: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0217: ldftn object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_021d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0222: ldnull
-		IL_0223: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0228: pop
-		IL_0229: ldc.i4.1
-		IL_022a: newarr [System.Runtime]System.Object
-		IL_022f: dup
-		IL_0230: ldc.i4.0
-		IL_0231: ldloc.0
-		IL_0232: stelem.ref
-		IL_0233: ldc.i4.0
-		IL_0234: ldelem.ref
-		IL_0235: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_023a: ldftn object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
-		IL_0240: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0245: ldnull
-		IL_0246: ldstr "3"
-		IL_024b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0250: pop
-		IL_0251: ret
+		IL_014d: ldloc.0
+		IL_014e: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_0153: ldnull
+		IL_0154: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+		IL_0159: pop
+		IL_015a: ldloc.0
+		IL_015b: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_0160: ldnull
+		IL_0161: ldc.r8 3
+		IL_016a: box [System.Runtime]System.Double
+		IL_016f: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
+		IL_0174: pop
+		IL_0175: ldstr "3"
+		IL_017a: stloc.s 9
+		IL_017c: ldloc.s 9
+		IL_017e: stloc.s 12
+		IL_0180: ldloc.s 12
+		IL_0182: stloc.s 6
+		IL_0184: ldloc.s 9
+		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_018b: stloc.s 13
+		IL_018d: ldloc.s 13
+		IL_018f: box [System.Runtime]System.Double
+		IL_0194: stloc.s 11
+		IL_0196: ldloc.s 13
+		IL_0198: ldc.r8 1
+		IL_01a1: sub
+		IL_01a2: stloc.s 13
+		IL_01a4: ldloc.s 13
+		IL_01a6: box [System.Runtime]System.Double
+		IL_01ab: stloc.s 14
+		IL_01ad: ldloc.s 14
+		IL_01af: stloc.s 9
+		IL_01b1: ldloc.s 11
+		IL_01b3: stloc.s 7
+		IL_01b5: ldloc.s 9
+		IL_01b7: stloc.s 11
+		IL_01b9: ldloc.s 11
+		IL_01bb: stloc.s 8
+		IL_01bd: ldnull
+		IL_01be: ldstr "global-string"
+		IL_01c3: ldloc.s 6
+		IL_01c5: ldloc.s 7
+		IL_01c7: ldloc.s 8
+		IL_01c9: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
+		IL_01ce: pop
+		IL_01cf: ldloc.0
+		IL_01d0: ldstr "3"
+		IL_01d5: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
+		IL_01da: ldloc.0
+		IL_01db: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_01e0: ldnull
+		IL_01e1: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+		IL_01e6: pop
+		IL_01e7: ldloc.0
+		IL_01e8: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
+		IL_01ed: ldnull
+		IL_01ee: ldstr "3"
+		IL_01f3: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
+		IL_01f8: pop
+		IL_01f9: ret
 	} // end of method UnaryOperator_MinusMinusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix
@@ -727,7 +691,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2463
+		// Method begins at RVA 0x240b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -1,4 +1,4 @@
-// IL code: UnaryOperator_MinusMinusPrefix
+﻿// IL code: UnaryOperator_MinusMinusPrefix
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x240d
+				// Method begins at RVA 0x23b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a9
+			// Method begins at RVA 0x2251
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2416
+				// Method begins at RVA 0x23be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x2278
 			// Header size: 12
 			// Code size: 93 (0x5d)
 			.maxstack 8
@@ -176,7 +176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241f
+				// Method begins at RVA 0x23c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,7 +203,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x233c
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -252,7 +252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2428
+				// Method begins at RVA 0x23d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,7 +278,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x2320
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -331,7 +331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2431
+				// Method begins at RVA 0x23d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,7 +358,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23c8
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -429,7 +429,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2404
+			// Method begins at RVA 0x23ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -455,7 +455,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 589 (0x24d)
+		// Code size: 501 (0x1f5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix/Scope,
@@ -601,102 +601,66 @@
 		IL_013a: ldc.r8 3
 		IL_0143: box [System.Runtime]System.Double
 		IL_0148: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldloc.0
-		IL_0156: stelem.ref
-		IL_0157: ldc.i4.0
-		IL_0158: ldelem.ref
-		IL_0159: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_015e: ldftn object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0169: ldnull
-		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_016f: pop
-		IL_0170: ldc.i4.1
-		IL_0171: newarr [System.Runtime]System.Object
-		IL_0176: dup
-		IL_0177: ldc.i4.0
-		IL_0178: ldloc.0
-		IL_0179: stelem.ref
-		IL_017a: ldc.i4.0
-		IL_017b: ldelem.ref
-		IL_017c: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0181: ldftn object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
-		IL_0187: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_018c: ldnull
-		IL_018d: ldc.r8 3
-		IL_0196: box [System.Runtime]System.Double
-		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_01a0: pop
-		IL_01a1: ldstr "3"
+		IL_014d: ldloc.0
+		IL_014e: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_0153: ldnull
+		IL_0154: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+		IL_0159: pop
+		IL_015a: ldloc.0
+		IL_015b: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_0160: ldnull
+		IL_0161: ldc.r8 3
+		IL_016a: box [System.Runtime]System.Double
+		IL_016f: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
+		IL_0174: pop
+		IL_0175: ldstr "3"
+		IL_017a: stloc.s 9
+		IL_017c: ldloc.s 9
+		IL_017e: stloc.s 12
+		IL_0180: ldloc.s 12
+		IL_0182: stloc.s 6
+		IL_0184: ldloc.s 9
+		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_018b: stloc.s 13
+		IL_018d: ldloc.s 13
+		IL_018f: ldc.r8 1
+		IL_0198: sub
+		IL_0199: stloc.s 13
+		IL_019b: ldloc.s 13
+		IL_019d: box [System.Runtime]System.Double
+		IL_01a2: stloc.s 11
+		IL_01a4: ldloc.s 11
 		IL_01a6: stloc.s 9
 		IL_01a8: ldloc.s 9
-		IL_01aa: stloc.s 12
-		IL_01ac: ldloc.s 12
-		IL_01ae: stloc.s 6
+		IL_01aa: stloc.s 11
+		IL_01ac: ldloc.s 11
+		IL_01ae: stloc.s 7
 		IL_01b0: ldloc.s 9
-		IL_01b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01b7: stloc.s 13
-		IL_01b9: ldloc.s 13
-		IL_01bb: ldc.r8 1
-		IL_01c4: sub
-		IL_01c5: stloc.s 13
-		IL_01c7: ldloc.s 13
-		IL_01c9: box [System.Runtime]System.Double
-		IL_01ce: stloc.s 11
-		IL_01d0: ldloc.s 11
-		IL_01d2: stloc.s 9
-		IL_01d4: ldloc.s 9
-		IL_01d6: stloc.s 11
-		IL_01d8: ldloc.s 11
-		IL_01da: stloc.s 7
-		IL_01dc: ldloc.s 9
-		IL_01de: stloc.s 11
-		IL_01e0: ldloc.s 11
-		IL_01e2: stloc.s 8
-		IL_01e4: ldnull
-		IL_01e5: ldstr "global-string"
-		IL_01ea: ldloc.s 6
-		IL_01ec: ldloc.s 7
-		IL_01ee: ldloc.s 8
-		IL_01f0: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_01f5: pop
-		IL_01f6: ldloc.0
-		IL_01f7: ldstr "3"
-		IL_01fc: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
-		IL_0201: ldc.i4.1
-		IL_0202: newarr [System.Runtime]System.Object
-		IL_0207: dup
-		IL_0208: ldc.i4.0
-		IL_0209: ldloc.0
-		IL_020a: stelem.ref
-		IL_020b: ldc.i4.0
-		IL_020c: ldelem.ref
-		IL_020d: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0212: ldftn object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_0218: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_021d: ldnull
-		IL_021e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0223: pop
-		IL_0224: ldc.i4.1
-		IL_0225: newarr [System.Runtime]System.Object
-		IL_022a: dup
-		IL_022b: ldc.i4.0
-		IL_022c: ldloc.0
-		IL_022d: stelem.ref
-		IL_022e: ldc.i4.0
-		IL_022f: ldelem.ref
-		IL_0230: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0235: ldftn object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
-		IL_023b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0240: ldnull
-		IL_0241: ldstr "3"
-		IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_024b: pop
-		IL_024c: ret
+		IL_01b2: stloc.s 11
+		IL_01b4: ldloc.s 11
+		IL_01b6: stloc.s 8
+		IL_01b8: ldnull
+		IL_01b9: ldstr "global-string"
+		IL_01be: ldloc.s 6
+		IL_01c0: ldloc.s 7
+		IL_01c2: ldloc.s 8
+		IL_01c4: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
+		IL_01c9: pop
+		IL_01ca: ldloc.0
+		IL_01cb: ldstr "3"
+		IL_01d0: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
+		IL_01d5: ldloc.0
+		IL_01d6: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_01db: ldnull
+		IL_01dc: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+		IL_01e1: pop
+		IL_01e2: ldloc.0
+		IL_01e3: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
+		IL_01e8: ldnull
+		IL_01e9: ldstr "3"
+		IL_01ee: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
+		IL_01f3: pop
+		IL_01f4: ret
 	} // end of method UnaryOperator_MinusMinusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix
@@ -708,7 +672,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x243a
+		// Method begins at RVA 0x23e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
@@ -1,4 +1,4 @@
-// IL code: UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+﻿// IL code: UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x224a
+					// Method begins at RVA 0x2236
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x212c
+				// Method begins at RVA 0x2118
 				// Header size: 12
 				// Code size: 256 (0x100)
 				.maxstack 8
@@ -163,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2241
+				// Method begins at RVA 0x222d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,7 +189,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20a0
 			// Header size: 12
 			// Code size: 108 (0x6c)
 			.maxstack 8
@@ -264,7 +264,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x2224
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -290,7 +290,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 87 (0x57)
+		// Code size: 65 (0x41)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope,
@@ -320,21 +320,12 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldc.i4.0
-		IL_003e: ldelem.ref
-		IL_003f: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope
-		IL_0044: ldftn object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
-		IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004f: ldnull
-		IL_0050: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0055: pop
-		IL_0056: ret
+		IL_0033: ldloc.0
+		IL_0034: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope
+		IL_0039: ldnull
+		IL_003a: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
+		IL_003f: pop
+		IL_0040: ret
 	} // end of method UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
@@ -346,7 +337,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2253
+		// Method begins at RVA 0x223f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -1,4 +1,4 @@
-// IL code: UnaryOperator_PlusPlusPostfix
+﻿// IL code: UnaryOperator_PlusPlusPostfix
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2436
+				// Method begins at RVA 0x23de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22ae
+			// Method begins at RVA 0x2256
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243f
+				// Method begins at RVA 0x23e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22d4
+			// Method begins at RVA 0x227c
 			// Header size: 12
 			// Code size: 104 (0x68)
 			.maxstack 8
@@ -181,7 +181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2448
+				// Method begins at RVA 0x23f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -208,7 +208,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -261,7 +261,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2451
+				// Method begins at RVA 0x23f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -287,7 +287,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2390
+			// Method begins at RVA 0x2338
 			// Header size: 12
 			// Code size: 76 (0x4c)
 			.maxstack 8
@@ -344,7 +344,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245a
+				// Method begins at RVA 0x2402
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -371,7 +371,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23e8
+			// Method begins at RVA 0x2390
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -446,7 +446,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x242d
+			// Method begins at RVA 0x23d5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -472,7 +472,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 594 (0x252)
+		// Code size: 506 (0x1fa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix/Scope,
@@ -619,103 +619,67 @@
 		IL_013a: ldc.r8 3
 		IL_0143: box [System.Runtime]System.Double
 		IL_0148: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldloc.0
-		IL_0156: stelem.ref
-		IL_0157: ldc.i4.0
-		IL_0158: ldelem.ref
-		IL_0159: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_015e: ldftn object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0169: ldnull
-		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_016f: pop
-		IL_0170: ldc.i4.1
-		IL_0171: newarr [System.Runtime]System.Object
-		IL_0176: dup
-		IL_0177: ldc.i4.0
-		IL_0178: ldloc.0
-		IL_0179: stelem.ref
-		IL_017a: ldc.i4.0
-		IL_017b: ldelem.ref
-		IL_017c: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0181: ldftn object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
-		IL_0187: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_018c: ldnull
-		IL_018d: ldc.r8 3
-		IL_0196: box [System.Runtime]System.Double
-		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_01a0: pop
-		IL_01a1: ldstr "3"
-		IL_01a6: stloc.s 9
-		IL_01a8: ldloc.s 9
-		IL_01aa: stloc.s 12
-		IL_01ac: ldloc.s 12
-		IL_01ae: stloc.s 6
-		IL_01b0: ldloc.s 9
-		IL_01b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01b7: stloc.s 13
-		IL_01b9: ldloc.s 13
-		IL_01bb: box [System.Runtime]System.Double
-		IL_01c0: stloc.s 11
-		IL_01c2: ldloc.s 13
-		IL_01c4: ldc.r8 1
-		IL_01cd: add
-		IL_01ce: stloc.s 13
-		IL_01d0: ldloc.s 13
-		IL_01d2: box [System.Runtime]System.Double
-		IL_01d7: stloc.s 14
-		IL_01d9: ldloc.s 14
-		IL_01db: stloc.s 9
-		IL_01dd: ldloc.s 11
-		IL_01df: stloc.s 7
-		IL_01e1: ldloc.s 9
-		IL_01e3: stloc.s 11
-		IL_01e5: ldloc.s 11
-		IL_01e7: stloc.s 8
-		IL_01e9: ldnull
-		IL_01ea: ldstr "global-string"
-		IL_01ef: ldloc.s 6
-		IL_01f1: ldloc.s 7
-		IL_01f3: ldloc.s 8
-		IL_01f5: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_01fa: pop
-		IL_01fb: ldloc.0
-		IL_01fc: ldstr "3"
-		IL_0201: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
-		IL_0206: ldc.i4.1
-		IL_0207: newarr [System.Runtime]System.Object
-		IL_020c: dup
-		IL_020d: ldc.i4.0
-		IL_020e: ldloc.0
-		IL_020f: stelem.ref
-		IL_0210: ldc.i4.0
-		IL_0211: ldelem.ref
-		IL_0212: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0217: ldftn object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_021d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0222: ldnull
-		IL_0223: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0228: pop
-		IL_0229: ldc.i4.1
-		IL_022a: newarr [System.Runtime]System.Object
-		IL_022f: dup
-		IL_0230: ldc.i4.0
-		IL_0231: ldloc.0
-		IL_0232: stelem.ref
-		IL_0233: ldc.i4.0
-		IL_0234: ldelem.ref
-		IL_0235: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_023a: ldftn object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
-		IL_0240: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0245: ldnull
-		IL_0246: ldstr "3"
-		IL_024b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_0250: pop
-		IL_0251: ret
+		IL_014d: ldloc.0
+		IL_014e: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_0153: ldnull
+		IL_0154: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+		IL_0159: pop
+		IL_015a: ldloc.0
+		IL_015b: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_0160: ldnull
+		IL_0161: ldc.r8 3
+		IL_016a: box [System.Runtime]System.Double
+		IL_016f: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
+		IL_0174: pop
+		IL_0175: ldstr "3"
+		IL_017a: stloc.s 9
+		IL_017c: ldloc.s 9
+		IL_017e: stloc.s 12
+		IL_0180: ldloc.s 12
+		IL_0182: stloc.s 6
+		IL_0184: ldloc.s 9
+		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_018b: stloc.s 13
+		IL_018d: ldloc.s 13
+		IL_018f: box [System.Runtime]System.Double
+		IL_0194: stloc.s 11
+		IL_0196: ldloc.s 13
+		IL_0198: ldc.r8 1
+		IL_01a1: add
+		IL_01a2: stloc.s 13
+		IL_01a4: ldloc.s 13
+		IL_01a6: box [System.Runtime]System.Double
+		IL_01ab: stloc.s 14
+		IL_01ad: ldloc.s 14
+		IL_01af: stloc.s 9
+		IL_01b1: ldloc.s 11
+		IL_01b3: stloc.s 7
+		IL_01b5: ldloc.s 9
+		IL_01b7: stloc.s 11
+		IL_01b9: ldloc.s 11
+		IL_01bb: stloc.s 8
+		IL_01bd: ldnull
+		IL_01be: ldstr "global-string"
+		IL_01c3: ldloc.s 6
+		IL_01c5: ldloc.s 7
+		IL_01c7: ldloc.s 8
+		IL_01c9: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
+		IL_01ce: pop
+		IL_01cf: ldloc.0
+		IL_01d0: ldstr "3"
+		IL_01d5: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
+		IL_01da: ldloc.0
+		IL_01db: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_01e0: ldnull
+		IL_01e1: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+		IL_01e6: pop
+		IL_01e7: ldloc.0
+		IL_01e8: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
+		IL_01ed: ldnull
+		IL_01ee: ldstr "3"
+		IL_01f3: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
+		IL_01f8: pop
+		IL_01f9: ret
 	} // end of method UnaryOperator_PlusPlusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix
@@ -727,7 +691,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2463
+		// Method begins at RVA 0x240b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -1,4 +1,4 @@
-// IL code: UnaryOperator_PlusPlusPrefix
+﻿// IL code: UnaryOperator_PlusPlusPrefix
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x240d
+				// Method begins at RVA 0x23b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a9
+			// Method begins at RVA 0x2251
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2416
+				// Method begins at RVA 0x23be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x2278
 			// Header size: 12
 			// Code size: 93 (0x5d)
 			.maxstack 8
@@ -176,7 +176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x241f
+				// Method begins at RVA 0x23c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,7 +203,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x233c
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -252,7 +252,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2428
+				// Method begins at RVA 0x23d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,7 +278,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2378
+			// Method begins at RVA 0x2320
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -331,7 +331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2431
+				// Method begins at RVA 0x23d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,7 +358,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23c8
+			// Method begins at RVA 0x2370
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -429,7 +429,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2404
+			// Method begins at RVA 0x23ac
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -455,7 +455,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 589 (0x24d)
+		// Code size: 501 (0x1f5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix/Scope,
@@ -601,102 +601,66 @@
 		IL_013a: ldc.r8 3
 		IL_0143: box [System.Runtime]System.Double
 		IL_0148: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
-		IL_014d: ldc.i4.1
-		IL_014e: newarr [System.Runtime]System.Object
-		IL_0153: dup
-		IL_0154: ldc.i4.0
-		IL_0155: ldloc.0
-		IL_0156: stelem.ref
-		IL_0157: ldc.i4.0
-		IL_0158: ldelem.ref
-		IL_0159: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_015e: ldftn object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0169: ldnull
-		IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_016f: pop
-		IL_0170: ldc.i4.1
-		IL_0171: newarr [System.Runtime]System.Object
-		IL_0176: dup
-		IL_0177: ldc.i4.0
-		IL_0178: ldloc.0
-		IL_0179: stelem.ref
-		IL_017a: ldc.i4.0
-		IL_017b: ldelem.ref
-		IL_017c: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0181: ldftn object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
-		IL_0187: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_018c: ldnull
-		IL_018d: ldc.r8 3
-		IL_0196: box [System.Runtime]System.Double
-		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_01a0: pop
-		IL_01a1: ldstr "3"
+		IL_014d: ldloc.0
+		IL_014e: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_0153: ldnull
+		IL_0154: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+		IL_0159: pop
+		IL_015a: ldloc.0
+		IL_015b: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_0160: ldnull
+		IL_0161: ldc.r8 3
+		IL_016a: box [System.Runtime]System.Double
+		IL_016f: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
+		IL_0174: pop
+		IL_0175: ldstr "3"
+		IL_017a: stloc.s 9
+		IL_017c: ldloc.s 9
+		IL_017e: stloc.s 12
+		IL_0180: ldloc.s 12
+		IL_0182: stloc.s 6
+		IL_0184: ldloc.s 9
+		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_018b: stloc.s 13
+		IL_018d: ldloc.s 13
+		IL_018f: ldc.r8 1
+		IL_0198: add
+		IL_0199: stloc.s 13
+		IL_019b: ldloc.s 13
+		IL_019d: box [System.Runtime]System.Double
+		IL_01a2: stloc.s 11
+		IL_01a4: ldloc.s 11
 		IL_01a6: stloc.s 9
 		IL_01a8: ldloc.s 9
-		IL_01aa: stloc.s 12
-		IL_01ac: ldloc.s 12
-		IL_01ae: stloc.s 6
+		IL_01aa: stloc.s 11
+		IL_01ac: ldloc.s 11
+		IL_01ae: stloc.s 7
 		IL_01b0: ldloc.s 9
-		IL_01b2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01b7: stloc.s 13
-		IL_01b9: ldloc.s 13
-		IL_01bb: ldc.r8 1
-		IL_01c4: add
-		IL_01c5: stloc.s 13
-		IL_01c7: ldloc.s 13
-		IL_01c9: box [System.Runtime]System.Double
-		IL_01ce: stloc.s 11
-		IL_01d0: ldloc.s 11
-		IL_01d2: stloc.s 9
-		IL_01d4: ldloc.s 9
-		IL_01d6: stloc.s 11
-		IL_01d8: ldloc.s 11
-		IL_01da: stloc.s 7
-		IL_01dc: ldloc.s 9
-		IL_01de: stloc.s 11
-		IL_01e0: ldloc.s 11
-		IL_01e2: stloc.s 8
-		IL_01e4: ldnull
-		IL_01e5: ldstr "global-string"
-		IL_01ea: ldloc.s 6
-		IL_01ec: ldloc.s 7
-		IL_01ee: ldloc.s 8
-		IL_01f0: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_01f5: pop
-		IL_01f6: ldloc.0
-		IL_01f7: ldstr "3"
-		IL_01fc: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
-		IL_0201: ldc.i4.1
-		IL_0202: newarr [System.Runtime]System.Object
-		IL_0207: dup
-		IL_0208: ldc.i4.0
-		IL_0209: ldloc.0
-		IL_020a: stelem.ref
-		IL_020b: ldc.i4.0
-		IL_020c: ldelem.ref
-		IL_020d: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0212: ldftn object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_0218: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_021d: ldnull
-		IL_021e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0223: pop
-		IL_0224: ldc.i4.1
-		IL_0225: newarr [System.Runtime]System.Object
-		IL_022a: dup
-		IL_022b: ldc.i4.0
-		IL_022c: ldloc.0
-		IL_022d: stelem.ref
-		IL_022e: ldc.i4.0
-		IL_022f: ldelem.ref
-		IL_0230: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0235: ldftn object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
-		IL_023b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0240: ldnull
-		IL_0241: ldstr "3"
-		IL_0246: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::Invoke(object, object)
-		IL_024b: pop
-		IL_024c: ret
+		IL_01b2: stloc.s 11
+		IL_01b4: ldloc.s 11
+		IL_01b6: stloc.s 8
+		IL_01b8: ldnull
+		IL_01b9: ldstr "global-string"
+		IL_01be: ldloc.s 6
+		IL_01c0: ldloc.s 7
+		IL_01c2: ldloc.s 8
+		IL_01c4: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
+		IL_01c9: pop
+		IL_01ca: ldloc.0
+		IL_01cb: ldstr "3"
+		IL_01d0: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
+		IL_01d5: ldloc.0
+		IL_01d6: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_01db: ldnull
+		IL_01dc: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+		IL_01e1: pop
+		IL_01e2: ldloc.0
+		IL_01e3: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
+		IL_01e8: ldnull
+		IL_01e9: ldstr "3"
+		IL_01ee: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
+		IL_01f3: pop
+		IL_01f4: ret
 	} // end of method UnaryOperator_PlusPlusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix
@@ -708,7 +672,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x243a
+		// Method begins at RVA 0x23e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_CapturedConst_BoolStringFieldType
+﻿// IL code: Variable_CapturedConst_BoolStringFieldType
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20f3
+				// Method begins at RVA 0x20dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d1
+			// Method begins at RVA 0x20bb
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ea
+			// Method begins at RVA 0x20d4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,7 +106,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 117 (0x75)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_BoolStringFieldType/Scope,
@@ -142,25 +142,16 @@
 		IL_003a: ldloc.0
 		IL_003b: ldstr "typed"
 		IL_0040: stfld string Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
-		IL_0045: ldc.i4.1
-		IL_0046: newarr [System.Runtime]System.Object
-		IL_004b: dup
-		IL_004c: ldc.i4.0
-		IL_004d: ldloc.0
-		IL_004e: stelem.ref
-		IL_004f: ldc.i4.0
-		IL_0050: ldelem.ref
-		IL_0051: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
-		IL_0056: ldftn object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
-		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0061: ldnull
-		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0067: stloc.2
-		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006d: ldloc.2
-		IL_006e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0073: pop
-		IL_0074: ret
+		IL_0045: ldloc.0
+		IL_0046: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
+		IL_004b: ldnull
+		IL_004c: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
+		IL_0051: stloc.2
+		IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0057: ldloc.2
+		IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005d: pop
+		IL_005e: ret
 	} // end of method Variable_CapturedConst_BoolStringFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_BoolStringFieldType
@@ -172,7 +163,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20fc
+		// Method begins at RVA 0x20e6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_CapturedConst_NumberFieldType
+﻿// IL code: Variable_CapturedConst_NumberFieldType
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20ee
+				// Method begins at RVA 0x20d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20ce
+			// Method begins at RVA 0x20b8
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e5
+			// Method begins at RVA 0x20cf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -102,7 +102,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 114 (0x72)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_NumberFieldType/Scope,
@@ -135,25 +135,16 @@
 		IL_0033: ldloc.0
 		IL_0034: ldc.r8 1000
 		IL_003d: stfld float64 Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
-		IL_0042: ldc.i4.1
-		IL_0043: newarr [System.Runtime]System.Object
-		IL_0048: dup
-		IL_0049: ldc.i4.0
-		IL_004a: ldloc.0
-		IL_004b: stelem.ref
-		IL_004c: ldc.i4.0
-		IL_004d: ldelem.ref
-		IL_004e: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
-		IL_0053: ldftn object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
-		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005e: ldnull
-		IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0064: stloc.2
-		IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006a: ldloc.2
-		IL_006b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0070: pop
-		IL_0071: ret
+		IL_0042: ldloc.0
+		IL_0043: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
+		IL_0048: ldnull
+		IL_0049: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
+		IL_004e: stloc.2
+		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0054: ldloc.2
+		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method Variable_CapturedConst_NumberFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_NumberFieldType
@@ -165,7 +156,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f7
+		// Method begins at RVA 0x20e1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_SpreadArgument.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_SpreadArgument.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_CapturedConst_SpreadArgument
+﻿// IL code: Variable_CapturedConst_SpreadArgument
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -118,7 +118,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 185 (0xb9)
+		// Code size: 186 (0xba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_SpreadArgument/Scope,
@@ -177,15 +177,16 @@
 		IL_009d: stloc.2
 		IL_009e: ldloc.2
 		IL_009f: stloc.1
-		IL_00a0: ldloc.1
-		IL_00a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_00ab: stloc.2
-		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b1: ldloc.2
-		IL_00b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b7: pop
-		IL_00b8: ret
+		IL_00a0: ldloc.0
+		IL_00a1: castclass Modules.Variable_CapturedConst_SpreadArgument/Scope
+		IL_00a6: ldnull
+		IL_00a7: call object Modules.Variable_CapturedConst_SpreadArgument/ArrowFunction_L2C17::__js_call__(class Modules.Variable_CapturedConst_SpreadArgument/Scope, object)
+		IL_00ac: stloc.2
+		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b2: ldloc.2
+		IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b8: pop
+		IL_00b9: ret
 	} // end of method Variable_CapturedConst_SpreadArgument::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_SpreadArgument

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_ObjectDestructuring_Captured
+﻿// IL code: Variable_ObjectDestructuring_Captured
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219a
+				// Method begins at RVA 0x2182
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2164
+			// Method begins at RVA 0x214c
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -87,7 +87,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2191
+			// Method begins at RVA 0x2179
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -113,7 +113,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 261 (0x105)
+		// Code size: 239 (0xef)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ObjectDestructuring_Captured/Scope,
@@ -188,26 +188,17 @@
 		IL_00c5: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
 		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 		IL_00cf: pop
-		IL_00d0: ldc.i4.1
-		IL_00d1: newarr [System.Runtime]System.Object
-		IL_00d6: dup
-		IL_00d7: ldc.i4.0
-		IL_00d8: ldloc.0
-		IL_00d9: stelem.ref
-		IL_00da: ldc.i4.0
-		IL_00db: ldelem.ref
-		IL_00dc: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
-		IL_00e1: ldftn object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
-		IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ec: ldnull
-		IL_00ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_00f2: stloc.3
-		IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f8: ldstr "compute()="
-		IL_00fd: ldloc.3
-		IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0103: pop
-		IL_0104: ret
+		IL_00d0: ldloc.0
+		IL_00d1: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
+		IL_00d6: ldnull
+		IL_00d7: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
+		IL_00dc: stloc.3
+		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e2: ldstr "compute()="
+		IL_00e7: ldloc.3
+		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ed: pop
+		IL_00ee: ret
 	} // end of method Variable_ObjectDestructuring_Captured::__js_module_init__
 
 } // end of class Modules.Variable_ObjectDestructuring_Captured
@@ -219,7 +210,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a3
+		// Method begins at RVA 0x218b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_TemporalDeadZoneCapturedRead
+﻿// IL code: Variable_TemporalDeadZoneCapturedRead
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x219b
+				// Method begins at RVA 0x2187
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x215c
+			// Method begins at RVA 0x2148
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a4
+				// Method begins at RVA 0x2190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21ad
+				// Method begins at RVA 0x2199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -125,7 +125,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2187
+			// Method begins at RVA 0x2173
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -154,7 +154,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 240 (0xf0)
+		// Code size: 218 (0xda)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneCapturedRead/Scope,
@@ -194,77 +194,68 @@
 		{
 			IL_0035: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L7C4::.ctor()
 			IL_003a: stloc.2
-			IL_003b: ldc.i4.1
-			IL_003c: newarr [System.Runtime]System.Object
-			IL_0041: dup
-			IL_0042: ldc.i4.0
-			IL_0043: ldloc.0
-			IL_0044: stelem.ref
-			IL_0045: ldc.i4.0
-			IL_0046: ldelem.ref
-			IL_0047: castclass Modules.Variable_TemporalDeadZoneCapturedRead/Scope
-			IL_004c: ldftn object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
-			IL_0052: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0057: ldnull
-			IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-			IL_005d: pop
-			IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0063: ldstr "NO_TDZ"
-			IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_006d: pop
-			IL_006e: leave IL_00c2
+			IL_003b: ldloc.0
+			IL_003c: castclass Modules.Variable_TemporalDeadZoneCapturedRead/Scope
+			IL_0041: ldnull
+			IL_0042: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
+			IL_0047: pop
+			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_004d: ldstr "NO_TDZ"
+			IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0057: pop
+			IL_0058: leave IL_00ac
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0073: stloc.3
-			IL_0074: ldloc.3
-			IL_0075: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_007a: dup
-			IL_007b: brtrue IL_0090
+			IL_005d: stloc.3
+			IL_005e: ldloc.3
+			IL_005f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0064: dup
+			IL_0065: brtrue IL_007a
 
-			IL_0080: pop
-			IL_0081: ldloc.3
-			IL_0082: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0087: dup
-			IL_0088: brtrue IL_009c
+			IL_006a: pop
+			IL_006b: ldloc.3
+			IL_006c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0071: dup
+			IL_0072: brtrue IL_0086
 
-			IL_008d: pop
-			IL_008e: rethrow
+			IL_0077: pop
+			IL_0078: rethrow
 
-			IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0095: stloc.s 4
-			IL_0097: br IL_009e
+			IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_007f: stloc.s 4
+			IL_0081: br IL_0088
 
-			IL_009c: stloc.s 4
+			IL_0086: stloc.s 4
 
-			IL_009e: ldloc.s 4
-			IL_00a0: stloc.s 8
-			IL_00a2: ldloc.s 8
-			IL_00a4: stloc.s 5
-			IL_00a6: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L10C12::.ctor()
-			IL_00ab: stloc.s 6
-			IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00b2: ldstr "TDZ_CAPTURED"
-			IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bc: pop
-			IL_00bd: leave IL_00c2
+			IL_0088: ldloc.s 4
+			IL_008a: stloc.s 8
+			IL_008c: ldloc.s 8
+			IL_008e: stloc.s 5
+			IL_0090: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L10C12::.ctor()
+			IL_0095: stloc.s 6
+			IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_009c: ldstr "TDZ_CAPTURED"
+			IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00a6: pop
+			IL_00a7: leave IL_00ac
 		} // end handler
 
-		IL_00c2: ldloc.0
-		IL_00c3: ldstr "ready"
-		IL_00c8: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00cd: ldloc.0
-		IL_00ce: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00d3: ldstr "Cannot access 'value' before initialization"
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00dd: stloc.s 8
-		IL_00df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e4: ldloc.s 8
-		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00eb: pop
-		IL_00ec: ldnull
-		IL_00ed: stloc.s 7
-		IL_00ef: ret
+		IL_00ac: ldloc.0
+		IL_00ad: ldstr "ready"
+		IL_00b2: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00b7: ldloc.0
+		IL_00b8: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00bd: ldstr "Cannot access 'value' before initialization"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_00c7: stloc.s 8
+		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ce: ldloc.s 8
+		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d5: pop
+		IL_00d6: ldnull
+		IL_00d7: stloc.s 7
+		IL_00d9: ret
 	} // end of method Variable_TemporalDeadZoneCapturedRead::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneCapturedRead
@@ -276,7 +267,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21b6
+		// Method begins at RVA 0x21a2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -1,4 +1,4 @@
-// IL code: WeakRef_Deref_KeptObjects
+﻿// IL code: WeakRef_Deref_KeptObjects
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ed
+				// Method begins at RVA 0x22d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x220c
+			// Method begins at RVA 0x21f8
 			// Header size: 12
 			// Code size: 125 (0x7d)
 			.maxstack 8
@@ -115,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2308
+				// Method begins at RVA 0x22f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -141,7 +141,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2298
+			// Method begins at RVA 0x2284
 			// Header size: 12
 			// Code size: 64 (0x40)
 			.maxstack 8
@@ -196,7 +196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f6
+				// Method begins at RVA 0x22e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -216,7 +216,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ff
+				// Method begins at RVA 0x22eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -238,7 +238,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22e4
+			// Method begins at RVA 0x22d0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -264,7 +264,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 415 (0x19f)
+		// Code size: 393 (0x189)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
@@ -300,136 +300,127 @@
 		IL_0030: stloc.s 8
 		IL_0032: ldloc.s 8
 		IL_0034: stloc.1
-		IL_0035: ldc.i4.1
-		IL_0036: newarr [System.Runtime]System.Object
-		IL_003b: dup
-		IL_003c: ldc.i4.0
-		IL_003d: ldloc.0
-		IL_003e: stelem.ref
-		IL_003f: ldc.i4.0
-		IL_0040: ldelem.ref
-		IL_0041: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_0046: ldftn object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0051: ldnull
-		IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::Invoke(object)
-		IL_0057: stloc.s 8
-		IL_0059: ldloc.0
-		IL_005a: ldloc.s 8
-		IL_005c: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_0061: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0066: ldstr "prototype"
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0070: ldstr "toString"
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: stloc.s 8
-		IL_0081: ldloc.s 8
-		IL_0083: ldstr "call"
-		IL_0088: ldloc.0
-		IL_0089: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0093: stloc.s 8
-		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009a: ldloc.s 8
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a1: pop
+		IL_0035: ldloc.0
+		IL_0036: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_003b: ldnull
+		IL_003c: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+		IL_0041: stloc.s 8
+		IL_0043: ldloc.0
+		IL_0044: ldloc.s 8
+		IL_0046: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
+		IL_004b: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0050: ldstr "prototype"
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_005a: ldstr "toString"
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0069: stloc.s 8
+		IL_006b: ldloc.s 8
+		IL_006d: ldstr "call"
+		IL_0072: ldloc.0
+		IL_0073: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007d: stloc.s 8
+		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0084: ldloc.s 8
+		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008b: pop
 		.try
 		{
-			IL_00a2: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L15C4::.ctor()
-			IL_00a7: stloc.2
-			IL_00a8: ldc.r8 123
-			IL_00b1: box [System.Runtime]System.Double
-			IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
+			IL_008c: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L15C4::.ctor()
+			IL_0091: stloc.2
+			IL_0092: ldc.r8 123
+			IL_009b: box [System.Runtime]System.Double
+			IL_00a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
+			IL_00a5: pop
+			IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ab: ldstr "primitive target threw:"
+			IL_00b0: ldc.i4.0
+			IL_00b1: box [System.Runtime]System.Boolean
+			IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_00bb: pop
-			IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c1: ldstr "primitive target threw:"
-			IL_00c6: ldc.i4.0
-			IL_00c7: box [System.Runtime]System.Boolean
-			IL_00cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00d1: pop
-			IL_00d2: leave IL_0148
+			IL_00bc: leave IL_0132
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00d7: stloc.3
-			IL_00d8: ldloc.3
-			IL_00d9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00de: dup
-			IL_00df: brtrue IL_00f4
+			IL_00c1: stloc.3
+			IL_00c2: ldloc.3
+			IL_00c3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00c8: dup
+			IL_00c9: brtrue IL_00de
 
-			IL_00e4: pop
-			IL_00e5: ldloc.3
-			IL_00e6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00eb: dup
-			IL_00ec: brtrue IL_0100
+			IL_00ce: pop
+			IL_00cf: ldloc.3
+			IL_00d0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00d5: dup
+			IL_00d6: brtrue IL_00ea
 
-			IL_00f1: pop
-			IL_00f2: rethrow
+			IL_00db: pop
+			IL_00dc: rethrow
 
-			IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00f9: stloc.s 4
-			IL_00fb: br IL_0102
+			IL_00de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00e3: stloc.s 4
+			IL_00e5: br IL_00ec
 
-			IL_0100: stloc.s 4
+			IL_00ea: stloc.s 4
 
-			IL_0102: ldloc.s 4
-			IL_0104: stloc.s 8
-			IL_0106: ldloc.s 8
-			IL_0108: stloc.s 5
-			IL_010a: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16::.ctor()
-			IL_010f: stloc.s 6
+			IL_00ec: ldloc.s 4
+			IL_00ee: stloc.s 8
+			IL_00f0: ldloc.s 8
+			IL_00f2: stloc.s 5
+			IL_00f4: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16::.ctor()
+			IL_00f9: stloc.s 6
+			IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0100: ldstr "primitive target threw:"
+			IL_0105: ldc.i4.1
+			IL_0106: box [System.Runtime]System.Boolean
+			IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0110: pop
 			IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0116: ldstr "primitive target threw:"
-			IL_011b: ldc.i4.1
-			IL_011c: box [System.Runtime]System.Boolean
-			IL_0121: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0126: pop
-			IL_0127: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012c: ldstr "primitive target name:"
-			IL_0131: ldloc.s 5
-			IL_0133: ldstr "name"
-			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0142: pop
-			IL_0143: leave IL_0148
+			IL_0116: ldstr "primitive target name:"
+			IL_011b: ldloc.s 5
+			IL_011d: ldstr "name"
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_012c: pop
+			IL_012d: leave IL_0132
 		} // end handler
 
-		IL_0148: ldc.i4.1
-		IL_0149: newarr [System.Runtime]System.Object
-		IL_014e: dup
-		IL_014f: ldc.i4.0
-		IL_0150: ldloc.0
-		IL_0151: stelem.ref
-		IL_0152: ldc.i4.0
-		IL_0153: ldelem.ref
-		IL_0154: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_0159: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_015f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0164: ldc.i4.1
-		IL_0165: newarr [System.Runtime]System.Object
-		IL_016a: dup
-		IL_016b: ldc.i4.0
-		IL_016c: ldloc.0
-		IL_016d: stelem.ref
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0178: ldc.i4.0
-		IL_0179: conv.r8
-		IL_017a: ldstr ""
-		IL_017f: ldc.i4.0
-		IL_0180: ldc.i4.1
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_018b: stloc.s 8
-		IL_018d: ldloc.s 8
-		IL_018f: ldc.i4.0
-		IL_0190: newarr [System.Runtime]System.Object
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_019a: pop
-		IL_019b: ldnull
-		IL_019c: stloc.s 7
-		IL_019e: ret
+		IL_0132: ldc.i4.1
+		IL_0133: newarr [System.Runtime]System.Object
+		IL_0138: dup
+		IL_0139: ldc.i4.0
+		IL_013a: ldloc.0
+		IL_013b: stelem.ref
+		IL_013c: ldc.i4.0
+		IL_013d: ldelem.ref
+		IL_013e: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_0143: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+		IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_014e: ldc.i4.1
+		IL_014f: newarr [System.Runtime]System.Object
+		IL_0154: dup
+		IL_0155: ldc.i4.0
+		IL_0156: ldloc.0
+		IL_0157: stelem.ref
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0162: ldc.i4.0
+		IL_0163: conv.r8
+		IL_0164: ldstr ""
+		IL_0169: ldc.i4.0
+		IL_016a: ldc.i4.1
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0175: stloc.s 8
+		IL_0177: ldloc.s 8
+		IL_0179: ldc.i4.0
+		IL_017a: newarr [System.Runtime]System.Object
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0184: pop
+		IL_0185: ldnull
+		IL_0186: stloc.s 7
+		IL_0188: ret
 	} // end of method WeakRef_Deref_KeptObjects::__js_module_init__
 
 } // end of class Modules.WeakRef_Deref_KeptObjects
@@ -441,7 +432,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2311
+		// Method begins at RVA 0x22fd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
This PR removes the main `dromaeo-3d-cube` performance gap by cutting overhead in the hottest function-call and array-access paths.

### Runtime/compiler changes
- Eliminates the per-call closure allocation in `Closure.InvokeFunctionCallWithArgs*`.
- Lowers safe `const`-bound arrow calls directly instead of going through runtime function-value dispatch.
- Emits direct IL `call` for direct callable invocations instead of creating a delegate and invoking it.
- Avoids allocating a one-slot scopes array when the callee only needs the single enclosing scope.
- Adds a dense numeric array fast path in `ObjectRuntime` so ordinary array reads/writes skip property-key conversion and descriptor lookup when no own descriptors are present.

### Why this mattered
`dromaeo-3d-cube-modern` was slower than Jint because the modern scenario uses many `const` arrow helpers and dense numeric array accesses. The benchmark was spending too much time in indirect call dispatch and array plumbing rather than the cube math itself.

### Benchmark result
- `dromaeo-3d-cube`: JROC 23.411 ms vs Jint 39.265 ms
- `dromaeo-3d-cube-modern`: JROC 29.607 ms vs Jint 38.869 ms

### Validation
- Full `Jroc.Tests` suite passes after the changes.
- Generator snapshot updates were accepted for the IL shape changes caused by the new call lowering.
- One execution snapshot (`Node.ChildProcess` message passing) was updated because the runtime behavior now takes the successful IPC path in that test.