### PR TITLE
hosting: define in-memory path behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - compiler/tests: add a public `Jroc.Core` compile-to-memory API that creates a fresh compiler service provider per request, supports source-text or file-backed input, and returns `JrocCompiledAssemblyArtifact` with focused success/failure coverage.
 - hosting/tests: add a collectible in-memory assembly loader for compiled artifacts, loading PE/PDB bytes through `AssemblyLoadContext.LoadFromStream(...)`, sharing the already-loaded runtime assembly, and covering deterministic unload boundaries.
 - hosting/tests: add `CompileAndLoadModule(...)` in-memory hosting APIs for typed and dynamic exports, returning disposable module handles that own both the hosted runtime proxy and the collectible assembly-load boundary.
+- hosting/tests: define the path-dependent in-memory hosting contract by keeping `Assembly.Location` empty, documenting that pure in-memory hosting never writes files implicitly, and covering the explicit `child_process.fork` configuration error when no launchable compiled assembly path is supplied.
 
 ## v0.10.1 - 2026-06-23
 

--- a/src/Compiler/JrocInMemoryCompiler.cs
+++ b/src/Compiler/JrocInMemoryCompiler.cs
@@ -6,6 +6,16 @@ namespace Jroc;
 
 public static class JrocInMemoryCompiler
 {
+    /// <summary>
+    /// Compiles JavaScript in memory, loads the generated assembly into a collectible load context,
+    /// evaluates the target module, and returns typed exports for host interaction.
+    /// </summary>
+    /// <remarks>
+    /// This API does not write the generated assembly to disk and does not infer a launchable path from
+    /// <see cref="Assembly.Location"/>. When hosted code may call <c>child_process.fork(...)</c>, pass
+    /// <see cref="JsModuleLoadOptions.CompiledAssemblyPath"/> explicitly so the child process knows which
+    /// compiled assembly to launch.
+    /// </remarks>
     public static JrocInMemoryModule<TExports> CompileAndLoadModule<TExports>(
         JrocInMemoryCompileRequest request,
         string? moduleId = null,
@@ -28,6 +38,16 @@ public static class JrocInMemoryCompiler
         }
     }
 
