### PR TITLE
runtime: isolate property descriptor overrides

### DIFF
--- a/src/JavaScriptRuntime/Array.cs
+++ b/src/JavaScriptRuntime/Array.cs
@@ -37,6 +37,8 @@ namespace JavaScriptRuntime
 
         private static ExpandoObject CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var exp = new ExpandoObject();
             ConfigurePrototype(exp);
             return exp;
@@ -49,6 +51,8 @@ namespace JavaScriptRuntime
 
         private static ExpandoObject CreateThreadPrototypeOverride()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new ExpandoObject();
             PropertyDescriptorStore.CopyOwnProperties(ImmutablePrototype, prototype);
 

--- a/src/JavaScriptRuntime/AsyncFunction.cs
+++ b/src/JavaScriptRuntime/AsyncFunction.cs
@@ -10,6 +10,8 @@ public static class AsyncFunction
 
     static AsyncFunction()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         Function.InitializeFunctionInstance(ConstructorValue);
         PrototypeChain.SetPrototype(ConstructorValue, GlobalThis.Function);
         PrototypeChain.SetPrototype(Prototype, Function.Prototype);
@@ -83,6 +85,8 @@ public static class AsyncFunction
 
     private static object CreatePrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         return new JsObject();
     }
 

--- a/src/JavaScriptRuntime/AsyncGeneratorFunction.cs
+++ b/src/JavaScriptRuntime/AsyncGeneratorFunction.cs
@@ -9,6 +9,8 @@ public static class AsyncGeneratorFunction
 
     static AsyncGeneratorFunction()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         JavaScriptRuntime.Function.InitializeFunctionInstance(_constructor, 1d, "AsyncGeneratorFunction", requiresInvocationContext: false);
         PrototypeChain.SetPrototype(_constructor, GlobalThis.Function);
         PropertyDescriptorStore.DefineOrUpdate(_constructor, "prototype", new JsPropertyDescriptor
@@ -30,6 +32,8 @@ public static class AsyncGeneratorFunction
 
     private static JsObject CreatePrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         var prototype = new JsObject();
         PrototypeChain.SetPrototype(prototype, JavaScriptRuntime.Function.Prototype);
         PropertyDescriptorStore.DefineOrUpdate(prototype, "constructor", new JsPropertyDescriptor

--- a/src/JavaScriptRuntime/AsyncIterator.cs
+++ b/src/JavaScriptRuntime/AsyncIterator.cs
@@ -8,6 +8,8 @@ public static class AsyncIterator
 
     internal static void ConfigureIntrinsicSurface(object asyncIteratorConstructorValue)
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         DefineDataProperty(asyncIteratorConstructorValue, "prototype", Prototype);
         DefineDataProperty(Prototype, "constructor", asyncIteratorConstructorValue);
         DefineDataProperty(Prototype, "next", (Func<object[], object?[]?, object?>)PrototypeNext);
@@ -26,6 +28,8 @@ public static class AsyncIterator
 
     private static object CreatePrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         return new JsObject();
     }
 

--- a/src/JavaScriptRuntime/Function.cs
+++ b/src/JavaScriptRuntime/Function.cs
@@ -17,11 +17,6 @@ namespace JavaScriptRuntime
     /// </summary>
 public static class Function
 {
-    private sealed class DeletedMetadataSlot
-    {
-        public readonly HashSet<string> Keys = new(StringComparer.Ordinal);
-    }
-
     private sealed class InvocationMetadataSlot
     {
         public bool RequiresInvocationContext;
@@ -31,7 +26,6 @@ public static class Function
     {
     }
 
-    private static readonly ConditionalWeakTable<Delegate, DeletedMetadataSlot> _deletedMetadataProperties = new();
     private static readonly ConditionalWeakTable<Delegate, InvocationMetadataSlot> _invocationMetadata = new();
     private static readonly ConditionalWeakTable<Delegate, UndefinedPrototypeSlot> _undefinedPrototypeFunctions = new();
 
@@ -40,6 +34,8 @@ public static class Function
 
     private static ExpandoObject CreatePrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         var exp = new ExpandoObject();
         DefinePrototypeMethod(exp, "apply", (Func<object[], object?[]?, object?>)PrototypeApply, 2);
         DefinePrototypeMethod(exp, "call", (Func<object[], object?[]?, object?>)PrototypeCall, 1);
@@ -54,7 +50,6 @@ public static class Function
     {
         var value = CreateBuiltinPrototypeFunction(method, length);
         PrototypeChain.SetPrototype(value, prototype);
-        ((IDictionary<string, object?>)prototype)[name] = value;
         PropertyDescriptorStore.DefineOrUpdate(prototype, name, new JsPropertyDescriptor
         {
             Kind = JsPropertyDescriptorKind.Data,
@@ -67,7 +62,15 @@ public static class Function
 
     internal static bool TryGetPrototypeValue(string name, out object? value)
     {
-        return ((IDictionary<string, object?>)Prototype).TryGetValue(name, out value);
+        if (PropertyDescriptorStore.TryGetOwn(Prototype, name, out var descriptor)
+            && descriptor.Kind == JsPropertyDescriptorKind.Data)
+        {
+            value = descriptor.Value;
+            return true;
+        }
+
+        value = null;
+        return false;
     }
 
     private static Func<object[], object?[]?, object?> CreateBuiltinPrototypeFunction(Func<object[], object?[]?, object?> method, double length)
@@ -94,6 +97,8 @@ public static class Function
 
     private static ExpandoObject CreateRestrictedPropertiesPrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         var exp = new ExpandoObject();
         DefineRestrictedProperty(exp, "caller");
         DefineRestrictedProperty(exp, "arguments");
@@ -676,7 +681,7 @@ public static class Function
         {
             if (target is null) throw new ArgumentNullException(nameof(target));
 
-            if (IsDeletedMetadataProperty(target, propName))
+            if (IsMetadataPropertyName(propName) && PropertyDescriptorStore.IsDeleted(target, propName))
             {
                 descriptor = null!;
                 return false;
@@ -725,22 +730,12 @@ public static class Function
 
             PropertyDescriptorStore.Delete(target, propName);
 
-            if (IsMetadataPropertyName(propName))
-            {
-                _deletedMetadataProperties.GetOrCreateValue(target).Keys.Add(propName);
-            }
-
             return true;
         }
 
         internal static void ClearDeletedMetadataProperty(Delegate target, string propName)
         {
             if (target is null) throw new ArgumentNullException(nameof(target));
-
-            if (_deletedMetadataProperties.TryGetValue(target, out var deleted))
-            {
-                deleted.Keys.Remove(propName);
-            }
         }
 
         private static bool IsSyntheticDynamicFunctionDeclaringTypeName(string? declaringTypeName)
@@ -789,10 +784,6 @@ public static class Function
             var scopeType = declaringType?.GetNestedType("Scope", BindingFlags.Public | BindingFlags.NonPublic);
             return scopeType != null && typeof(GeneratorScope).IsAssignableFrom(scopeType);
         }
-
-        private static bool IsDeletedMetadataProperty(Delegate target, string propName)
-            => _deletedMetadataProperties.TryGetValue(target, out var deleted)
-                && deleted.Keys.Contains(propName);
 
         private static bool IsMetadataPropertyName(string propName)
             => string.Equals(propName, "length", StringComparison.Ordinal)

--- a/src/JavaScriptRuntime/GeneratorObject.cs
+++ b/src/JavaScriptRuntime/GeneratorObject.cs
@@ -44,6 +44,8 @@ public sealed class GeneratorObject : IJavaScriptIterator
 
     static GeneratorObject()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         Function.InitializeFunctionInstance(_generatorFunctionConstructor, 1d, "GeneratorFunction", requiresInvocationContext: false);
         PrototypeChain.SetPrototype(_generatorFunctionConstructor, GlobalThis.Function);
         PropertyDescriptorStore.DefineOrUpdate(_generatorFunctionConstructor, "prototype", new JsPropertyDescriptor
@@ -58,6 +60,8 @@ public sealed class GeneratorObject : IJavaScriptIterator
 
     private static object CreatePrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         var prototype = new JsObject();
         PrototypeChain.SetPrototype(prototype, Iterator.Prototype);
         DefineDataProperty(prototype, "constructor", _generatorFunctionConstructor);
@@ -70,6 +74,8 @@ public sealed class GeneratorObject : IJavaScriptIterator
 
     private static object CreateGeneratorFunctionPrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         var prototype = new JsObject();
         PrototypeChain.SetPrototype(prototype, Function.Prototype);
         DefineDataProperty(prototype, "constructor", _generatorFunctionConstructor);

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -276,6 +276,8 @@ namespace JavaScriptRuntime
 
         static GlobalThis()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.Prototype, _objectPrototypeValue);
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.RestrictedPropertiesPrototype, JavaScriptRuntime.Function.Prototype);
             DefineIntrinsicToStringTagProperty(Math, "Math");
@@ -736,6 +738,15 @@ namespace JavaScriptRuntime
             set
             {
                 _serviceProvider.Value = value;
+                if (value?.TryResolve<IPropertyDescriptorStore>(out var propertyDescriptorStore) == true
+                    && propertyDescriptorStore != null)
+                {
+                    PropertyDescriptorStore.SetCurrentRuntimeStore(propertyDescriptorStore);
+                }
+                else
+                {
+                    PropertyDescriptorStore.SetCurrentRuntimeStore(null);
+                }
 
                 // Each configured runtime corresponds to a new execution context/realm.
                 // Ensure we don't leak a prior global object across Engine.Execute calls on the same thread.

--- a/src/JavaScriptRuntime/Iterator.cs
+++ b/src/JavaScriptRuntime/Iterator.cs
@@ -11,6 +11,8 @@ public static class Iterator
 
     internal static void ConfigureIntrinsicSurface(object iteratorConstructorValue)
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         DefineDataProperty(iteratorConstructorValue, "prototype", Prototype);
         DefineDataProperty(iteratorConstructorValue, "from", (Func<object[], object?[]?, object?>)ConstructorFrom);
 
@@ -70,11 +72,15 @@ public static class Iterator
 
     private static object CreatePrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         return new JsObject();
     }
 
     private static object CreateHelperPrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         var prototype = new JsObject();
         PrototypeChain.SetPrototype(prototype, Prototype);
         return prototype;

--- a/src/JavaScriptRuntime/Map.cs
+++ b/src/JavaScriptRuntime/Map.cs
@@ -16,6 +16,8 @@ namespace JavaScriptRuntime
 
         private static ExpandoObject CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var exp = new ExpandoObject();
             DefinePrototypeMethod(exp, "set", PrototypeSet);
             DefinePrototypeMethod(exp, "get", PrototypeGet);

--- a/src/JavaScriptRuntime/Node/Url.cs
+++ b/src/JavaScriptRuntime/Node/Url.cs
@@ -14,6 +14,8 @@ namespace JavaScriptRuntime.Node
 
         static Url()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             ConfigureConstructorSurface(URLConstructorValue, global::JavaScriptRuntime.Node.URL.Prototype);
             ConfigureConstructorSurface(URLSearchParamsConstructorValue, global::JavaScriptRuntime.Node.URLSearchParams.Prototype);
         }
@@ -293,6 +295,8 @@ namespace JavaScriptRuntime.Node
 
         private static object CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "toJSON", PrototypeToJson);
             DefinePrototypeMethod(prototype, "toString", PrototypeToString);
@@ -645,6 +649,8 @@ namespace JavaScriptRuntime.Node
 
         private static object CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "append", PrototypeAppend);
             DefinePrototypeMethod(prototype, "delete", PrototypeDelete);

--- a/src/JavaScriptRuntime/Object.cs
+++ b/src/JavaScriptRuntime/Object.cs
@@ -887,6 +887,8 @@ namespace JavaScriptRuntime
 
         public static void ConfigureIntrinsicSurface(object objectConstructorValue, object objectPrototypeValue)
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             DefineBuiltinDataProperty(objectConstructorValue, "prototype", objectPrototypeValue, enumerable: false, configurable: true, writable: true);
 
             DefineBuiltinDataProperty(objectConstructorValue, "assign", _objectAssignValue);
@@ -1449,7 +1451,7 @@ namespace JavaScriptRuntime
                 array.length = (double)arrayIndex + 1;
             }
 
-            if (obj is IDictionary<string, object?> dict)
+            if (obj is IDictionary<string, object?> dict && !PropertyDescriptorStore.HasIntrinsicProperties(obj))
             {
                 if (appliedDescriptor.Kind == JsPropertyDescriptorKind.Accessor)
                 {
@@ -1992,7 +1994,9 @@ namespace JavaScriptRuntime
                 Set = setter
             });
 
-            if (target is IDictionary<string, object?> dict && !dict.ContainsKey(key))
+            if (target is IDictionary<string, object?> dict
+                && !PropertyDescriptorStore.HasIntrinsicProperties(target)
+                && !dict.ContainsKey(key))
             {
                 dict[key] = null;
             }
@@ -2034,7 +2038,9 @@ namespace JavaScriptRuntime
                 Set = setter
             });
 
