### PR TITLE
test: expand in-memory hosting coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - hosting/tests: add a collectible in-memory assembly loader for compiled artifacts, loading PE/PDB bytes through `AssemblyLoadContext.LoadFromStream(...)`, sharing the already-loaded runtime assembly, and covering deterministic unload boundaries.
 - hosting/tests: add `CompileAndLoadModule(...)` in-memory hosting APIs for typed and dynamic exports, returning disposable module handles that own both the hosted runtime proxy and the collectible assembly-load boundary.
 - hosting/tests: define the path-dependent in-memory hosting contract by keeping `Assembly.Location` empty, documenting that pure in-memory hosting never writes files implicitly, and covering the explicit `child_process.fork` configuration error when no launchable compiled assembly path is supplied.
+- hosting/tests: expand in-memory coverage to include an `EmitPdb=true` compile-and-load path so the first-cut optional PDB behavior stays covered end-to-end.
 
 ## v0.10.1 - 2026-06-23
 

--- a/tests/Jroc.Tests/JrocInMemoryCompileAndLoadTests.cs
+++ b/tests/Jroc.Tests/JrocInMemoryCompileAndLoadTests.cs
@@ -21,6 +21,34 @@ public sealed class JrocInMemoryCompileAndLoadTests
     }
 
     [Fact]
+    public void CompileAndLoadModule_WithTypedExportsAndEmitPdb_LoadsExportsWithoutDiskAssembly()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "InMemoryCompileAndLoadPdb", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            var entryPath = Path.Combine(tempRoot, "typed-inmemory-module.js");
+
+            using var module = JrocInMemoryCompiler.CompileAndLoadModule<ICalculatorExports>(
+                new JrocInMemoryCompileRequest(entryPath)
+                {
+                    SourceText = "\"use strict\";\nexports.add = (left, right) => left + right;\n",
+                    EmitPdb = true
+                });
+
+            Assert.Equal(11d, module.Exports.add(5, 6));
+            Assert.Equal("typed-inmemory-module", module.AssemblyName);
+            Assert.Equal(string.Empty, module.Assembly.Location);
+            Assert.Empty(Directory.EnumerateFileSystemEntries(tempRoot));
+        }
+        finally
+        {
+            try { Directory.Delete(tempRoot, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
     public void CompileAndLoadModule_WithDynamicExports_UsesInferredModuleId()
     {
         var entryPath = Path.Combine(Path.GetTempPath(), "dynamic-inmemory-module.js");


### PR DESCRIPTION
## Summary
- expand in-memory hosting coverage with an `EmitPdb=true` compile-and-load regression
- keep explicit coverage for dynamic/typed exports, collectible unload, and path-dependent `Assembly.Location` / `child_process.fork(...)` behavior
- ensure the first-cut optional PDB path stays exercised end-to-end without writing disk artifacts implicitly

## Testing
- dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~JrocInMemoryCompileAndLoadTests|FullyQualifiedName~JrocInMemoryPathBehaviorTests|FullyQualifiedName~JrocInMemoryAssemblyLoaderTests|FullyQualifiedName~JrocInMemoryCompilerTests|FullyQualifiedName~CompiledAssemblyArtifactTests" --nologo

Closes #1275.