### PR TITLE
compiler: add compile-to-memory API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - compiler/tests: extract a reusable compiled-assembly artifact for in-memory PE/PDB emission, keep file-backed output as a consumer of that artifact, and add regression coverage for artifact-only compilation without writing generated output files.
+- compiler/tests: add a public `Jroc.Core` compile-to-memory API that creates a fresh compiler service provider per request, supports source-text or file-backed input, and returns `JrocCompiledAssemblyArtifact` with focused success/failure coverage.
 
 ## v0.10.1 - 2026-06-23
 

--- a/src/Compiler/JrocInMemoryCompileRequest.cs
+++ b/src/Compiler/JrocInMemoryCompileRequest.cs
@@ -1,0 +1,20 @@
+namespace Jroc;
+
+public sealed record JrocInMemoryCompileRequest(string EntryFilePath)
+{
+    public string? SourceText { get; init; }
+
+    public IFileSystem? FileSystem { get; init; }
+
+    public string? RootModuleIdOverride { get; init; }
+
+    public bool EmitPdb { get; init; }
+
+    public bool Verbose { get; init; }
+
+    public string? DiagnosticFilePath { get; init; }
+
+    public bool AnalyzeUnused { get; init; }
+
+    public bool GenerateModuleExportContracts { get; init; } = true;
+}

--- a/src/Compiler/JrocInMemoryCompiler.cs
+++ b/src/Compiler/JrocInMemoryCompiler.cs
@@ -1,0 +1,151 @@
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jroc;
+
+public static class JrocInMemoryCompiler
+{
+    public static JrocCompiledAssemblyArtifact Compile(
+        JrocInMemoryCompileRequest request,
+        ICompilerOutput? compilerOutput = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.EntryFilePath);
+
+        var options = new CompilerOptions
+        {
+            EmitPdb = request.EmitPdb,
+            Verbose = request.Verbose,
+            DiagnosticFilePath = request.DiagnosticFilePath,
+            AnalyzeUnused = request.AnalyzeUnused,
+            GenerateModuleExportContracts = request.GenerateModuleExportContracts
+        };
+
+        var effectiveFileSystem = CreateEffectiveFileSystem(request);
+        var capturingOutput = new CapturingCompilerOutput(compilerOutput);
+        using var services = CompilerServices.BuildServiceProvider(
+            options,
+            fileSystem: effectiveFileSystem,
+            compilerOutput: capturingOutput);
+
+        var compiler = services.GetRequiredService<Compiler>();
+        var artifact = compiler.CompileToArtifact(request.EntryFilePath, request.RootModuleIdOverride);
+        if (artifact is not null)
+        {
+            return artifact;
+        }
+
+        throw new InvalidOperationException(BuildCompilationFailureMessage(capturingOutput));
+    }
+
+    private static IFileSystem CreateEffectiveFileSystem(JrocInMemoryCompileRequest request)
+    {
+        if (request.SourceText is null)
+        {
+            return request.FileSystem ?? new FileSystem();
+        }
+
+        return new OverlayFileSystem(
+            request.FileSystem ?? new FileSystem(),
+            request.EntryFilePath,
+            request.SourceText);
+    }
+
+    private static string BuildCompilationFailureMessage(CapturingCompilerOutput compilerOutput)
+    {
+        var message = new StringBuilder("Compilation failed.");
+
+        if (!string.IsNullOrWhiteSpace(compilerOutput.Errors))
+        {
+            message.AppendLine()
+                .AppendLine("Errors:")
+                .Append(compilerOutput.Errors.TrimEnd());
+        }
+
+        if (!string.IsNullOrWhiteSpace(compilerOutput.Warnings))
+        {
+            message.AppendLine()
+                .AppendLine("Warnings:")
+                .Append(compilerOutput.Warnings.TrimEnd());
+        }
+
+        if (!string.IsNullOrWhiteSpace(compilerOutput.Output))
+        {
+            message.AppendLine()
+                .AppendLine("Output:")
+                .Append(compilerOutput.Output.TrimEnd());
+        }
+
+        return message.ToString();
+    }
+
+    private sealed class CapturingCompilerOutput(ICompilerOutput? inner) : ICompilerOutput
+    {
+        private readonly StringBuilder _output = new();
+        private readonly StringBuilder _warnings = new();
+        private readonly StringBuilder _errors = new();
+
+        public string Output => _output.ToString();
+
+        public string Warnings => _warnings.ToString();
+
+        public string Errors => _errors.ToString();
+
+        public void WriteLine(string message)
+        {
+            _output.AppendLine(message);
+            inner?.WriteLine(message);
+        }
+
+        public void WriteLine()
+        {
+            _output.AppendLine();
+            inner?.WriteLine();
+        }
+
+        public void WriteLineWarning(string message)
+        {
+            _warnings.AppendLine(message);
+            inner?.WriteLineWarning(message);
+        }
+
+        public void WriteLineError(string message)
+        {
+            _errors.AppendLine(message);
+            inner?.WriteLineError(message);
+        }
+    }
+
+    private sealed class OverlayFileSystem(IFileSystem inner, string overlayPath, string overlayContent) : IFileSystem
+    {
+        private readonly string _overlayPath = NormalizePath(overlayPath);
+        private readonly byte[] _overlayBytes = Encoding.UTF8.GetBytes(overlayContent);
+
+        public string ReadAllText(string path)
+        {
+            return IsOverlayPath(path)
+                ? overlayContent
+                : inner.ReadAllText(path);
+        }
+
+        public byte[] ReadAllBytes(string path)
+        {
+            return IsOverlayPath(path)
+                ? _overlayBytes
+                : inner.ReadAllBytes(path);
+        }
+
+        public bool FileExists(string path)
+        {
+            return IsOverlayPath(path) || inner.FileExists(path);
+        }
+
+        private bool IsOverlayPath(string path) => string.Equals(_overlayPath, NormalizePath(path), StringComparison.OrdinalIgnoreCase);
+
+        private static string NormalizePath(string path)
+        {
+            var normalized = path.Replace('/', Path.DirectorySeparatorChar);
+            return Path.GetFullPath(normalized);
+        }
+    }
+}

