### PR TITLE
fix(test262): align Math/JSON/Reflect @@toStringTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - runtime/tests/docs/test262: unskip the remaining non-`eval` global-object/value-property ports, mirroring top-level `var` bindings onto `globalThis` and enforcing strict assignment errors for `NaN`/`undefined`.
 - runtime/tests/docs/test262: implement `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` constructor properties and unskip the new non-`eval` Number constructor/value-property ports (`S15.7.1.1_A1`, `MAX_SAFE_INTEGER`, `MIN_SAFE_INTEGER`).
 - runtime/tests/docs/test262: align Math value-property descriptors by exposing constant data properties (`E`, `LN10`, `LN2`, `LOG10E`, `LOG2E`, `PI`, `SQRT1_2`, `SQRT2`) and add the new non-`eval` `prop-desc` ports for `E`, `LN10`, and `LN2`.
+- runtime/tests/docs/test262: align non-writable `@@toStringTag` descriptors for Math/JSON/Reflect and add the new non-`eval` `Symbol.toStringTag` ports for those built-ins.
 
 ## v0.10.0 - 2026-06-21
 

--- a/docs/ECMA262/21/Section21_3.json
+++ b/docs/ECMA262/21/Section21_3.json
@@ -66,7 +66,7 @@
     {
       "clause": "21.3.1.9",
       "title": "Math [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%"
     },
     {
@@ -321,6 +321,19 @@
         "test/built-ins/Math/SQRT2/value.js"
       ],
       "notes": "Checked-in coverage now includes representative value checks for the exposed numeric Math constants E, LN10, LN2, LOG10E, LOG2E, PI, and SQRT2, plus descriptor-attribute checks for E/LN10/LN2 (`writable: false`, `enumerable: false`, `configurable: false`)."
+    },
+    {
+      "clause": "21.3.1.9",
+      "feature": "Math[@@toStringTag] descriptor",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%",
+      "testScripts": [
+        "tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs"
+      ],
+      "test262Paths": [
+        "test/built-ins/Math/Symbol.toStringTag.js"
+      ],
+      "notes": "Checked-in coverage now includes Math @@toStringTag value and descriptor attributes (`value: \"Math\"`, `writable: false`, `enumerable: false`, `configurable: true`)."
     },
     {
       "clause": "21.3.2.33",

--- a/docs/ECMA262/21/Section21_3.md
+++ b/docs/ECMA262/21/Section21_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section21](Section21.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-06-22T20:21:29Z
+> Last generated (UTC): 2026-06-22T20:50:08Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -23,7 +23,7 @@
 | 21.3.1.6 | Math.PI | Supported | [tc39.es](https://tc39.es/ecma262/#sec-math.pi) |
 | 21.3.1.7 | Math.SQRT1_2 | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.sqrt1_2) |
 | 21.3.1.8 | Math.SQRT2 | Supported | [tc39.es](https://tc39.es/ecma262/#sec-math.sqrt2) |
-| 21.3.1.9 | Math [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%) |
+| 21.3.1.9 | Math [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%) |
 | 21.3.2 | Function Properties of the Math Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-properties-of-the-math-object) |
 | 21.3.2.1 | Math.abs ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.abs) |
 | 21.3.2.2 | Math.acos ( x ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-math.acos) |
@@ -72,6 +72,12 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | Math numeric value properties | Supported | `tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs` | `test/built-ins/Math/E/value.js`<br>`test/built-ins/Math/E/prop-desc.js`<br>`test/built-ins/Math/LN10/value.js`<br>`test/built-ins/Math/LN10/prop-desc.js`<br>`test/built-ins/Math/LN2/value.js`<br>`test/built-ins/Math/LN2/prop-desc.js`<br>`test/built-ins/Math/LOG10E/value.js`<br>`test/built-ins/Math/LOG2E/value.js`<br>`test/built-ins/Math/PI/value.js`<br>`test/built-ins/Math/SQRT2/value.js` | Checked-in coverage now includes representative value checks for the exposed numeric Math constants E, LN10, LN2, LOG10E, LOG2E, PI, and SQRT2, plus descriptor-attribute checks for E/LN10/LN2 (`writable: false`, `enumerable: false`, `configurable: false`). |
+
+### 21.3.1.9 ([tc39.es](https://tc39.es/ecma262/#sec-math-%symbol.tostringtag%))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Math[@@toStringTag] descriptor | Supported | `tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs` | `test/built-ins/Math/Symbol.toStringTag.js` | Checked-in coverage now includes Math @@toStringTag value and descriptor attributes (`value: "Math"`, `writable: false`, `enumerable: false`, `configurable: true`). |
 
 ### 21.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-function-properties-of-the-math-object))
 