-            if (target is IDictionary<string, object?> dict && !dict.ContainsKey(key))
+            if (target is IDictionary<string, object?> dict
+                && !PropertyDescriptorStore.HasIntrinsicProperties(target)
+                && !dict.ContainsKey(key))
             {
                 dict[key] = null;
             }
@@ -5001,7 +5007,7 @@ namespace JavaScriptRuntime
                 return;
             }
 
-            if (target is IDictionary<string, object?> dict)
+            if (target is IDictionary<string, object?> dict && !PropertyDescriptorStore.HasIntrinsicProperties(target))
             {
                 dict[key] = value;
                 return;
@@ -5037,31 +5043,22 @@ namespace JavaScriptRuntime
             // ExpandoObject: copy all enumerable own properties.
             if (source is System.Dynamic.ExpandoObject exp)
             {
-                var src = (IDictionary<string, object?>)exp;
-                foreach (var kvp in src)
+                var srcSeen = new HashSet<string>(StringComparer.Ordinal);
+                EnumerateOwnEnumerableProperties(exp, srcSeen, (key, value) =>
                 {
-                    if (!PropertyDescriptorStore.IsEnumerableOrDefaultTrue(exp, kvp.Key))
-                    {
-                        continue;
-                    }
-
-                    setOwnProperty(kvp.Key, kvp.Value);
-                }
+                    setOwnProperty(key, value);
+                }, includeEncodedSymbolKeys: true);
                 return target;
             }
 
             // IDictionary<string, object?>: treat keys as enumerable properties.
             if (source is IDictionary<string, object?> dict)
             {
-                foreach (var kvp in dict)
+                var srcSeen = new HashSet<string>(StringComparer.Ordinal);
+                EnumerateOwnEnumerableProperties(dict, srcSeen, (key, value) =>
                 {
-                    if (!PropertyDescriptorStore.IsEnumerableOrDefaultTrue(source, kvp.Key))
-                    {
-                        continue;
-                    }
-
-                    setOwnProperty(kvp.Key, kvp.Value);
-                }
+                    setOwnProperty(key, value);
+                }, includeEncodedSymbolKeys: true);
                 return target;
             }
 
@@ -5272,21 +5269,12 @@ namespace JavaScriptRuntime
             // ExpandoObject (object literal)
             if (obj is System.Dynamic.ExpandoObject exp)
             {
-                var dict = (IDictionary<string, object?>)exp;
-                var keys = new JavaScriptRuntime.Array(
-                    dict.Keys
-                        .Where(k => PropertyDescriptorStore.IsEnumerableOrDefaultTrue(exp, k))
-                        .Cast<object?>());
-                return keys;
+                return new JavaScriptRuntime.Array(GetOwnEnumerableKeysInOrder(exp).Cast<object?>());
             }
 
             if (obj is IDictionary<string, object?> dictGeneric)
             {
-                var keys = new JavaScriptRuntime.Array(
-                    dictGeneric.Keys
-                        .Where(k => PropertyDescriptorStore.IsEnumerableOrDefaultTrue(obj, k))
-                        .Cast<object?>());
-                return keys;
+                return new JavaScriptRuntime.Array(GetOwnEnumerableKeysInOrder(dictGeneric).Cast<object?>());
             }
 
             // JS Array: enumerate indices
