### PR TITLE
compiler: extract compiled assembly artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/tests: extract a reusable compiled-assembly artifact for in-memory PE/PDB emission, keep file-backed output as a consumer of that artifact, and add regression coverage for artifact-only compilation without writing generated output files.
 
 ## v0.10.1 - 2026-06-23
 

--- a/src/Compiler/Compiler.cs
+++ b/src/Compiler/Compiler.cs
@@ -36,6 +36,28 @@ public class Compiler
 
     public bool Compile(string inputFile, string? rootModuleIdOverride = null)
     {
+        var artifact = CompileToArtifact(inputFile, rootModuleIdOverride);
+        if (artifact is null)
+        {
+            return false;
+        }
+
+        // Resolve and validate output directory; create if missing
+        if (!EnsureOutputPathExists(inputFile, this.outputDirectory, out var outputPath))
+        {
+            return false;
+        }
+
+        var assemblyGenerator = _serviceProvider.GetRequiredService<AssemblyGenerator>();
+        assemblyGenerator.PersistArtifact(artifact, outputPath);
+
+        _ux.WriteLine($"Compilation succeeded. Output written to {outputPath}");
+
+        return true;
+    }
+
+    internal JrocCompiledAssemblyArtifact? CompileToArtifact(string inputFile, string? rootModuleIdOverride = null)
+    {
         // When diagnostics are enabled, capture IR pipeline failure reasons to aid debugging.
         if (this.diagnosticsEnabled)
         {
@@ -46,17 +68,17 @@ public class Compiler
         var modules = this._moduleLoader.LoadModules(inputFile, rootModuleIdOverride);
         if (modules == null)
         {
-            return false;
+            return null;
         }
 
         if (!this._moduleLoader.LinkModules(modules, _ux))
         {
-            return false;
+            return null;
         }
 
         if (!this._moduleLoader.PlanModuleEvaluation(modules, _ux))
         {
-            return false;
+            return null;
         }
 
         // Analyze unused code (if requested)
@@ -93,20 +115,8 @@ public class Compiler
             _diagnosticLogger.LogInformation("Generating dotnet assembly...");
         }
         var assemblyGenerator = _serviceProvider.GetRequiredService<AssemblyGenerator>();
-
-        // Resolve and validate output directory; create if missing
-        if (!EnsureOutputPathExists(inputFile, this.outputDirectory, out var outputPath))
-        {
-            return false;
-        }
-
         var assemblyName = Path.GetFileNameWithoutExtension(inputFile);
-
-        assemblyGenerator.Generate(modules, assemblyName, outputPath);
-
-        _ux.WriteLine($"Compilation succeeded. Output written to {outputPath}");
-
-        return true;
+        return assemblyGenerator.GenerateArtifact(modules, assemblyName);
     }
 
     private bool EnsureOutputPathExists(string inputFile, string? outputDirectory, out string outputPath)

--- a/src/Compiler/DebugSymbols/PortablePdbEmitter.cs
+++ b/src/Compiler/DebugSymbols/PortablePdbEmitter.cs
@@ -13,17 +13,15 @@ namespace Jroc.DebugSymbols;
 
 internal static class PortablePdbEmitter
 {
-    public static (BlobContentId pdbContentId, ushort portablePdbVersion) Emit(
+    public static (byte[] pdbBytes, BlobContentId pdbContentId, ushort portablePdbVersion) EmitToBytes(
         MetadataBuilder assemblyMetadata,
         DebugSymbolRegistry debugRegistry,
         IFileSystem fileSystem,
-        string pdbPath,
         MethodDefinitionHandle entryPoint)
     {
         ArgumentNullException.ThrowIfNull(assemblyMetadata);
         ArgumentNullException.ThrowIfNull(debugRegistry);
         ArgumentNullException.ThrowIfNull(fileSystem);
-        ArgumentNullException.ThrowIfNull(pdbPath);
 
         var pdbMetadata = new MetadataBuilder();
 
@@ -289,8 +287,24 @@ internal static class PortablePdbEmitter
         var pdbBlob = new BlobBuilder();
         BlobContentId pdbContentId = pdbBuilder.Serialize(pdbBlob);
 
+        return (pdbBlob.ToArray(), pdbContentId, pdbBuilder.FormatVersion);
+    }
+
+    public static (BlobContentId pdbContentId, ushort portablePdbVersion) Emit(
+        MetadataBuilder assemblyMetadata,
+        DebugSymbolRegistry debugRegistry,
+        IFileSystem fileSystem,
+        string pdbPath,
+        MethodDefinitionHandle entryPoint)
+    {
+        ArgumentNullException.ThrowIfNull(pdbPath);
+        var (pdbBytes, pdbContentId, portablePdbVersion) = EmitToBytes(
+            assemblyMetadata,
+            debugRegistry,
+            fileSystem,
+            entryPoint);
+
         Directory.CreateDirectory(Path.GetDirectoryName(pdbPath) ?? ".");
-        var pdbBytes = pdbBlob.ToArray();
         const int maxAttempts = 20;
         for (int attempt = 1; attempt <= maxAttempts; attempt++)
         {
@@ -305,6 +319,6 @@ internal static class PortablePdbEmitter
             }
         }
 
-        return (pdbContentId, pdbBuilder.FormatVersion);
+        return (pdbContentId, portablePdbVersion);
     }
 }

