### PR TITLE
fix(test262): align Math value-property descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 - runtime/tests/docs/test262: unskip the remaining non-`eval` global-object/value-property ports, mirroring top-level `var` bindings onto `globalThis` and enforcing strict assignment errors for `NaN`/`undefined`.
 - runtime/tests/docs/test262: implement `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` constructor properties and unskip the new non-`eval` Number constructor/value-property ports (`S15.7.1.1_A1`, `MAX_SAFE_INTEGER`, `MIN_SAFE_INTEGER`).
+- runtime/tests/docs/test262: align Math value-property descriptors by exposing constant data properties (`E`, `LN10`, `LN2`, `LOG10E`, `LOG2E`, `PI`, `SQRT1_2`, `SQRT2`) and add the new non-`eval` `prop-desc` ports for `E`, `LN10`, and `LN2`.
 
 ## v0.10.0 - 2026-06-21
 

--- a/docs/ECMA262/21/Section21_3.json
+++ b/docs/ECMA262/21/Section21_3.json
@@ -12,7 +12,7 @@
     {
       "clause": "21.3.1",
       "title": "Value Properties of the Math Object",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-value-properties-of-the-math-object"
     },
     {
@@ -310,14 +310,17 @@
       ],
       "test262Paths": [
         "test/built-ins/Math/E/value.js",
+        "test/built-ins/Math/E/prop-desc.js",
         "test/built-ins/Math/LN10/value.js",
+        "test/built-ins/Math/LN10/prop-desc.js",
         "test/built-ins/Math/LN2/value.js",
+        "test/built-ins/Math/LN2/prop-desc.js",
         "test/built-ins/Math/LOG10E/value.js",
         "test/built-ins/Math/LOG2E/value.js",
         "test/built-ins/Math/PI/value.js",
         "test/built-ins/Math/SQRT2/value.js"
       ],
