### PR TITLE
fix(test262): align Object.fromEntries iterator closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - runtime/tests/docs/test262: implement `Array.prototype.at` method for accessing array elements by index with support for negative indices, and add 10 new non-`eval` test262 ports covering basic usage, negative indices, parameter coercion, descriptor validation, and error handling.
+- runtime/tests/docs/test262: harden `Object.fromEntries` iterator-closing semantics so abrupt entry/key/value failures close iterators correctly without overwriting the original throw completion, and add 5 new non-`eval` Object.fromEntries iterator-edge test262 ports.
 - runtime/tests/docs/test262: align `Object()` / `Object(null)` / `Object(undefined)` callable semantics with ordinary-object creation so the new built-ins/Object constructor ports inherit `Object.prototype` methods and match `new Object(...)`.
 - runtime/tests/docs/test262: unskip the remaining non-`eval` global-object/value-property ports, mirroring top-level `var` bindings onto `globalThis` and enforcing strict assignment errors for `NaN`/`undefined`.
 - runtime/tests/docs/test262: implement `Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER` constructor properties and unskip the new non-`eval` Number constructor/value-property ports (`S15.7.1.1_A1`, `MAX_SAFE_INTEGER`, `MIN_SAFE_INTEGER`).

--- a/docs/ECMA262/20/Section20_1.json
+++ b/docs/ECMA262/20/Section20_1.json
@@ -414,9 +414,17 @@
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-object.fromentries",
         "testScripts": [
-          "tests/Jroc.Tests/Object/JavaScript/Object_FromEntries_Basic.js"
+          "tests/Jroc.Tests/Object/JavaScript/Object_FromEntries_Basic.js",
+          "tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/ExecutionTests.cs"
         ],