--- a/src/Compiler/JrocCompiledAssemblyArtifact.cs
+++ b/src/Compiler/JrocCompiledAssemblyArtifact.cs
@@ -1,0 +1,7 @@
+namespace Jroc;
+
+public sealed record JrocCompiledAssemblyArtifact(
+    string AssemblyName,
+    byte[] PeBytes,
+    byte[]? PdbBytes,
+    IReadOnlyList<string> ModuleIds);

--- a/src/Compiler/Services/AssemblyGenerator.cs
+++ b/src/Compiler/Services/AssemblyGenerator.cs
@@ -62,6 +62,12 @@ namespace Jroc.Services
         /// <param name="outputPath">The directory to output the generated assembly and related files to.</param>
         public void Generate(Modules modules, string assemblyName, string outputPath)
         {
+            var artifact = GenerateArtifact(modules, assemblyName);
+            PersistArtifact(artifact, outputPath);
+        }
+
+        public JrocCompiledAssemblyArtifact GenerateArtifact(Modules modules, string assemblyName)
+        {
             createAssemblyMetadata(assemblyName);
 
             EmitDebuggableAttributeIfEnabled();
@@ -258,7 +264,7 @@ namespace Jroc.Services
             // This must happen after all TypeDefs have been created.
             _serviceProvider.GetRequiredService<NestedTypeRelationshipRegistry>().EmitAllSorted(_metadataBuilder);
 
-            this.CreateAssembly(assemblyName, outputPath);
+            return CreateCompiledAssemblyArtifact(assemblyName, CollectPublishedModuleIds(modules));
         }
 
         private void EmitDebuggableAttributeIfEnabled()
@@ -645,86 +651,19 @@ namespace Jroc.Services
             throw new ArgumentOutOfRangeException(nameof(value), "Value too large for compressed integer encoding.");
         }
 
-        private void CreateAssembly(string name, string outputPath)
+        internal void PersistArtifact(JrocCompiledAssemblyArtifact artifact, string outputPath)
         {
-            var options = _serviceProvider.GetRequiredService<CompilerOptions>();
+            ArgumentNullException.ThrowIfNull(artifact);
+            ArgumentNullException.ThrowIfNull(outputPath);
 
-            DebugDirectoryBuilder? debugDirectoryBuilder = null;
-            if (options.EmitPdb)
+            var name = artifact.AssemblyName;
+            string assemblyDll = Path.Combine(outputPath, $"{name}.dll");
+            WriteBytesAtomicallyWithRetry(assemblyDll, artifact.PeBytes);
+
+            if (artifact.PdbBytes is { Length: > 0 } pdbBytes)
             {
                 var pdbPath = Path.Combine(outputPath, $"{name}.pdb");
-
-                var debugRegistry = _serviceProvider.GetRequiredService<DebugSymbolRegistry>();
-                var fileSystem = _serviceProvider.GetRequiredService<IFileSystem>();
-                var (pdbContentId, portablePdbVersion) = PortablePdbEmitter.Emit(_metadataBuilder, debugRegistry, fileSystem, pdbPath, this._entryPoint);
-
-                debugDirectoryBuilder = new DebugDirectoryBuilder();
-                debugDirectoryBuilder.AddCodeViewEntry(Path.GetFileName(pdbPath), pdbContentId, portablePdbVersion);
-            }
-
-            var pe = new ManagedPEBuilder(
-                PEHeaderBuilder.CreateLibraryHeader(),
-                new MetadataRootBuilder(_metadataBuilder),
-                _ilBuilder,
-                mappedFieldData: null,
-                entryPoint: this._entryPoint,
-                flags: CorFlags.ILOnly,
-                debugDirectoryBuilder: debugDirectoryBuilder);
-
-            var peImage = new BlobBuilder();
-            pe.Serialize(peImage);
-
-            string assemblyDll = Path.Combine(outputPath, $"{name}.dll");
-
-            // In test runs (and on some machines with aggressive file scanning), the just-produced
-            // assembly can briefly be locked by another process. Retry a few times to avoid flaky
-            // failures while still surfacing a persistent lock.
-            var peBytes = peImage.ToArray();
-
-            // Fail-fast: validate metadata invariants that would otherwise surface later as
-            // BadImageFormatException during Assembly.Load.
-            ClrMetadataConsistencyValidator.ValidateOrThrow(peBytes, label: name);
-            // Windows can keep the output DLL briefly locked (AV/indexing/build hosts). Writing the final
-            // file repeatedly can prolong the lock (each write can re-trigger scanning), so we write to a
-            // unique temp file first and then retry only the final replace.
-            string tempDll = assemblyDll + ".tmp_" + Guid.NewGuid().ToString("N");
-            File.WriteAllBytes(tempDll, peBytes);
-
-            try
-            {
-                const int maxReplaceWaitMs = 60_000;
-                long startTick = Environment.TickCount64;
-                int attempt = 0;
-                while (true)
-                {
-                    attempt++;
-                    try
-                    {
-                        File.Move(tempDll, assemblyDll, overwrite: true);
-                        break;
-                    }
-                    catch (IOException) when ((Environment.TickCount64 - startTick) < maxReplaceWaitMs)
-                    {
-                        int delayMs = Math.Min(1000, 50 * attempt);
-                        Thread.Sleep(delayMs);
-                    }
-                    catch (UnauthorizedAccessException) when ((Environment.TickCount64 - startTick) < maxReplaceWaitMs)
-                    {
-                        int delayMs = Math.Min(1000, 50 * attempt);
-                        Thread.Sleep(delayMs);
-                    }
-                }
-            }
-            finally
-            {
-                try
-                {
-                    if (File.Exists(tempDll)) File.Delete(tempDll);
-                }
-                catch (IOException)
-                {
-                    // Best-effort cleanup; temp files are safe to leave behind.
-                }
+                WriteBytesAtomicallyWithRetry(pdbPath, pdbBytes);
             }
 
             RuntimeConfigWriter.WriteRuntimeConfigJson(assemblyDll, typeof(object).Assembly.GetName());
@@ -782,6 +721,113 @@ namespace Jroc.Services
                             throw;
                         }
                     }
