### PR TITLE
hosting: add compile-and-load in-memory API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - compiler/tests: extract a reusable compiled-assembly artifact for in-memory PE/PDB emission, keep file-backed output as a consumer of that artifact, and add regression coverage for artifact-only compilation without writing generated output files.
 - compiler/tests: add a public `Jroc.Core` compile-to-memory API that creates a fresh compiler service provider per request, supports source-text or file-backed input, and returns `JrocCompiledAssemblyArtifact` with focused success/failure coverage.
 - hosting/tests: add a collectible in-memory assembly loader for compiled artifacts, loading PE/PDB bytes through `AssemblyLoadContext.LoadFromStream(...)`, sharing the already-loaded runtime assembly, and covering deterministic unload boundaries.
+- hosting/tests: add `CompileAndLoadModule(...)` in-memory hosting APIs for typed and dynamic exports, returning disposable module handles that own both the hosted runtime proxy and the collectible assembly-load boundary.
 
 ## v0.10.1 - 2026-06-23
 

--- a/src/Compiler/JrocInMemoryCompiler.cs
+++ b/src/Compiler/JrocInMemoryCompiler.cs
@@ -1,10 +1,56 @@
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
+using Jroc.Runtime;
 
 namespace Jroc;
 
 public static class JrocInMemoryCompiler
 {
+    public static JrocInMemoryModule<TExports> CompileAndLoadModule<TExports>(
+        JrocInMemoryCompileRequest request,
+        string? moduleId = null,
+        JsModuleLoadOptions? options = null)
+        where TExports : class
+    {
+        var artifact = Compile(request);
+        var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
+
+        try
+        {
+            var resolvedModuleId = ResolveTypedModuleId<TExports>(request, artifact, moduleId);
+            var exports = JsEngine.LoadModule<TExports>(loadedAssembly.Assembly, resolvedModuleId, options);
+            return new JrocInMemoryModule<TExports>(loadedAssembly, exports);
+        }
+        catch
+        {
+            loadedAssembly.Dispose();
+            throw;
+        }
+    }
+
+    public static JrocInMemoryModule CompileAndLoadModule(
+        JrocInMemoryCompileRequest request,
+        string? moduleId = null,
+        JsModuleLoadOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var artifact = Compile(request);
+        var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
+
+        try
+        {
+            var resolvedModuleId = ResolveModuleId(request, artifact, moduleId);
+            var exports = JsEngine.LoadModule(loadedAssembly.Assembly, resolvedModuleId, options);
+            return new JrocInMemoryModule(loadedAssembly, exports, exports);
+        }
+        catch
+        {
+            loadedAssembly.Dispose();
+            throw;
+        }
+    }
+
     public static JrocCompiledAssemblyArtifact Compile(
         JrocInMemoryCompileRequest request,
         ICompilerOutput? compilerOutput = null)
@@ -77,6 +123,95 @@ public static class JrocInMemoryCompiler
         }
 
         return message.ToString();