@@ -5600,12 +5588,12 @@ namespace JavaScriptRuntime
 
                 desc.Value = value;
                 PropertyDescriptorStore.DefineOrUpdate(obj, name, desc);
-                if (obj is System.Dynamic.ExpandoObject expDesc)
+                if (obj is System.Dynamic.ExpandoObject expDesc && !PropertyDescriptorStore.HasIntrinsicProperties(obj))
                 {
                     var dict = (IDictionary<string, object?>)expDesc;
                     dict[name] = value;
                 }
-                else if (obj is IDictionary<string, object?> dictDesc)
+                else if (obj is IDictionary<string, object?> dictDesc && !PropertyDescriptorStore.HasIntrinsicProperties(obj))
                 {
                     dictDesc[name] = value;
                 }
@@ -5624,7 +5612,10 @@ namespace JavaScriptRuntime
                     return value;
                 }
 
-                dict[name] = value;
+                if (!PropertyDescriptorStore.HasIntrinsicProperties(obj))
+                {
+                    dict[name] = value;
+                }
                 PropertyDescriptorStore.DefineOrUpdate(obj, name, new JsPropertyDescriptor
                 {
                     Kind = JsPropertyDescriptorKind.Data,
@@ -5649,7 +5640,10 @@ namespace JavaScriptRuntime
                     return value;
                 }
 
-                dictGeneric[name] = value;
+                if (!PropertyDescriptorStore.HasIntrinsicProperties(obj))
+                {
+                    dictGeneric[name] = value;
+                }
                 PropertyDescriptorStore.DefineOrUpdate(obj, name, new JsPropertyDescriptor
                 {
                     Kind = JsPropertyDescriptorKind.Data,

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -282,11 +282,11 @@ namespace JavaScriptRuntime
                 return Object.defineProperty(target, key, CreateDataPropertyDescriptor(value, enumerable));
             }
 
-            if (target is JsObject jsObject)
+            if (target is JsObject jsObject && !PropertyDescriptorStore.HasIntrinsicProperties(target))
             {
                 setJsObjectValue(jsObject, key, value);
             }
-            else if (target is IDictionary<string, object?> dict)
+            else if (target is IDictionary<string, object?> dict && !PropertyDescriptorStore.HasIntrinsicProperties(target))
             {
                 dict[key] = value;
             }
@@ -398,38 +398,50 @@ namespace JavaScriptRuntime
             if (receiver is System.Dynamic.ExpandoObject exp)
             {
                 var dict = (System.Collections.Generic.IDictionary<string, object?>)exp;
-                dict.Remove(key);
+                if (!PropertyDescriptorStore.HasIntrinsicProperties(receiver))
+                {
+                    dict.Remove(key);
+                }
+
                 PropertyDescriptorStore.Delete(receiver, key);
                 return true;
             }
 
             if (receiver is System.Collections.Generic.IDictionary<string, object?> dictGeneric)
             {
-                dictGeneric.Remove(key);
+                if (!PropertyDescriptorStore.HasIntrinsicProperties(receiver))
+                {
+                    dictGeneric.Remove(key);
+                }
+
                 PropertyDescriptorStore.Delete(receiver, key);
                 return true;
             }
 
             if (receiver is System.Collections.IDictionary dictObj)
             {
-                if (dictObj.Contains(key))
+                if (!PropertyDescriptorStore.HasIntrinsicProperties(receiver) && dictObj.Contains(key))
                 {
                     dictObj.Remove(key);
                     return true;
                 }
 
                 object? match = null;
-                foreach (var k in dictObj.Keys)
+                if (!PropertyDescriptorStore.HasIntrinsicProperties(receiver))
                 {
-                    if (string.Equals(DotNet2JSConversions.ToString(k), key, StringComparison.Ordinal))
+                    foreach (var k in dictObj.Keys)
                     {
-                        match = k;
-                        break;
+                        if (string.Equals(DotNet2JSConversions.ToString(k), key, StringComparison.Ordinal))
+                        {
+                            match = k;
+                            break;
+                        }
                     }
-                }
-                if (match != null)
-                {
-                    dictObj.Remove(match);
+
+                    if (match != null)
+                    {
+                        dictObj.Remove(match);
+                    }
                 }
 
                 PropertyDescriptorStore.Delete(receiver, key);

--- a/src/JavaScriptRuntime/Promise.cs
+++ b/src/JavaScriptRuntime/Promise.cs
@@ -52,6 +52,8 @@ public sealed class Promise
 
     private static object CreatePrototype()
     {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
         var prototype = new JsObject();
         Function.InitializeFunctionInstance(PrototypeThenValue, 2d, "then");
         Function.MarkUndefinedPrototype(PrototypeThenValue);

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace JavaScriptRuntime;
 
@@ -27,22 +29,357 @@ internal sealed class JsPropertyDescriptor
     public object? Set { get; set; }
 }
 
-internal static class PropertyDescriptorStore
+internal interface IPropertyDescriptorStore
 {
-    private sealed class Slot
+    bool TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor);
+    bool HasAny(object target);
+    void DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor);
+    IEnumerable<string> GetOwnKeys(object target);
+    bool Delete(object target, string key);
+    void Clear(object target);
+    bool IsEnumerableOrDefaultTrue(object target, string key);
+}
+
+internal enum PropertyDescriptorOverrideKind
+{
+    Add,
+    Modify,
+    Delete
+}
+
+internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
+{
+    private sealed class DescriptorSlot
     {
+        public readonly object SyncRoot = new();
         public readonly Dictionary<string, JsPropertyDescriptor> Descriptors = new(StringComparer.Ordinal);
         public readonly List<string> KeyOrder = new();
     }
 
-    private static readonly ConditionalWeakTable<object, Slot> _slots = new();
+    private sealed class OverrideSlot
+    {
+        public readonly object SyncRoot = new();
+        public readonly Dictionary<string, PropertyDescriptorOverride> Overrides = new(StringComparer.Ordinal);
+        public readonly List<string> KeyOrder = new();
+    }
 
-    private static bool TryGetMirroredRawClassPrototype(object target, out object mirroredTarget)
+    private sealed class PropertyDescriptorOverride
+    {
+        public required PropertyDescriptorOverrideKind Kind { get; init; }
+        public JsPropertyDescriptor? Descriptor { get; init; }
+    }
+
+    private sealed class IntrinsicPropertyDescriptorStore : IPropertyDescriptorStore
+    {
+        private readonly ConditionalWeakTable<object, DescriptorSlot> _slots = new();
+
+        public bool TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
+        {
+            ValidateTargetAndKey(target, key);
+
+            if (_slots.TryGetValue(target, out var slot))
+            {
+                lock (slot.SyncRoot)
+                {
+                    if (slot.Descriptors.TryGetValue(key, out var stored))
+                    {
+                        descriptor = CloneDescriptor(stored);
+                        return true;
+                    }
+                }
+            }
+
+            descriptor = null!;
+            return false;
+        }
+
+        public bool HasAny(object target)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+
+            if (!_slots.TryGetValue(target, out var slot))
+            {
+                return false;
+            }
+
+            lock (slot.SyncRoot)
+            {
+                return slot.Descriptors.Count != 0;
+            }
+        }
+
+        public void DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor)
+        {
+            ValidateTargetAndKey(target, key);
+            ArgumentNullException.ThrowIfNull(descriptor);
+
+            DefineOrUpdateCore(target, key, descriptor);
+
+            if (TryGetMirroredRawClassPrototype(target, TryGetOwn, out var mirroredTarget))
+            {
+                DefineOrUpdateCore(mirroredTarget, key, descriptor);
+            }
+        }
+
+        public IEnumerable<string> GetOwnKeys(object target)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+
+            if (_slots.TryGetValue(target, out var slot))
+            {
+                lock (slot.SyncRoot)
+                {
+                    return slot.KeyOrder.ToArray();
+                }
+            }
+
+            return System.Array.Empty<string>();
+        }
+
+        public bool Delete(object target, string key)
+        {
+            ValidateTargetAndKey(target, key);
+
+            var removed = DeleteCore(target, key);
+            if (removed
+                && TryGetMirroredRawClassPrototype(target, TryGetOwn, out var mirroredTarget))
+            {
+                _ = DeleteCore(mirroredTarget, key);
+            }
+
+            return removed;
+        }
+
+        public void Clear(object target)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+            _slots.Remove(target);
+        }
+
+        public bool IsEnumerableOrDefaultTrue(object target, string key)
+            => !TryGetOwn(target, key, out var desc) || desc.Enumerable;
+
+        private void DefineOrUpdateCore(object target, string key, JsPropertyDescriptor descriptor)
+        {
+            if (target is Delegate del)
+            {
+                Function.ClearDeletedMetadataProperty(del, key);
+            }
+
+            var slot = _slots.GetOrCreateValue(target);
+            lock (slot.SyncRoot)
+            {
+                if (!slot.Descriptors.ContainsKey(key))
+                {
+                    slot.KeyOrder.Add(key);
+                }
+
+                slot.Descriptors[key] = CloneDescriptor(descriptor);
+            }
+        }
+
+        private bool DeleteCore(object target, string key)
+        {
+            if (!_slots.TryGetValue(target, out var slot))
+            {
+                return false;
+            }
+
+            lock (slot.SyncRoot)
+            {
+                var removed = slot.Descriptors.Remove(key);
+                if (removed)
+                {
+                    slot.KeyOrder.Remove(key);
+                }
+
+                return removed;
+            }
+        }
+    }
+
+    private static readonly IntrinsicPropertyDescriptorStore _intrinsicStore = new();
+    private static readonly ThreadLocal<IPropertyDescriptorStore?> _currentRuntimeStore = new(() => null);
+    private static readonly ThreadLocal<int> _intrinsicInitializationDepth = new(() => 0);
+
+    private readonly ConditionalWeakTable<object, OverrideSlot> _overrideSlots = new();
+
+    public PropertyDescriptorStore()
+    {
+    }
+
+    internal static void SetCurrentRuntimeStore(IPropertyDescriptorStore? store)
+        => _currentRuntimeStore.Value = store;
+
+    internal static IDisposable BeginIntrinsicInitialization()
+    {
+        _intrinsicInitializationDepth.Value++;
+        return new IntrinsicInitializationScope();
+    }
+
+    internal static JsPropertyDescriptor CloneDescriptor(JsPropertyDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        return new JsPropertyDescriptor
+        {
+            Kind = descriptor.Kind,
+            Enumerable = descriptor.Enumerable,
+            Configurable = descriptor.Configurable,
+            Value = descriptor.Value,
+            Writable = descriptor.Writable,
+            Get = descriptor.Get,
+            Set = descriptor.Set
+        };
+    }
+
+    public static bool TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
+        => CurrentStore.TryGetOwn(target, key, out descriptor);
+
+    public static bool HasAny(object target)
+        => CurrentStore.HasAny(target);
+
+    internal static bool HasIntrinsicProperties(object target)
+        => _intrinsicStore.HasAny(target);
+
+    internal static bool IsDeleted(object target, string key)
+    {
+        ValidateTargetAndKey(target, key);
+        return CurrentStore is PropertyDescriptorStore runtimeStore
+            && runtimeStore.HasDeletedOverride(target, key);
+    }
+
+    public static void DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor)
+        => CurrentStore.DefineOrUpdate(target, key, descriptor);
+
+    internal static void CopyOwnProperties(object source, object target)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(target);
+
+        foreach (var key in GetOwnKeys(source))
+        {
+            if (TryGetOwn(source, key, out var descriptor))
+            {
+                DefineOrUpdate(target, key, descriptor);
+            }
+        }
+    }
+
+    public static IEnumerable<string> GetOwnKeys(object target)
+        => CurrentStore.GetOwnKeys(target);
+
+    public static bool Delete(object target, string key)
+        => CurrentStore.Delete(target, key);
+
+    internal static void Clear(object target)
+        => CurrentStore.Clear(target);
+
+    public static bool IsEnumerableOrDefaultTrue(object target, string key)
+        => CurrentStore.IsEnumerableOrDefaultTrue(target, key);
+
+    bool IPropertyDescriptorStore.TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
+    {
+        ValidateTargetAndKey(target, key);
+
+        if (TryGetOverride(target, key, out var entry))
+        {
+            if (entry.Kind == PropertyDescriptorOverrideKind.Delete)
+            {
+                descriptor = null!;
+                return false;
+            }
+
+            descriptor = CloneDescriptor(entry.Descriptor!);
+            return true;
+        }
+
+        return _intrinsicStore.TryGetOwn(target, key, out descriptor);
+    }
+
+    bool IPropertyDescriptorStore.HasAny(object target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return GetOwnKeysForRuntimeStore(target).Any();
+    }
+
+    void IPropertyDescriptorStore.DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor)
+    {
+        ValidateTargetAndKey(target, key);
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        DefineOrUpdateOverride(target, key, descriptor);
+
+        if (TryGetMirroredRawClassPrototype(target, ((IPropertyDescriptorStore)this).TryGetOwn, out var mirroredTarget))
+        {
+            DefineOrUpdateOverride(mirroredTarget, key, descriptor);
+        }
+    }
+
+    IEnumerable<string> IPropertyDescriptorStore.GetOwnKeys(object target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return GetOwnKeysForRuntimeStore(target);
+    }
+
+    bool IPropertyDescriptorStore.Delete(object target, string key)
+    {
+        ValidateTargetAndKey(target, key);
+
+        var removed = DeleteOverride(target, key);
+        if (removed
+            && TryGetMirroredRawClassPrototype(target, ((IPropertyDescriptorStore)this).TryGetOwn, out var mirroredTarget))
+        {
+            _ = DeleteOverride(mirroredTarget, key);
+        }
+
+        return removed;
+    }
+
+    void IPropertyDescriptorStore.Clear(object target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        _overrideSlots.Remove(target);
+    }
+
+    bool IPropertyDescriptorStore.IsEnumerableOrDefaultTrue(object target, string key)
+        => !((IPropertyDescriptorStore)this).TryGetOwn(target, key, out var desc) || desc.Enumerable;
+
+    private static IPropertyDescriptorStore CurrentStore
+        => _intrinsicInitializationDepth.Value > 0
+            ? _intrinsicStore
+            : _currentRuntimeStore.Value ?? _intrinsicStore;
+
+    private sealed class IntrinsicInitializationScope : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _intrinsicInitializationDepth.Value--;
+        }
+    }
+
+    private static void ValidateTargetAndKey(object target, string key)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(key);
+    }
+
+    private static bool TryGetMirroredRawClassPrototype(
+        object target,
+        TryGetOwnDescriptor tryGetOwn,
+        out object mirroredTarget)
     {
         mirroredTarget = null!;
 
-        if (!_slots.TryGetValue(target, out var slot)
-            || !slot.Descriptors.TryGetValue("constructor", out var constructorDescriptor)
+        if (!tryGetOwn(target, "constructor", out var constructorDescriptor)
             || constructorDescriptor.Kind != JsPropertyDescriptorKind.Data
             || constructorDescriptor.Value is not ClassConstructorValue classConstructorValue)
         {
@@ -60,146 +397,138 @@ internal static class PropertyDescriptorStore
         return true;
     }
 
-    internal static JsPropertyDescriptor CloneDescriptor(JsPropertyDescriptor descriptor)
+    private delegate bool TryGetOwnDescriptor(object target, string key, out JsPropertyDescriptor descriptor);
+
+    private bool TryGetOverride(object target, string key, out PropertyDescriptorOverride entry)
     {
-        if (descriptor == null) throw new ArgumentNullException(nameof(descriptor));
-
-        return new JsPropertyDescriptor
+        if (_overrideSlots.TryGetValue(target, out var slot))
         {
-            Kind = descriptor.Kind,
-            Enumerable = descriptor.Enumerable,
-            Configurable = descriptor.Configurable,
-            Value = descriptor.Value,
-            Writable = descriptor.Writable,
-            Get = descriptor.Get,
-            Set = descriptor.Set
-        };
-    }
-
-    public static bool TryGetOwn(object target, string key, out JsPropertyDescriptor descriptor)
-    {
-        if (target == null) throw new ArgumentNullException(nameof(target));
-        if (key == null) throw new ArgumentNullException(nameof(key));
-
-        if (_slots.TryGetValue(target, out var slot))
-        {
-            return slot.Descriptors.TryGetValue(key, out descriptor!);
+            lock (slot.SyncRoot)
+            {
+                return slot.Overrides.TryGetValue(key, out entry!);
+            }
         }
 
-        descriptor = null!;
+        entry = null!;
         return false;
     }
 
-    public static bool HasAny(object target)
+    private void DefineOrUpdateOverride(object target, string key, JsPropertyDescriptor descriptor)
     {
-        if (target == null) throw new ArgumentNullException(nameof(target));
-
-        return _slots.TryGetValue(target, out var slot)
-            && slot.Descriptors.Count != 0;
-    }
-
-    public static void DefineOrUpdate(object target, string key, JsPropertyDescriptor descriptor)
-    {
-        if (target == null) throw new ArgumentNullException(nameof(target));
-        if (key == null) throw new ArgumentNullException(nameof(key));
-        if (descriptor == null) throw new ArgumentNullException(nameof(descriptor));
-
         if (target is Delegate del)
         {
             Function.ClearDeletedMetadataProperty(del, key);
         }
 
-        var slot = _slots.GetOrCreateValue(target);
-        if (!slot.Descriptors.ContainsKey(key))
-        {
-            slot.KeyOrder.Add(key);
-        }
-        slot.Descriptors[key] = descriptor;
+        var hasIntrinsic = _intrinsicStore.TryGetOwn(target, key, out _);
+        var slot = _overrideSlots.GetOrCreateValue(target);
 
-        if (TryGetMirroredRawClassPrototype(target, out var mirroredTarget))
+        lock (slot.SyncRoot)
         {
-            var mirroredSlot = _slots.GetOrCreateValue(mirroredTarget);
-            if (!mirroredSlot.Descriptors.ContainsKey(key))
+            var hadDeleteOverride = slot.Overrides.TryGetValue(key, out var existing)
+                && existing.Kind == PropertyDescriptorOverrideKind.Delete;
+            var shouldTrackOrder = (!hasIntrinsic || hadDeleteOverride)
+                && (!slot.KeyOrder.Contains(key));
+
+            if (shouldTrackOrder)
             {
-                mirroredSlot.KeyOrder.Add(key);
+                slot.KeyOrder.Add(key);
             }
 
-            mirroredSlot.Descriptors[key] = new JsPropertyDescriptor
+            slot.Overrides[key] = new PropertyDescriptorOverride
             {
-                Kind = descriptor.Kind,
-                Enumerable = descriptor.Enumerable,
-                Configurable = descriptor.Configurable,
-                Value = descriptor.Value,
-                Writable = descriptor.Writable,
-                Get = descriptor.Get,
-                Set = descriptor.Set
+                Kind = hasIntrinsic && !hadDeleteOverride
+                    ? PropertyDescriptorOverrideKind.Modify
+                    : PropertyDescriptorOverrideKind.Add,
+                Descriptor = CloneDescriptor(descriptor)
             };
         }
     }
 
-    internal static void CopyOwnProperties(object source, object target)
+    private bool DeleteOverride(object target, string key)
     {
-        if (source == null) throw new ArgumentNullException(nameof(source));
-        if (target == null) throw new ArgumentNullException(nameof(target));
+        var hasIntrinsic = _intrinsicStore.TryGetOwn(target, key, out _);
+        var slot = _overrideSlots.GetOrCreateValue(target);
 
-        foreach (var key in GetOwnKeys(source))
+        lock (slot.SyncRoot)
         {
-            if (TryGetOwn(source, key, out var descriptor))
-            {
-                DefineOrUpdate(target, key, CloneDescriptor(descriptor));
-            }
-        }
-    }
+            var hasOverride = slot.Overrides.TryGetValue(key, out var existing)
+                && existing.Kind != PropertyDescriptorOverrideKind.Delete;
 
-    public static IEnumerable<string> GetOwnKeys(object target)
-    {
-        if (target == null) throw new ArgumentNullException(nameof(target));
-
-        if (_slots.TryGetValue(target, out var slot))
-        {
-            var keys = slot.KeyOrder.ToArray();
-            return keys;
-        }
-
-        return System.Array.Empty<string>();
-    }
-
-    public static bool Delete(object target, string key)
-    {
-        if (target == null) throw new ArgumentNullException(nameof(target));
-        if (key == null) throw new ArgumentNullException(nameof(key));
-
-        if (_slots.TryGetValue(target, out var slot))
-        {
-            var removed = slot.Descriptors.Remove(key);
-            if (removed)
+            if (!hasIntrinsic && !hasOverride)
             {
                 slot.KeyOrder.Remove(key);
-            }
-
-            if (removed && TryGetMirroredRawClassPrototype(target, out var mirroredTarget) && _slots.TryGetValue(mirroredTarget, out var mirroredSlot))
-            {
-                if (mirroredSlot.Descriptors.Remove(key))
+                slot.Overrides[key] = new PropertyDescriptorOverride
                 {
-                    mirroredSlot.KeyOrder.Remove(key);
-                }
+                    Kind = PropertyDescriptorOverrideKind.Delete
+                };
+                return false;
             }
 
-            return removed;
+            if (hasIntrinsic)
+            {
+                slot.KeyOrder.Remove(key);
+                slot.Overrides[key] = new PropertyDescriptorOverride
+                {
+                    Kind = PropertyDescriptorOverrideKind.Delete
+                };
+                return true;
+            }
+
+            slot.KeyOrder.Remove(key);
+            slot.Overrides[key] = new PropertyDescriptorOverride
+            {
+                Kind = PropertyDescriptorOverrideKind.Delete
+            };
+            return true;
+        }
+    }
+
+    private IEnumerable<string> GetOwnKeysForRuntimeStore(object target)
+    {
+        var keys = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var key in _intrinsicStore.GetOwnKeys(target))
+        {
+            if (!IsIntrinsicKeySuppressedByOverride(target, key) && seen.Add(key))
+            {
+                keys.Add(key);
+            }
         }
 
-        return false;
+        if (_overrideSlots.TryGetValue(target, out var slot))
+        {
+            lock (slot.SyncRoot)
+            {
+                foreach (var key in slot.KeyOrder.ToArray())
+                {
+                    if (!slot.Overrides.TryGetValue(key, out var entry)
+                        || entry.Kind == PropertyDescriptorOverrideKind.Delete)
+                    {
+                        continue;
+                    }
+
+                    if (seen.Add(key))
+                    {
+                        keys.Add(key);
+                    }
+                }
+            }
+        }
+
+        return keys;
     }
 