+                }
+            }
+        }
+
+        private JrocCompiledAssemblyArtifact CreateCompiledAssemblyArtifact(string name, IReadOnlyList<string> moduleIds)
+        {
+            var options = _serviceProvider.GetRequiredService<CompilerOptions>();
+
+            DebugDirectoryBuilder? debugDirectoryBuilder = null;
+            byte[]? pdbBytes = null;
+            if (options.EmitPdb)
+            {
+                var debugRegistry = _serviceProvider.GetRequiredService<DebugSymbolRegistry>();
+                var fileSystem = _serviceProvider.GetRequiredService<IFileSystem>();
+                var emittedPdb = PortablePdbEmitter.EmitToBytes(_metadataBuilder, debugRegistry, fileSystem, this._entryPoint);
+                pdbBytes = emittedPdb.pdbBytes;
+
+                debugDirectoryBuilder = new DebugDirectoryBuilder();
+                debugDirectoryBuilder.AddCodeViewEntry($"{name}.pdb", emittedPdb.pdbContentId, emittedPdb.portablePdbVersion);
+            }
+
+            var pe = new ManagedPEBuilder(
+                PEHeaderBuilder.CreateLibraryHeader(),
+                new MetadataRootBuilder(_metadataBuilder),
+                _ilBuilder,
+                mappedFieldData: null,
+                entryPoint: this._entryPoint,
+                flags: CorFlags.ILOnly,
+                debugDirectoryBuilder: debugDirectoryBuilder);
+
+            var peImage = new BlobBuilder();
+            pe.Serialize(peImage);
+            var peBytes = peImage.ToArray();
+
+            // Fail-fast: validate metadata invariants that would otherwise surface later as
+            // BadImageFormatException during Assembly.Load.
+            ClrMetadataConsistencyValidator.ValidateOrThrow(peBytes, label: name);
+
+            return new JrocCompiledAssemblyArtifact(name, peBytes, pdbBytes, moduleIds);
+        }
+
+        private static IReadOnlyList<string> CollectPublishedModuleIds(Modules modules)
+        {
+            var publishedIds = new List<string>();
+            foreach (var module in modules._modules.Values)
+            {
+                if (!publishedIds.Contains(module.ModuleId, StringComparer.OrdinalIgnoreCase))
+                {
+                    publishedIds.Add(module.ModuleId);
+                }
+
+                foreach (var alias in module.AliasModuleIds)
+                {
+                    if (!publishedIds.Contains(alias, StringComparer.OrdinalIgnoreCase))
+                    {
+                        publishedIds.Add(alias);
+                    }
+                }
+            }
+
+            return publishedIds;
+        }
+
+        private static void WriteBytesAtomicallyWithRetry(string destinationPath, byte[] bytes)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(destinationPath) ?? ".");
+
+            // Windows can keep the output file briefly locked (AV/indexing/build hosts). Writing the final
+            // file repeatedly can prolong the lock (each write can re-trigger scanning), so we write to a
+            // unique temp file first and then retry only the final replace.
+            string tempPath = destinationPath + ".tmp_" + Guid.NewGuid().ToString("N");
+            File.WriteAllBytes(tempPath, bytes);
+
+            try
+            {
+                const int maxReplaceWaitMs = 60_000;
+                long startTick = Environment.TickCount64;
+                int attempt = 0;
+                while (true)
+                {
+                    attempt++;
+                    try
+                    {
+                        File.Move(tempPath, destinationPath, overwrite: true);
+                        break;
+                    }
+                    catch (IOException) when ((Environment.TickCount64 - startTick) < maxReplaceWaitMs)
+                    {
+                        int delayMs = Math.Min(1000, 50 * attempt);
+                        Thread.Sleep(delayMs);
+                    }
+                    catch (UnauthorizedAccessException) when ((Environment.TickCount64 - startTick) < maxReplaceWaitMs)
+                    {
+                        int delayMs = Math.Min(1000, 50 * attempt);
+                        Thread.Sleep(delayMs);
+                    }
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (File.Exists(tempPath)) File.Delete(tempPath);
+                }
+                catch (IOException)
+                {
+                    // Best-effort cleanup; temp files are safe to leave behind.
                 }
             }
         }