+    }
+
+    private static string ResolveTypedModuleId<TExports>(
+        JrocInMemoryCompileRequest request,
+        JrocCompiledAssemblyArtifact artifact,
+        string? explicitModuleId)
+        where TExports : class
+    {
+        var matchedExplicitModuleId = MatchPublishedModuleId(artifact, explicitModuleId);
+        if (!string.IsNullOrWhiteSpace(matchedExplicitModuleId))
+        {
+            return matchedExplicitModuleId;
+        }
+
+        var contractType = typeof(TExports);
+        var moduleAttribute = contractType.GetCustomAttributes(typeof(JsModuleAttribute), inherit: false)
+            .OfType<JsModuleAttribute>()
+            .FirstOrDefault();
+        var matchedAttributeModuleId = MatchPublishedModuleId(artifact, moduleAttribute?.ModuleId);
+        if (!string.IsNullOrWhiteSpace(matchedAttributeModuleId))
+        {
+            return matchedAttributeModuleId;
+        }
+
+        return ResolveModuleId(request, artifact, explicitModuleId: null);
+    }
+
+    private static string ResolveModuleId(
+        JrocInMemoryCompileRequest request,
+        JrocCompiledAssemblyArtifact artifact,
+        string? explicitModuleId)
+    {
+        var matchedExplicitModuleId = MatchPublishedModuleId(artifact, explicitModuleId);
+        if (!string.IsNullOrWhiteSpace(matchedExplicitModuleId))
+        {
+            return matchedExplicitModuleId;
+        }
+
+        if (artifact.ModuleIds.Count == 1)
+        {
+            return artifact.ModuleIds[0];
+        }
+
+        var matchedRootOverrideModuleId = MatchPublishedModuleId(artifact, request.RootModuleIdOverride);
+        if (!string.IsNullOrWhiteSpace(matchedRootOverrideModuleId))
+        {
+            return matchedRootOverrideModuleId;
+        }
+
+        throw new InvalidOperationException(
+            "Unable to infer the module id for compile-and-load. " +
+            "Pass moduleId explicitly, set RootModuleIdOverride on the compile request, " +
+            $"or compile an artifact with a single module id. Available module ids: {string.Join(", ", artifact.ModuleIds)}");
+    }
+
+    private static string? MatchPublishedModuleId(JrocCompiledAssemblyArtifact artifact, string? candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return null;
+        }
+
+        var normalizedCandidate = NormalizeModuleId(candidate);
+        return artifact.ModuleIds.FirstOrDefault(moduleId =>
+            string.Equals(NormalizeModuleId(moduleId), normalizedCandidate, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizeModuleId(string moduleId)
+    {
+        var normalized = moduleId.Trim().Replace('\\', '/');
+        if (normalized.StartsWith("./", StringComparison.Ordinal))
+        {
+            normalized = normalized[2..];
+        }
+
+        if (normalized.StartsWith("/", StringComparison.Ordinal))
+        {
+            normalized = normalized[1..];
+        }
+
+        if (normalized.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
+            || normalized.EndsWith(".mjs", StringComparison.OrdinalIgnoreCase)
+            || normalized.EndsWith(".cjs", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = Path.ChangeExtension(normalized.Replace('/', Path.DirectorySeparatorChar), null) ?? normalized;
+            normalized = normalized.Replace('\\', '/');
+        }
+
+        return normalized;
     }
 
     private sealed class CapturingCompilerOutput(ICompilerOutput? inner) : ICompilerOutput

--- a/src/Compiler/JrocInMemoryModule.cs
+++ b/src/Compiler/JrocInMemoryModule.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using System.Threading;
+
+namespace Jroc;
+
+public class JrocInMemoryModule : IDisposable
+{
+    private object? _exports;
+    private IDisposable? _exportsDisposable;
+    private JrocLoadedAssembly? _loadedAssembly;
+    private int _disposed;
+
+    internal JrocInMemoryModule(JrocLoadedAssembly loadedAssembly, object exports, IDisposable exportsDisposable)
+    {
+        _loadedAssembly = loadedAssembly;
+        _exports = exports;
+        _exportsDisposable = exportsDisposable;
+    }
+
+    public object Exports => _exports ?? throw new ObjectDisposedException(nameof(JrocInMemoryModule));
+
+    public Assembly Assembly => LoadedAssembly.Assembly;
+
+    public string AssemblyName => Assembly.GetName().Name ?? string.Empty;
+
+    public IReadOnlyList<string> ModuleIds => LoadedAssembly.ModuleIds;
+
+    public WeakReference LoadContextWeakReference => LoadedAssembly.LoadContextWeakReference;
+
+    protected JrocLoadedAssembly LoadedAssembly => _loadedAssembly ?? throw new ObjectDisposedException(nameof(JrocInMemoryModule));
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        Exception? disposeException = null;
+
+        try
+        {
+            _exportsDisposable?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            disposeException = ex;
+        }
+        finally
+        {
+            _exportsDisposable = null;
+            _exports = null;
+        }
+
+        try
+        {
+            _loadedAssembly?.Dispose();
+        }
+        finally
+        {
+            _loadedAssembly = null;
+        }
+
+        if (disposeException is not null)
+        {
+            throw disposeException;
+        }
+    }
+}

--- a/src/Compiler/JrocInMemoryModuleOfT.cs
+++ b/src/Compiler/JrocInMemoryModuleOfT.cs
@@ -1,0 +1,16 @@
+namespace Jroc;
+
+public sealed class JrocInMemoryModule<TExports> : JrocInMemoryModule
+    where TExports : class
+{
+    internal JrocInMemoryModule(JrocLoadedAssembly loadedAssembly, TExports exports)
+        : base(
+            loadedAssembly,
+            exports,
+            exports as IDisposable
+                ?? throw new InvalidOperationException($"{typeof(TExports).FullName} must implement IDisposable."))
+    {
+    }
+
+    public new TExports Exports => (TExports)base.Exports;
+}

--- a/tests/Jroc.Tests/JrocInMemoryCompileAndLoadTests.cs
+++ b/tests/Jroc.Tests/JrocInMemoryCompileAndLoadTests.cs
@@ -1,0 +1,63 @@
+using Jroc.Runtime;
+
+namespace Jroc.Tests;
+
+public sealed class JrocInMemoryCompileAndLoadTests
+{
+    [Fact]
+    public void CompileAndLoadModule_WithTypedExports_LoadsAndInvokesExportsWithoutDiskAssembly()
+    {
+        var entryPath = Path.Combine(Path.GetTempPath(), "typed-inmemory-module.js");
+
+        using var module = JrocInMemoryCompiler.CompileAndLoadModule<ICalculatorExports>(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = "\"use strict\";\nexports.add = (left, right) => left + right;\n"
+            });
+
+        Assert.Equal(5d, module.Exports.add(2, 3));
+        Assert.Equal("typed-inmemory-module", module.AssemblyName);
+        Assert.Contains("typed-inmemory-module", module.ModuleIds, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CompileAndLoadModule_WithDynamicExports_UsesInferredModuleId()
+    {
+        var entryPath = Path.Combine(Path.GetTempPath(), "dynamic-inmemory-module.js");
+
+        using var module = JrocInMemoryCompiler.CompileAndLoadModule(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = "\"use strict\";\nexports.answer = () => 42;\n"
+            });
+
+        dynamic exports = module.Exports;
+        Assert.Equal(42d, (double)exports.answer());
+        Assert.Equal("dynamic-inmemory-module", module.AssemblyName);
+        Assert.Contains("dynamic-inmemory-module", module.ModuleIds, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CompileAndLoadModule_Dispose_ClosesHostedAccessAndLoadBoundary()
+    {
+        var entryPath = Path.Combine(Path.GetTempPath(), "typed-inmemory-unload.js");
+        var module = JrocInMemoryCompiler.CompileAndLoadModule<ICalculatorExports>(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = "\"use strict\";\nexports.add = (left, right) => left + right;\n"
+            });
+
+        Assert.Equal(9d, module.Exports.add(4, 5));
+
+        module.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => _ = module.Exports);
+        Assert.Throws<ObjectDisposedException>(() => _ = module.Assembly);
+    }
+
+    [JsModule("typed-inmemory-module")]
+    public interface ICalculatorExports : IDisposable
+    {
+        double add(double left, double right);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CompileAndLoadModule(...)` in-memory hosting APIs for typed and dynamic exports
- return disposable module handles that own both the hosted runtime proxy and the collectible assembly-load boundary
- add focused coverage for typed invocation, dynamic invocation, and post-dispose boundary behavior

## Testing
- dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~JrocInMemoryCompileAndLoadTests|FullyQualifiedName~JrocInMemoryAssemblyLoaderTests|FullyQualifiedName~JrocInMemoryCompilerTests" --nologo

Closes #1273.