### PR TITLE
perf: use in-memory compile in JrocRuntime benchmark adapter

### DIFF
--- a/tests/performance/Benchmarks/Runtimes/JrocRuntime.cs
+++ b/tests/performance/Benchmarks/Runtimes/JrocRuntime.cs
@@ -1,14 +1,11 @@
 using System.Diagnostics;
-using System.Reflection;
-using System.Runtime.Loader;
 using Jroc;
 using Jroc.Runtime;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Benchmarks.Runtimes;
 
 /// <summary>
-/// jroc runtime adapter - compiles JavaScript to .NET IL and executes.
+/// jroc runtime adapter - compiles JavaScript to .NET IL in memory and executes.
 /// Separates compile time from execution time.
 /// </summary>
 public class JrocRuntime : IJavaScriptRuntime
@@ -19,163 +16,56 @@ public class JrocRuntime : IJavaScriptRuntime
     {
         var result = new RuntimeExecutionResult { Success = false };
 
-        // Create temp directory for compilation output
-        var tempDir = Path.Combine(Path.GetTempPath(), $"jroc-benchmark-{Guid.NewGuid()}");
-        var tempScriptFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.js");
-        var outputName = "benchmark";
+        // Use a stable fake path; SourceText overlay means the file need not exist on disk.
+        var entryPath = Path.Combine(Path.GetTempPath(), scriptName);
+        var request = new JrocInMemoryCompileRequest(entryPath)
+        {
+            SourceText = scriptContent
+        };
 
+        JrocCompiledAssemblyArtifact artifact;
+
+        // Measure compilation time
+        var compileStopwatch = Stopwatch.StartNew();
         try
         {
-            Directory.CreateDirectory(tempDir);
-
-            // Write script to temp file
-            File.WriteAllText(tempScriptFile, scriptContent);
-
-            // Measure compilation time
-            var compileStopwatch = Stopwatch.StartNew();
-
-            try
-            {
-                // Build compiler with service provider
-                var options = new CompilerOptions { OutputDirectory = tempDir };
-                var serviceProvider = CompilerServices.BuildServiceProvider(options);
-                var compiler = serviceProvider.GetRequiredService<Compiler>();
-
-                // Compile the JavaScript
-                if (!compiler.Compile(tempScriptFile, outputName))
-                {
-                    result.Success = false;
-                    result.Error = "jroc compilation failed";
-                    return result;
-                }
-            }
-            catch (Exception ex)
-            {
-                result.Success = false;
-                result.Error = $"jroc compilation failed: {ex.Message}";
-                return result;
-            }
-
-            compileStopwatch.Stop();
-            result.CompileTime = compileStopwatch.Elapsed;
-
-            // Find the generated DLL (it's named after the input file, not the outputName parameter)
-            var dllFiles = Directory.GetFiles(tempDir, "*.dll", SearchOption.TopDirectoryOnly)
-                .Where(f => !f.Contains("JavaScriptRuntime"))  // Exclude the runtime DLL
-                .ToArray();
-            
-            if (dllFiles.Length == 0)
-            {
-                result.Success = false;
-                result.Error = $"jroc compiled output not found in: {tempDir}";
-                return result;
-            }
-
-            var dllPath = dllFiles[0];
-
-            var fullDllPath = Path.GetFullPath(dllPath);
-            var moduleLoadContext = new BenchmarkModuleLoadContext(
-                typeof(JavaScriptRuntime.EnvironmentProvider).Assembly,
-                fullDllPath,
-                $"jroc-benchmark-runtime-{Guid.NewGuid():N}");
-
-            try
-            {
-                var assembly = moduleLoadContext.LoadFromAssemblyPath(fullDllPath);
-                var moduleId = ResolveModuleId(assembly, outputName);
-
-                // Measure execution time
-                var executeStopwatch = Stopwatch.StartNew();
-                using var exports = JsEngine.LoadModule(assembly, moduleId);
-                executeStopwatch.Stop();
-
-                result.Success = true;
-                result.ExecutionTime = executeStopwatch.Elapsed;
-                result.Output = string.Empty;
-            }
-            finally
-            {
-                moduleLoadContext.Unload();
-            }
+            artifact = JrocInMemoryCompiler.Compile(request);
         }
         catch (Exception ex)
         {
-            result.Success = false;
+            result.Error = $"jroc compilation failed: {ex.Message}";
+            return result;
+        }
+        finally
+        {
+            compileStopwatch.Stop();
+        }
+
+        result.CompileTime = compileStopwatch.Elapsed;
+
+        // Load the compiled assembly from memory and execute
+        var loadedAssembly = JrocInMemoryAssemblyLoader.Load(artifact);
+        try
+        {
+            var moduleId = artifact.ModuleIds[0];
+
+            var executeStopwatch = Stopwatch.StartNew();
+            using var exports = JsEngine.LoadModule(loadedAssembly.Assembly, moduleId);
+            executeStopwatch.Stop();
+
+            result.Success = true;
+            result.ExecutionTime = executeStopwatch.Elapsed;
+            result.Output = string.Empty;
+        }
+        catch (Exception ex)
+        {
             result.Error = $"jroc execution failed: {ex.Message}";
         }
         finally
         {
-            // Clean up temp files
-            try
-            {
-                if (File.Exists(tempScriptFile))
-                {
-                    File.Delete(tempScriptFile);
-                }
-                if (Directory.Exists(tempDir))
-                {
-                    Directory.Delete(tempDir, recursive: true);
-                }
-            }
-            catch
-            {
-                // Ignore cleanup errors
-            }
+            loadedAssembly.Dispose();
         }
 
         return result;
-    }
-
-    private static string ResolveModuleId(Assembly assembly, string fallback)
-    {
-        var moduleIds = assembly
-            .GetCustomAttributes<JsCompiledModuleAttribute>()
-            .Select(a => a.ModuleId)
-            .Where(m => !string.IsNullOrWhiteSpace(m))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-
-        if (moduleIds.Length == 0)
-        {
-            return fallback;
-        }
-
-        if (moduleIds.Contains(fallback, StringComparer.Ordinal))
-        {
-            return fallback;
-        }
-
-        return moduleIds[0];
-    }
-
-    private sealed class BenchmarkModuleLoadContext : AssemblyLoadContext
-    {
-        private readonly Assembly _runtimeAssembly;
-        private readonly string _runtimeAssemblyName;
-        private readonly AssemblyDependencyResolver _resolver;
-
-        public BenchmarkModuleLoadContext(Assembly runtimeAssembly, string mainAssemblyPath, string contextName)
-            : base(contextName, isCollectible: true)
-        {
-            _runtimeAssembly = runtimeAssembly;
-            _runtimeAssemblyName = runtimeAssembly.GetName().Name ?? nameof(JavaScriptRuntime.EnvironmentProvider);
-            _resolver = new AssemblyDependencyResolver(mainAssemblyPath);
-        }
-
-        protected override Assembly? Load(AssemblyName assemblyName)
-        {
-            if (string.Equals(assemblyName.Name, _runtimeAssemblyName, StringComparison.Ordinal))
-            {
-                return _runtimeAssembly;
-            }
-
-            var resolvedPath = _resolver.ResolveAssemblyToPath(assemblyName);
-            if (!string.IsNullOrWhiteSpace(resolvedPath))
-            {
-                return LoadFromAssemblyPath(resolvedPath);
-            }
-
-            return null;
-        }
     }
 }


### PR DESCRIPTION
## Summary

Replaces the disk-based compile workflow in \JrocRuntime.Execute\ with the \JrocInMemoryCompiler\ API introduced for in-memory hosting.

## Changes

**Before:** Write script to a temp \.js\ file → compile to a temp directory → scan for the output DLL → load from path via custom \BenchmarkModuleLoadContext\ → delete temp files.

**After:** Pass \SourceText\ via \JrocInMemoryCompileRequest\ → compile to bytes with \JrocInMemoryCompiler.Compile()\ → load from \MemoryStream\ via \JrocInMemoryAssemblyLoader.Load()\ → run with \JsEngine.LoadModule()\.

### Removed
- Temp file/directory creation and cleanup code
- Custom \BenchmarkModuleLoadContext\ (replaced by the in-memory loader's built-in \SharedRuntimeAssemblyLoadContext\)
- \ResolveModuleId\ helper (replaced by \rtifact.ModuleIds[0]\)

### Benefits
- No disk I/O during benchmarks → lower noise in measurements
- No temp-file cleanup needed
- Consistent with how the rest of the codebase uses the in-memory pipeline