--- a/docs/ECMA262/25/Section25_5.json
+++ b/docs/ECMA262/25/Section25_5.json
@@ -72,7 +72,7 @@
     {
       "clause": "25.5.3",
       "title": "JSON [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%"
     }
   ],
@@ -127,6 +127,19 @@
           "test/built-ins/JSON/stringify/value-tojson-result.js"
         ],
         "notes": "JSON.stringify is implemented for ordinary objects and arrays. Current bounded test262 coverage exercises the builtin function object surface (`JSON.stringify`, `.length`, `.name`, and property descriptor metadata), ordinary property-order serialization, array-replacer ordering/filtering/deduplication, boxed string/number replacer entries, ignored undefined/sparse replacer entries, proxy/revoked-proxy abrupt completion, replacer function return-value serialization, selected toJSON return-value serialization, and string space/gap formatting. Broader cyclic, exotic, BigInt, and cross-realm behavior remains limited."
+      },
+      {
+        "clause": "25.5.3",
+        "feature": "JSON[@@toStringTag] descriptor",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/JSON/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/JSON/Symbol.toStringTag.js"
+        ],
+        "notes": "Checked-in coverage now includes JSON @@toStringTag value and descriptor attributes (`value: \"JSON\"`, `writable: false`, `enumerable: false`, `configurable: true`)."
       }
     ]
   }

--- a/docs/ECMA262/25/Section25_5.md
+++ b/docs/ECMA262/25/Section25_5.md
@@ -4,7 +4,7 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-06-20T15:28:45Z
+> Last generated (UTC): 2026-06-22T20:50:08Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -24,7 +24,7 @@
 | 25.5.2.4 | UnicodeEscape ( C ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-unicodeescape) |
 | 25.5.2.5 | SerializeJSONObject ( state , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonobject) |
 | 25.5.2.6 | SerializeJSONArray ( state , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonarray) |
-| 25.5.3 | JSON [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%) |
+| 25.5.3 | JSON [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%) |
 
 ## Support
 
@@ -41,4 +41,10 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | JSON.stringify | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/JSON/stringify/ExecutionTests.cs` | `test/built-ins/JSON/stringify/builtin.js`<br>`test/built-ins/JSON/stringify/length.js`<br>`test/built-ins/JSON/stringify/name.js`<br>`test/built-ins/JSON/stringify/property-order.js`<br>`test/built-ins/JSON/stringify/prop-desc.js`<br>`test/built-ins/JSON/stringify/replacer-array-abrupt.js`<br>`test/built-ins/JSON/stringify/replacer-array-duplicates.js`<br>`test/built-ins/JSON/stringify/replacer-array-empty.js`<br>`test/built-ins/JSON/stringify/replacer-array-number.js`<br>`test/built-ins/JSON/stringify/replacer-array-number-object.js`<br>`test/built-ins/JSON/stringify/replacer-array-order.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy-revoked.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy-revoked-realm.js`<br>`test/built-ins/JSON/stringify/replacer-array-string-object.js`<br>`test/built-ins/JSON/stringify/replacer-array-undefined.js`<br>`test/built-ins/JSON/stringify/replacer-function-result.js`<br>`test/built-ins/JSON/stringify/space-string.js`<br>`test/built-ins/JSON/stringify/value-tojson-result.js` | JSON.stringify is implemented for ordinary objects and arrays. Current bounded test262 coverage exercises the builtin function object surface (`JSON.stringify`, `.length`, `.name`, and property descriptor metadata), ordinary property-order serialization, array-replacer ordering/filtering/deduplication, boxed string/number replacer entries, ignored undefined/sparse replacer entries, proxy/revoked-proxy abrupt completion, replacer function return-value serialization, selected toJSON return-value serialization, and string space/gap formatting. Broader cyclic, exotic, BigInt, and cross-realm behavior remains limited. |
+
+### 25.5.3 ([tc39.es](https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| JSON[@@toStringTag] descriptor | Supported | `tests/Jroc.Test262.Tests/built-ins/JSON/ExecutionTests.cs` | `test/built-ins/JSON/Symbol.toStringTag.js` | Checked-in coverage now includes JSON @@toStringTag value and descriptor attributes (`value: "JSON"`, `writable: false`, `enumerable: false`, `configurable: true`). |
 

--- a/docs/ECMA262/28/Section28_1.json
+++ b/docs/ECMA262/28/Section28_1.json
@@ -90,8 +90,25 @@
     {
       "clause": "28.1.14",
       "title": "Reflect [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-reflect-%symbol.tostringtag%"
     }
-  ]
+  ],
+  "support": {
+    "entries": [
+      {
+        "clause": "28.1.14",
+        "feature": "Reflect[@@toStringTag] descriptor",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-reflect-%symbol.tostringtag%",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/Reflect/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/Reflect/Symbol.toStringTag.js"
+        ],
+        "notes": "Checked-in coverage now includes Reflect @@toStringTag value and descriptor attributes (`value: \"Reflect\"`, `writable: false`, `enumerable: false`, `configurable: true`)."
+      }
+    ]
+  }
 }