--- a/tests/Jroc.Tests/JrocInMemoryCompilerTests.cs
+++ b/tests/Jroc.Tests/JrocInMemoryCompilerTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Jroc.Tests;
+
+public sealed class JrocInMemoryCompilerTests
+{
+    [Fact]
+    public void Compile_WithSourceText_ReturnsArtifactWithoutWritingFiles()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "JrocInMemoryCompiler", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var entryPath = Path.Combine(outputPath, "memory-entry.js");
+            var dllPath = Path.Combine(outputPath, "memory-entry.dll");
+
+            var artifact = JrocInMemoryCompiler.Compile(new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = "\"use strict\";\nexports.answer = 42;\n",
+                EmitPdb = true
+            });
+
+            Assert.Equal("memory-entry", artifact.AssemblyName);
+            Assert.Contains("memory-entry", artifact.ModuleIds, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEmpty(artifact.PeBytes);
+            Assert.NotNull(artifact.PdbBytes);
+            Assert.NotEmpty(artifact.PdbBytes!);
+            Assert.False(File.Exists(dllPath), $"Did not expect '{dllPath}' to be written.");
+
+            using var peStream = new MemoryStream(artifact.PeBytes, writable: false);
+            using var peReader = new PEReader(peStream);
+            var codeViewEntry = Assert.Single(peReader.ReadDebugDirectory(), entry => entry.Type == DebugDirectoryEntryType.CodeView);
+            var codeView = peReader.ReadCodeViewDebugDirectoryData(codeViewEntry);
+            Assert.Equal("memory-entry.pdb", codeView.Path);
+
+            using var pdbStream = new MemoryStream(artifact.PdbBytes!, writable: false);
+            using var provider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
+            Assert.True(provider.GetMetadataReader().Documents.Any());
+        }
+        finally
+        {
+            try { Directory.Delete(outputPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Compile_WithFileBackedInput_ReturnsArtifact()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "JrocInMemoryCompilerFileBacked", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outputPath);
+
+        try
+        {
+            var entryPath = Path.Combine(outputPath, "file-backed.js");
+            File.WriteAllText(entryPath, "\"use strict\";\nmodule.exports = 123;\n");
+
+            var artifact = JrocInMemoryCompiler.Compile(new JrocInMemoryCompileRequest(entryPath));
+
+            Assert.Equal("file-backed", artifact.AssemblyName);
+            Assert.Contains("file-backed", artifact.ModuleIds, StringComparer.OrdinalIgnoreCase);
+            Assert.NotEmpty(artifact.PeBytes);
+            Assert.Null(artifact.PdbBytes);
+        }
+        finally
+        {
+            try { Directory.Delete(outputPath, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Compile_WhenCompilationFails_ThrowsWithCapturedErrors()
+    {
+        var entryPath = Path.Combine(Path.GetTempPath(), "broken-memory-entry.js");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => JrocInMemoryCompiler.Compile(new JrocInMemoryCompileRequest(entryPath)
+        {
+            SourceText = "\"use strict\";\nmodule.exports = ;\n"
+        }));
+
+        Assert.Contains("Compilation failed.", ex.Message);
+        Assert.Contains("Parse Errors:", ex.Message);
+        Assert.Contains("Unexpected token", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- add a public `JrocInMemoryCompiler.Compile(...)` API in `Jroc.Core` that returns `JrocCompiledAssemblyArtifact`
- support both source-text and file-backed inputs while creating a fresh compiler service provider per compilation
- capture compiler diagnostics for failure reporting and add focused success/failure regression coverage

## Testing
- dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~JrocInMemoryCompilerTests|FullyQualifiedName~CompiledAssemblyArtifactTests|FullyQualifiedName~PortablePdbSmokeTests" --nologo

Closes #1271.