### PR TITLE
fix(test262): make Number safe-integer ports pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - runtime/tests/docs/test262: unskip the remaining non-`eval` global-object/value-property ports, mirroring top-level `var` bindings onto `globalThis` and enforcing strict assignment errors for `NaN`/`undefined`.
+- runtime/tests/docs/test262: implement `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` constructor properties and unskip the new non-`eval` Number constructor/value-property ports (`S15.7.1.1_A1`, `MAX_SAFE_INTEGER`, `MIN_SAFE_INTEGER`).
 
 ## v0.10.0 - 2026-06-21
 

--- a/docs/ECMA262/21/Section21_1.json
+++ b/docs/ECMA262/21/Section21_1.json
@@ -60,7 +60,7 @@
     {
       "clause": "21.1.2.6",
       "title": "Number.MAX_SAFE_INTEGER",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-number.max_safe_integer"
     },
     {
@@ -72,7 +72,7 @@
     {
       "clause": "21.1.2.8",
       "title": "Number.MIN_SAFE_INTEGER",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-number.min_safe_integer"
     },
     {
@@ -186,6 +186,7 @@
         "status": "Supported with Limitations",
         "test262Paths": [
           "built-ins/Number/return-abrupt-tonumber-value.js",
+          "built-ins/Number/S15.7.1.1_A1.js",
           "built-ins/Number/S9.3_A1_T1.js",
           "built-ins/Number/S9.3.1_A17.js",
           "built-ins/Number/S9.3_A2_T1.js",
@@ -194,7 +195,7 @@
           "built-ins/Number/S9.3.1_A1.js",
           "built-ins/Number/S9.3.1_A7.js"
         ],
-        "notes": "Direct calls to the global Number function are lowered to TypeUtilities.ToNumber and preserve observable abrupt completions even when the converted value is discarded. Checked-in coverage now includes representative undefined, null, boolean, numeric, empty-string, decimal-string, NaN, and hexadecimal-string coercion cases. Wrapper construction is supported for the currently modeled Number object surface, but full Number constructor/prototype semantics remain incomplete."
+        "notes": "Direct calls to the global Number function are lowered to TypeUtilities.ToNumber and preserve observable abrupt completions even when the converted value is discarded. Checked-in coverage now includes representative undefined, null, boolean, numeric, empty-string, decimal-string, NaN, hexadecimal-string, object-wrapper, and non-canonical infinity-string coercion cases. Wrapper construction is supported for the currently modeled Number object surface, but full Number constructor/prototype semantics remain incomplete."
       },
       {
         "clause": "21.1.2.1",
@@ -256,6 +257,24 @@
           "test/built-ins/Number/isNaN/prop-desc.js"
         ],
         "notes": "Number.isNaN is exposed on the Number constructor with the expected callable metadata and property descriptor, does not coerce non-number arguments, and returns true only for Number NaN values."
+      },
+      {
+        "clause": "21.1.2.6",
+        "feature": "Number.MAX_SAFE_INTEGER",
+        "status": "Supported",
+        "test262Paths": [
+          "built-ins/Number/MAX_SAFE_INTEGER.js"
+        ],
+        "notes": "Exposed on the Number constructor as a non-writable, non-enumerable, non-configurable data property with value 9007199254740991."
+      },
+      {
+        "clause": "21.1.2.8",
+        "feature": "Number.MIN_SAFE_INTEGER",
+        "status": "Supported",
+        "test262Paths": [
+          "built-ins/Number/MIN_SAFE_INTEGER.js"
+        ],
+        "notes": "Exposed on the Number constructor as a non-writable, non-enumerable, non-configurable data property with value -9007199254740991."
       },
       {
         "clause": "21.1.2.12",

--- a/docs/ECMA262/21/Section21_1.md
+++ b/docs/ECMA262/21/Section21_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-29T14:16:08Z
+> Last generated (UTC): 2026-06-22T16:27:37Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -22,9 +22,9 @@
 | 21.1.2.3 | Number.isInteger ( number ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-number.isinteger) |
 | 21.1.2.4 | Number.isNaN ( number ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number.isnan) |
 | 21.1.2.5 | Number.isSafeInteger ( number ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.issafeinteger) |
-| 21.1.2.6 | Number.MAX_SAFE_INTEGER | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.max_safe_integer) |
+| 21.1.2.6 | Number.MAX_SAFE_INTEGER | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number.max_safe_integer) |
 | 21.1.2.7 | Number.MAX_VALUE | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.max_value) |