-      "notes": "Checked-in coverage now includes representative value checks for the exposed numeric Math constants E, LN10, LN2, LOG10E, LOG2E, PI, and SQRT2."
+      "notes": "Checked-in coverage now includes representative value checks for the exposed numeric Math constants E, LN10, LN2, LOG10E, LOG2E, PI, and SQRT2, plus descriptor-attribute checks for E/LN10/LN2 (`writable: false`, `enumerable: false`, `configurable: false`)."
     },
     {
       "clause": "21.3.2.33",

--- a/docs/ECMA262/21/Section21_3.md
+++ b/docs/ECMA262/21/Section21_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-29T14:16:08Z
+> Last generated (UTC): 2026-06-22T20:21:29Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,7 +14,7 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 21.3.1 | Value Properties of the Math Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-value-properties-of-the-math-object) |
+| 21.3.1 | Value Properties of the Math Object | Supported | [tc39.es](https://tc39.es/ecma262/#sec-value-properties-of-the-math-object) |
 | 21.3.1.1 | Math.E | Supported | [tc39.es](https://tc39.es/ecma262/#sec-math.e) |
 | 21.3.1.2 | Math.LN10 | Supported | [tc39.es](https://tc39.es/ecma262/#sec-math.ln10) |
 | 21.3.1.3 | Math.LN2 | Supported | [tc39.es](https://tc39.es/ecma262/#sec-math.ln2) |
@@ -71,7 +71,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Math numeric value properties | Supported | `tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs` | `test/built-ins/Math/E/value.js`<br>`test/built-ins/Math/LN10/value.js`<br>`test/built-ins/Math/LN2/value.js`<br>`test/built-ins/Math/LOG10E/value.js`<br>`test/built-ins/Math/LOG2E/value.js`<br>`test/built-ins/Math/PI/value.js`<br>`test/built-ins/Math/SQRT2/value.js` | Checked-in coverage now includes representative value checks for the exposed numeric Math constants E, LN10, LN2, LOG10E, LOG2E, PI, and SQRT2. |
+| Math numeric value properties | Supported | `tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs` | `test/built-ins/Math/E/value.js`<br>`test/built-ins/Math/E/prop-desc.js`<br>`test/built-ins/Math/LN10/value.js`<br>`test/built-ins/Math/LN10/prop-desc.js`<br>`test/built-ins/Math/LN2/value.js`<br>`test/built-ins/Math/LN2/prop-desc.js`<br>`test/built-ins/Math/LOG10E/value.js`<br>`test/built-ins/Math/LOG2E/value.js`<br>`test/built-ins/Math/PI/value.js`<br>`test/built-ins/Math/SQRT2/value.js` | Checked-in coverage now includes representative value checks for the exposed numeric Math constants E, LN10, LN2, LOG10E, LOG2E, PI, and SQRT2, plus descriptor-attribute checks for E/LN10/LN2 (`writable: false`, `enumerable: false`, `configurable: false`). |
 
 ### 21.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-function-properties-of-the-math-object))
 

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -279,6 +279,14 @@ namespace JavaScriptRuntime
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.Prototype, _objectPrototypeValue);
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.RestrictedPropertiesPrototype, JavaScriptRuntime.Function.Prototype);
             DefineIntrinsicDataProperty(Math, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "Math");
+            DefineIntrinsicConstantDataProperty(Math, "E", JavaScriptRuntime.Math.E);
+            DefineIntrinsicConstantDataProperty(Math, "LN10", JavaScriptRuntime.Math.LN10);
+            DefineIntrinsicConstantDataProperty(Math, "LN2", JavaScriptRuntime.Math.LN2);
+            DefineIntrinsicConstantDataProperty(Math, "LOG10E", JavaScriptRuntime.Math.LOG10E);
+            DefineIntrinsicConstantDataProperty(Math, "LOG2E", JavaScriptRuntime.Math.LOG2E);
+            DefineIntrinsicConstantDataProperty(Math, "PI", JavaScriptRuntime.Math.PI);
+            DefineIntrinsicConstantDataProperty(Math, "SQRT1_2", JavaScriptRuntime.Math.SQRT1_2);
+            DefineIntrinsicConstantDataProperty(Math, "SQRT2", JavaScriptRuntime.Math.SQRT2);
             DefineIntrinsicDataProperty(JSON, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "JSON");
             DefineIntrinsicDataProperty(Reflect, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "Reflect");
             DefineIntrinsicDataProperty(_intlValue, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "Intl");

--- a/tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs
@@ -41,13 +41,25 @@ public class ExecutionTests : DiskExecutionTestsBase
     public Task E_value()
         => ExecutionTestFromFile("E/value");
 
+    [Fact(DisplayName = "E/prop-desc")]
+    public Task E_prop_desc()
+        => ExecutionTestFromFile("E/prop-desc");
+
     [Fact(DisplayName = "LN10/value")]
     public Task LN10_value()
         => ExecutionTestFromFile("LN10/value");
 
+    [Fact(DisplayName = "LN10/prop-desc")]
+    public Task LN10_prop_desc()
+        => ExecutionTestFromFile("LN10/prop-desc");
+
     [Fact(DisplayName = "LN2/value")]
     public Task LN2_value()
         => ExecutionTestFromFile("LN2/value");
+
+    [Fact(DisplayName = "LN2/prop-desc")]
+    public Task LN2_prop_desc()
+        => ExecutionTestFromFile("LN2/prop-desc");
 
     [Fact(DisplayName = "LOG10E/value")]
     public Task LOG10E_value()

--- a/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/E/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/E/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-math.e
+description: >
+  "E" property of Math
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+  false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(Math, "E");
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.configurable === false);

--- a/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/LN10/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/LN10/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-math.ln10
+description: >
+  "LN10" property of Math
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+  false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(Math, "LN10");
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.configurable === false);

--- a/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/LN2/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/LN2/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2017 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-math.ln2
+description: >
+  "LN2" property of Math
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+  false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(Math, "LN2");
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.configurable === false);

--- a/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.E_prop_desc.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.E_prop_desc.verified.txt
@@ -1,0 +1,4 @@
+﻿true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.LN10_prop_desc.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.LN10_prop_desc.verified.txt
@@ -1,0 +1,4 @@
+﻿true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.LN2_prop_desc.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.LN2_prop_desc.verified.txt
@@ -1,0 +1,4 @@
+﻿true
+true
+true
+true


### PR DESCRIPTION
Port 3 failing non-eval test262 Math descriptor cases (E/LN10/LN2 prop-desc), align Math constant descriptor wiring in runtime, and update changelog plus ECMA-262 section 21.3 docs.