-    internal static void Clear(object target)
-    {
-        if (target == null) throw new ArgumentNullException(nameof(target));
+    private bool IsDeletedOverride(object target, string key)
+        => TryGetOverride(target, key, out var entry)
+            && entry.Kind == PropertyDescriptorOverrideKind.Delete;
 
-        _slots.Remove(target);
-    }
+    private bool HasDeletedOverride(object target, string key)
+        => IsDeletedOverride(target, key);
 
-    public static bool IsEnumerableOrDefaultTrue(object target, string key)
-    {
-        return !TryGetOwn(target, key, out var desc) || desc.Enumerable;
-    }
+    private bool IsIntrinsicKeySuppressedByOverride(object target, string key)
+        => TryGetOverride(target, key, out var entry)
+            && (entry.Kind == PropertyDescriptorOverrideKind.Delete
+                || entry.Kind == PropertyDescriptorOverrideKind.Add);
 }

--- a/src/JavaScriptRuntime/RegExp.cs
+++ b/src/JavaScriptRuntime/RegExp.cs
@@ -253,6 +253,8 @@ namespace JavaScriptRuntime
 
         private static ExpandoObject CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new ExpandoObject();
             DefineSymbolMethod(prototype, MatchSymbolPropertyKey, MatchSymbolDelegate);
             DefineSymbolMethod(prototype, ReplaceSymbolPropertyKey, ReplaceSymbolDelegate);

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -21,7 +21,6 @@ public class RuntimeServices
     private static readonly ConcurrentDictionary<string, ExpandoObject> _importMetaByUrl = new(StringComparer.Ordinal);
     private static readonly ConcurrentDictionary<string, JavaScriptRuntime.CommonJS.RequireDelegate> _requireByModuleId = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConditionalWeakTable<Type, LazyClassMetadataSlot> _lazyClassMetadata = new();