-| 21.1.2.8 | Number.MIN_SAFE_INTEGER | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.min_safe_integer) |
+| 21.1.2.8 | Number.MIN_SAFE_INTEGER | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number.min_safe_integer) |
 | 21.1.2.9 | Number.MIN_VALUE | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.min_value) |
 | 21.1.2.10 | Number.NaN | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number.nan) |
 | 21.1.2.11 | Number.NEGATIVE_INFINITY | Supported | [tc39.es](https://tc39.es/ecma262/#sec-number.negative_infinity) |
@@ -51,7 +51,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Number ( value ) | Supported with Limitations |  | `built-ins/Number/return-abrupt-tonumber-value.js`<br>`built-ins/Number/S9.3_A1_T1.js`<br>`built-ins/Number/S9.3.1_A17.js`<br>`built-ins/Number/S9.3_A2_T1.js`<br>`built-ins/Number/S9.3_A3_T1.js`<br>`built-ins/Number/S9.3_A4.1_T1.js`<br>`built-ins/Number/S9.3.1_A1.js`<br>`built-ins/Number/S9.3.1_A7.js` | Direct calls to the global Number function are lowered to TypeUtilities.ToNumber and preserve observable abrupt completions even when the converted value is discarded. Checked-in coverage now includes representative undefined, null, boolean, numeric, empty-string, decimal-string, NaN, and hexadecimal-string coercion cases. Wrapper construction is supported for the currently modeled Number object surface, but full Number constructor/prototype semantics remain incomplete. |
+| Number ( value ) | Supported with Limitations |  | `built-ins/Number/return-abrupt-tonumber-value.js`<br>`built-ins/Number/S15.7.1.1_A1.js`<br>`built-ins/Number/S9.3_A1_T1.js`<br>`built-ins/Number/S9.3.1_A17.js`<br>`built-ins/Number/S9.3_A2_T1.js`<br>`built-ins/Number/S9.3_A3_T1.js`<br>`built-ins/Number/S9.3_A4.1_T1.js`<br>`built-ins/Number/S9.3.1_A1.js`<br>`built-ins/Number/S9.3.1_A7.js` | Direct calls to the global Number function are lowered to TypeUtilities.ToNumber and preserve observable abrupt completions even when the converted value is discarded. Checked-in coverage now includes representative undefined, null, boolean, numeric, empty-string, decimal-string, NaN, hexadecimal-string, object-wrapper, and non-canonical infinity-string coercion cases. Wrapper construction is supported for the currently modeled Number object surface, but full Number constructor/prototype semantics remain incomplete. |
 
 ### 21.1.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-number.epsilon))
 
@@ -76,6 +76,18 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | Number.isNaN(number) | Supported | `tests/Jroc.Test262.Tests/built-ins/Number/isNaN/ExecutionTests.cs` | `test/built-ins/Number/isNaN/arg-is-not-number.js`<br>`test/built-ins/Number/isNaN/length.js`<br>`test/built-ins/Number/isNaN/name.js`<br>`test/built-ins/Number/isNaN/nan.js`<br>`test/built-ins/Number/isNaN/not-a-constructor.js`<br>`test/built-ins/Number/isNaN/not-nan.js`<br>`test/built-ins/Number/isNaN/prop-desc.js` | Number.isNaN is exposed on the Number constructor with the expected callable metadata and property descriptor, does not coerce non-number arguments, and returns true only for Number NaN values. |
+
+### 21.1.2.6 ([tc39.es](https://tc39.es/ecma262/#sec-number.max_safe_integer))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Number.MAX_SAFE_INTEGER | Supported |  | `built-ins/Number/MAX_SAFE_INTEGER.js` | Exposed on the Number constructor as a non-writable, non-enumerable, non-configurable data property with value 9007199254740991. |
+
+### 21.1.2.8 ([tc39.es](https://tc39.es/ecma262/#sec-number.min_safe_integer))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Number.MIN_SAFE_INTEGER | Supported |  | `built-ins/Number/MIN_SAFE_INTEGER.js` | Exposed on the Number constructor as a non-writable, non-enumerable, non-configurable data property with value -9007199254740991. |
 
 ### 21.1.2.11 ([tc39.es](https://tc39.es/ecma262/#sec-number.negative_infinity))
 

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -495,6 +495,8 @@ namespace JavaScriptRuntime
             });
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "MAX_VALUE", double.MaxValue);
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "MIN_VALUE", double.Epsilon);
+            DefineIntrinsicConstantDataProperty(_numberFunctionValue, "MAX_SAFE_INTEGER", 9007199254740991d);
+            DefineIntrinsicConstantDataProperty(_numberFunctionValue, "MIN_SAFE_INTEGER", -9007199254740991d);
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "NaN", double.NaN);
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "NEGATIVE_INFINITY", double.NegativeInfinity);
             DefineIntrinsicConstantDataProperty(_numberFunctionValue, "POSITIVE_INFINITY", double.PositiveInfinity);