--- a/docs/ECMA262/28/Section28_1.md
+++ b/docs/ECMA262/28/Section28_1.md
@@ -1,11 +1,41 @@
-<!-- AUTO-GENERATED: splitEcma262SectionsIntoSubsections.ps1 -->
+<!-- AUTO-GENERATED: generateEcma262SectionMarkdown.js -->
 
 # Section 28.1: The Reflect Object
 
 [Back to Section28](Section28.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-06-22T20:50:08Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
 | 28.1 | The Reflect Object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect-object) |
+
+## Subclauses
+
+| Clause | Title | Status | Spec |
+|---:|---|---|---|
+| 28.1.1 | Reflect.apply ( target , thisArgument , argumentsList ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.apply) |
+| 28.1.2 | Reflect.construct ( target , argumentsList [ , newTarget ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.construct) |
+| 28.1.3 | Reflect.defineProperty ( target , propertyKey , attributes ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.defineproperty) |
+| 28.1.4 | Reflect.deleteProperty ( target , propertyKey ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.deleteproperty) |
+| 28.1.5 | Reflect.get ( target , propertyKey [ , receiver ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.get) |
+| 28.1.6 | Reflect.getOwnPropertyDescriptor ( target , propertyKey ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.getownpropertydescriptor) |
+| 28.1.7 | Reflect.getPrototypeOf ( target ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.getprototypeof) |
+| 28.1.8 | Reflect.has ( target , propertyKey ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.has) |
+| 28.1.9 | Reflect.isExtensible ( target ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.isextensible) |
+| 28.1.10 | Reflect.ownKeys ( target ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.ownkeys) |
+| 28.1.11 | Reflect.preventExtensions ( target ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.preventextensions) |
+| 28.1.12 | Reflect.set ( target , propertyKey , V [ , receiver ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.set) |
+| 28.1.13 | Reflect.setPrototypeOf ( target , proto ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-reflect.setprototypeof) |
+| 28.1.14 | Reflect [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-reflect-%symbol.tostringtag%) |
+
+## Support
+
+Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 28.1.14 ([tc39.es](https://tc39.es/ecma262/#sec-reflect-%symbol.tostringtag%))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Reflect[@@toStringTag] descriptor | Supported | `tests/Jroc.Test262.Tests/built-ins/Reflect/ExecutionTests.cs` | `test/built-ins/Reflect/Symbol.toStringTag.js` | Checked-in coverage now includes Reflect @@toStringTag value and descriptor attributes (`value: "Reflect"`, `writable: false`, `enumerable: false`, `configurable: true`). |
+

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -278,7 +278,7 @@ namespace JavaScriptRuntime
         {
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.Prototype, _objectPrototypeValue);
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.RestrictedPropertiesPrototype, JavaScriptRuntime.Function.Prototype);
-            DefineIntrinsicDataProperty(Math, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "Math");
+            DefineIntrinsicToStringTagProperty(Math, "Math");
             DefineIntrinsicConstantDataProperty(Math, "E", JavaScriptRuntime.Math.E);
             DefineIntrinsicConstantDataProperty(Math, "LN10", JavaScriptRuntime.Math.LN10);
             DefineIntrinsicConstantDataProperty(Math, "LN2", JavaScriptRuntime.Math.LN2);
@@ -287,9 +287,9 @@ namespace JavaScriptRuntime
             DefineIntrinsicConstantDataProperty(Math, "PI", JavaScriptRuntime.Math.PI);
             DefineIntrinsicConstantDataProperty(Math, "SQRT1_2", JavaScriptRuntime.Math.SQRT1_2);
             DefineIntrinsicConstantDataProperty(Math, "SQRT2", JavaScriptRuntime.Math.SQRT2);
-            DefineIntrinsicDataProperty(JSON, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "JSON");
-            DefineIntrinsicDataProperty(Reflect, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "Reflect");
-            DefineIntrinsicDataProperty(_intlValue, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, "Intl");
+            DefineIntrinsicToStringTagProperty(JSON, "JSON");
+            DefineIntrinsicToStringTagProperty(Reflect, "Reflect");
+            DefineIntrinsicToStringTagProperty(_intlValue, "Intl");
             DefineIntrinsicDataProperty(_intlValue, "NumberFormat", typeof(JavaScriptRuntime.IntlNumberFormat));
             DefineIntrinsicDataProperty(_intlValue, "Segmenter", typeof(JavaScriptRuntime.IntlSegmenter));
 
@@ -875,6 +875,18 @@ namespace JavaScriptRuntime
                 Kind = JsPropertyDescriptorKind.Data,
                 Enumerable = false,
                 Configurable = false,
+                Writable = false,
+                Value = value
+            });
+        }
+
+        private static void DefineIntrinsicToStringTagProperty(object target, string value)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(target, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
                 Writable = false,
                 Value = value
             });

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/ExecutionTests.cs
@@ -13,4 +13,8 @@ public class ExecutionTests : ExecutionTestsBase
     [Fact(DisplayName = "15.12-0-4")]
     public Task _15_12_0_4()
         => ExecutionTest("15.12-0-4");
