### PR TITLE
hosting: release in-memory module require roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - hosting/tests: add `CompileAndLoadModule(...)` in-memory hosting APIs for typed and dynamic exports, returning disposable module handles that own both the hosted runtime proxy and the collectible assembly-load boundary.
 - hosting/tests: define the path-dependent in-memory hosting contract by keeping `Assembly.Location` empty, documenting that pure in-memory hosting never writes files implicitly, and covering the explicit `child_process.fork` configuration error when no launchable compiled assembly path is supplied.
 - hosting/tests: expand in-memory coverage to include an `EmitPdb=true` compile-and-load path so the first-cut optional PDB behavior stays covered end-to-end.
+- runtime/hosting/tests: unregister hosted module require delegates during runtime shutdown so full in-memory compile-and-load modules can release their collectible load contexts after disposal.
 
 ## v0.10.1 - 2026-06-23
 

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -287,6 +287,11 @@ internal sealed class JsRuntimeInstance : IDisposable
         }
         finally
         {
+            if (_serviceProvider?.TryResolve<RuntimeExecutionContext>(out var runtimeContext) == true && runtimeContext != null)
+            {
+                RuntimeServices.UnregisterModuleRequires(runtimeContext.RegisteredModuleRequires);
+            }
+
             // Clear ambient global provider to avoid leaking thread-local state after thread exits.
             GlobalThis.ServiceProvider = null;
 

--- a/src/JavaScriptRuntime/RuntimeExecutionContext.cs
+++ b/src/JavaScriptRuntime/RuntimeExecutionContext.cs
@@ -1,7 +1,11 @@
 namespace JavaScriptRuntime;
 
+using JavaScriptRuntime.CommonJS;
+
 internal sealed class RuntimeExecutionContext
 {
+    private readonly List<KeyValuePair<string, RequireDelegate>> _registeredModuleRequires = new();
+
     internal RuntimeExecutionContext(bool isHosted, string? compiledAssemblyPath = null)
     {
         IsHosted = isHosted;
@@ -11,4 +15,11 @@ internal sealed class RuntimeExecutionContext
     internal bool IsHosted { get; }
 
     internal string? CompiledAssemblyPath { get; }
+
+    internal IReadOnlyList<KeyValuePair<string, RequireDelegate>> RegisteredModuleRequires => _registeredModuleRequires;
+
+    internal void TrackModuleRequire(string moduleId, RequireDelegate require)
+    {
+        _registeredModuleRequires.Add(new KeyValuePair<string, RequireDelegate>(moduleId, require));
+    }
 }

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -991,6 +991,19 @@ public class RuntimeServices
         }
 
         _requireByModuleId[moduleId] = require;
+        if (GlobalThis.ServiceProvider?.TryResolve<RuntimeExecutionContext>(out var runtimeContext) == true
+            && runtimeContext?.IsHosted == true)
+        {
+            runtimeContext.TrackModuleRequire(moduleId, require);
+        }
+    }
+
+    internal static void UnregisterModuleRequires(IEnumerable<KeyValuePair<string, CommonJS.RequireDelegate>> moduleRequires)
+    {
+        foreach (var moduleRequire in moduleRequires)
+        {
+            ((ICollection<KeyValuePair<string, CommonJS.RequireDelegate>>)_requireByModuleId).Remove(moduleRequire);
+        }
     }
 
     /// <summary>

--- a/tests/Jroc.Tests/JrocInMemoryCompileAndLoadTests.cs
+++ b/tests/Jroc.Tests/JrocInMemoryCompileAndLoadTests.cs
@@ -1,4 +1,5 @@
 using Jroc.Runtime;
+using System.Runtime.CompilerServices;
 
 namespace Jroc.Tests;
 
@@ -81,6 +82,42 @@ public sealed class JrocInMemoryCompileAndLoadTests
 
         Assert.Throws<ObjectDisposedException>(() => _ = module.Exports);
         Assert.Throws<ObjectDisposedException>(() => _ = module.Assembly);
+    }
+
+    [Fact]
+    public void CompileAndLoadModule_Dispose_AllowsCollectibleLoadContextToUnload()
+    {
+        var weakReference = LoadAndDisposeHostedModule();
+
+        for (int i = 0; weakReference.IsAlive && i < 10; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        Assert.False(weakReference.IsAlive);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference LoadAndDisposeHostedModule()
+    {
+        var entryPath = Path.Combine(Path.GetTempPath(), "typed-inmemory-hosted-unload.js");
+        var module = JrocInMemoryCompiler.CompileAndLoadModule<ICalculatorExports>(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                SourceText = "\"use strict\";\nexports.add = (left, right) => left + right;\n"
+            });
+
+        try
+        {
+            Assert.Equal(17d, module.Exports.add(8, 9));
+            return module.LoadContextWeakReference;
+        }
+        finally
+        {
+            module.Dispose();
+        }
     }
 
     [JsModule("typed-inmemory-module")]


### PR DESCRIPTION
## Summary
- unregister hosted module `require` delegates during runtime shutdown so static dynamic-import lookup state does not keep hosted modules rooted
- track the module-id/filename require registrations owned by each hosted `RuntimeExecutionContext`
- add a full `CompileAndLoadModule(...)` WeakReference unload regression that proves the collectible load context can be collected after module disposal and GC

## Testing
- dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~JrocInMemoryCompileAndLoadTests|FullyQualifiedName~JrocInMemoryPathBehaviorTests|FullyQualifiedName~JrocInMemoryAssemblyLoaderTests|FullyQualifiedName~JrocInMemoryCompilerTests|FullyQualifiedName~CompiledAssemblyArtifactTests|FullyQualifiedName~CliTests" --nologo

Completes the remaining unload/leak acceptance gap for #1268.