### PR TITLE
fix(test262): align Object() callable semantics

### DIFF
--- a/.github/skills/find-failing-test262-tests/SKILL.md
+++ b/.github/skills/find-failing-test262-tests/SKILL.md
@@ -20,6 +20,7 @@ Identify failing test262 test cases that:
    - Check if test file is already ported by looking at `tests/Jroc.Test262.Tests/<area>/JavaScript/`
    - Use the test262 relative path as the lookup key (e.g., `test/built-ins/Array/prototype/at/returns-item.js`)
    - Exclude tests that require fully unsupported features (check comments in test file)
+   - Cross-check `docs/ECMA262/` for nearby clauses still marked unsupported or partial support; those gaps often point to missing runtime/compiler behavior behind failing test262 cases
 
 3. **Filter for scope**:
    - Prefer tests that require small fixes: missing methods, property descriptors, small implementations
@@ -49,6 +50,7 @@ node scripts/test262/runMvp.js --filter "built-ins/Array/prototype" --limit 60
 - Avoid tests with `Symbol` in the name unless a Symbol feature was just added
 - Read the test file header (after `/*---`) to see what features it requires
 - Check the error message in RUNTIME-MISMATCH to understand the gap
+- Use `docs/ECMA262/` as a second discovery source: unsupported or partially supported spec entries can help you predict which test262 areas are likely still broken
 
 ## Repo Context
 
@@ -56,4 +58,4 @@ node scripts/test262/runMvp.js --filter "built-ins/Array/prototype" --limit 60
 - Ported tests: `tests/Jroc.Test262.Tests/<category>/<feature>/JavaScript/`
 - Execution tests: `tests/Jroc.Test262.Tests/<category>/<feature>/ExecutionTests.cs`
 - Running test262 MVP: `node scripts/test262/runMvp.js` (fastest way to discover failing tests)
-
+- Spec support docs: `docs/ECMA262/` (use clause status and support notes to spot missing functionality)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - runtime/tests/docs/test262: implement `Array.prototype.at` method for accessing array elements by index with support for negative indices, and add 10 new non-`eval` test262 ports covering basic usage, negative indices, parameter coercion, descriptor validation, and error handling.
+- runtime/tests/docs/test262: align `Object()` / `Object(null)` / `Object(undefined)` callable semantics with ordinary-object creation so the new built-ins/Object constructor ports inherit `Object.prototype` methods and match `new Object(...)`.
 - runtime/tests/docs/test262: unskip the remaining non-`eval` global-object/value-property ports, mirroring top-level `var` bindings onto `globalThis` and enforcing strict assignment errors for `NaN`/`undefined`.
 - runtime/tests/docs/test262: implement `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` constructor properties and unskip the new non-`eval` Number constructor/value-property ports (`S15.7.1.1_A1`, `MAX_SAFE_INTEGER`, `MIN_SAFE_INTEGER`).
 - runtime/tests/docs/test262: align Math value-property descriptors by exposing constant data properties (`E`, `LN10`, `LN2`, `LOG10E`, `LOG2E`, `PI`, `SQRT1_2`, `SQRT2`) and add the new non-`eval` `prop-desc` ports for `E`, `LN10`, and `LN2`.

--- a/docs/ECMA262/20/Section20_1.json
+++ b/docs/ECMA262/20/Section20_1.json
@@ -294,9 +294,15 @@
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-object-value",
         "testScripts": [
-          "tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js"
+          "tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js",
+          "tests/Jroc.Test262.Tests/built-ins/Object/ExecutionTests.cs"
         ],