+
+    [Fact(DisplayName = "Symbol.toStringTag")]
+    public Task Symbol_toStringTag()
+        => ExecutionTest("Symbol.toStringTag");
 }

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/JavaScript/Symbol.toStringTag.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/JavaScript/Symbol.toStringTag.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 24.3.3
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    "JSON".
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.toStringTag]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(JSON, Symbol.toStringTag);
+console.log(JSON[Symbol.toStringTag] === "JSON");
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.configurable === true);

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/Snapshots/ExecutionTests.Symbol_toStringTag.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/Snapshots/ExecutionTests.Symbol_toStringTag.verified.txt
@@ -1,0 +1,5 @@
+﻿true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/ExecutionTests.cs
@@ -93,4 +93,8 @@ public class ExecutionTests : DiskExecutionTestsBase
     public Task SQRT1_2_value()
         => ExecutionTestFromFile("SQRT1_2/value");
 
+    [Fact(DisplayName = "Symbol.toStringTag")]
+    public Task Symbol_toStringTag()
+        => ExecutionTestFromFile("Symbol.toStringTag");
+
 }

--- a/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/Symbol.toStringTag.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/JavaScript/Symbol.toStringTag.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+es6id: 20.2.1.9
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    "Math".
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.toStringTag]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(Math, Symbol.toStringTag);
+console.log(Math[Symbol.toStringTag] === "Math");
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.configurable === true);

--- a/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.Symbol_toStringTag.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Math/Snapshots/ExecutionTests.Symbol_toStringTag.verified.txt
@@ -1,0 +1,5 @@
+﻿true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Reflect/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Reflect/ExecutionTests.cs
@@ -1,0 +1,12 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.Reflect;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.Reflect") { }
+
+    [Fact(DisplayName = "Symbol.toStringTag")]
+    public Task Symbol_toStringTag()
+        => ExecutionTestFromFile("Symbol.toStringTag");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/Reflect/JavaScript/Symbol.toStringTag.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Reflect/JavaScript/Symbol.toStringTag.js
@@ -1,0 +1,21 @@
+// Copyright (C) 2020 Jordan Harband. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    "Reflect".
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.toStringTag, Reflect]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(Reflect, Symbol.toStringTag);
+console.log(Reflect[Symbol.toStringTag] === "Reflect");
+console.log(desc !== undefined);
+console.log(desc !== undefined && desc.writable === false);
+console.log(desc !== undefined && desc.enumerable === false);
+console.log(desc !== undefined && desc.configurable === true);

--- a/tests/Jroc.Test262.Tests/built-ins/Reflect/Snapshots/ExecutionTests.Symbol_toStringTag.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Reflect/Snapshots/ExecutionTests.Symbol_toStringTag.verified.txt
@@ -1,0 +1,5 @@
+﻿true
+true
+true
+true
+true


### PR DESCRIPTION
Port 3 failing non-eval test262 Symbol.toStringTag cases for Math/JSON/Reflect, align runtime @@toStringTag descriptor attributes, and update changelog plus ECMA-262 docs (21.3, 25.5, 28.1).