### PR TITLE
fix: add missing YAML frontmatter to find-failing-test262-tests skill

### DIFF
--- a/.github/skills/find-failing-test262-tests/SKILL.md
+++ b/.github/skills/find-failing-test262-tests/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: find-failing-test262-tests
+description: Discover which test262 tests are failing and not yet ported into tests/Jroc.Test262.Tests, identifying good candidates for future porting cycles.
+tier: standard
+applyTo: 'tests/Jroc.Test262.Tests/**,scripts/test262/**,docs/ECMA262/**'
+---
+
 # Find Failing Test262 Tests
 
 Use this skill when you need to discover which test262 tests are failing but haven't yet been ported into this repo's test suite.


### PR DESCRIPTION
## Problem

The ind-failing-test262-tests skill was failing to load because it was missing the required YAML frontmatter block that Copilot needs to register skills.

## Fix

Added the required frontmatter to .github/skills/find-failing-test262-tests/SKILL.md:

\\\yaml
---
name: find-failing-test262-tests
description: Discover which test262 tests are failing and not yet ported into tests/Jroc.Test262.Tests, identifying good candidates for future porting cycles.
tier: standard
applyTo: 'tests/Jroc.Test262.Tests/**,scripts/test262/**,docs/ECMA262/**'
---
\\\

This matches the pattern used by the working 	est262-porting skill.