-    private static readonly ConditionalWeakTable<object, DeletedLazyClassMethodSlot> _deletedLazyClassMethodProperties = new();
 
     // ABI compatibility: when a callee doesn't need scopes, we still pass a 1-element scopes array.
     // NOTE: Consumers must treat scopes arrays as immutable.
@@ -36,11 +35,6 @@ public class RuntimeServices
     private sealed class LazyClassMetadataSlot
     {
         public readonly List<LazyClassMethodDataProperty> Methods = new();
-    }
-
-    private sealed class DeletedLazyClassMethodSlot
-    {
-        public readonly HashSet<string> Keys = new(StringComparer.Ordinal);
     }
 
     private sealed record LazyClassMethodDataProperty(
@@ -481,7 +475,7 @@ public class RuntimeServices
         out JsPropertyDescriptor descriptor)
     {
         descriptor = null!;
-        if (IsLazyClassMethodPropertyDeleted(target, propName)
+        if (PropertyDescriptorStore.IsDeleted(target, propName)
             || !TryResolveLazyClassMethodTarget(target, out var ownerType, out var ownerValue, out var isStatic)
             || !_lazyClassMetadata.TryGetValue(ownerType, out var slot))
         {
@@ -529,7 +523,7 @@ public class RuntimeServices
         {
             return slot.Methods
                 .Where(method => method.IsStatic == isStatic
-                    && !IsLazyClassMethodPropertyDeleted(target, method.PropertyKey)
+                    && !PropertyDescriptorStore.IsDeleted(target, method.PropertyKey)
                     && !PropertyDescriptorStore.TryGetOwn(target, method.PropertyKey, out _))
                 .Select(method => method.PropertyKey)
                 .ToArray();
@@ -554,24 +548,7 @@ public class RuntimeServices
             }
         }
 
-        var deletedSlot = _deletedLazyClassMethodProperties.GetOrCreateValue(target);
-        lock (deletedSlot)
-        {
-            deletedSlot.Keys.Add(propName);
-        }
-    }
-
-    private static bool IsLazyClassMethodPropertyDeleted(object target, string propName)
-    {
-        if (!_deletedLazyClassMethodProperties.TryGetValue(target, out var deletedSlot))
-        {
-            return false;
-        }
-
-        lock (deletedSlot)
-        {
-            return deletedSlot.Keys.Contains(propName);
-        }
+        PropertyDescriptorStore.Delete(target, propName);
     }
 
     private static bool TryResolveLazyClassMethodTarget(
@@ -1095,6 +1072,7 @@ public class RuntimeServices
         container.Register<EngineCore.IFinalizationRegistryHost, EngineCore.FinalizationRegistryHost>();
         container.Register<CommonJS.Require>();
         container.Register<LocalModulesAssembly>();
+        container.RegisterInstance<IPropertyDescriptorStore>(new PropertyDescriptorStore());
         container.Register<IEnvironment, DefaultEnvironment>();
         container.Register<Node.IChildProcessLauncher, Node.DefaultChildProcessLauncher>();
         

--- a/src/JavaScriptRuntime/Set.cs
+++ b/src/JavaScriptRuntime/Set.cs
@@ -15,6 +15,8 @@ namespace JavaScriptRuntime
 
         private static ExpandoObject CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var exp = new ExpandoObject();
             DefinePrototypeMethod(exp, "add", PrototypeAdd);
             DefinePrototypeMethod(exp, "has", PrototypeHas);

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -50,6 +50,8 @@ namespace JavaScriptRuntime
 
         private static ExpandoObject CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new ExpandoObject();
 
             DefinePrototypeMethod(prototype, "at", (Func<object[], object?[]?, object?>)PrototypeAt, 1);
@@ -91,6 +93,8 @@ namespace JavaScriptRuntime
 
         private static ExpandoObject CreateStringIteratorPrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new ExpandoObject();
             DefinePrototypeMethod(prototype, "next", (Func<object[], object?[]?, object?>)StringIteratorPrototypeNext, 0);
             DefinePrototypeMethod(prototype, IteratorSymbolPropertyKey, (Func<object[], object?[]?, object?>)StringIteratorPrototypeIterator, 0);
@@ -124,6 +128,8 @@ namespace JavaScriptRuntime
 
         public static void ConfigureIntrinsicSurface(object stringConstructorValue)
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             PrototypeChain.SetPrototype(Prototype, GlobalThis.ObjectPrototypeValue);
             PrototypeChain.SetPrototype(StringIteratorPrototype, GlobalThis.ObjectPrototypeValue);
             PropertyDescriptorStore.DefineOrUpdate(stringConstructorValue, "prototype", new JsPropertyDescriptor

--- a/src/JavaScriptRuntime/Uint8Array.cs
+++ b/src/JavaScriptRuntime/Uint8Array.cs
@@ -10,6 +10,8 @@ namespace JavaScriptRuntime
 
         static Uint8Array()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             PrototypeChain.SetPrototype(Prototype, GlobalThis.ObjectPrototypeValue);
 
             PropertyDescriptorStore.DefineOrUpdate(typeof(Uint8Array), "prototype", new JsPropertyDescriptor
@@ -165,7 +167,11 @@ namespace JavaScriptRuntime
             => new Uint8Array(buffer, byteOffset, length);
 
         private static JsObject CreatePrototype()
-            => new();
+        {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+            return new JsObject();
+        }
 
         private void InitializeIntrinsicSurface()
             => PrototypeChain.SetPrototype(this, Prototype);

--- a/src/JavaScriptRuntime/WeakMap.cs
+++ b/src/JavaScriptRuntime/WeakMap.cs
@@ -159,6 +159,8 @@ namespace JavaScriptRuntime
 
         private static object CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "delete", PrototypeDelete);
             DefinePrototypeMethod(prototype, "get", PrototypeGet);

--- a/src/JavaScriptRuntime/WeakSet.cs
+++ b/src/JavaScriptRuntime/WeakSet.cs
@@ -114,6 +114,8 @@ namespace JavaScriptRuntime
 
         private static object CreatePrototype()
         {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
             var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "add", PrototypeAdd);
             DefinePrototypeMethod(prototype, "delete", PrototypeDelete);

--- a/tests/Jroc.Tests/Array/RuntimePrototypeIsolationTests.cs
+++ b/tests/Jroc.Tests/Array/RuntimePrototypeIsolationTests.cs
@@ -37,6 +37,40 @@ public class RuntimePrototypeIsolationTests
     }
 
     [Fact]
+    public void InMemoryScripts_DoNotShareObjectPrototypeDescriptorMutations()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-object-prototype-descriptors",
+            "Runtime.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-object-prototype-descriptors",
+            "Runtime.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "runtime-one",
+                "runtime-one",
+                "getter-runtime-one",
+                "setter-runtime-one",
+                "3",
+                string.Empty),
+            mutationResult.Output);
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "true",
+                "undefined",
+                "true",
+                "true",
+                "0",
+                string.Empty),
+            readResult.Output);
+    }
+
+    [Fact]
     public void ArrayPrototype_UsesThreadLocalOverrides()
     {
         var results = new string?[2];
@@ -83,6 +117,77 @@ public class RuntimePrototypeIsolationTests
             });
     }
 