-        "notes": "Implemented in JavaScriptRuntime.Object.fromEntries. Creates an object from an iterable of [key, value] pairs using GetIterator. Supports array-like entries. Symbol keys and full iterator protocol edge cases are not implemented."
+        "test262Paths": [
+          "test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-accessor.js",
+          "test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-tostring.js",
+          "test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-value-accessor.js",
+          "test/built-ins/Object/fromEntries/iterator-not-closed-for-next-returning-non-object.js",
+          "test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-done-accessor.js"
+        ],
+        "notes": "Implemented in JavaScriptRuntime.Object.fromEntries. Creates an object from an iterable of [key, value] pairs using GetIterator, now preserving the original abrupt completion while still closing the iterator for entry/key/value extraction failures and avoiding IteratorClose on IteratorStep failures where the spec forbids it. Supports array-like entries. Symbol keys and broader iterator/proxy edge cases are still partial."
       },
       {
         "clause": "20.1.2.8",

--- a/docs/ECMA262/20/Section20_1.md
+++ b/docs/ECMA262/20/Section20_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-06-23T22:43:30Z
+> Last generated (UTC): 2026-06-23T23:18:17Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -117,7 +117,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| Object.fromEntries | Supported with Limitations | [`Object_FromEntries_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_FromEntries_Basic.js) |  | Implemented in JavaScriptRuntime.Object.fromEntries. Creates an object from an iterable of [key, value] pairs using GetIterator. Supports array-like entries. Symbol keys and full iterator protocol edge cases are not implemented. |
+| Object.fromEntries | Supported with Limitations | [`Object_FromEntries_Basic.js`](../../../tests/Jroc.Tests/Object/JavaScript/Object_FromEntries_Basic.js)<br>`tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/ExecutionTests.cs` | `test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-accessor.js`<br>`test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-key-tostring.js`<br>`test/built-ins/Object/fromEntries/iterator-closed-for-throwing-entry-value-accessor.js`<br>`test/built-ins/Object/fromEntries/iterator-not-closed-for-next-returning-non-object.js`<br>`test/built-ins/Object/fromEntries/iterator-not-closed-for-throwing-done-accessor.js` | Implemented in JavaScriptRuntime.Object.fromEntries. Creates an object from an iterable of [key, value] pairs using GetIterator, now preserving the original abrupt completion while still closing the iterator for entry/key/value extraction failures and avoiding IteratorClose on IteratorStep failures where the spec forbids it. Supports array-like entries. Symbol keys and broader iterator/proxy edge cases are still partial. |
 
 ### 20.1.2.8 ([tc39.es](https://tc39.es/ecma262/#sec-object.getownpropertydescriptor))
 

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -1337,16 +1337,16 @@ namespace JavaScriptRuntime
             // Get iterator for the iterable
             var iterator = GetIterator(iterable);
 
-            try
+            while (true)
             {
-                while (true)
+                var iterResult = IteratorNext(iterator);
+                if (IteratorResultDone(iterResult))
                 {
-                    var iterResult = IteratorNext(iterator);
-                    if (IteratorResultDone(iterResult))
-                    {
-                        break;
-                    }
+                    break;
+                }
 
+                try
+                {
                     var entry = IteratorResultValue(iterResult);
                     if (entry is null || entry is JsNull)
                     {
@@ -1386,10 +1386,11 @@ namespace JavaScriptRuntime
                     var keyStr = ToPropertyKeyString(key);
                     dict[keyStr] = value;
                 }
-            }
-            finally
-            {
-                IteratorClose(iterator);
+                catch
+                {
+                    IteratorCloseForThrowCompletion(iterator);
+                    throw;
+                }
             }
 
             return result;

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/ExecutionTests.cs
@@ -1,0 +1,28 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.Object.fromEntries;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.Object.fromEntries") { }
+
+    [Fact(DisplayName = "iterator-closed-for-throwing-entry-key-accessor")]
+    public Task iterator_closed_for_throwing_entry_key_accessor()
+        => ExecutionTestFromFile("iterator-closed-for-throwing-entry-key-accessor");
+
+    [Fact(DisplayName = "iterator-closed-for-throwing-entry-key-tostring")]
+    public Task iterator_closed_for_throwing_entry_key_tostring()
+        => ExecutionTestFromFile("iterator-closed-for-throwing-entry-key-tostring");
+
+    [Fact(DisplayName = "iterator-closed-for-throwing-entry-value-accessor")]
+    public Task iterator_closed_for_throwing_entry_value_accessor()
+        => ExecutionTestFromFile("iterator-closed-for-throwing-entry-value-accessor");
+
+    [Fact(DisplayName = "iterator-not-closed-for-next-returning-non-object")]
+    public Task iterator_not_closed_for_next_returning_non_object()
+        => ExecutionTestFromFile("iterator-not-closed-for-next-returning-non-object");
+
+    [Fact(DisplayName = "iterator-not-closed-for-throwing-done-accessor")]
+    public Task iterator_not_closed_for_throwing_done_accessor()
+        => ExecutionTestFromFile("iterator-not-closed-for-throwing-done-accessor");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-closed-for-throwing-entry-key-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-closed-for-throwing-entry-key-accessor.js
@@ -1,0 +1,65 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.fromentries
+description: Closes iterators when accessing an entry's key throws.
+info: |
+  Object.fromEntries ( iterable )
+
+  ...
+  4. Let stepsDefine be the algorithm steps defined in CreateDataPropertyOnObject Functions.
+  5. Let adder be CreateBuiltinFunction(stepsDefine, « »).
+  6. Return ? AddEntriesFromIterable(obj, iterable, adder).
+
+  AddEntriesFromIterable ( target, iterable, adder )
+
+  ...
+  4. Repeat,
+    ...
+    e. Let k be Get(nextItem, "0").
+    f. If k is an abrupt completion, return ? IteratorClose(iteratorRecord, k).
+
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    var advanced = false;
+    return {
+      next: function() {
+        if (advanced) {
+          throw new Error('should only advance once');
+        }
+        advanced = true;
+        return {
+          done: false,
+          value: {
+            get '0'() {
+              throw new DummyError();
+            },
+          },
+        };
+      },
+      return: function() {
+        if (returned) {
+          throw new Error('should only return once');
+        }
+        returned = true;
+      },
+    };
+  },
+};
+
+var threwDummyError = false;
+try {
+  Object.fromEntries(iterable);
+} catch (error) {
+  threwDummyError = error instanceof DummyError;
+}
+
+console.log(threwDummyError);
+console.log(returned);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-closed-for-throwing-entry-key-tostring.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-closed-for-throwing-entry-key-tostring.js
@@ -1,0 +1,67 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.fromentries
+description: Closes iterators when toString on a key throws.
+info: |
+  Object.fromEntries ( iterable )
+
+  ...
+  4. Let stepsDefine be the algorithm steps defined in CreateDataPropertyOnObject Functions.
+  5. Let adder be CreateBuiltinFunction(stepsDefine, « »).
+  6. Return ? AddEntriesFromIterable(obj, iterable, adder).
+
+  AddEntriesFromIterable ( target, iterable, adder )
+
+  ...
+  4. Repeat,
+    ...
+    e. Let k be Get(nextItem, "0").
+    f. If k is an abrupt completion, return ? IteratorClose(iteratorRecord, k).
+
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    var advanced = false;
+    return {
+      next: function() {
+        if (advanced) {
+          throw new Error('should only advance once');
+        }
+        advanced = true;
+        return {
+          done: false,
+          value: {
+            0: {
+              toString: function() {
+                throw new DummyError();
+              },
+            },
+          },
+        };
+      },
+      return: function() {
+        if (returned) {
+          throw new Error('should only return once');
+        }
+        returned = true;
+      },
+    };
+  },
+};
+
+var threwDummyError = false;
+try {
+  Object.fromEntries(iterable);
+} catch (error) {
+  threwDummyError = error instanceof DummyError;
+}
+
+console.log(threwDummyError);
+console.log(returned);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-closed-for-throwing-entry-value-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-closed-for-throwing-entry-value-accessor.js
@@ -1,0 +1,68 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.fromentries
+description: Closes iterators when accessing an entry's value throws.
+info: |
+  Object.fromEntries ( iterable )
+
+  ...
+  4. Let stepsDefine be the algorithm steps defined in CreateDataPropertyOnObject Functions.
+  5. Let adder be CreateBuiltinFunction(stepsDefine, « »).
+  6. Return ? AddEntriesFromIterable(obj, iterable, adder).
+
+  AddEntriesFromIterable ( target, iterable, adder )
+
+  ...
+  4. Repeat,
+    ...
+    g. Let v be Get(nextItem, "1").
+    h. If v is an abrupt completion, return ? IteratorClose(iteratorRecord, v).
+
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    var advanced = false;
+    return {
+      next: function() {
+        if (advanced) {
+          throw new Error('should only advance once');
+        }
+        advanced = true;
+        return {
+          done: false,
+          value: {
+            get '0'() {
+              return 'key';
+            },
+            get '1'() {
+              throw new DummyError();
+            },
+          },
+        };
+      },
+      return: function() {
+        if (returned) {
+          throw new Error('should only return once');
+        }
+        returned = true;
+      },
+    };
+  },
+};
+
+var threwDummyError = false;
+try {
+  Object.fromEntries(iterable);
+} catch (error) {
+  threwDummyError = error instanceof DummyError;
+}
+
+console.log(threwDummyError);
+console.log(returned);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-not-closed-for-next-returning-non-object.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-not-closed-for-next-returning-non-object.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.fromentries
+description: Does not close iterators with a `next` method which returns a non-object.
+info: |
+  Object.fromEntries ( iterable )
+
+  ...
+  4. Let stepsDefine be the algorithm steps defined in CreateDataPropertyOnObject Functions.
+  5. Let adder be CreateBuiltinFunction(stepsDefine, « »).
+  6. Return ? AddEntriesFromIterable(obj, iterable, adder).
+
+  AddEntriesFromIterable ( target, iterable, adder )
+
+  ...
+  4. Repeat,
+    a. Let next be ? IteratorStep(iteratorRecord).
+
+
+  IteratorStep ( iteratorRecord )
+
+  1. Let result be ? IteratorNext(iteratorRecord).
+
+
+  IteratorNext ( iteratorRecord [ , value ] )
+
+  ...
+  3. If Type(result) is not Object, throw a TypeError exception.
+
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    return {
+      next: function() {
+        return null;
+      },
+      return: function() {
+        returned = true;
+      },
+    };
+  },
+};
+
+var threwTypeError = false;
+try {
+  Object.fromEntries(iterable);
+} catch (error) {
+  threwTypeError = error instanceof TypeError;
+}
+
+console.log(typeof Object.fromEntries === 'function');
+console.log(threwTypeError);
+console.log(returned === false);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-not-closed-for-throwing-done-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/JavaScript/iterator-not-closed-for-throwing-done-accessor.js
@@ -1,0 +1,63 @@
+// Copyright (C) 2018 Kevin Gibbons. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-object.fromentries
+description: Does not close iterators with a `done` accessor which throws.
+info: |
+  Object.fromEntries ( iterable )
+
+  ...
+  4. Let stepsDefine be the algorithm steps defined in CreateDataPropertyOnObject Functions.
+  5. Let adder be CreateBuiltinFunction(stepsDefine, « »).
+  6. Return ? AddEntriesFromIterable(obj, iterable, adder).
+
+  AddEntriesFromIterable ( target, iterable, adder )
+
+  ...
+  4. Repeat,
+    a. Let next be ? IteratorStep(iteratorRecord).
+
+
+  IteratorStep ( iteratorRecord )
+
+  1. Let result be ? IteratorNext(iteratorRecord).
+
+
+  IteratorNext ( iteratorRecord [ , value ] )
+
+  ...
+  3. If Type(result) is not Object, throw a TypeError exception.
+
+features: [Symbol.iterator, Object.fromEntries]
+---*/
+
+function DummyError() {}
+
+var returned = false;
+var iterable = {
+  [Symbol.iterator]: function() {
+    return {
+      next: function() {
+        return {
+          get done() {
+            throw new DummyError();
+          },
+        };
+      },
+      return: function() {
+        returned = true;
+      },
+    };
+  },
+};
+
+var threwDummyError = false;
+try {
+  Object.fromEntries(iterable);
+} catch (error) {
+  threwDummyError = error instanceof DummyError;
+}
+
+console.log(threwDummyError);
+console.log(returned === false);

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_closed_for_throwing_entry_key_accessor.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_closed_for_throwing_entry_key_accessor.verified.txt
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_closed_for_throwing_entry_key_tostring.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_closed_for_throwing_entry_key_tostring.verified.txt
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_closed_for_throwing_entry_value_accessor.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_closed_for_throwing_entry_value_accessor.verified.txt
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_not_closed_for_next_returning_non_object.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_not_closed_for_next_returning_non_object.verified.txt
@@ -1,0 +1,3 @@
+true
+true
+true

--- a/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_not_closed_for_throwing_done_accessor.verified.txt
+++ b/tests/Jroc.Test262.Tests/built-ins/Object/fromEntries/Snapshots/ExecutionTests.iterator_not_closed_for_throwing_done_accessor.verified.txt
@@ -1,0 +1,2 @@
+true
+true


### PR DESCRIPTION
## Summary
- fix Object.fromEntries so abrupt entry/key/value failures preserve the original throw while still performing IteratorClose when required
- avoid calling IteratorClose for IteratorStep failures where the spec says the iterator must not be closed
- port 5 failing Object.fromEntries test262 iterator-edge cases and update the changelog and ECMA-262 docs

## Testing
- targeted Jroc.Test262.Tests Object.fromEntries ports
- targeted Jroc.Tests Object_FromEntries coverage
- broader Jroc.Test262.Tests built_ins.Object slice