--- a/tests/Jroc.Test262.Tests/built-ins/Number/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Number/ExecutionTests.cs
@@ -22,6 +22,14 @@ public class ExecutionTests : DiskExecutionTestsBase
     public Task EPSILON()
         => ExecutionTestFromFile("EPSILON");
 
+    [Fact(DisplayName = "MAX_SAFE_INTEGER")]
+    public Task MAX_SAFE_INTEGER()
+        => ExecutionTestFromFile("MAX_SAFE_INTEGER");
+
+    [Fact(DisplayName = "MIN_SAFE_INTEGER")]
+    public Task MIN_SAFE_INTEGER()
+        => ExecutionTestFromFile("MIN_SAFE_INTEGER");
+
     [Fact(DisplayName = "NaN")]
     public Task NaN()
         => ExecutionTestFromFile("NaN");
@@ -77,5 +85,9 @@ public class ExecutionTests : DiskExecutionTestsBase
     [Fact(DisplayName = "MAX_VALUE/S15.7.3.2_A2")]
     public Task MAX_VALUE_S15_7_3_2_A2()
         => ExecutionTestFromFile("MAX_VALUE/S15.7.3.2_A2");
+
+    [Fact(DisplayName = "S15.7.1.1_A1")]
+    public Task S15_7_1_1_A1()
+        => ExecutionTestFromFile("S15.7.1.1_A1");
 
 }

--- a/tests/Jroc.Test262.Tests/built-ins/Number/JavaScript/MAX_SAFE_INTEGER.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Number/JavaScript/MAX_SAFE_INTEGER.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Property descriptor for `Number.MAX_SAFE_INTEGER`
+esid: sec-number.max_safe_integer
+info: |
+    The value of Number.MAX_SAFE_INTEGER is 9007199254740991
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(Number, 'MAX_SAFE_INTEGER');
+
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.set === undefined);
+console.log(desc !== undefined && desc.get === undefined);
+console.log(desc !== undefined && desc.value === 9007199254740991);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.configurable === false);

--- a/tests/Jroc.Test262.Tests/built-ins/Number/JavaScript/MIN_SAFE_INTEGER.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Number/JavaScript/MIN_SAFE_INTEGER.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: Property descriptor for `Number.MIN_SAFE_INTEGER`
+esid: sec-number.min_safe_integer
+info: |
+    The value of Number.MIN_SAFE_INTEGER is -9007199254740991
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(Number, 'MIN_SAFE_INTEGER');
+
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.set === undefined);
+console.log(desc !== undefined && desc.get === undefined);
+console.log(desc !== undefined && desc.value === -9007199254740991);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.configurable === false);

--- a/tests/Jroc.Test262.Tests/built-ins/Number/JavaScript/S15.7.1.1_A1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Number/JavaScript/S15.7.1.1_A1.js
@@ -1,0 +1,18 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    Number([value]) returns a number value (not a Number object) computed by
+    ToNumber(value) if value was supplied
+es5id: 15.7.1.1_A1
+description: Used values "10", 10, new String("10"), new Object(10) and "abc"
+---*/
+
+console.log(typeof Number("10") === "number");
+console.log(typeof Number(10) === "number");
+console.log(typeof Number(new String("10")) === "number");
+console.log(typeof Number(new Object(10)) === "number");
+console.log(Object.is(Number("abc"), NaN));
+console.log(Object.is(Number("INFINITY"), NaN));
+console.log(Object.is(Number("infinity"), NaN));

--- a/tests/Jroc.Test262.Tests/built-ins/Number/Snapshots/ExecutionTests.MAX_SAFE_INTEGER.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Number/Snapshots/ExecutionTests.MAX_SAFE_INTEGER.verified.txt
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Number/Snapshots/ExecutionTests.MIN_SAFE_INTEGER.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Number/Snapshots/ExecutionTests.MIN_SAFE_INTEGER.verified.txt
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Number/Snapshots/ExecutionTests.S15_7_1_1_A1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Number/Snapshots/ExecutionTests.S15_7_1_1_A1.verified.txt
@@ -1,0 +1,7 @@
+true
+true
+true
+true
+true
+true
+true


### PR DESCRIPTION
## Summary
- implement `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` as intrinsic constant data properties on the Number constructor
- unskip and wire 3 newly added non-`eval` Number test262 ports in `tests/Jroc.Test262.Tests/built-ins/Number`
- refresh ECMA-262 Number coverage docs and changelog entries for the expanded support surface

## Test262 ports now passing
- `built-ins/Number/MAX_SAFE_INTEGER.js`
- `built-ins/Number/MIN_SAFE_INTEGER.js`
- `built-ins/Number/S15.7.1.1_A1.js`

## Validation
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj -c Release --filter "FullyQualifiedName~built_ins.Number" --nologo`