+    [Fact]
+    public void ArrayPrototypeThreadOverride_RetainsIntrinsicDescriptorsAcrossSerialRuntimeStores()
+    {
+        JavaScriptRuntime.Array.ResetPrototypeForTests();
+
+        try
+        {
+            var firstRuntime = RuntimeServices.BuildServiceProvider();
+            var secondRuntime = RuntimeServices.BuildServiceProvider();
+
+            GlobalThis.ServiceProvider = firstRuntime;
+            var firstPrototype = ObjectRuntime.GetItem(GlobalThis.Array, "prototype")
+                ?? throw new InvalidOperationException("Array.prototype was not configured.");
+            Assert.NotNull(ObjectRuntime.GetItem(firstPrototype, "push"));
+
+            GlobalThis.ServiceProvider = null;
+            GlobalThis.ServiceProvider = secondRuntime;
+
+            var secondPrototype = ObjectRuntime.GetItem(GlobalThis.Array, "prototype")
+                ?? throw new InvalidOperationException("Array.prototype was not configured.");
+            Assert.Same(firstPrototype, secondPrototype);
+            Assert.NotNull(ObjectRuntime.GetItem(secondPrototype, "push"));
+            Assert.NotNull(ObjectRuntime.GetItem(new JavaScriptRuntime.Array(), "push"));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+            JavaScriptRuntime.Array.ResetPrototypeForTests();
+        }
+    }
+
+    [Fact]
+    public void ObjectAssign_UsesDescriptorOverlayForIntrinsicDictionaryBackedPrototypes()
+    {
+        JavaScriptRuntime.Array.ResetPrototypeForTests();
+
+        try
+        {
+            var firstRuntime = RuntimeServices.BuildServiceProvider();
+            var secondRuntime = RuntimeServices.BuildServiceProvider();
+
+            GlobalThis.ServiceProvider = firstRuntime;
+            var arrayPrototype = ObjectRuntime.GetItem(GlobalThis.Array, "prototype")
+                ?? throw new InvalidOperationException("Array.prototype was not configured.");
+            ObjectRuntime.SetProperty(arrayPrototype, "assignSourceLeak", "runtime-one");
+
+            var copied = new JsObject();
+            JavaScriptRuntime.Object.assign(copied, arrayPrototype);
+            Assert.Equal("runtime-one", ObjectRuntime.GetItem(copied, "assignSourceLeak"));
+
+            var source = new JsObject();
+            ObjectRuntime.SetProperty(source, "assignTargetLeak", "runtime-one");
+            JavaScriptRuntime.Object.assign(arrayPrototype, source);
+            Assert.Equal("runtime-one", ObjectRuntime.GetItem(arrayPrototype, "assignTargetLeak"));
+
+            GlobalThis.ServiceProvider = null;
+            GlobalThis.ServiceProvider = secondRuntime;
+
+            var secondPrototype = ObjectRuntime.GetItem(GlobalThis.Array, "prototype")
+                ?? throw new InvalidOperationException("Array.prototype was not configured.");
+            Assert.Same(arrayPrototype, secondPrototype);
+            Assert.Null(JavaScriptRuntime.Object.getOwnPropertyDescriptor(secondPrototype, "assignSourceLeak"));
+            Assert.Null(JavaScriptRuntime.Object.getOwnPropertyDescriptor(secondPrototype, "assignTargetLeak"));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+            JavaScriptRuntime.Array.ResetPrototypeForTests();
+        }
+    }
+
     private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
         => testName switch
         {
@@ -111,6 +216,62 @@ public class RuntimePrototypeIsolationTests
                 console.log(pushDescriptor.enumerable);
                 console.log(pushDescriptor.configurable);
                 console.log(pushDescriptor.writable);
+                """, null),
+            "mutate-object-prototype-descriptors" => ("""
+                Object.defineProperty(Object.prototype, "prototypeLeakCheck", {
+                  value: "runtime-one",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+
+                var child = Object.create(Object.prototype);
+                console.log(child.prototypeLeakCheck);
+
+                var shadow = Object.create(Object.prototype);
+                Object.defineProperty(shadow, "prototypeLeakCheck", {
+                  value: "own-shadow",
+                  enumerable: false,
+                  configurable: true,
+                  writable: true
+                });
+                delete shadow.prototypeLeakCheck;
+                console.log(shadow.prototypeLeakCheck);
+
+                Object.prototype.__defineGetter__("getterLeakCheck", function() {
+                  return "getter-runtime-one";
+                });
+                console.log(({}).getterLeakCheck);
+
+                Object.prototype.__defineSetter__("setterLeakCheck", function(value) {
+                  this.setterValue = value;
+                });
+                var setterChild = {};
+                setterChild.setterLeakCheck = "setter-runtime-one";
+                console.log(setterChild.setterValue);
+
+                var count = 0;
+                for (var key in JSON) {
+                  count++;
+                }
+                console.log(count);
+                """, null),
+            "read-object-prototype-descriptors" => ("""
+                var leakedDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "prototypeLeakCheck");
+                var getterDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "getterLeakCheck");
+                var setterDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "setterLeakCheck");
+                var child = Object.create(Object.prototype);
+
+                console.log(leakedDescriptor === undefined);
+                console.log(typeof child.prototypeLeakCheck);
+                console.log(getterDescriptor === undefined);
+                console.log(setterDescriptor === undefined);
+
+                var count = 0;
+                for (var key in JSON) {
+                  count++;
+                }
+                console.log(count);
                 """, null),
             _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
         };

--- a/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
+++ b/tests/Jroc.Tests/PropertyDescriptorStoreTests.cs
@@ -1,0 +1,251 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
+
+namespace Jroc.Tests;
+
+public class PropertyDescriptorStoreTests
+{
+    [Fact]
+    public void RuntimeStore_FallsBackToIntrinsicDescriptor_AndKeepsOverrideIsolated()
+    {
+        var target = new JsObject();
+        using (PropertyDescriptorStore.BeginIntrinsicInitialization())
+        {
+            PropertyDescriptorStore.DefineOrUpdate(target, "answer", DataDescriptor(42d, enumerable: false));
+        }
+
+        var firstRuntime = RuntimeServices.BuildServiceProvider();
+        var secondRuntime = RuntimeServices.BuildServiceProvider();
+
+        try
+        {
+            GlobalThis.ServiceProvider = firstRuntime;
+            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "answer", out var firstBase));
+            Assert.Equal(42d, firstBase.Value);
+            Assert.False(firstBase.Enumerable);
+
+            PropertyDescriptorStore.DefineOrUpdate(target, "answer", DataDescriptor(84d, enumerable: true));
+            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "answer", out var firstOverride));
+            Assert.Equal(84d, firstOverride.Value);
+            Assert.True(firstOverride.Enumerable);
+
+            GlobalThis.ServiceProvider = secondRuntime;
+            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "answer", out var secondRuntimeDescriptor));
+            Assert.Equal(42d, secondRuntimeDescriptor.Value);
+            Assert.False(secondRuntimeDescriptor.Enumerable);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void RuntimeStore_DeleteOverride_MasksIntrinsicDescriptor()
+    {
+        var target = new JsObject();
+        using (PropertyDescriptorStore.BeginIntrinsicInitialization())
+        {
+            PropertyDescriptorStore.DefineOrUpdate(target, "intrinsic", DataDescriptor("base", enumerable: true));
+        }
+
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+
+            Assert.True(PropertyDescriptorStore.Delete(target, "intrinsic"));
+            Assert.False(PropertyDescriptorStore.TryGetOwn(target, "intrinsic", out _));
+            Assert.DoesNotContain("intrinsic", PropertyDescriptorStore.GetOwnKeys(target));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+
+        Assert.True(PropertyDescriptorStore.TryGetOwn(target, "intrinsic", out var intrinsicDescriptor));
+        Assert.Equal("base", intrinsicDescriptor.Value);
+    }
+
+    [Fact]
+    public void RuntimeStore_MergesIntrinsicAndOverrideKeyOrder()
+    {
+        var target = new JsObject();
+        using (PropertyDescriptorStore.BeginIntrinsicInitialization())
+        {
+            PropertyDescriptorStore.DefineOrUpdate(target, "baseA", DataDescriptor(1d));
+            PropertyDescriptorStore.DefineOrUpdate(target, "baseB", DataDescriptor(2d));
+        }
+
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+
+            PropertyDescriptorStore.DefineOrUpdate(target, "runtimeA", DataDescriptor(3d));
+            PropertyDescriptorStore.DefineOrUpdate(target, "baseA", DataDescriptor(4d));
+            PropertyDescriptorStore.DefineOrUpdate(target, "runtimeB", DataDescriptor(5d));
+            Assert.True(PropertyDescriptorStore.Delete(target, "baseB"));
+
+            Assert.Equal(new[] { "baseA", "runtimeA", "runtimeB" }, PropertyDescriptorStore.GetOwnKeys(target));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void RuntimeStore_RedefinedIntrinsicKeyUsesRuntimeInsertionOrderAfterDelete()
+    {
+        var target = new JsObject();
+        using (PropertyDescriptorStore.BeginIntrinsicInitialization())
+        {
+            PropertyDescriptorStore.DefineOrUpdate(target, "baseA", DataDescriptor(1d));
+            PropertyDescriptorStore.DefineOrUpdate(target, "baseB", DataDescriptor(2d));
+        }
+
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+
+            Assert.True(PropertyDescriptorStore.Delete(target, "baseA"));
+            PropertyDescriptorStore.DefineOrUpdate(target, "runtimeA", DataDescriptor(3d));
+            PropertyDescriptorStore.DefineOrUpdate(target, "baseA", DataDescriptor(4d));
+
+            Assert.Equal(new[] { "baseB", "runtimeA", "baseA" }, PropertyDescriptorStore.GetOwnKeys(target));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void RuntimeStore_FunctionMetadataDelete_IsScopedToCurrentRuntime()
+    {
+        Func<object[], object?[]?, object?> functionValue = static (_, _) => null;
+        var firstRuntime = RuntimeServices.BuildServiceProvider();
+        var secondRuntime = RuntimeServices.BuildServiceProvider();
+
+        try
+        {
+            GlobalThis.ServiceProvider = firstRuntime;
+            Assert.NotNull(JavaScriptRuntime.Object.getOwnPropertyDescriptor(functionValue, "name"));
+
+            Assert.True(ObjectRuntime.DeleteProperty(functionValue, "name"));
+            Assert.Null(JavaScriptRuntime.Object.getOwnPropertyDescriptor(functionValue, "name"));
+
+            GlobalThis.ServiceProvider = secondRuntime;
+            Assert.NotNull(JavaScriptRuntime.Object.getOwnPropertyDescriptor(functionValue, "name"));
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void RuntimeStore_FunctionPrototypeDelete_DoesNotMutateSharedBackingDictionary()
+    {
+        var firstRuntime = RuntimeServices.BuildServiceProvider();
+        var secondRuntime = RuntimeServices.BuildServiceProvider();
+
+        try
+        {
+            GlobalThis.ServiceProvider = firstRuntime;
+            Assert.True(JavaScriptRuntime.Function.TryGetPrototypeValue("bind", out _));
+
+            Assert.True(ObjectRuntime.DeleteProperty(JavaScriptRuntime.Function.Prototype, "bind"));
+            Assert.False(JavaScriptRuntime.Function.TryGetPrototypeValue("bind", out _));
+
+            GlobalThis.ServiceProvider = secondRuntime;
+            Assert.True(JavaScriptRuntime.Function.TryGetPrototypeValue("bind", out var bindValue));
+            Assert.NotNull(bindValue);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void RuntimeStore_ReturnsClonedDescriptors()
+    {
+        var target = new JsObject();
+        using (PropertyDescriptorStore.BeginIntrinsicInitialization())
+        {
+            PropertyDescriptorStore.DefineOrUpdate(target, "value", DataDescriptor("original"));
+        }
+
+        var runtime = RuntimeServices.BuildServiceProvider();
+        try
+        {
+            GlobalThis.ServiceProvider = runtime;
+
+            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "value", out var descriptor));
+            descriptor.Value = "mutated copy";
+
+            Assert.True(PropertyDescriptorStore.TryGetOwn(target, "value", out var reread));
+            Assert.Equal("original", reread.Value);
+        }
+        finally
+        {
+            GlobalThis.ServiceProvider = null;
+        }
+    }
+
+    [Fact]
+    public void IntrinsicStore_AllowsConcurrentRuntimeReads()
+    {
+        var target = new JsObject();
+        using (PropertyDescriptorStore.BeginIntrinsicInitialization())
+        {
+            PropertyDescriptorStore.DefineOrUpdate(target, "stable", DataDescriptor("base"));
+        }
+
+        var exceptions = new List<Exception>();
+        var sync = new object();
+
+        Parallel.For(0, 16, _ =>
+        {
+            try
+            {
+                var runtime = RuntimeServices.BuildServiceProvider();
+                GlobalThis.ServiceProvider = runtime;
+                for (var i = 0; i < 500; i++)
+                {
+                    if (!PropertyDescriptorStore.TryGetOwn(target, "stable", out var descriptor)
+                        || !Equals("base", descriptor.Value))
+                    {
+                        throw new InvalidOperationException("Intrinsic descriptor lookup returned an unexpected value.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                lock (sync)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+            finally
+            {
+                GlobalThis.ServiceProvider = null;
+            }
+        });
+
+        Assert.Empty(exceptions);
+    }
+
+    private static JsPropertyDescriptor DataDescriptor(object? value, bool enumerable = true)
+        => new()
+        {
+            Kind = JsPropertyDescriptorKind.Data,
+            Value = value,
+            Writable = true,
+            Enumerable = enumerable,
+            Configurable = true
+        };
+}


### PR DESCRIPTION
## Summary
- Refactor `PropertyDescriptorStore` into a static compatibility facade backed by thread-safe immutable intrinsic descriptors plus per-runtime DI override stores.
- Route runtime descriptor adds/modifies/deletes through scoped overrides with tombstones, descriptor cloning, merged key order, and intrinsic fallback.
- Scope bootstrap descriptor writes for built-in prototypes/functions and add isolation coverage for Array/Object prototypes, Function metadata, Object.assign/spread, and legacy getter/setter paths.
- Resolves the built-in prototype descriptor mutation bleed described in #1285 using per-runtime descriptor overlays rather than process-global mutable descriptor state.

Closes #1285.

## Validation
- `dotnet build --nologo`
- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Debug --filter "FullyQualifiedName~Object|FullyQualifiedName~Array|FullyQualifiedName~String|FullyQualifiedName~Json|FullyQualifiedName~Generator|FullyQualifiedName~Node.Url|FullyQualifiedName~PropertyDescriptorStoreTests|FullyQualifiedName~RuntimePrototypeIsolationTests" --nologo`
- `dotnet test tests\Jroc.Test262.Tests\Jroc.Test262.Tests.csproj -c Debug --filter "FullyQualifiedName~built_ins.JSON|FullyQualifiedName~built_ins.Array|FullyQualifiedName~built_ins.String|FullyQualifiedName~built_ins.Object" --nologo`

Note: a full local `Jroc.Tests` run was attempted earlier but stopped because `C:\Temp` filled up; targeted affected suites above passed after cleanup.
