### PR TITLE
test(perf): add Okojo runtime to BenchmarkDotNet suite

### DIFF
--- a/tests/performance/Benchmarks/Benchmarks.csproj
+++ b/tests/performance/Benchmarks/Benchmarks.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Jint" Version="4.2.0" />
+    <PackageReference Include="Okojo" Version="0.1.2-preview.1" />
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.5.1" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.1" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.1" />

--- a/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
+++ b/tests/performance/Benchmarks/JavaScriptRuntimeBenchmarks.cs
@@ -22,6 +22,7 @@ public class JavaScriptRuntimeBenchmarks
     private readonly Dictionary<string, string> _scripts = new();
     private readonly Dictionary<string, string> _scenarioKeyToScriptName = new(StringComparer.Ordinal);
     private readonly JintRuntime _jintRuntime = new();
+    private readonly OkojoRuntime _okojoRuntime = new();
     private readonly ClearScriptRuntime _clearScriptRuntime = new();
     private readonly JrocRuntime _jrocRuntime = new();
 
@@ -78,6 +79,18 @@ public class JavaScriptRuntimeBenchmarks
         if (!result.Success)
         {
             throw new Exception($"Jint execution failed: {result.Error}");
+        }
+    }
+
+    [Benchmark(Description = "Okojo")]
+    public void Okojo()
+    {
+        var script = _scripts[ScriptName];
+        var result = _okojoRuntime.Execute(script, $"{ResolveScriptName(ScriptName)}.js");
+        
+        if (!result.Success)
+        {
+            throw new Exception($"Okojo execution failed: {result.Error}");
         }
     }
 

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -4,6 +4,7 @@ This directory contains a comprehensive BenchmarkDotNet-based performance benchm
 
 - **ClearScript** - .NET-hosted V8 runtime
 - **Jint** - .NET JavaScript interpreter
+- **Okojo** - fully managed .NET JavaScript runtime
 - **jroc** - JavaScript-to-IL AOT compiler
 
 ## Purpose
@@ -31,6 +32,7 @@ Benchmarks/
 │   ├── IJavaScriptRuntime.cs
 │   ├── ClearScriptRuntime.cs
 │   ├── JintRuntime.cs
+│   ├── OkojoRuntime.cs
 │   └── JrocRuntime.cs
 ├── Compliance/          # Licensing and provenance tracking
 │   └── PROVENANCE.md
@@ -188,6 +190,7 @@ Intel Core i7-9700K CPU 3.60GHz (Coffee Lake), 1 CPU, 8 logical and 8 physical c
 
 - **ClearScript**: New hosted V8 engine instance per iteration
 - **Jint**: New engine instance per iteration
+- **Okojo**: New runtime instance per iteration
 - **jroc**: Pre-compiled or compile+execute per iteration
 
 Direct Node.js process-per-iteration measurements are intentionally excluded from the default cross-runtime suite because they include temp-file creation, process startup, stdout/stderr capture, and process teardown. Those numbers are useful as a CLI cold-start metric, but they are not a fair comparison to in-process .NET runtimes. ClearScript is used instead as the .NET-hosted V8 comparison point.

--- a/tests/performance/Benchmarks/Runtimes/OkojoRuntime.cs
+++ b/tests/performance/Benchmarks/Runtimes/OkojoRuntime.cs
@@ -1,0 +1,39 @@
+using System.Diagnostics;
+using Okojo;
+using Okojo.Runtime;
+
+namespace Benchmarks.Runtimes;
+
+/// <summary>
+/// Okojo runtime adapter - executes JavaScript through the managed Okojo runtime.
+/// </summary>
+public sealed class OkojoRuntime : IJavaScriptRuntime
+{
+    public string Name => "Okojo";
+
+    public RuntimeExecutionResult Execute(string scriptContent, string scriptName = "script.js")
+    {
+        var result = new RuntimeExecutionResult { Success = false };
+
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            using var runtime = JsRuntime.CreateBuilder().Build();
+            runtime.MainRealm.Evaluate(scriptContent);
+
+            stopwatch.Stop();
+
+            result.ExecutionTime = stopwatch.Elapsed;
+            result.Success = true;
+            result.Output = string.Empty;
+        }
+        catch (Exception ex)
+        {
+            result.Success = false;
+            result.Error = $"Okojo execution failed: {ex.Message}";
+        }
+
+        return result;
+    }
+}

--- a/tests/performance/Benchmarks/ValidationTest.cs
+++ b/tests/performance/Benchmarks/ValidationTest.cs
@@ -88,6 +88,24 @@ public static class ValidationTest
             Console.WriteLine($"   Exception: {ex.Message}");
         }
 
+        // Test Okojo
+        Console.WriteLine("\n4. Testing Okojo...");
+        try
+        {
+            var okojoRuntime = new OkojoRuntime();
+            var okojoResult = okojoRuntime.Execute(script, "minimal.js");
+            Console.WriteLine($"   Success: {okojoResult.Success}");
+            Console.WriteLine($"   Execution Time: {okojoResult.ExecutionTime.TotalMilliseconds}ms");
+            if (!okojoResult.Success)
+            {
+                Console.WriteLine($"   Error: {okojoResult.Error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"   Exception: {ex.Message}");
+        }
+
         Console.WriteLine("\nAll runtime adapters tested!");
     }
 }


### PR DESCRIPTION
## Summary
- Add an `OkojoRuntime` adapter to the BenchmarkDotNet runtime harness.
- Wire Okojo into `JavaScriptRuntimeBenchmarks` and runtime validation.
- Add the `Okojo` NuGet package reference to the benchmarks project.
- Update benchmark README runtime coverage notes.

## Why
This extends the .NET benchmark runtime comparisons to include Okojo alongside Jint, ClearScript, and jroc.