--- a/tests/Jroc.Tests/CompiledAssemblyArtifactTests.cs
+++ b/tests/Jroc.Tests/CompiledAssemblyArtifactTests.cs
@@ -1,0 +1,66 @@
+using Jroc.Services;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Jroc.Tests;
+
+public sealed class CompiledAssemblyArtifactTests
+{
+    [Fact]
+    public void CompileToArtifact_WithEmitPdb_ProducesReusableBytes_WithoutWritingOutputFiles()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "CompiledAssemblyArtifact", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var jsPath = Path.Combine(outputPath, "artifact.js");
+            var dllPath = Path.Combine(outputPath, "artifact.dll");
+            var pdbPath = Path.Combine(outputPath, "artifact.pdb");
+            var runtimeConfigPath = Path.Combine(outputPath, "artifact.runtimeconfig.json");
+
+            var mockFs = new MockFileSystem();
+            mockFs.AddFile(jsPath, "\"use strict\";\nexports.answer = 42;\n");
+
+            var options = new CompilerOptions
+            {
+                OutputDirectory = outputPath,
+                EmitPdb = true
+            };
+
+            var logger = new TestLogger();
+            var serviceProvider = CompilerServices.BuildServiceProvider(options, mockFs, logger);
+            var compiler = serviceProvider.GetRequiredService<Compiler>();
+
+            var artifact = compiler.CompileToArtifact(jsPath);
+
+            Assert.NotNull(artifact);
+            Assert.Equal("artifact", artifact.AssemblyName);
+            Assert.Contains("artifact", artifact.ModuleIds, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEmpty(artifact.PeBytes);
+            Assert.NotNull(artifact.PdbBytes);
+            Assert.NotEmpty(artifact.PdbBytes!);
+            Assert.False(File.Exists(dllPath), $"Did not expect '{dllPath}' to be written during artifact compilation.");
+            Assert.False(File.Exists(pdbPath), $"Did not expect '{pdbPath}' to be written during artifact compilation.");
+            Assert.False(File.Exists(runtimeConfigPath), $"Did not expect '{runtimeConfigPath}' to be written during artifact compilation.");
+
+            using var peStream = new MemoryStream(artifact.PeBytes, writable: false);
+            using var peReader = new PEReader(peStream);
+            var debugDirectory = peReader.ReadDebugDirectory();
+            var codeViewEntry = Assert.Single(debugDirectory, entry => entry.Type == DebugDirectoryEntryType.CodeView);
+            var codeView = peReader.ReadCodeViewDebugDirectoryData(codeViewEntry);
+            Assert.Equal("artifact.pdb", codeView.Path);
+
+            using var pdbStream = new MemoryStream(artifact.PdbBytes!, writable: false);
+            using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+            var pdbReader = provider.GetMetadataReader();
+            Assert.True(pdbReader.Documents.Any(), "Expected at least one document row in the in-memory PDB.");
+            Assert.True(pdbReader.MethodDebugInformation.Any(), "Expected method debug information in the in-memory PDB.");
+        }
+        finally
+        {
+            try { Directory.Delete(outputPath, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract a reusable compiled assembly artifact so the compiler can emit PE/PDB bytes before deciding whether to persist files
- keep disk-backed output as a consumer of that artifact, including runtimeconfig/runtime dependency copying
- add regression coverage for artifact-only compilation without writing output files

## Testing
- dotnet tool restore
- dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~CompiledAssemblyArtifactTests|FullyQualifiedName~PortablePdbSmokeTests|FullyQualifiedName~CliTests" --nologo

Closes #1270.