### PR TITLE
fix: retry Mitata jroc install on release

### DIFF
--- a/.github/workflows/mitata-suite.yml
+++ b/.github/workflows/mitata-suite.yml
@@ -137,11 +137,21 @@ jobs:
         run: |
           set -euo pipefail
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-          if dotnet tool list --global | awk '{print $1}' | grep -qx "jroc"; then
-            dotnet tool update --global jroc --version "${JROC_PACKAGE_VERSION}"
-          else
-            dotnet tool install --global jroc --version "${JROC_PACKAGE_VERSION}"
-          fi
+          tries=20
+          delay=30
+          for i in $(seq 1 $tries); do
+            dotnet nuget locals http-cache --clear || true
+            if dotnet tool install --global jroc --version "${JROC_PACKAGE_VERSION}"; then
+              echo "Installed jroc ${JROC_PACKAGE_VERSION}"
+              exit 0
+            fi
+
+            echo "Attempt $i/$tries: jroc ${JROC_PACKAGE_VERSION} not available yet on NuGet; waiting ${delay}s..."
+            sleep $delay
+          done
+
+          echo "Failed to install jroc ${JROC_PACKAGE_VERSION} from NuGet after $tries attempts" >&2
+          exit 1
 
       - name: Run mitata benchmark suite
         shell: bash


### PR DESCRIPTION
## Summary
Mitata release runs were failing after publish because the workflow treated NuGet indexing as the only readiness signal. In the failing release, the package index reported `jroc` as available, but `dotnet tool install --global jroc --version <release>` still returned a 404 moments later.

### Fix
- Replace the one-shot `dotnet tool install/update` step with the same retry pattern used by the other release workflows.
- Clear the NuGet HTTP cache between attempts so the runner does not keep a stale miss.
- Keep retrying until the published `jroc` tool is actually installable, then proceed with the benchmark run.

### Why this is safe
This only changes release-time workflow robustness. It does not touch compiler/runtime code or benchmark logic, so product behavior is unchanged.

### Verification
- The workflow YAML parses cleanly.
- The retry logic matches the existing smoke/release workflow pattern for package-index propagation delays.