-        "notes": "Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). Null/undefined return a new empty object; non-null values are returned unchanged (no ToObject boxing/wrapping of primitives)."
+        "test262Paths": [
+          "test/built-ins/Object/S15.2.1.1_A1_T1.js",
+          "test/built-ins/Object/S15.2.1.1_A1_T2.js",
+          "test/built-ins/Object/S15.2.1.1_A1_T3.js"
+        ],
+        "notes": "Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). No-argument, null, and undefined calls now create ordinary objects with `Object.prototype`; primitive strings, numbers, booleans, symbols, and bigints are wrapped; object values are returned unchanged. Full wrapper/internal-slot fidelity remains partial outside the covered cases."
       },
       {
         "clause": "20.1.2.1",

--- a/docs/ECMA262/20/Section20_1.md
+++ b/docs/ECMA262/20/Section20_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-24T13:17:15Z
+> Last generated (UTC): 2026-06-23T22:43:30Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -69,7 +69,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Object(value) (callable semantics) | Supported with Limitations | [`IntrinsicCallables_Object_Callable_ReturnsObject.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js) |  | Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). Null/undefined return a new empty object; non-null values are returned unchanged (no ToObject boxing/wrapping of primitives). |
+| Object(value) (callable semantics) | Supported with Limitations | [`IntrinsicCallables_Object_Callable_ReturnsObject.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/ExecutionTests.cs` | `test/built-ins/Object/S15.2.1.1_A1_T1.js`<br>`test/built-ins/Object/S15.2.1.1_A1_T2.js`<br>`test/built-ins/Object/S15.2.1.1_A1_T3.js` | Calls to Object(...) are lowered to JavaScriptRuntime.Object.Construct(...). No-argument, null, and undefined calls now create ordinary objects with `Object.prototype`; primitive strings, numbers, booleans, symbols, and bigints are wrapped; object values are returned unchanged. Full wrapper/internal-slot fidelity remains partial outside the covered cases. |
 
 ### 20.1.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-object.assign))
 
@@ -81,7 +81,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Object.create | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/create/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.create using the opt-in PrototypeChain side-table to set [[Prototype]] (including null-prototype objects via JS null). When a properties bag is provided, it is applied via defineProperties. Current bounded test262 coverage exercises the function surface, primitive-first-argument TypeError paths, returned-object identity, explicit prototype wiring, and enumerable property-bag inclusion/exclusion. This does not implement full OrdinaryObjectCreate invariants or exotic object behaviors. |
+| Object.create | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Function_Prototype_ObjectCreate_ObjectPrototype.js`](../../../tests/Jroc.Tests/Function/JavaScript/Function_Prototype_ObjectCreate_ObjectPrototype.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/create/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.create using the opt-in PrototypeChain side-table to set [[Prototype]] (including null-prototype objects via JS null). When a properties bag is provided, it is applied via defineProperties. Current bounded test262 coverage exercises the function surface, null/undefined guards, null-prototype creation, explicit prototype wiring, and property-bag initialization. This does not implement full OrdinaryObjectCreate invariants or exotic object behaviors. |
 
 ### 20.1.2.3 ([tc39.es](https://tc39.es/ecma262/#sec-object.defineproperties))
 
@@ -123,7 +123,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Object.getOwnPropertyDescriptor | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) | `tests/Jroc.Test262.Tests/built-ins/Object/getOwnPropertyDescriptor/ExecutionTests.cs` | Implemented in JavaScriptRuntime.Object.getOwnPropertyDescriptor. Returns descriptor objects for own string and symbol keys on ordinary jroc objects, and the current bounded test262 coverage exercises own data-property reflection plus property-key coercion for undefined, null, booleans, numbers, and the empty string. Full host-object descriptor fidelity remains limited. |
+| Object.getOwnPropertyDescriptor | Supported with Limitations | [`ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_NullPrototype_And_GetOwnPropertyDescriptor.js)<br>[`ObjectCreate_WithPropertyDescriptors.js`](../../../tests/Jroc.Tests/Object/JavaScript/ObjectCreate_WithPropertyDescriptors.js)<br>[`Object_SymbolKey_Descriptors_And_Enumeration.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_SymbolKey_Descriptors_And_Enumeration.js) | `test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-0-1.js`<br>`test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-1-1.js`<br>`test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-1.js`<br>`test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-10.js`<br>`test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-18.js` | Implemented in JavaScriptRuntime.Object.getOwnPropertyDescriptor. Returns descriptor objects for own string and symbol keys on ordinary jroc objects, and the current bounded test262 coverage also exercises descriptor reflection for several ordinary/built-in receivers, including property-key normalization for numeric -0. Full host-object descriptor fidelity remains limited. |
 
 ### 20.1.2.9 ([tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptors))
 
@@ -135,7 +135,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Object.getOwnPropertyNames | Supported with Limitations | [`Object_GetOwnPropertyNames_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/getOwnPropertyNames/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.getOwnPropertyNames using ordered own-key helpers plus descriptor/dynamic stores. Returns only string keys, preserving ordinary-object numeric-then-string ordering while excluding symbol keys. Current bounded test262 coverage exercises the function surface, null/undefined TypeError paths, returned-array identity/length, ordinary own-name lookup, and primitive-string coercion. |
+| Object.getOwnPropertyNames | Supported with Limitations | [`Object_GetOwnPropertyNames_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_GetOwnPropertyNames_Basic.js)<br>[`Object_OwnPropertyKeyOrdering.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_OwnPropertyKeyOrdering.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/getOwnPropertyNames/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.getOwnPropertyNames using ordered own-key helpers plus descriptor/dynamic stores. Returns only string keys, preserving ordinary-object numeric-then-string ordering while excluding symbol keys. Current bounded test262 coverage exercises the function surface, returned-array identity/length, and ordinary object own-name lookup. |
 
 ### 20.1.2.11 ([tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertysymbols))
 
@@ -153,7 +153,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Object.getPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/PrototypeChain_Basic.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/getPrototypeOf/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.getPrototypeOf using an opt-in side-table prototype store (JavaScriptRuntime.PrototypeChain). Current bounded test262 coverage exercises the function surface, missing-argument TypeError behavior, constructor/prototype-object relationships for ordinary built-ins, and explicit custom prototype chains. This does not currently model default Object.prototype; if no prototype has been explicitly assigned, this returns undefined (null). |
+| Object.getPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/PrototypeChain_Basic.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/getPrototypeOf/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.getPrototypeOf using an opt-in side-table prototype store (JavaScriptRuntime.PrototypeChain). Current bounded test262 coverage exercises the function surface, null/undefined guard behavior, constructor prototype relationships, and explicit custom prototype chains. This does not currently model default Object.prototype; if no prototype has been explicitly assigned, this returns undefined (null). |
 
 ### 20.1.2.13 ([tc39.es](https://tc39.es/ecma262/#sec-object.groupby))
 
@@ -219,7 +219,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Object.setPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/PrototypeChain_Basic.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/setPrototypeOf/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.setPrototypeOf using an opt-in side-table prototype store. Current bounded test262 coverage exercises successful prototype mutation, the null/undefined-target and invalid-prototype TypeError paths, and the exposed function property descriptor. Rejects null/undefined targets; accepts object-like targets. Does not yet implement full invariant checks, extensibility, or exotic object behaviors. |
+| Object.setPrototypeOf | Supported with Limitations | [`PrototypeChain_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/PrototypeChain_Basic.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/setPrototypeOf/ExecutionTests.cs` |  | Implemented in JavaScriptRuntime.Object.setPrototypeOf using an opt-in side-table prototype store. Current bounded test262 coverage exercises successful prototype mutation plus the null/undefined-target and invalid-prototype TypeError paths. Rejects null/undefined targets; accepts object-like targets. Does not yet implement full invariant checks, extensibility, or exotic object behaviors. |
 
 ### 20.1.2.24 ([tc39.es](https://tc39.es/ecma262/#sec-object.values))
 
@@ -310,3 +310,4 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | Properties of Object instances | Supported with Limitations | [`Object_Prototype_Constructor_IsPrototypeOf.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_Prototype_Constructor_IsPrototypeOf.js)<br>[`PrototypeChain_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/PrototypeChain_Basic.js) |  | Instance-level Object.prototype methods are available through the runtime intrinsic Object.prototype surface; default prototype linkage remains opt-in via runtime prototype-chain mode. |
+

--- a/docs/ECMA262/7/Section7_1.json
+++ b/docs/ECMA262/7/Section7_1.json
@@ -286,9 +286,15 @@
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-toobject",
         "testScripts": [
-          "tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js"
+          "tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js",
+          "tests/Jroc.Test262.Tests/built-ins/Object/ExecutionTests.cs"
         ],
-        "notes": "Object(value) callable behavior is implemented minimally; full wrapper object/internal slot fidelity is incomplete."
+        "test262Paths": [
+          "test/built-ins/Object/S15.2.1.1_A1_T1.js",
+          "test/built-ins/Object/S15.2.1.1_A1_T2.js",
+          "test/built-ins/Object/S15.2.1.1_A1_T3.js"
+        ],
+        "notes": "The Object(value) callable path now covers the ordinary-object cases for no-argument, null, and undefined inputs and preserves primitive wrapper coercions for the covered scalar types. Full wrapper object/internal slot fidelity is still incomplete outside the documented coverage."
       },
       {
         "clause": "7.1.19",

--- a/docs/ECMA262/7/Section7_1.md
+++ b/docs/ECMA262/7/Section7_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-24T04:56:25Z
+> Last generated (UTC): 2026-06-23T22:43:30Z
 
 Type conversion in JROC is implemented on an as-needed basis for supported language features and intrinsics. Some conversions are partial/minimal implementations intended to support specific call sites (e.g., BigInt(value)).
 
@@ -108,7 +108,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| ToObject coercion (Object(value) callable path) | Supported with Limitations | [`IntrinsicCallables_Object_Callable_ReturnsObject.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js) |  | Object(value) callable behavior is implemented minimally; full wrapper object/internal slot fidelity is incomplete. |
+| ToObject coercion (Object(value) callable path) | Supported with Limitations | [`IntrinsicCallables_Object_Callable_ReturnsObject.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Object_Callable_ReturnsObject.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/ExecutionTests.cs` | `test/built-ins/Object/S15.2.1.1_A1_T1.js`<br>`test/built-ins/Object/S15.2.1.1_A1_T2.js`<br>`test/built-ins/Object/S15.2.1.1_A1_T3.js` | The Object(value) callable path now covers the ordinary-object cases for no-argument, null, and undefined inputs and preserves primitive wrapper coercions for the covered scalar types. Full wrapper object/internal slot fidelity is still incomplete outside the documented coverage. |
 
 ### 7.1.19 ([tc39.es](https://tc39.es/ecma262/#sec-topropertykey))
 

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -2114,22 +2114,23 @@ namespace JavaScriptRuntime
         }
 
         /// <summary>
-        /// Implements the JavaScript Object() callable semantics: returns a new empty object.
+        /// Implements the JavaScript Object() callable semantics: returns a new ordinary object
+        /// whose prototype is Object.prototype.
         /// </summary>
         public static object Construct()
         {
-            return new JavaScriptRuntime.Object();
+            return CreateOrdinaryObject();
         }
 
         /// <summary>
-        /// Implements the JavaScript Object(value) callable semantics: returns a new empty object
+        /// Implements the JavaScript Object(value) callable semantics: returns a new ordinary object
         /// for null/undefined, boxes primitives, and returns object values unchanged.
         /// </summary>
         public static object Construct(object? value)
         {
             if (value is null || value is JsNull)
             {
-                return new JavaScriptRuntime.Object();
+                return CreateOrdinaryObject();
             }
 
             if (value is string or char[] or System.Text.StringBuilder)

--- a/tests/Jroc.Test262.Tests/built-ins/Object/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/ExecutionTests.cs
@@ -1,0 +1,20 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.Object;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.Object") { }
+
+    [Fact(DisplayName = "S15.2.1.1_A1_T1")]
+    public Task S15_2_1_1_A1_T1()
+        => ExecutionTestFromFile("S15.2.1.1_A1_T1");
+
+    [Fact(DisplayName = "S15.2.1.1_A1_T2")]
+    public Task S15_2_1_1_A1_T2()
+        => ExecutionTestFromFile("S15.2.1.1_A1_T2");
+
+    [Fact(DisplayName = "S15.2.1.1_A1_T3")]
+    public Task S15_2_1_1_A1_T3()
+        => ExecutionTestFromFile("S15.2.1.1_A1_T3");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/Object/JavaScript/S15.2.1.1_A1_T1.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/JavaScript/S15.2.1.1_A1_T1.js
@@ -1,0 +1,19 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    When the Object(value) is called and the value is null, undefined or not supplied,
+    create and return a new Object object if the object constructor had been called with the same arguments (15.2.2.1)
+es5id: 15.2.1.1_A1_T1
+description: Creating Object(null) and checking its properties
+---*/
+
+var __obj = Object(null);
+var n__obj = new Object(null);
+
+console.log(__obj.toString() === n__obj.toString());
+console.log(__obj.constructor === n__obj.constructor);
+console.log(__obj.prototype === n__obj.prototype);
+console.log(__obj.toLocaleString() === n__obj.toLocaleString());
+console.log(typeof __obj === typeof n__obj);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/JavaScript/S15.2.1.1_A1_T2.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/JavaScript/S15.2.1.1_A1_T2.js
@@ -1,0 +1,19 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    When the Object(value) is called and the value is null, undefined or not supplied,
+    create and return a new Object object if the object constructor had been called with the same arguments (15.2.2.1)
+es5id: 15.2.1.1_A1_T2
+description: Creating Object(void 0) and checking its properties
+---*/
+
+var __obj = Object(void 0);
+var n__obj = new Object(void 0);
+
+console.log(__obj.toString() === n__obj.toString());
+console.log(__obj.constructor === n__obj.constructor);
+console.log(__obj.prototype === n__obj.prototype);
+console.log(__obj.toLocaleString() === n__obj.toLocaleString());
+console.log(typeof __obj === typeof n__obj);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/JavaScript/S15.2.1.1_A1_T3.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/JavaScript/S15.2.1.1_A1_T3.js
@@ -1,0 +1,19 @@
+// Copyright 2009 the Sputnik authors.  All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+info: |
+    When the Object(value) is called and the value is null, undefined or not supplied,
+    create and return a new Object object if the object constructor had been called with the same arguments (15.2.2.1)
+es5id: 15.2.1.1_A1_T3
+description: Creating Object() and checking its properties
+---*/
+
+var __obj = Object();
+var n__obj = new Object();
+
+console.log(__obj.toString() === n__obj.toString());
+console.log(__obj.constructor === n__obj.constructor);
+console.log(__obj.prototype === n__obj.prototype);
+console.log(__obj.toLocaleString() === n__obj.toLocaleString());
+console.log(typeof __obj === typeof n__obj);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/Snapshots/ExecutionTests.S15_2_1_1_A1_T1.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/Snapshots/ExecutionTests.S15_2_1_1_A1_T1.verified.txt
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Object/Snapshots/ExecutionTests.S15_2_1_1_A1_T2.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/Snapshots/ExecutionTests.S15_2_1_1_A1_T2.verified.txt
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Object/Snapshots/ExecutionTests.S15_2_1_1_A1_T3.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/Snapshots/ExecutionTests.S15_2_1_1_A1_T3.verified.txt
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true


### PR DESCRIPTION
## Summary
- align Object(), Object(null), and Object(undefined) with ordinary-object creation so the result inherits Object.prototype
- port 3 failing built-ins/Object test262 constructor cases and record the coverage in ECMA-262 docs and the changelog
- update the failing-test262 skill to also use docs/ECMA262 as a discovery source

## Testing
- targeted Jroc.Test262.Tests Object constructor ports
- targeted Jroc.Tests intrinsic callable Object coverage
- broader Jroc.Test262.Tests built_ins.Object slice
- broader Jroc.Tests Object and IntrinsicCallables slices