+    /// <summary>
+    /// Compiles JavaScript in memory, loads the generated assembly into a collectible load context,
+    /// evaluates the target module, and returns a dynamic/reflection-friendly exports proxy.
+    /// </summary>
+    /// <remarks>
+    /// This API does not write the generated assembly to disk and does not infer a launchable path from
+    /// <see cref="Assembly.Location"/>. When hosted code may call <c>child_process.fork(...)</c>, pass
+    /// <see cref="JsModuleLoadOptions.CompiledAssemblyPath"/> explicitly so the child process knows which
+    /// compiled assembly to launch.
+    /// </remarks>
     public static JrocInMemoryModule CompileAndLoadModule(
         JrocInMemoryCompileRequest request,
         string? moduleId = null,

--- a/src/Compiler/JrocInMemoryModule.cs
+++ b/src/Compiler/JrocInMemoryModule.cs
@@ -19,6 +19,9 @@ public class JrocInMemoryModule : IDisposable
 
     public object Exports => _exports ?? throw new ObjectDisposedException(nameof(JrocInMemoryModule));
 
+    /// <summary>
+    /// The generated assembly loaded from memory. Its <see cref="Assembly.Location"/> is typically empty.
+    /// </summary>
     public Assembly Assembly => LoadedAssembly.Assembly;
 
     public string AssemblyName => Assembly.GetName().Name ?? string.Empty;

--- a/tests/Jroc.Tests/JrocInMemoryPathBehaviorTests.cs
+++ b/tests/Jroc.Tests/JrocInMemoryPathBehaviorTests.cs
@@ -7,15 +7,26 @@ public sealed class JrocInMemoryPathBehaviorTests
     [Fact]
     public void CompileAndLoadModule_DoesNotMaterializeAssemblyToDiskImplicitly()
     {
-        var entryPath = Path.Combine(Path.GetTempPath(), "inmemory-location-check.js");
+        var tempRoot = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "InMemoryPathBehavior", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
 
-        using var module = JrocInMemoryCompiler.CompileAndLoadModule(
-            new JrocInMemoryCompileRequest(entryPath)
-            {
-                SourceText = "\"use strict\";\nexports.value = 123;\n"
-            });
+        try
+        {
+            var entryPath = Path.Combine(tempRoot, "inmemory-location-check.js");
 
-        Assert.Equal(string.Empty, module.Assembly.Location);
+            using var module = JrocInMemoryCompiler.CompileAndLoadModule(
+                new JrocInMemoryCompileRequest(entryPath)
+                {
+                    SourceText = "\"use strict\";\nexports.value = 123;\n"
+                });
+
+            Assert.Equal(string.Empty, module.Assembly.Location);
+            Assert.Empty(Directory.EnumerateFileSystemEntries(tempRoot));
+        }
+        finally
+        {
+            try { Directory.Delete(tempRoot, recursive: true); } catch { }
+        }
     }
 
     [Fact]

--- a/tests/Jroc.Tests/JrocInMemoryPathBehaviorTests.cs
+++ b/tests/Jroc.Tests/JrocInMemoryPathBehaviorTests.cs
@@ -1,0 +1,58 @@
+using Jroc.Runtime;
+
+namespace Jroc.Tests;
+
+public sealed class JrocInMemoryPathBehaviorTests
+{
+    [Fact]
+    public void CompileAndLoadModule_DoesNotMaterializeAssemblyToDiskImplicitly()
+    {
+        var entryPath = Path.Combine(Path.GetTempPath(), "inmemory-location-check.js");
+
+        using var module = JrocInMemoryCompiler.CompileAndLoadModule(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = "\"use strict\";\nexports.value = 123;\n"
+            });
+
+        Assert.Equal(string.Empty, module.Assembly.Location);
+    }
+
+    [Fact]
+    public void CompileAndLoadModule_WhenHostedForkNeedsCompiledAssemblyPath_ThrowsExplicitConfigurationError()
+    {
+        var entryPath = Path.Combine(Path.GetTempPath(), "inmemory-fork.js");
+
+        using var module = JrocInMemoryCompiler.CompileAndLoadModule<IHostedForkExports>(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = """
+                    "use strict";
+                    const child_process = require("child_process");
+                    exports.attemptFork = function () {
+                        child_process.fork("./child.js");
+                    };
+                    """
+            });
+
+        var ex = Assert.Throws<JsInvocationException>(() => module.Exports.attemptFork());
+        Assert.Equal("inmemory-fork", ex.ModuleId);
+        Assert.Equal("attemptFork", ex.MemberName);
+
+        var jsError = Assert.IsType<JsErrorException>(ex.InnerException);
+        Assert.Equal("Error", jsError.JsName);
+        Assert.Contains(
+            "child_process.fork requires a compiled assembly path when running under JsEngine hosting",
+            jsError.JsMessage ?? jsError.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "Pass JsModuleLoadOptions.CompiledAssemblyPath",
+            jsError.JsMessage ?? jsError.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    public interface IHostedForkExports : IDisposable
+    {
+        void attemptFork();
+    }
+}


### PR DESCRIPTION
## Summary
- define the in-memory hosting path contract around `Assembly.Location` and hosted path-dependent features
- document that pure in-memory compile-and-load never writes files implicitly and does not infer `CompiledAssemblyPath`
- add focused coverage for the explicit hosted `child_process.fork(...)` configuration error in in-memory mode

## Testing
- dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~JrocInMemoryPathBehaviorTests|FullyQualifiedName~JrocInMemoryCompileAndLoadTests|FullyQualifiedName~JrocInMemoryAssemblyLoaderTests" --nologo

Closes #1274.