### PR TITLE
hosting: add collectible in-memory assembly loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 - compiler/tests: extract a reusable compiled-assembly artifact for in-memory PE/PDB emission, keep file-backed output as a consumer of that artifact, and add regression coverage for artifact-only compilation without writing generated output files.
 - compiler/tests: add a public `Jroc.Core` compile-to-memory API that creates a fresh compiler service provider per request, supports source-text or file-backed input, and returns `JrocCompiledAssemblyArtifact` with focused success/failure coverage.
+- hosting/tests: add a collectible in-memory assembly loader for compiled artifacts, loading PE/PDB bytes through `AssemblyLoadContext.LoadFromStream(...)`, sharing the already-loaded runtime assembly, and covering deterministic unload boundaries.
 
 ## v0.10.1 - 2026-06-23
 

--- a/src/Compiler/JrocInMemoryAssemblyLoader.cs
+++ b/src/Compiler/JrocInMemoryAssemblyLoader.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+
+namespace Jroc;
+
+public static class JrocInMemoryAssemblyLoader
+{
+    public static JrocLoadedAssembly Load(JrocCompiledAssemblyArtifact artifact)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        ArgumentNullException.ThrowIfNull(artifact.PeBytes);
+
+        var runtimeAssembly = typeof(JavaScriptRuntime.Object).Assembly;
+        var loadContext = new SharedRuntimeAssemblyLoadContext(artifact.AssemblyName, runtimeAssembly);
+
+        try
+        {
+            using var peStream = new MemoryStream(artifact.PeBytes, writable: false);
+            Assembly assembly;
+            if (artifact.PdbBytes is { Length: > 0 } pdbBytes)
+            {
+                using var pdbStream = new MemoryStream(pdbBytes, writable: false);
+                assembly = loadContext.LoadFromStream(peStream, pdbStream);
+            }
+            else
+            {
+                assembly = loadContext.LoadFromStream(peStream);
+            }
+
+            // Force type resolution while the loader still owns the boundary so missing runtime
+            // dependencies fail deterministically here instead of later at first use.
+            _ = assembly.GetTypes();
+
+            return new JrocLoadedAssembly(loadContext, assembly, artifact.ModuleIds);
+        }
+        catch
+        {
+            loadContext.Unload();
+            throw;
+        }
+    }
+
+    private sealed class SharedRuntimeAssemblyLoadContext(string assemblyName, Assembly sharedRuntimeAssembly)
+        : AssemblyLoadContext($"JROC:{assemblyName}:{Guid.NewGuid():N}", isCollectible: true)
+    {
+        private readonly string _sharedRuntimeAssemblyName = sharedRuntimeAssembly.GetName().Name
+            ?? throw new InvalidOperationException("JavaScript runtime assembly name is required for in-memory loading.");
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            return string.Equals(assemblyName.Name, _sharedRuntimeAssemblyName, StringComparison.Ordinal)
+                ? sharedRuntimeAssembly
+                : null;
+        }
+    }
+}

--- a/src/Compiler/JrocLoadedAssembly.cs
+++ b/src/Compiler/JrocLoadedAssembly.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+
+namespace Jroc;
+
+public sealed class JrocLoadedAssembly : IDisposable
+{
+    private Assembly? _assembly;
+    private AssemblyLoadContext? _loadContext;
+    private int _disposed;
+
+    internal JrocLoadedAssembly(
+        AssemblyLoadContext loadContext,
+        Assembly assembly,
+        IReadOnlyList<string> moduleIds)
+    {
+        _loadContext = loadContext;
+        _assembly = assembly;
+        ModuleIds = moduleIds.ToArray();
+        LoadContextWeakReference = new WeakReference(loadContext);
+    }
+
+    public Assembly Assembly => _assembly ?? throw new ObjectDisposedException(nameof(JrocLoadedAssembly));
+
+    public IReadOnlyList<string> ModuleIds { get; }
+
+    public WeakReference LoadContextWeakReference { get; }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _assembly = null;
+        var loadContext = Interlocked.Exchange(ref _loadContext, null);
+        loadContext?.Unload();
+    }
+}

--- a/tests/Jroc.Tests/JrocInMemoryAssemblyLoaderTests.cs
+++ b/tests/Jroc.Tests/JrocInMemoryAssemblyLoaderTests.cs
@@ -1,0 +1,57 @@
+using System.Runtime.Loader;
+
+namespace Jroc.Tests;
+
+public sealed class JrocInMemoryAssemblyLoaderTests
+{
+    [Fact]
+    public void Load_WithCompiledArtifact_LoadsIntoCollectibleContext_AndSharesRuntimeAssembly()
+    {
+        var artifact = JrocInMemoryCompiler.Compile(new JrocInMemoryCompileRequest(Path.Combine(Path.GetTempPath(), "loader-entry.js"))
+        {
+            SourceText = "\"use strict\";\nmodule.exports = 123;\n",
+            EmitPdb = true
+        });
+
+        using var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
+
+        Assert.Equal(artifact.AssemblyName, loadedAssembly.Assembly.GetName().Name);
+        Assert.Equal(artifact.ModuleIds, loadedAssembly.ModuleIds);
+
+        var loadContext = AssemblyLoadContext.GetLoadContext(loadedAssembly.Assembly);
+        Assert.NotNull(loadContext);
+        Assert.True(loadContext!.IsCollectible);
+
+        var runtimeAssemblyName = typeof(JavaScriptRuntime.Object).Assembly.GetName().Name;
+        Assert.DoesNotContain(
+            loadContext.Assemblies,
+            assembly => !ReferenceEquals(assembly, loadedAssembly.Assembly)
+                && string.Equals(assembly.GetName().Name, runtimeAssemblyName, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Dispose_AllowsLoadContextToBecomeCollectible()
+    {
+        var weakReference = LoadAndDispose();
+
+        for (int i = 0; weakReference.IsAlive && i < 10; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        Assert.False(weakReference.IsAlive);
+    }
+
+    private static WeakReference LoadAndDispose()
+    {
+        var artifact = JrocInMemoryCompiler.Compile(new JrocInMemoryCompileRequest(Path.Combine(Path.GetTempPath(), "loader-unload-entry.js"))
+        {
+            SourceText = "\"use strict\";\nmodule.exports = 456;\n"
+        });
+
+        using var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
+        return loadedAssembly.LoadContextWeakReference;
+    }
+}


### PR DESCRIPTION
## Summary
- add a collectible in-memory assembly loader for `JrocCompiledAssemblyArtifact`
- load PE/PDB bytes through `AssemblyLoadContext.LoadFromStream(...)` while sharing the already-loaded runtime assembly
- add unload-boundary regression coverage for collectible load contexts

## Testing
- dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~JrocInMemoryAssemblyLoaderTests|FullyQualifiedName~JrocInMemoryCompilerTests|FullyQualifiedName~CompiledAssemblyArtifactTests" --nologo

Closes #1272.