### PR TITLE
perf(il): reduce typed argument boxing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/tests: reduce redundant object materialization when typed numeric temps flow into user-class method calls, trimming boxing in prime/class-method generator snapshots.
 
 ## v0.11.1 - 2026-06-27
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Arithmetic.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Arithmetic.cs
@@ -131,6 +131,12 @@ internal sealed partial class LIRToILCompiler
                 break;
 
             case LIRConvertToObject convertToObject:
+                if (GetTempVariableSlot(convertToObject.Result) < 0
+                    && !IsTempUsedByAnyInstructionOperand(convertToObject.Result, convertToObject))
+                {
+                    break;
+                }
+
                 if (!IsMaterialized(convertToObject.Result, allocation))
                 {
                     break;

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.TempsAndExceptions.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.TempsAndExceptions.cs
@@ -22,6 +22,12 @@ internal sealed partial class LIRToILCompiler
         {
             // Copy temp variable
             case LIRCopyTemp copyTemp:
+                if (GetTempVariableSlot(copyTemp.Destination) < 0
+                    && !IsTempUsedByAnyInstructionOperand(copyTemp.Destination, copyTemp))
+                {
+                    return true;
+                }
+
                 if (TryGetSameILLocalSlot(copyTemp.Source, copyTemp.Destination, allocation, out _))
                 {
                     return true;

--- a/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
+++ b/src/Compiler/IL/LIRToILCompiler.TempsLocals.cs
@@ -2007,6 +2007,37 @@ internal sealed partial class LIRToILCompiler
         return allocation.IsMaterialized(temp);
     }
 
+    private bool IsTempUsedByAnyInstructionOperand(TempVariable temp, LIRInstruction ignoredInstruction)
+    {
+        foreach (var instruction in MethodBody.Instructions)
+        {
+            if (ReferenceEquals(instruction, ignoredInstruction))
+            {
+                continue;
+            }
+
+            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(instruction))
+            {
+                if (used.Index == temp.Index)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private int GetTempVariableSlot(TempVariable temp)
+    {
+        if (temp.Index >= 0 && temp.Index < MethodBody.TempVariableSlots.Count)
+        {
+            return MethodBody.TempVariableSlots[temp.Index];
+        }
+
+        return -1;
+    }
+
     private void EmitStoreTemp(TempVariable temp, InstructionEncoder ilEncoder, TempLocalAllocation allocation)
     {
         if (!IsMaterialized(temp, allocation))

--- a/src/Compiler/IL/TempLocalAllocator.cs
+++ b/src/Compiler/IL/TempLocalAllocator.cs
@@ -688,6 +688,10 @@ internal static class TempLocalAllocator
                 yield return getItemAsNumber.Object;
                 yield return getItemAsNumber.Index;
                 break;
+            case LIRGetItemAsNumberString getItemAsNumberString:
+                yield return getItemAsNumberString.Object;
+                yield return getItemAsNumberString.Index;
+                break;
             case LIRSetItem setItem:
                 yield return setItem.Object;
                 yield return setItem.Index;
@@ -1148,6 +1152,9 @@ internal static class TempLocalAllocator
                 return true;
             case LIRGetItemAsNumber getItemAsNumber:
                 defined = getItemAsNumber.Result;
+                return true;
+            case LIRGetItemAsNumberString getItemAsNumberString:
+                defined = getItemAsNumberString.Result;
                 return true;
 
             case LIRSetItem setItem:

--- a/src/Compiler/IR/LIR/LIRMemberCallNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRMemberCallNormalization.cs
@@ -21,11 +21,18 @@ internal static class LIRMemberCallNormalization
 
         // Map: argsArrayTempIndex -> (defInstructionIndex, elements)
         var buildArrays = new Dictionary<int, (int DefIndex, IReadOnlyList<TempVariable> Elements)>();
+        var convertToObjectDefs = new Dictionary<int, int>();
         for (int i = 0; i < methodBody.Instructions.Count; i++)
         {
-            if (methodBody.Instructions[i] is LIRBuildArray buildArray && buildArray.Result.Index >= 0)
+            switch (methodBody.Instructions[i])
             {
-                buildArrays[buildArray.Result.Index] = (i, buildArray.Elements);
+                case LIRBuildArray buildArray when buildArray.Result.Index >= 0:
+                    buildArrays[buildArray.Result.Index] = (i, buildArray.Elements);
+                    break;
+
+                case LIRConvertToObject convertToObject when convertToObject.Result.Index >= 0:
+                    convertToObjectDefs[convertToObject.Result.Index] = i;
+                    break;
             }
         }
 
@@ -112,6 +119,15 @@ internal static class LIRMemberCallNormalization
             // This enables early-binding for chained calls without runtime type tests.
             var resolvedReceiverEntityHandle = (EntityHandle)receiverTypeHandle;
             bool resultIsReceiverType = !returnTypeHandle.IsNil && returnTypeHandle.Equals(resolvedReceiverEntityHandle);
+            var normalizedArguments = ForwardBoxedArgumentsToTypedSources(
+                methodBody,
+                arguments,
+                parameterClrTypes,
+                maxParamCount,
+                convertToObjectDefs,
+                buildArrayDefIndex,
+                i,
+                indicesToRemove);
 
             // Receiver-proven typed case: emit direct early-bound call without runtime-dispatch fallback.
             if (receiver.Index >= 0
@@ -126,7 +142,7 @@ internal static class LIRMemberCallNormalization
                     returnClrType,
                     maxParamCount,
                     parameterClrTypes,
-                    arguments,
+                    normalizedArguments,
                     result);
 
                 if (result.Index >= 0)
@@ -160,7 +176,7 @@ internal static class LIRMemberCallNormalization
                 returnClrType,
                 maxParamCount,
                 parameterClrTypes,
-                arguments,
+                normalizedArguments,
                 result);
 
             if (buildArrayDefIndex >= 0)
@@ -329,24 +345,7 @@ internal static class LIRMemberCallNormalization
     }
 
     private static bool AreCompatiblePinnedSlotStorages(ValueStorage slotStorage, ValueStorage desiredStorage)
-    {
-        if (slotStorage.Kind != desiredStorage.Kind)
-        {
-            return false;
-        }
-
-        if (slotStorage.ClrType != desiredStorage.ClrType)
-        {
-            return false;
-        }
-
-        if (!slotStorage.TypeHandle.IsNil || !desiredStorage.TypeHandle.IsNil)
-        {
-            return slotStorage.TypeHandle.Equals(desiredStorage.TypeHandle);
-        }
-
-        return string.Equals(slotStorage.ScopeName, desiredStorage.ScopeName, StringComparison.Ordinal);
-    }
+        => ValueStorageFacts.IsSameRuntimeRepresentation(slotStorage, desiredStorage);
 
     private static int GetTempVariableSlot(MethodBodyIR methodBody, TempVariable temp)
     {
@@ -356,6 +355,179 @@ internal static class LIRMemberCallNormalization
         }
 
         return -1;
+    }
+
+    private static IReadOnlyList<TempVariable> ForwardBoxedArgumentsToTypedSources(
+        MethodBodyIR methodBody,
+        IReadOnlyList<TempVariable> arguments,
+        IReadOnlyList<Type?> parameterClrTypes,
+        int maxParamCount,
+        IReadOnlyDictionary<int, int> convertToObjectDefs,
+        int buildArrayDefIndex,
+        int callInstructionIndex,
+        HashSet<int> indicesToRemove)
+    {
+        if (arguments.Count == 0 || convertToObjectDefs.Count == 0)
+        {
+            return arguments;
+        }
+
+        TempVariable[]? rewritten = null;
+
+        for (int argIndex = 0; argIndex < arguments.Count; argIndex++)
+        {
+            if (argIndex >= maxParamCount || argIndex >= parameterClrTypes.Count)
+            {
+                continue;
+            }
+
+            var parameterClrType = parameterClrTypes[argIndex];
+            if (parameterClrType == null || parameterClrType == typeof(object))
+            {
+                continue;
+            }
+
+            var argument = arguments[argIndex];
+            if (argument.Index < 0
+                || !convertToObjectDefs.TryGetValue(argument.Index, out var convertDefIndex)
+                || methodBody.Instructions[convertDefIndex] is not LIRConvertToObject convertToObject
+                || !CanForwardConvertToObjectSource(methodBody, convertToObject, parameterClrType, convertDefIndex, callInstructionIndex))
+            {
+                continue;
+            }
+
+            rewritten ??= arguments.ToArray();
+            rewritten[argIndex] = convertToObject.Source;
+
+            if (GetTempVariableSlot(methodBody, convertToObject.Result) >= 0)
+            {
+                continue;
+            }
+
+            var ignoredInstructions = new HashSet<int> { convertDefIndex, callInstructionIndex };
+            if (buildArrayDefIndex >= 0)
+            {
+                ignoredInstructions.Add(buildArrayDefIndex);
+            }
+
+            if (!IsTempUsedOutside(methodBody, convertToObject.Result, ignoredInstructions))
+            {
+                indicesToRemove.Add(convertDefIndex);
+            }
+        }
+
+        return rewritten ?? arguments;
+    }
+
+    private static bool CanForwardConvertToObjectSource(
+        MethodBodyIR methodBody,
+        LIRConvertToObject convertToObject,
+        Type parameterClrType,
+        int convertInstructionIndex,
+        int callInstructionIndex)
+    {
+        var sourceStorage = GetTempStorage(methodBody, convertToObject.Source);
+        var targetStorage = parameterClrType.IsValueType
+            ? new ValueStorage(ValueStorageKind.UnboxedValue, parameterClrType)
+            : new ValueStorage(ValueStorageKind.Reference, parameterClrType);
+
+        if (!ValueStorageFacts.CanFlowTo(sourceStorage, targetStorage))
+        {
+            return false;
+        }
+
+        // Keep this rewrite to stable, already-evaluated values. The old LIRBuildArray
+        // materialized arguments before dispatch; forwarding an effectful source could
+        // otherwise move evaluation into the direct/fallback call branches.
+        return IsStableAlreadyEvaluatedTemp(methodBody, convertToObject.Source, convertInstructionIndex, callInstructionIndex);
+    }
+
+    private static bool IsStableAlreadyEvaluatedTemp(
+        MethodBodyIR methodBody,
+        TempVariable temp,
+        int snapshotInstructionIndex,
+        int useInstructionIndex)
+    {
+        var variableSlot = GetTempVariableSlot(methodBody, temp);
+        if (variableSlot >= 0)
+        {
+            return methodBody.SingleAssignmentSlots.Contains(variableSlot)
+                || !IsVariableSlotWrittenBetween(methodBody, variableSlot, snapshotInstructionIndex, useInstructionIndex);
+        }
+
+        return TryFindDefInstruction(methodBody, temp) switch
+        {
+            LIRConstNumber or LIRConstString or LIRConstBoolean or LIRConstUndefined or LIRConstNull => true,
+            LIRLoadParameter or LIRLoadThis => true,
+            LIRCopyTemp copyTemp => IsStableAlreadyEvaluatedTemp(methodBody, copyTemp.Source, snapshotInstructionIndex, useInstructionIndex),
+            _ => false
+        };
+    }
+
+    private static bool IsVariableSlotWrittenBetween(MethodBodyIR methodBody, int variableSlot, int startInstructionIndex, int endInstructionIndex)
+    {
+        if (startInstructionIndex >= endInstructionIndex)
+        {
+            return true;
+        }
+
+        for (int i = startInstructionIndex + 1; i < endInstructionIndex; i++)
+        {
+            if (TempLocalAllocator.TryGetDefinedTemp(methodBody.Instructions[i], out var defined)
+                && GetTempVariableSlot(methodBody, defined) == variableSlot)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static LIRInstruction? TryFindDefInstruction(MethodBodyIR methodBody, TempVariable temp)
+    {
+        foreach (var instruction in methodBody.Instructions)
+        {
+            if (TryGetDefinedTemp(instruction, out var defined) && defined.Index == temp.Index)
+            {
+                return instruction;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetDefinedTemp(LIRInstruction instruction, out TempVariable defined)
+    {
+        switch (instruction)
+        {
+            case LIRConstNumber x: defined = x.Result; return true;
+            case LIRConstString x: defined = x.Result; return true;
+            case LIRConstBoolean x: defined = x.Result; return true;
+            case LIRConstUndefined x: defined = x.Result; return true;
+            case LIRConstNull x: defined = x.Result; return true;
+            case LIRLoadParameter x: defined = x.Result; return true;
+            case LIRLoadThis x: defined = x.Result; return true;
+            case LIRCopyTemp x: defined = x.Destination; return true;
+            default:
+                defined = default;
+                return false;
+        }
+    }
+
+    private static ValueStorage GetTempStorage(MethodBodyIR methodBody, TempVariable temp)
+    {
+        var variableSlot = GetTempVariableSlot(methodBody, temp);
+        if (variableSlot >= 0 && variableSlot < methodBody.VariableStorages.Count)
+        {
+            return methodBody.VariableStorages[variableSlot];
+        }
+
+        if (temp.Index >= 0 && temp.Index < methodBody.TempStorages.Count)
+        {
+            return methodBody.TempStorages[temp.Index];
+        }
+
+        return new ValueStorage(ValueStorageKind.Unknown);
     }
 
     private static bool IsTempUsedOutside(MethodBodyIR methodBody, TempVariable temp, HashSet<int> ignoreInstructionIndices)

--- a/src/Compiler/IR/LIR/LIRTypeNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRTypeNormalization.cs
@@ -1,3 +1,4 @@
+using Jroc.IL;
 using Jroc.Services;
 using System.Reflection;
 
@@ -171,6 +172,9 @@ internal static class LIRTypeNormalization
                 i--; // account for removed instruction
             }
         }
+
+        ForwardBoxedArgumentsForDirectUserClassCalls(methodBody, classRegistry);
+        RemoveDeadObjectMaterializations(methodBody);
 
         // After rewrites, some anonymous variable slots (e.g., `$forOf_iter`) may become unused
         // if we coalesce temps onto existing slots. Compact variable slots to avoid emitting
@@ -438,6 +442,67 @@ internal static class LIRTypeNormalization
         return false;
     }
 
+    private static void RemoveDeadObjectMaterializations(MethodBodyIR methodBody)
+    {
+        var indicesToRemove = new HashSet<int>();
+
+        for (int i = 0; i < methodBody.Instructions.Count; i++)
+        {
+            if (methodBody.Instructions[i] is not LIRConvertToObject convertToObject)
+            {
+                continue;
+            }
+
+            if (GetTempVariableSlot(methodBody, convertToObject.Result) >= 0)
+            {
+                continue;
+            }
+
+            if (!IsTempUsedOutsideByInstructionOperands(methodBody, convertToObject.Result, i))
+            {
+                indicesToRemove.Add(i);
+            }
+        }
+
+        if (indicesToRemove.Count == 0)
+        {
+            return;
+        }
+
+        var newInstructions = new List<LIRInstruction>(methodBody.Instructions.Count - indicesToRemove.Count);
+        for (int i = 0; i < methodBody.Instructions.Count; i++)
+        {
+            if (!indicesToRemove.Contains(i))
+            {
+                newInstructions.Add(methodBody.Instructions[i]);
+            }
+        }
+
+        methodBody.Instructions.Clear();
+        methodBody.Instructions.AddRange(newInstructions);
+    }
+
+    private static bool IsTempUsedOutsideByInstructionOperands(MethodBodyIR methodBody, TempVariable temp, int ignoreInstructionIndex)
+    {
+        for (int i = 0; i < methodBody.Instructions.Count; i++)
+        {
+            if (i == ignoreInstructionIndex)
+            {
+                continue;
+            }
+
+            foreach (var used in TempLocalAllocator.EnumerateUsedTemps(methodBody.Instructions[i]))
+            {
+                if (used.Index == temp.Index)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private static bool TryMatchTypeofFunctionComparison(
         TempVariable left,
         TempVariable right,
@@ -545,6 +610,137 @@ internal static class LIRTypeNormalization
         return temp;
     }
 
+    private static void ForwardBoxedArgumentsForDirectUserClassCalls(MethodBodyIR methodBody, ClassRegistry classRegistry)
+    {
+        for (int i = 0; i < methodBody.Instructions.Count; i++)
+        {
+            if (methodBody.Instructions[i] is not LIRCallUserClassInstanceMethod callUserClass)
+            {
+                continue;
+            }
+
+            if (!classRegistry.TryGetMethodParameterClrTypes(
+                    callUserClass.RegistryClassName,
+                    callUserClass.MethodName,
+                    out var parameterClrTypes))
+            {
+                continue;
+            }
+
+            var argsToPass = Math.Min(callUserClass.Arguments.Count, callUserClass.MaxParamCount);
+            TempVariable[]? rewrittenArguments = null;
+
+            for (int argIndex = 0; argIndex < argsToPass; argIndex++)
+            {
+                if (argIndex >= parameterClrTypes.Count)
+                {
+                    continue;
+                }
+
+                var parameterClrType = parameterClrTypes[argIndex];
+                if (parameterClrType == null || parameterClrType == typeof(object))
+                {
+                    continue;
+                }
+
+                var argument = callUserClass.Arguments[argIndex];
+                if (!TryFindConvertToObjectDefinition(methodBody, argument, out var convertToObject, out var convertInstructionIndex)
+                    || !CanForwardConvertToObjectSourceToParameter(methodBody, convertToObject, parameterClrType, convertInstructionIndex, i))
+                {
+                    continue;
+                }
+
+                rewrittenArguments ??= callUserClass.Arguments.ToArray();
+                rewrittenArguments[argIndex] = convertToObject.Source;
+            }
+
+            if (rewrittenArguments != null)
+            {
+                methodBody.Instructions[i] = callUserClass with { Arguments = rewrittenArguments };
+            }
+        }
+    }
+
+    private static bool TryFindConvertToObjectDefinition(
+        MethodBodyIR methodBody,
+        TempVariable temp,
+        out LIRConvertToObject convertToObject,
+        out int instructionIndex)
+    {
+        for (int i = 0; i < methodBody.Instructions.Count; i++)
+        {
+            var instruction = methodBody.Instructions[i];
+            if (instruction is LIRConvertToObject candidate && candidate.Result.Index == temp.Index)
+            {
+                convertToObject = candidate;
+                instructionIndex = i;
+                return true;
+            }
+        }
+
+        convertToObject = default!;
+        instructionIndex = -1;
+        return false;
+    }
+
+    private static bool CanForwardConvertToObjectSourceToParameter(
+        MethodBodyIR methodBody,
+        LIRConvertToObject convertToObject,
+        Type parameterClrType,
+        int convertInstructionIndex,
+        int callInstructionIndex)
+    {
+        var sourceStorage = GetTempStorage(methodBody, convertToObject.Source);
+        var targetStorage = parameterClrType.IsValueType
+            ? new ValueStorage(ValueStorageKind.UnboxedValue, parameterClrType)
+            : new ValueStorage(ValueStorageKind.Reference, parameterClrType);
+
+        return ValueStorageFacts.CanFlowTo(sourceStorage, targetStorage)
+            && IsStableAlreadyEvaluatedTemp(methodBody, convertToObject.Source, convertInstructionIndex, callInstructionIndex);
+    }
+
+    private static bool IsStableAlreadyEvaluatedTemp(
+        MethodBodyIR methodBody,
+        TempVariable temp,
+        int snapshotInstructionIndex,
+        int useInstructionIndex)
+    {
+        var variableSlot = GetTempVariableSlot(methodBody, temp);
+        if (variableSlot >= 0)
+        {
+            return methodBody.SingleAssignmentSlots.Contains(variableSlot)
+                || !IsVariableSlotWrittenBetween(methodBody, variableSlot, snapshotInstructionIndex, useInstructionIndex);
+        }
+
+        return TryFindInstructionDefiningTemp(methodBody, temp, out var definitionIndex)
+            && methodBody.Instructions[definitionIndex] switch
+            {
+                LIRConstNumber or LIRConstString or LIRConstBoolean or LIRConstUndefined or LIRConstNull => true,
+                LIRLoadParameter or LIRLoadThis => true,
+                LIRCopyTemp copyTemp => IsStableAlreadyEvaluatedTemp(methodBody, copyTemp.Source, snapshotInstructionIndex, useInstructionIndex),
+                _ => false
+            };
+    }
+
+    private static bool IsVariableSlotWrittenBetween(MethodBodyIR methodBody, int variableSlot, int startInstructionIndex, int endInstructionIndex)
+    {
+        if (startInstructionIndex >= endInstructionIndex)
+        {
+            return true;
+        }
+
+        for (int i = startInstructionIndex + 1; i < endInstructionIndex; i++)
+        {
+            if (TempLocalAllocator.TryGetDefinedTemp(methodBody.Instructions[i], out var defined)
+                && GetTempVariableSlot(methodBody, defined) == variableSlot)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static void RemoveDeadDefinitionChain(MethodBodyIR methodBody, TempVariable temp)
     {
         while (TryFindInstructionDefiningTemp(methodBody, temp, out var definitionIndex))
@@ -592,6 +788,12 @@ internal static class LIRTypeNormalization
             {
                 case LIRTypeof typeofInstruction when typeofInstruction.Result.Index == temp.Index:
                 case LIRConstString constString when constString.Result.Index == temp.Index:
+                case LIRConstNumber constNumber when constNumber.Result.Index == temp.Index:
+                case LIRConstBoolean constBoolean when constBoolean.Result.Index == temp.Index:
+                case LIRConstUndefined constUndefined when constUndefined.Result.Index == temp.Index:
+                case LIRConstNull constNull when constNull.Result.Index == temp.Index:
+                case LIRLoadParameter loadParameter when loadParameter.Result.Index == temp.Index:
+                case LIRLoadThis loadThis when loadThis.Result.Index == temp.Index:
                 case LIRCopyTemp copyTemp when copyTemp.Destination.Index == temp.Index:
                     definitionIndex = i;
                     return true;

--- a/src/Compiler/IR/LIR/ValueStorageFacts.cs
+++ b/src/Compiler/IR/LIR/ValueStorageFacts.cs
@@ -1,0 +1,46 @@
+namespace Jroc.IR;
+
+internal static class ValueStorageFacts
+{
+    internal static bool IsSameRuntimeRepresentation(ValueStorage left, ValueStorage right)
+    {
+        if (left.Kind != right.Kind || left.ClrType != right.ClrType)
+        {
+            return false;
+        }
+
+        if (!left.TypeHandle.IsNil || !right.TypeHandle.IsNil)
+        {
+            return left.TypeHandle.Equals(right.TypeHandle);
+        }
+
+        return string.Equals(left.ScopeName, right.ScopeName, StringComparison.Ordinal);
+    }
+
+    internal static bool CanFlowTo(ValueStorage source, ValueStorage target)
+    {
+        if (IsSameRuntimeRepresentation(source, target))
+        {
+            return true;
+        }
+
+        if (target.Kind == ValueStorageKind.Reference && target.ClrType == typeof(object))
+        {
+            return source.Kind is ValueStorageKind.UnboxedValue or ValueStorageKind.BoxedValue or ValueStorageKind.Reference;
+        }
+
+        if (source.Kind == ValueStorageKind.Reference
+            && target.Kind == ValueStorageKind.Reference
+            && source.ClrType != null
+            && target.ClrType != null
+            && target.ClrType.IsAssignableFrom(source.ClrType)
+            && source.TypeHandle.IsNil
+            && target.TypeHandle.IsNil)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/src/Compiler/TypedTempOptimization.md
+++ b/src/Compiler/TypedTempOptimization.md
@@ -1,0 +1,410 @@
+# Typed temp optimization notes
+
+This document explains the typed-temp cleanup work introduced for issue #451.
+It is written in two layers:
+
+1. An "explain like I'm 5" section with small examples.
+2. A technical section that maps those examples to the LIR and IL compiler code.
+
+The goal is to make it easier for humans to understand why these optimizations
+exist, what they are allowed to change, and what they must never change.
+
+## Part 1: Explain like I'm 5
+
+### The toy-box version
+
+Imagine the compiler has a number, like `42`.
+
+Sometimes the compiler puts that number in a plain number box:
+
+```text
+42
+```
+
+Sometimes it wraps that number in a bigger "anything can go here" box:
+
+```text
+object box containing 42
+```
+
+That bigger box is useful when JavaScript needs a value that could be anything:
+a number, a string, an object, `undefined`, and so on. But if the next thing we
+do already expects a number, putting the number into the big box and then taking
+it back out is wasted work.
+
+This PR teaches the compiler to notice some of those cases and skip the wasted
+box.
+
+### Simple example: passing a number to a method
+
+JavaScript:
+
+```javascript
+class Counter {
+  add(x) {
+    return x + 1;
+  }
+}
+
+const c = new Counter();
+console.log(c.add(41));
+```
+
+The method `add` has a parameter `x`. After earlier compiler passes, Jroc may
+know that `x` is used as a number. The old path could still do work like this:
+
+```text
+make number 41
+put 41 into an object box
+call Counter.add, which expects a number
+take 41 back out as a number
+```
+
+The optimized path is:
+
+```text
+make number 41
+call Counter.add with the number directly
+```
+
+The JavaScript behavior is the same, but the generated IL has less boxing and
+fewer temporary object locals.
+
+### Simple example: why we cannot always skip the box
+
+JavaScript arguments are evaluated left to right. That means the first argument
+must keep the value it had when the first argument was evaluated.
+
+```javascript
+let x = 1;
+obj.method(x, x = 2);
+```
+
+The first argument is `1`. The second argument changes `x` to `2`. The method
+must still receive:
+
+```text
+first argument: 1
+second argument: 2
+```
+
+If the compiler is careless and says, "I will just load `x` later when I call
+the method," it might accidentally pass:
+
+```text
+first argument: 2
+second argument: 2
+```
+
+That would be wrong.
+
+So the optimization only forwards a typed value when it is safe:
+
+- the value is a constant, parameter, `this`, or another already-safe value;
+- or the value lives in a variable slot that cannot change;
+- or the value lives in a variable slot that does not get written again between
+  the original boxing point and the call.
+
+In other words, the compiler only skips the object box when it can still preserve
+the original JavaScript value.
+
+### Simple example: removing an unused object box
+
+Sometimes the compiler used to build an object box, then later no instruction
+actually needed it:
+
+```text
+make number 10
+put 10 into object box tempA
+call typed method with number 10 directly
+```
+
+After the call was rewritten to use the number directly, `tempA` became dead.
+The optimized compiler removes the dead object-box instruction:
+
+```text
+make number 10
+call typed method with number 10 directly
+```
+
+### Simple example: pinned variables are special
+
+Some temps are not just disposable scratch values. They are pinned to a real IL
+local that represents an important compiler variable, such as loop state.
+
+For those temps, a "copy" or "convert" instruction can be doing important work
+even if it looks unused in a simple temp-use scan. It might be updating the local
+that the next loop iteration reads.
+
+This PR is careful not to remove writes to pinned variable slots.
+
+## Part 2: Technical details
+
+### Background: values have storage facts
+
+Jroc's LIR tracks how each temp is represented through `ValueStorage`:
+
+```csharp
+public sealed record ValueStorage(
+    ValueStorageKind Kind,
+    Type? ClrType = null,
+    EntityHandle TypeHandle = default,
+    string? ScopeName = null);
+```
+
+The most relevant storage kinds for this PR are:
+
+- `UnboxedValue`: a CLR value type such as `double` or `bool`.
+- `BoxedValue`: a value that has been boxed for object-shaped JavaScript flow.
+- `Reference`: a CLR reference type such as `object`, `string`, a runtime type,
+  or a generated user-class type handle.
+- `Unknown`: storage is not statically known.
+
+Correctness depends on distinguishing "same JavaScript value" from "same runtime
+representation." A `double` temp and an `object` temp might both represent the
+JavaScript number `42`, but they are not interchangeable at an IL call boundary
+unless the boundary expects the representation we are providing.
+
+### `ValueStorageFacts`
+
+This PR adds `ValueStorageFacts` as a small central place for storage
+compatibility checks used by normalization passes.
+
+`IsSameRuntimeRepresentation(left, right)` returns true when both storages can
+share the same IL local representation:
+
+- same `ValueStorageKind`;
+- same CLR type;
+- same metadata type handle when either side has one;
+- otherwise same scope name.
+
+This is stricter than "can be converted." It is used for cases such as deciding
+whether a typed call result can safely retag a temp that is pinned to an existing
+variable slot.
+
+`CanFlowTo(source, target)` answers whether a source representation can be used
+where a target representation is expected without changing semantics:
+
+- identical runtime representations can flow;
+- any known unboxed, boxed, or reference value can flow to `object`;
+- reference values can flow to assignable reference targets when both sides use
+  CLR types rather than generated metadata handles.
+
+The helper intentionally does not claim that unboxed `double` can flow to
+`object` by magic at every boundary. The caller still decides whether a boundary
+requires materialization or whether it is trying to avoid materialization.
+
+### Optimization 1: forwarding boxed arguments for typed member calls
+
+`LIRMemberCallNormalization` rewrites generic member calls into typed member
+calls when the class registry can prove a unique user-class method target.
+
+Before this PR, a generic call site could carry arguments through an object array
+or object-shaped temps even after the call was normalized to a typed method call.
+That produced patterns like:
+
+```text
+LIRConvertToObject(numberTemp -> boxedTemp)
+LIRBuildArray([boxedTemp] -> argsArray)
+LIRCallMember(receiver, "method", argsArray -> result)
+```
+
+After method resolution, the call can become:
+
+```text
+LIRCallTypedMember(receiver, ..., [numberTemp] -> result)
+```
+
+when the target parameter is known to be a non-`object` numeric or boolean type
+and the original source temp can safely flow to that parameter type.
+
+The relevant helper is:
+
+```csharp
+ForwardBoxedArgumentsToTypedSources(...)
+```
+
+It checks each call argument and rewrites only when all of these are true:
+
+1. The argument temp is defined by `LIRConvertToObject`.
+2. The target parameter type is known.
+3. The target parameter type is not `object`.
+4. `ValueStorageFacts.CanFlowTo(sourceStorage, targetStorage)` is true.
+5. The source temp is stable from the original conversion point through the call.
+
+The non-`object` parameter check matters. If a method parameter is `object`,
+forwarding an unboxed source would just move boxing into both the typed-call path
+and the fallback path. That can increase boxing rather than reduce it.
+
+### Optimization 2: forwarding boxed arguments for direct user-class calls
+
+`LIRTypeNormalization` also handles direct `LIRCallUserClassInstanceMethod`
+instructions. These are already direct calls to generated user-class methods,
+but their argument list can still contain object materializations created before
+the method signature was known precisely enough.
+
+This PR adds:
+
+```csharp
+ForwardBoxedArgumentsForDirectUserClassCalls(...)
+```
+
+It performs the same core rewrite as member-call normalization, but for direct
+user-class call instructions:
+
+```text
+before:
+  LIRConvertToObject(sourceNumber -> boxedArg)
+  LIRCallUserClassInstanceMethod(..., [boxedArg])
+
+after:
+  LIRConvertToObject(sourceNumber -> boxedArg)   // later removed if dead
+  LIRCallUserClassInstanceMethod(..., [sourceNumber])
+```
+
+The follow-up dead-materialization pass can then remove the conversion if no
+remaining instruction operand uses `boxedArg`.
+
+### Stability checks and JavaScript evaluation order
+
+The most important safety rule in this PR is that forwarding must not change
+when a value is observed.
+
+`LIRConvertToObject` acts like a snapshot point for the value it boxes. If the
+source temp is backed by a mutable variable slot, replacing the boxed temp with
+the source temp can accidentally observe a later value.
+
+To prevent that, both normalization passes use a stability check with the
+conversion instruction index and call instruction index.
+
+A temp is considered stable when:
+
+- it is pinned to a variable slot listed in `MethodBodyIR.SingleAssignmentSlots`;
+- or it is pinned to a variable slot that is not written between the conversion
+  instruction and the call instruction;
+- or it is defined by a stable definition such as a constant, `LIRLoadParameter`,
+  `LIRLoadThis`, or a copy chain whose source is stable.
+
+The range check is deliberately conservative:
+
+```text
+convert index < checked instructions < call index
+```
+
+If the same variable slot is written in that interval, forwarding is rejected.
+When the instruction order is unexpected, the check also rejects forwarding.
+
+This protects patterns where JavaScript argument evaluation or intermediate LIR
+instructions mutate the source variable after the object materialization point.
+
+### Optimization 3: removing dead object materializations
+
+Once a typed call uses the original typed temp, the old boxed temp may become
+dead. `LIRTypeNormalization.RemoveDeadObjectMaterializations` removes
+`LIRConvertToObject` instructions when:
+
+- the result is not pinned to a variable slot; and
+- no other instruction operand uses the result temp.
+
+The pinned-slot guard is required because a temp can be both a temp and a write
+to a stable IL local. Removing such an instruction can break loop-carried state,
+try/finally state, generator state, or other compiler-created variables.
+
+The use scan relies on `TempLocalAllocator.EnumerateUsedTemps`, so this PR also
+adds missing tracking for `LIRGetItemAsNumberString`. Without that, a boxed temp
+used by string-key item access could be incorrectly deleted.
+
+### Optimization 4: skipping dead IL emission for object conversions
+
+The IL emitter also has a defensive skip for dead `LIRConvertToObject`
+instructions:
+
+```csharp
+if (GetTempVariableSlot(convertToObject.Result) < 0
+    && !IsTempUsedByAnyInstructionOperand(convertToObject.Result, convertToObject))
+{
+    break;
+}
+```
+
+This is intentionally narrower than "not used anywhere." It only skips emission
+when the conversion result is not mapped to a variable slot. If it is mapped to a
+variable slot, emitting the conversion may be the write that keeps that slot up
+to date.
+
+This mirrors the LIR-level dead-materialization rule.
+
+### Optimization 5: skipping dead temp copies
+
+`LIRCopyTemp` emission now skips a copy only when:
+
+- the destination is not pinned to a variable slot; and
+- the destination is not consumed by another instruction operand.
+
+That avoids object-local churn for dead scratch copies while preserving copies
+that are actually writes to compiler variables.
+
+This distinction matters because `TempVariableSlots` can map an SSA temp to a
+declared or anonymous variable local. Such a temp may have no later temp operand
+uses but still be read through the variable slot by later generated IL.
+
+### Temp allocation and `LIRGetItemAsNumberString`
+
+This PR updates `TempLocalAllocator` in two related ways:
+
+1. `EnumerateUsedTemps` now reports the `Object` and `Index` operands for
+   `LIRGetItemAsNumberString`.
+2. `TryGetDefinedTemp` now reports its `Result`.
+
+This keeps liveness, dead-temp checks, and stackification decisions consistent
+with IL emission. If an instruction emits IL that loads a temp, the allocator
+must report that temp as used.
+
+### Why snapshots changed beyond the headline examples
+
+The primary human-readable wins are reductions in `box` instructions in these
+snapshots:
+
+- `Prime_SetBitsTrue_LargeStep_OptimizedVsNaive`: `box` 33 -> 30.
+- `Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes`: `box` 72 -> 71.
+- `Compile_Performance_PrimeJavaScript`: `box` 52 -> 51.
+- `Classes_ClassMethod_ForLoop_CallsAnotherMethod`: `box` 5 -> 4.
+
+Other generator snapshots can change because removing or preserving a temp
+materialization changes local signatures, local numbering, stackification, or
+method body offsets. Those changes are expected when the IL is semantically
+equivalent and the relevant execution/generator tests pass.
+
+### Invariants for future changes
+
+Future typed-temp optimizations should preserve these invariants:
+
+1. Do not forward through an object materialization if doing so can observe a
+   later value than JavaScript would observe.
+2. Do not remove an instruction that writes to a pinned variable slot unless the
+   slot write is proven redundant.
+3. Do not use `ValueStorageFacts.IsSameRuntimeRepresentation` as a general
+   conversion test. It is intentionally stricter.
+4. Keep `TempLocalAllocator.EnumerateUsedTemps` and `TryGetDefinedTemp` in sync
+   with every instruction shape that IL emission reads or writes.
+5. Treat `object` call boundaries differently from typed boundaries. Avoiding a
+   box for a typed parameter is good; moving a box to a runtime-dispatch fallback
+   can be neutral or worse.
+6. Prefer conservative rejection over clever forwarding when instruction order,
+   storage facts, or variable-slot mutation is unclear.
+
+### Where to look in code
+
+- `IR/LIR/ValueStorageFacts.cs`: shared storage compatibility helpers.
+- `IR/LIR/LIRMemberCallNormalization.cs`: generic member-call to typed-call
+  normalization and boxed-argument forwarding.
+- `IR/LIR/LIRTypeNormalization.cs`: direct user-class call forwarding and dead
+  object-materialization removal.
+- `IL/LIRToILCompiler.InstructionEmission.Arithmetic.cs`: defensive skip for
+  dead object conversions at IL emission time.
+- `IL/LIRToILCompiler.InstructionEmission.TempsAndExceptions.cs`: defensive skip
+  for dead non-pinned temp copies.
+- `IL/LIRToILCompiler.TempsLocals.cs`: helper methods used by IL emission to
+  check temp operand use and variable-slot pinning.
+- `IL/TempLocalAllocator.cs`: temp use/def tracking that liveness,
+  materialization, and stackification depend on.

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cb2
+				// Method begins at RVA 0x5ca2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cc4
+					// Method begins at RVA 0x5cb4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ccd
+					// Method begins at RVA 0x5cbd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cd6
+					// Method begins at RVA 0x5cc6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cbb
+				// Method begins at RVA 0x5cab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ce8
+					// Method begins at RVA 0x5cd8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cdf
+				// Method begins at RVA 0x5ccf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -429,7 +429,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cfa
+					// Method begins at RVA 0x5cea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -447,7 +447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cf1
+				// Method begins at RVA 0x5ce1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -569,7 +569,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d03
+				// Method begins at RVA 0x5cf3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1693,7 +1693,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5ca9
+			// Method begins at RVA 0x5c99
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1993,7 +1993,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d15
+				// Method begins at RVA 0x5d05
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2081,7 +2081,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5d30
+						// Method begins at RVA 0x5d20
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2099,7 +2099,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d27
+					// Method begins at RVA 0x5d17
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2117,7 +2117,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d1e
+				// Method begins at RVA 0x5d0e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2249,7 +2249,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5d4b
+						// Method begins at RVA 0x5d3b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2267,7 +2267,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d42
+					// Method begins at RVA 0x5d32
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2285,7 +2285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d39
+				// Method begins at RVA 0x5d29
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2468,7 +2468,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d5d
+					// Method begins at RVA 0x5d4d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2486,7 +2486,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d54
+				// Method begins at RVA 0x5d44
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2514,7 +2514,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5d78
+						// Method begins at RVA 0x5d68
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2532,7 +2532,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d6f
+					// Method begins at RVA 0x5d5f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2550,7 +2550,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d66
+				// Method begins at RVA 0x5d56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2716,7 +2716,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d8a
+					// Method begins at RVA 0x5d7a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2734,7 +2734,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d81
+				// Method begins at RVA 0x5d71
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2854,7 +2854,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d93
+				// Method begins at RVA 0x5d83
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2882,7 +2882,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5dae
+						// Method begins at RVA 0x5d9e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2902,7 +2902,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5db7
+						// Method begins at RVA 0x5da7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2922,7 +2922,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5dc0
+						// Method begins at RVA 0x5db0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2942,7 +2942,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5dc9
+						// Method begins at RVA 0x5db9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2960,7 +2960,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5da5
+					// Method begins at RVA 0x5d95
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2978,7 +2978,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d9c
+				// Method begins at RVA 0x5d8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3162,7 +3162,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5de4
+						// Method begins at RVA 0x5dd4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3182,7 +3182,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5ded
+						// Method begins at RVA 0x5ddd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3202,7 +3202,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5df6
+						// Method begins at RVA 0x5de6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3220,7 +3220,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ddb
+					// Method begins at RVA 0x5dcb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3238,7 +3238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5dd2
+				// Method begins at RVA 0x5dc2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3270,7 +3270,7 @@
 			)
 			// Method begins at RVA 0x3dd8
 			// Header size: 12
-			// Code size: 444 (0x1bc)
+			// Code size: 436 (0x1b4)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3312,7 +3312,7 @@
 				IL_003c: ldloc.s 9
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_017e
+				IL_0045: brfalse IL_0176
 
 				IL_004a: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37::.ctor()
 				IL_004f: stloc.2
@@ -3334,7 +3334,7 @@
 				IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 				IL_0084: stloc.s 11
 				IL_0086: ldloc.s 11
-				IL_0088: brfalse IL_00cb
+				IL_0088: brfalse IL_00c7
 
 				IL_008d: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L119C31::.ctor()
 				IL_0092: stloc.s 4
@@ -3344,110 +3344,106 @@
 				IL_009f: pop
 				IL_00a0: ldarg.3
 				IL_00a1: ldstr "index"
-				IL_00a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00ab: ldc.r8 1
-				IL_00b4: add
-				IL_00b5: stloc.s 10
-				IL_00b7: ldarg.3
-				IL_00b8: ldstr "index"
-				IL_00bd: ldloc.s 10
-				IL_00bf: ldc.i4.1
-				IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_00c5: pop
-				IL_00c6: br IL_0017
+				IL_00a6: ldarg.3
+				IL_00a7: ldstr "index"
+				IL_00ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00b1: ldc.r8 1
+				IL_00ba: add
+				IL_00bb: ldc.i4.1
+				IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00c1: pop
+				IL_00c2: br IL_0017
 
-				IL_00cb: ldarg.0
-				IL_00cc: castclass Modules.test262_metadataParser/Scope
-				IL_00d1: ldnull
-				IL_00d2: ldloc.3
-				IL_00d3: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_00d8: stloc.s 9
-				IL_00da: ldloc.s 9
-				IL_00dc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00e1: stloc.s 10
-				IL_00e3: ldloc.s 10
-				IL_00e5: stloc.s 5
-				IL_00e7: ldloc.s 5
-				IL_00e9: ldarg.s parentIndent
-				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f0: cgt
-				IL_00f2: ldc.i4.0
-				IL_00f3: ceq
-				IL_00f5: brfalse IL_0106
+				IL_00c7: ldarg.0
+				IL_00c8: castclass Modules.test262_metadataParser/Scope
+				IL_00cd: ldnull
+				IL_00ce: ldloc.3
+				IL_00cf: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_00d4: stloc.s 9
+				IL_00d6: ldloc.s 9
+				IL_00d8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00dd: stloc.s 10
+				IL_00df: ldloc.s 10
+				IL_00e1: stloc.s 5
+				IL_00e3: ldloc.s 5
+				IL_00e5: ldarg.s parentIndent
+				IL_00e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ec: cgt
+				IL_00ee: ldc.i4.0
+				IL_00ef: ceq
+				IL_00f1: brfalse IL_0102
 
-				IL_00fa: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
-				IL_00ff: stloc.s 6
-				IL_0101: br IL_017e
+				IL_00f6: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
+				IL_00fb: stloc.s 6
+				IL_00fd: br IL_0176
 
-				IL_0106: ldloc.1
-				IL_0107: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_010c: stloc.s 10
-				IL_010e: ldloc.s 10
-				IL_0110: ldc.r8 0.0
-				IL_0119: clt
-				IL_011b: brfalse IL_0133
+				IL_0102: ldloc.1
+				IL_0103: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0108: stloc.s 10
+				IL_010a: ldloc.s 10
+				IL_010c: ldc.r8 0.0
+				IL_0115: clt
+				IL_0117: brfalse IL_012f
 
-				IL_0120: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
-				IL_0125: stloc.s 7
-				IL_0127: ldloc.s 5
-				IL_0129: box [System.Runtime]System.Double
-				IL_012e: stloc.s 12
-				IL_0130: ldloc.s 12
-				IL_0132: stloc.1
+				IL_011c: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
+				IL_0121: stloc.s 7
+				IL_0123: ldloc.s 5
+				IL_0125: box [System.Runtime]System.Double
+				IL_012a: stloc.s 12
+				IL_012c: ldloc.s 12
+				IL_012e: stloc.1
 
-				IL_0133: ldloc.3
-				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0139: stloc.s 9
-				IL_013b: ldloc.s 9
-				IL_013d: ldstr "substring"
-				IL_0142: ldloc.1
-				IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0148: stloc.s 9
-				IL_014a: ldloc.0
-				IL_014b: ldloc.s 9
-				IL_014d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0152: pop
-				IL_0153: ldarg.3
-				IL_0154: ldstr "index"
-				IL_0159: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_015e: ldc.r8 1
-				IL_0167: add
-				IL_0168: stloc.s 10
-				IL_016a: ldarg.3
-				IL_016b: ldstr "index"
-				IL_0170: ldloc.s 10
-				IL_0172: ldc.i4.1
-				IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0178: pop
-				IL_0179: br IL_0017
+				IL_012f: ldloc.3
+				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0135: stloc.s 9
+				IL_0137: ldloc.s 9
+				IL_0139: ldstr "substring"
+				IL_013e: ldloc.1
+				IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0144: stloc.s 9
+				IL_0146: ldloc.0
+				IL_0147: ldloc.s 9
+				IL_0149: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_014e: pop
+				IL_014f: ldarg.3
+				IL_0150: ldstr "index"
+				IL_0155: ldarg.3
+				IL_0156: ldstr "index"
+				IL_015b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0160: ldc.r8 1
+				IL_0169: add
+				IL_016a: ldc.i4.1
+				IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0170: pop
+				IL_0171: br IL_0017
 			// end loop
 
-			IL_017e: ldarg.s style
-			IL_0180: ldstr ">"
-			IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_018a: stloc.s 11
-			IL_018c: ldloc.s 11
-			IL_018e: brfalse IL_01a3
+			IL_0176: ldarg.s style
+			IL_0178: ldstr ">"
+			IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0182: stloc.s 11
+			IL_0184: ldloc.s 11
+			IL_0186: brfalse IL_019b
 
-			IL_0193: ldarg.0
-			IL_0194: castclass Modules.test262_metadataParser/Scope
-			IL_0199: ldnull
-			IL_019a: ldloc.0
-			IL_019b: tail.
-			IL_019d: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_01a2: ret
+			IL_018b: ldarg.0
+			IL_018c: castclass Modules.test262_metadataParser/Scope
+			IL_0191: ldnull
+			IL_0192: ldloc.0
+			IL_0193: tail.
+			IL_0195: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_019a: ret
 
-			IL_01a3: ldloc.0
-			IL_01a4: ldc.i4.1
-			IL_01a5: newarr [System.Runtime]System.Object
-			IL_01aa: dup
-			IL_01ab: ldc.i4.0
-			IL_01ac: ldstr "\n"
-			IL_01b1: stelem.ref
-			IL_01b2: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01b7: stloc.s 13
-			IL_01b9: ldloc.s 13
-			IL_01bb: ret
+			IL_019b: ldloc.0
+			IL_019c: ldc.i4.1
+			IL_019d: newarr [System.Runtime]System.Object
+			IL_01a2: dup
+			IL_01a3: ldc.i4.0
+			IL_01a4: ldstr "\n"
+			IL_01a9: stelem.ref
+			IL_01aa: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01af: stloc.s 13
+			IL_01b1: ldloc.s 13
+			IL_01b3: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -3467,7 +3463,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e08
+					// Method begins at RVA 0x5df8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3487,7 +3483,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e11
+					// Method begins at RVA 0x5e01
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3507,7 +3503,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e1a
+					// Method begins at RVA 0x5e0a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3525,7 +3521,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5dff
+				// Method begins at RVA 0x5def
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3554,7 +3550,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3fa0
+			// Method begins at RVA 0x3f98
 			// Header size: 12
 			// Code size: 387 (0x183)
 			.maxstack 8
@@ -3750,7 +3746,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e35
+						// Method begins at RVA 0x5e25
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3770,7 +3766,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e3e
+						// Method begins at RVA 0x5e2e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3790,7 +3786,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e47
+						// Method begins at RVA 0x5e37
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3810,7 +3806,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e50
+						// Method begins at RVA 0x5e40
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3830,7 +3826,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e59
+						// Method begins at RVA 0x5e49
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3850,7 +3846,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e62
+						// Method begins at RVA 0x5e52
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3870,7 +3866,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e6b
+						// Method begins at RVA 0x5e5b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3888,7 +3884,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e2c
+					// Method begins at RVA 0x5e1c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3906,7 +3902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e23
+				// Method begins at RVA 0x5e13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3935,9 +3931,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4130
+			// Method begins at RVA 0x4128
 			// Header size: 12
-			// Code size: 919 (0x397)
+			// Code size: 911 (0x38f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -3990,7 +3986,7 @@
 				IL_002b: ldloc.s 19
 				IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0032: clt
-				IL_0034: brfalse IL_0395
+				IL_0034: brfalse IL_038d
 
 				IL_0039: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37::.ctor()
 				IL_003e: stloc.1
@@ -4012,287 +4008,283 @@
 				IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 				IL_0073: stloc.s 21
 				IL_0075: ldloc.s 21
-				IL_0077: brfalse IL_00ad
+				IL_0077: brfalse IL_00a9
 
 				IL_007c: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L167C31::.ctor()
 				IL_0081: stloc.3
 				IL_0082: ldarg.3
 				IL_0083: ldstr "index"
-				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_008d: ldc.r8 1
-				IL_0096: add
-				IL_0097: stloc.s 20
-				IL_0099: ldarg.3
-				IL_009a: ldstr "index"
-				IL_009f: ldloc.s 20
-				IL_00a1: ldc.i4.1
-				IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_00a7: pop
-				IL_00a8: br IL_0006
+				IL_0088: ldarg.3
+				IL_0089: ldstr "index"
+				IL_008e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0093: ldc.r8 1
+				IL_009c: add
+				IL_009d: ldc.i4.1
+				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00a3: pop
+				IL_00a4: br IL_0006
 
-				IL_00ad: ldarg.0
-				IL_00ae: castclass Modules.test262_metadataParser/Scope
-				IL_00b3: ldnull
-				IL_00b4: ldloc.2
-				IL_00b5: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_00ba: stloc.s 19
-				IL_00bc: ldloc.s 19
-				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00c3: stloc.s 20
-				IL_00c5: ldloc.s 20
-				IL_00c7: stloc.s 4
-				IL_00c9: ldloc.s 4
-				IL_00cb: ldarg.s baseIndent
-				IL_00cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00d2: clt
-				IL_00d4: brfalse IL_00e5
+				IL_00a9: ldarg.0
+				IL_00aa: castclass Modules.test262_metadataParser/Scope
+				IL_00af: ldnull
+				IL_00b0: ldloc.2
+				IL_00b1: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_00b6: stloc.s 19
+				IL_00b8: ldloc.s 19
+				IL_00ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00bf: stloc.s 20
+				IL_00c1: ldloc.s 20
+				IL_00c3: stloc.s 4
+				IL_00c5: ldloc.s 4
+				IL_00c7: ldarg.s baseIndent
+				IL_00c9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ce: clt
+				IL_00d0: brfalse IL_00e1
 
-				IL_00d9: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
-				IL_00de: stloc.s 5
-				IL_00e0: br IL_0395
+				IL_00d5: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
+				IL_00da: stloc.s 5
+				IL_00dc: br IL_038d
 
-				IL_00e5: ldloc.s 4
-				IL_00e7: ldarg.s baseIndent
-				IL_00e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ee: cgt
-				IL_00f0: brfalse IL_0165
+				IL_00e1: ldloc.s 4
+				IL_00e3: ldarg.s baseIndent
+				IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ea: cgt
+				IL_00ec: brfalse IL_0161
 
-				IL_00f5: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
-				IL_00fa: stloc.s 6
-				IL_00fc: ldarg.3
-				IL_00fd: ldstr "index"
-				IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0107: ldc.r8 1
-				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0115: stloc.s 22
-				IL_0117: ldloc.s 22
-				IL_0119: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_011e: stloc.s 23
-				IL_0120: ldstr "Unexpected indentation at frontmatter line "
-				IL_0125: ldloc.s 23
-				IL_0127: call string [System.Runtime]System.String::Concat(string, string)
-				IL_012c: stloc.s 23
-				IL_012e: ldloc.s 23
-				IL_0130: ldstr "."
-				IL_0135: call string [System.Runtime]System.String::Concat(string, string)
-				IL_013a: stloc.s 23
-				IL_013c: ldloc.s 23
-				IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0143: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0148: stloc.s 19
-				IL_014a: ldloc.s 19
-				IL_014c: stloc.s 7
-				IL_014e: ldloc.s 7
-				IL_0150: isinst [System.Runtime]System.Exception
-				IL_0155: dup
-				IL_0156: brtrue IL_0164
+				IL_00f1: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
+				IL_00f6: stloc.s 6
+				IL_00f8: ldarg.3
+				IL_00f9: ldstr "index"
+				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0103: ldc.r8 1
+				IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0111: stloc.s 22
+				IL_0113: ldloc.s 22
+				IL_0115: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_011a: stloc.s 23
+				IL_011c: ldstr "Unexpected indentation at frontmatter line "
+				IL_0121: ldloc.s 23
+				IL_0123: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0128: stloc.s 23
+				IL_012a: ldloc.s 23
+				IL_012c: ldstr "."
+				IL_0131: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0136: stloc.s 23
+				IL_0138: ldloc.s 23
+				IL_013a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0144: stloc.s 19
+				IL_0146: ldloc.s 19
+				IL_0148: stloc.s 7
+				IL_014a: ldloc.s 7
+				IL_014c: isinst [System.Runtime]System.Exception
+				IL_0151: dup
+				IL_0152: brtrue IL_0160
 
-				IL_015b: pop
-				IL_015c: ldloc.s 7
-				IL_015e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0163: throw
+				IL_0157: pop
+				IL_0158: ldloc.s 7
+				IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_015f: throw
 
-				IL_0164: throw
+				IL_0160: throw
 
-				IL_0165: ldloc.2
-				IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_016b: stloc.s 19
-				IL_016d: ldloc.s 4
-				IL_016f: box [System.Runtime]System.Double
-				IL_0174: stloc.s 24
-				IL_0176: ldloc.s 19
-				IL_0178: ldstr "substring"
-				IL_017d: ldloc.s 24
-				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0184: stloc.s 19
-				IL_0186: ldloc.s 19
-				IL_0188: stloc.s 8
-				IL_018a: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_018f: ldstr ""
-				IL_0194: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0199: stloc.s 25
-				IL_019b: ldloc.s 25
-				IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01a2: stloc.s 19
-				IL_01a4: ldloc.s 19
-				IL_01a6: ldstr "exec"
-				IL_01ab: ldloc.s 8
-				IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01b2: stloc.s 19
-				IL_01b4: ldloc.s 19
-				IL_01b6: stloc.s 9
-				IL_01b8: ldloc.s 9
-				IL_01ba: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_01bf: ldc.i4.0
-				IL_01c0: ceq
-				IL_01c2: stloc.s 21
-				IL_01c4: ldloc.s 21
-				IL_01c6: brfalse IL_024f
+				IL_0161: ldloc.2
+				IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0167: stloc.s 19
+				IL_0169: ldloc.s 4
+				IL_016b: box [System.Runtime]System.Double
+				IL_0170: stloc.s 24
+				IL_0172: ldloc.s 19
+				IL_0174: ldstr "substring"
+				IL_0179: ldloc.s 24
+				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0180: stloc.s 19
+				IL_0182: ldloc.s 19
+				IL_0184: stloc.s 8
+				IL_0186: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_018b: ldstr ""
+				IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0195: stloc.s 25
+				IL_0197: ldloc.s 25
+				IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_019e: stloc.s 19
+				IL_01a0: ldloc.s 19
+				IL_01a2: ldstr "exec"
+				IL_01a7: ldloc.s 8
+				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01ae: stloc.s 19
+				IL_01b0: ldloc.s 19
+				IL_01b2: stloc.s 9
+				IL_01b4: ldloc.s 9
+				IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01bb: ldc.i4.0
+				IL_01bc: ceq
+				IL_01be: stloc.s 21
+				IL_01c0: ldloc.s 21
+				IL_01c2: brfalse IL_024b
 
-				IL_01cb: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
-				IL_01d0: stloc.s 10
-				IL_01d2: ldarg.3
-				IL_01d3: ldstr "index"
-				IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01dd: ldc.r8 1
-				IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01eb: stloc.s 22
-				IL_01ed: ldloc.s 22
-				IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01f4: stloc.s 23
-				IL_01f6: ldstr "Invalid frontmatter line "
-				IL_01fb: ldloc.s 23
-				IL_01fd: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0202: stloc.s 23
-				IL_0204: ldloc.s 23
-				IL_0206: ldstr ": "
-				IL_020b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0210: stloc.s 23
-				IL_0212: ldloc.s 8
-				IL_0214: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0219: stloc.s 26
-				IL_021b: ldloc.s 23
-				IL_021d: ldloc.s 26
-				IL_021f: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0224: stloc.s 26
-				IL_0226: ldloc.s 26
-				IL_0228: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0232: stloc.s 19
-				IL_0234: ldloc.s 19
-				IL_0236: stloc.s 11
-				IL_0238: ldloc.s 11
-				IL_023a: isinst [System.Runtime]System.Exception
-				IL_023f: dup
-				IL_0240: brtrue IL_024e
+				IL_01c7: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
+				IL_01cc: stloc.s 10
+				IL_01ce: ldarg.3
+				IL_01cf: ldstr "index"
+				IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01d9: ldc.r8 1
+				IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01e7: stloc.s 22
+				IL_01e9: ldloc.s 22
+				IL_01eb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01f0: stloc.s 23
+				IL_01f2: ldstr "Invalid frontmatter line "
+				IL_01f7: ldloc.s 23
+				IL_01f9: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01fe: stloc.s 23
+				IL_0200: ldloc.s 23
+				IL_0202: ldstr ": "
+				IL_0207: call string [System.Runtime]System.String::Concat(string, string)
+				IL_020c: stloc.s 23
+				IL_020e: ldloc.s 8
+				IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0215: stloc.s 26
+				IL_0217: ldloc.s 23
+				IL_0219: ldloc.s 26
+				IL_021b: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0220: stloc.s 26
+				IL_0222: ldloc.s 26
+				IL_0224: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0229: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_022e: stloc.s 19
+				IL_0230: ldloc.s 19
+				IL_0232: stloc.s 11
+				IL_0234: ldloc.s 11
+				IL_0236: isinst [System.Runtime]System.Exception
+				IL_023b: dup
+				IL_023c: brtrue IL_024a
 
-				IL_0245: pop
-				IL_0246: ldloc.s 11
-				IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_024d: throw
+				IL_0241: pop
+				IL_0242: ldloc.s 11
+				IL_0244: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0249: throw
 
-				IL_024e: throw
+				IL_024a: throw
 
-				IL_024f: ldloc.s 9
-				IL_0251: ldc.r8 1
-				IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_025f: stloc.s 12
-				IL_0261: ldloc.s 9
-				IL_0263: ldc.r8 2
-				IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0276: stloc.s 19
-				IL_0278: ldloc.s 19
-				IL_027a: ldstr "trim"
-				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0284: stloc.s 19
-				IL_0286: ldloc.s 19
-				IL_0288: stloc.s 13
-				IL_028a: ldarg.3
-				IL_028b: ldstr "index"
-				IL_0290: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0295: ldc.r8 1
-				IL_029e: add
-				IL_029f: stloc.s 20
-				IL_02a1: ldarg.3
-				IL_02a2: ldstr "index"
-				IL_02a7: ldloc.s 20
-				IL_02a9: ldc.i4.1
-				IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_02af: pop
-				IL_02b0: ldnull
-				IL_02b1: stloc.s 14
-				IL_02b3: ldloc.s 13
-				IL_02b5: ldstr "|"
-				IL_02ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02bf: stloc.s 21
-				IL_02c1: ldloc.s 21
-				IL_02c3: box [System.Runtime]System.Boolean
-				IL_02c8: stloc.s 27
-				IL_02ca: ldloc.s 27
-				IL_02cc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02d1: stloc.s 21
-				IL_02d3: ldloc.s 21
-				IL_02d5: brtrue IL_02fa
+				IL_024b: ldloc.s 9
+				IL_024d: ldc.r8 1
+				IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_025b: stloc.s 12
+				IL_025d: ldloc.s 9
+				IL_025f: ldc.r8 2
+				IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0272: stloc.s 19
+				IL_0274: ldloc.s 19
+				IL_0276: ldstr "trim"
+				IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0280: stloc.s 19
+				IL_0282: ldloc.s 19
+				IL_0284: stloc.s 13
+				IL_0286: ldarg.3
+				IL_0287: ldstr "index"
+				IL_028c: ldarg.3
+				IL_028d: ldstr "index"
+				IL_0292: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0297: ldc.r8 1
+				IL_02a0: add
+				IL_02a1: ldc.i4.1
+				IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_02a7: pop
+				IL_02a8: ldnull
+				IL_02a9: stloc.s 14
+				IL_02ab: ldloc.s 13
+				IL_02ad: ldstr "|"
+				IL_02b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02b7: stloc.s 21
+				IL_02b9: ldloc.s 21
+				IL_02bb: box [System.Runtime]System.Boolean
+				IL_02c0: stloc.s 27
+				IL_02c2: ldloc.s 27
+				IL_02c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02c9: stloc.s 21
+				IL_02cb: ldloc.s 21
+				IL_02cd: brtrue IL_02f2
 
-				IL_02da: ldloc.s 13
-				IL_02dc: ldstr ">"
-				IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02e6: stloc.s 21
-				IL_02e8: ldloc.s 21
-				IL_02ea: box [System.Runtime]System.Boolean
-				IL_02ef: stloc.s 28
-				IL_02f1: ldloc.s 28
-				IL_02f3: stloc.s 29
-				IL_02f5: br IL_02fe
+				IL_02d2: ldloc.s 13
+				IL_02d4: ldstr ">"
+				IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02de: stloc.s 21
+				IL_02e0: ldloc.s 21
+				IL_02e2: box [System.Runtime]System.Boolean
+				IL_02e7: stloc.s 28
+				IL_02e9: ldloc.s 28
+				IL_02eb: stloc.s 29
+				IL_02ed: br IL_02f6
 
-				IL_02fa: ldloc.s 27
-				IL_02fc: stloc.s 29
+				IL_02f2: ldloc.s 27
+				IL_02f4: stloc.s 29
 
-				IL_02fe: ldloc.s 29
-				IL_0300: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0305: stloc.s 21
-				IL_0307: ldloc.s 21
-				IL_0309: brfalse IL_0332
+				IL_02f6: ldloc.s 29
+				IL_02f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02fd: stloc.s 21
+				IL_02ff: ldloc.s 21
+				IL_0301: brfalse IL_032a
 
-				IL_030e: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
-				IL_0313: stloc.s 15
-				IL_0315: ldarg.0
-				IL_0316: castclass Modules.test262_metadataParser/Scope
-				IL_031b: ldnull
-				IL_031c: ldarg.2
-				IL_031d: ldarg.3
-				IL_031e: ldarg.s baseIndent
-				IL_0320: ldloc.s 13
-				IL_0322: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object, object)
-				IL_0327: stloc.s 19
-				IL_0329: ldloc.s 19
-				IL_032b: stloc.s 14
-				IL_032d: br IL_0384
+				IL_0306: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
+				IL_030b: stloc.s 15
+				IL_030d: ldarg.0
+				IL_030e: castclass Modules.test262_metadataParser/Scope
+				IL_0313: ldnull
+				IL_0314: ldarg.2
+				IL_0315: ldarg.3
+				IL_0316: ldarg.s baseIndent
+				IL_0318: ldloc.s 13
+				IL_031a: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object, object)
+				IL_031f: stloc.s 19
+				IL_0321: ldloc.s 19
+				IL_0323: stloc.s 14
+				IL_0325: br IL_037c
 
-				IL_0332: ldloc.s 13
-				IL_0334: ldstr ""
-				IL_0339: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_033e: stloc.s 21
-				IL_0340: ldloc.s 21
-				IL_0342: brfalse IL_0369
+				IL_032a: ldloc.s 13
+				IL_032c: ldstr ""
+				IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0336: stloc.s 21
+				IL_0338: ldloc.s 21
+				IL_033a: brfalse IL_0361
 
-				IL_0347: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
-				IL_034c: stloc.s 16
-				IL_034e: ldarg.0
-				IL_034f: castclass Modules.test262_metadataParser/Scope
-				IL_0354: ldnull
-				IL_0355: ldarg.2
-				IL_0356: ldarg.3
-				IL_0357: ldarg.s baseIndent
-				IL_0359: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-				IL_035e: stloc.s 19
-				IL_0360: ldloc.s 19
-				IL_0362: stloc.s 14
-				IL_0364: br IL_0384
+				IL_033f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
+				IL_0344: stloc.s 16
+				IL_0346: ldarg.0
+				IL_0347: castclass Modules.test262_metadataParser/Scope
+				IL_034c: ldnull
+				IL_034d: ldarg.2
+				IL_034e: ldarg.3
+				IL_034f: ldarg.s baseIndent
+				IL_0351: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+				IL_0356: stloc.s 19
+				IL_0358: ldloc.s 19
+				IL_035a: stloc.s 14
+				IL_035c: br IL_037c
 
-				IL_0369: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
-				IL_036e: stloc.s 17
-				IL_0370: ldarg.0
-				IL_0371: castclass Modules.test262_metadataParser/Scope
-				IL_0376: ldnull
-				IL_0377: ldloc.s 13
-				IL_0379: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_037e: stloc.s 19
-				IL_0380: ldloc.s 19
-				IL_0382: stloc.s 14
+				IL_0361: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
+				IL_0366: stloc.s 17
+				IL_0368: ldarg.0
+				IL_0369: castclass Modules.test262_metadataParser/Scope
+				IL_036e: ldnull
+				IL_036f: ldloc.s 13
+				IL_0371: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0376: stloc.s 19
+				IL_0378: ldloc.s 19
+				IL_037a: stloc.s 14
 
-				IL_0384: ldloc.0
-				IL_0385: ldloc.s 12
-				IL_0387: ldloc.s 14
-				IL_0389: ldc.i4.1
-				IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_038f: pop
-				IL_0390: br IL_0006
+				IL_037c: ldloc.0
+				IL_037d: ldloc.s 12
+				IL_037f: ldloc.s 14
+				IL_0381: ldc.i4.1
+				IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0387: pop
+				IL_0388: br IL_0006
 			// end loop
 
-			IL_0395: ldloc.0
-			IL_0396: ret
+			IL_038d: ldloc.0
+			IL_038e: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -4308,7 +4300,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e74
+				// Method begins at RVA 0x5e64
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4335,7 +4327,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x44d4
+			// Method begins at RVA 0x44c4
 			// Header size: 12
 			// Code size: 93 (0x5d)
 			.maxstack 8
@@ -4397,7 +4389,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e86
+					// Method begins at RVA 0x5e76
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4417,7 +4409,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e8f
+					// Method begins at RVA 0x5e7f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4437,7 +4429,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e98
+					// Method begins at RVA 0x5e88
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4455,7 +4447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e7d
+				// Method begins at RVA 0x5e6d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4482,7 +4474,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4540
+			// Method begins at RVA 0x4530
 			// Header size: 12
 			// Code size: 348 (0x15c)
 			.maxstack 8
@@ -4634,7 +4626,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ea1
+				// Method begins at RVA 0x5e91
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4658,7 +4650,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x46a8
+			// Method begins at RVA 0x4698
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -4717,7 +4709,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5eb3
+					// Method begins at RVA 0x5ea3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4735,7 +4727,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5eaa
+				// Method begins at RVA 0x5e9a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4759,7 +4751,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x46fc
+			// Method begins at RVA 0x46ec
 			// Header size: 12
 			// Code size: 125 (0x7d)
 			.maxstack 8
@@ -4837,7 +4829,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ebc
+				// Method begins at RVA 0x5eac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4862,7 +4854,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x4788
+			// Method begins at RVA 0x4778
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4910,7 +4902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ec5
+				// Method begins at RVA 0x5eb5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4937,7 +4929,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x47c8
+			// Method begins at RVA 0x47b8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -4986,7 +4978,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ed7
+					// Method begins at RVA 0x5ec7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5006,7 +4998,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ee0
+					// Method begins at RVA 0x5ed0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5024,7 +5016,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ece
+				// Method begins at RVA 0x5ebe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5052,7 +5044,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5efb
+						// Method begins at RVA 0x5eeb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5070,7 +5062,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ef2
+					// Method begins at RVA 0x5ee2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5088,7 +5080,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ee9
+				// Method begins at RVA 0x5ed9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5117,7 +5109,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4814
+			// Method begins at RVA 0x4804
 			// Header size: 12
 			// Code size: 405 (0x195)
 			.maxstack 8
@@ -5311,7 +5303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f0d
+					// Method begins at RVA 0x5efd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5331,7 +5323,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f16
+					// Method begins at RVA 0x5f06
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5349,7 +5341,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f04
+				// Method begins at RVA 0x5ef4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5378,7 +5370,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x49b8
+			// Method begins at RVA 0x49a8
 			// Header size: 12
 			// Code size: 220 (0xdc)
 			.maxstack 8
@@ -5504,7 +5496,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f28
+					// Method begins at RVA 0x5f18
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5524,7 +5516,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f31
+					// Method begins at RVA 0x5f21
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5544,7 +5536,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f3a
+					// Method begins at RVA 0x5f2a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5564,7 +5556,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f5e
+					// Method begins at RVA 0x5f4e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5582,7 +5574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f1f
+				// Method begins at RVA 0x5f0f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5610,7 +5602,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f55
+						// Method begins at RVA 0x5f45
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5628,7 +5620,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f4c
+					// Method begins at RVA 0x5f3c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5646,7 +5638,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f43
+				// Method begins at RVA 0x5f33
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5674,7 +5666,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4aa0
+			// Method begins at RVA 0x4a90
 			// Header size: 12
 			// Code size: 971 (0x3cb)
 			.maxstack 8
@@ -6091,7 +6083,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f94
+						// Method begins at RVA 0x5f84
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6111,7 +6103,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f9d
+						// Method begins at RVA 0x5f8d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6131,7 +6123,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5fa6
+						// Method begins at RVA 0x5f96
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6149,7 +6141,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f8b
+					// Method begins at RVA 0x5f7b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6169,7 +6161,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5faf
+					// Method begins at RVA 0x5f9f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6189,7 +6181,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fb8
+					// Method begins at RVA 0x5fa8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6207,7 +6199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f67
+				// Method begins at RVA 0x5f57
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6235,7 +6227,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f82
+						// Method begins at RVA 0x5f72
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6253,7 +6245,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f79
+					// Method begins at RVA 0x5f69
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6271,7 +6263,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f70
+				// Method begins at RVA 0x5f60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6299,7 +6291,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5fd3
+						// Method begins at RVA 0x5fc3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6317,7 +6309,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fca
+					// Method begins at RVA 0x5fba
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6335,7 +6327,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5fc1
+				// Method begins at RVA 0x5fb1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6364,7 +6356,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4e78
+			// Method begins at RVA 0x4e68
 			// Header size: 12
 			// Code size: 1461 (0x5b5)
 			.maxstack 8
@@ -6961,7 +6953,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fe5
+					// Method begins at RVA 0x5fd5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6981,7 +6973,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fee
+					// Method begins at RVA 0x5fde
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7001,7 +6993,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ff7
+					// Method begins at RVA 0x5fe7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7021,7 +7013,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6000
+					// Method begins at RVA 0x5ff0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7041,7 +7033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6009
+					// Method begins at RVA 0x5ff9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7061,7 +7053,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6012
+					// Method begins at RVA 0x6002
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7081,7 +7073,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x601b
+					// Method begins at RVA 0x600b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7099,7 +7091,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5fdc
+				// Method begins at RVA 0x5fcc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7128,7 +7120,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x543c
+			// Method begins at RVA 0x542c
 			// Header size: 12
 			// Code size: 549 (0x225)
 			.maxstack 8
@@ -7357,7 +7349,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6063
+					// Method begins at RVA 0x6053
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7375,7 +7367,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6024
+				// Method begins at RVA 0x6014
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7403,7 +7395,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x603f
+						// Method begins at RVA 0x602f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7421,7 +7413,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6036
+					// Method begins at RVA 0x6026
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7439,7 +7431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x602d
+				// Method begins at RVA 0x601d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7467,7 +7459,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x605a
+						// Method begins at RVA 0x604a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7485,7 +7477,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6051
+					// Method begins at RVA 0x6041
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7503,7 +7495,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6048
+				// Method begins at RVA 0x6038
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7531,7 +7523,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5670
+			// Method begins at RVA 0x5660
 			// Header size: 12
 			// Code size: 1497 (0x5d9)
 			.maxstack 8
@@ -8121,7 +8113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x606c
+				// Method begins at RVA 0x605c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8148,7 +8140,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5c58
+			// Method begins at RVA 0x5c48
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -8248,7 +8240,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5d0c
+			// Method begins at RVA 0x5cfc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8838,7 +8830,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6075
+		// Method begins at RVA 0x6065
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_ClassMethod_ForLoop_CallsAnotherMethod
+﻿// IL code: Classes_ClassMethod_ForLoop_CallsAnotherMethod
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f0
+				// Method begins at RVA 0x21e8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f9
+				// Method begins at RVA 0x21f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2202
+				// Method begins at RVA 0x21fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x220b
+				// Method begins at RVA 0x2203
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -102,7 +102,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x221d
+					// Method begins at RVA 0x2215
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -120,7 +120,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2214
+				// Method begins at RVA 0x220c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -140,7 +140,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2226
+				// Method begins at RVA 0x221e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -197,7 +197,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x21a4
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -228,12 +228,11 @@
 			)
 			// Method begins at RVA 0x215c
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 60 (0x3c)
 			.maxstack 8
 			.locals init (
 				[0] float64,
-				[1] class Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/Scope_For_L11C9/Block_L11C37,
-				[2] object
+				[1] class Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/Scope_For_L11C9/Block_L11C37
 			)
 
 			IL_0000: ldc.r8 1
@@ -245,26 +244,23 @@
 				IL_0011: cgt
 				IL_0013: ldc.i4.0
 				IL_0014: ceq
-				IL_0016: brfalse IL_0041
+				IL_0016: brfalse IL_003a
 
 				IL_001b: newobj instance void Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/Scope_For_L11C9/Block_L11C37::.ctor()
 				IL_0020: stloc.1
-				IL_0021: ldloc.0
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: stloc.2
-				IL_0028: ldarg.0
+				IL_0021: ldarg.0
+				IL_0022: ldloc.0
+				IL_0023: callvirt instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::'add'(float64)
+				IL_0028: pop
 				IL_0029: ldloc.0
-				IL_002a: callvirt instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::'add'(float64)
-				IL_002f: pop
-				IL_0030: ldloc.0
-				IL_0031: ldc.r8 1
-				IL_003a: add
-				IL_003b: stloc.0
-				IL_003c: br IL_000a
+				IL_002a: ldc.r8 1
+				IL_0033: add
+				IL_0034: stloc.0
+				IL_0035: br IL_000a
 			// end loop
 
-			IL_0041: ldnull
-			IL_0042: ret
+			IL_003a: ldnull
+			IL_003b: ret
 		} // end of method Accumulator::addRange
 
 		.method public hidebysig 
@@ -273,7 +269,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d3
+			// Method begins at RVA 0x21cb
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -296,7 +292,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21e7
+			// Method begins at RVA 0x21df
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -415,7 +411,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x222f
+		// Method begins at RVA 0x2227
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_PropertyNullishAssignment.verified.txt
+++ b/tests/Jroc.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_PropertyNullishAssignment.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2175
+			// Method begins at RVA 0x2169
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 281 (0x119)
+		// Code size: 269 (0x10d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CompoundAssignment_PropertyNullishAssignment/Scope,
@@ -66,93 +66,81 @@
 		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_0038: stloc.2
 		IL_0039: ldloc.2
-		IL_003a: brfalse IL_0051
+		IL_003a: brfalse IL_004f
 
 		IL_003f: ldloc.2
 		IL_0040: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0045: brtrue IL_0051
+		IL_0045: brtrue IL_004f
 
-		IL_004a: ldloc.2
-		IL_004b: pop
-		IL_004c: br IL_0066
+		IL_004a: br IL_0062
 
-		IL_0051: ldloc.1
-		IL_0052: ldstr "throw"
-		IL_0057: ldc.i4.0
-		IL_0058: box [System.Runtime]System.Boolean
-		IL_005d: ldc.i4.0
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0063: stloc.2
-		IL_0064: ldloc.2
-		IL_0065: pop
+		IL_004f: ldloc.1
+		IL_0050: ldstr "throw"
+		IL_0055: ldc.i4.0
+		IL_0056: box [System.Runtime]System.Boolean
+		IL_005b: ldc.i4.0
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0061: stloc.2
 
-		IL_0066: ldloc.1
-		IL_0067: ldstr "filter"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: stloc.2
-		IL_0072: ldloc.2
-		IL_0073: brfalse IL_008a
+		IL_0062: ldloc.1
+		IL_0063: ldstr "filter"
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006d: stloc.2
+		IL_006e: ldloc.2
+		IL_006f: brfalse IL_0084
 
-		IL_0078: ldloc.2
-		IL_0079: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_007e: brtrue IL_008a
+		IL_0074: ldloc.2
+		IL_0075: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_007a: brtrue IL_0084
 
-		IL_0083: ldloc.2
-		IL_0084: pop
-		IL_0085: br IL_009e
+		IL_007f: br IL_0096
 
-		IL_008a: ldloc.1
-		IL_008b: ldstr "filter"
-		IL_0090: ldstr "all"
-		IL_0095: ldc.i4.0
-		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_009b: stloc.2
-		IL_009c: ldloc.2
-		IL_009d: pop
+		IL_0084: ldloc.1
+		IL_0085: ldstr "filter"
+		IL_008a: ldstr "all"
+		IL_008f: ldc.i4.0
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0095: stloc.2
 
-		IL_009e: ldloc.1
-		IL_009f: ldstr "format"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a9: stloc.2
-		IL_00aa: ldloc.2
-		IL_00ab: brfalse IL_00c2
+		IL_0096: ldloc.1
+		IL_0097: ldstr "format"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: stloc.2
+		IL_00a2: ldloc.2
+		IL_00a3: brfalse IL_00b8
 
-		IL_00b0: ldloc.2
-		IL_00b1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00b6: brtrue IL_00c2
+		IL_00a8: ldloc.2
+		IL_00a9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00ae: brtrue IL_00b8
 
-		IL_00bb: ldloc.2
-		IL_00bc: pop
-		IL_00bd: br IL_00d6
+		IL_00b3: br IL_00ca
 
-		IL_00c2: ldloc.1
-		IL_00c3: ldstr "format"
-		IL_00c8: ldstr "other"
-		IL_00cd: ldc.i4.0
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00d3: stloc.2
-		IL_00d4: ldloc.2
-		IL_00d5: pop
+		IL_00b8: ldloc.1
+		IL_00b9: ldstr "format"
+		IL_00be: ldstr "other"
+		IL_00c3: ldc.i4.0
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_00c9: stloc.2
 
-		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00db: ldloc.1
-		IL_00dc: ldstr "throw"
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00eb: pop
-		IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f1: ldloc.1
-		IL_00f2: ldstr "filter"
-		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0101: pop
-		IL_0102: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0107: ldloc.1
-		IL_0108: ldstr "format"
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0117: pop
-		IL_0118: ret
+		IL_00ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cf: ldloc.1
+		IL_00d0: ldstr "throw"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00df: pop
+		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e5: ldloc.1
+		IL_00e6: ldstr "filter"
+		IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f5: pop
+		IL_00f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fb: ldloc.1
+		IL_00fc: ldstr "format"
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010b: pop
+		IL_010c: ret
 	} // end of method CompoundAssignment_PropertyNullishAssignment::__js_module_init__
 
 } // end of class Modules.CompoundAssignment_PropertyNullishAssignment
@@ -164,7 +152,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x217e
+		// Method begins at RVA 0x2172
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Mutation_DeleteAndAdd.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Mutation_DeleteAndAdd.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2129
+			// Method begins at RVA 0x2126
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2144
+					// Method begins at RVA 0x2141
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213b
+				// Method begins at RVA 0x2138
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2132
+			// Method begins at RVA 0x212f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,7 +104,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 205 (0xcd)
+		// Code size: 202 (0xca)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForIn_Mutation_DeleteAndAdd/Scope,
@@ -144,7 +144,7 @@
 			IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 			IL_005e: stloc.s 7
 			IL_0060: ldloc.s 7
-			IL_0062: brtrue IL_00cc
+			IL_0062: brtrue IL_00c9
 
 			IL_0067: ldloc.s 6
 			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -162,7 +162,7 @@
 			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_0091: stloc.s 7
 			IL_0093: ldloc.s 7
-			IL_0095: brfalse IL_00c7
+			IL_0095: brfalse IL_00c4
 
 			IL_009a: newobj instance void Modules.ControlFlow_ForIn_Mutation_DeleteAndAdd/Scope_ForIn_L5C5/Block_L5C21/Block_L7C17::.ctor()
 			IL_009f: stloc.s 5
@@ -170,19 +170,17 @@
 			IL_00a2: ldstr "b"
 			IL_00a7: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
 			IL_00ac: stloc.s 7
-			IL_00ae: ldloc.s 7
-			IL_00b0: pop
-			IL_00b1: ldloc.1
-			IL_00b2: ldstr "d"
-			IL_00b7: ldc.r8 4
-			IL_00c0: ldc.i4.1
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_00c6: pop
+			IL_00ae: ldloc.1
+			IL_00af: ldstr "d"
+			IL_00b4: ldc.r8 4
+			IL_00bd: ldc.i4.1
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_00c3: pop
 
-			IL_00c7: br IL_004f
+			IL_00c4: br IL_004f
 		// end loop
 
-		IL_00cc: ret
+		IL_00c9: ret
 	} // end of method ControlFlow_ForIn_Mutation_DeleteAndAdd::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForIn_Mutation_DeleteAndAdd
@@ -194,7 +192,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214d
+		// Method begins at RVA 0x214a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Generator_YieldStar_ArrayBasic
+﻿// IL code: Generator_YieldStar_ArrayBasic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24be
+				// Method begins at RVA 0x24bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 			)
 			// Method begins at RVA 0x21c4
 			// Header size: 12
-			// Code size: 741 (0x2e5)
+			// Code size: 738 (0x2e2)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_YieldStar_ArrayBasic/g/Scope,
@@ -206,7 +206,7 @@
 			IL_0196: ldc.i4.0
 			IL_0197: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 			IL_019c: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01a1: br IL_02c9
+			IL_01a1: br IL_02c6
 
 			IL_01a6: ldloc.0
 			IL_01a7: ldc.r8 2
@@ -325,17 +325,14 @@
 			IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
 			IL_02c5: ret
 
-			IL_02c6: ldloc.s 7
-			IL_02c8: pop
-
-			IL_02c9: ldloc.0
-			IL_02ca: ldc.i4.1
-			IL_02cb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02d0: ldc.r8 99
-			IL_02d9: box [System.Runtime]System.Double
-			IL_02de: ldc.i4.1
-			IL_02df: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02e4: ret
+			IL_02c6: ldloc.0
+			IL_02c7: ldc.i4.1
+			IL_02c8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02cd: ldc.r8 99
+			IL_02d6: box [System.Runtime]System.Double
+			IL_02db: ldc.i4.1
+			IL_02dc: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02e1: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -353,7 +350,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24b5
+			// Method begins at RVA 0x24b2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -519,7 +516,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24c7
+		// Method begins at RVA 0x24c4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3263
+					// Method begins at RVA 0x3253
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x325a
+				// Method begins at RVA 0x324a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -238,7 +238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x326c
+				// Method begins at RVA 0x325c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -496,7 +496,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3155
+				// Method begins at RVA 0x3145
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -516,7 +516,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x315e
+				// Method begins at RVA 0x314e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -536,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3167
+				// Method begins at RVA 0x3157
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -564,7 +564,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3182
+						// Method begins at RVA 0x3172
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -588,7 +588,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3194
+							// Method begins at RVA 0x3184
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -606,7 +606,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x318b
+						// Method begins at RVA 0x317b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -624,7 +624,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3179
+					// Method begins at RVA 0x3169
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -652,7 +652,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x31af
+							// Method begins at RVA 0x319f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -670,7 +670,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31a6
+						// Method begins at RVA 0x3196
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -688,7 +688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x319d
+					// Method begins at RVA 0x318d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -712,7 +712,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x31c1
+						// Method begins at RVA 0x31b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -730,7 +730,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31b8
+					// Method begins at RVA 0x31a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -748,7 +748,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3170
+				// Method begins at RVA 0x3160
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -768,7 +768,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ca
+				// Method begins at RVA 0x31ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -792,7 +792,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x31dc
+					// Method begins at RVA 0x31cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -810,7 +810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31d3
+				// Method begins at RVA 0x31c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -887,7 +887,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2af8
+			// Method begins at RVA 0x2af0
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -959,7 +959,7 @@
 			)
 			// Method begins at RVA 0x28c4
 			// Header size: 12
-			// Code size: 552 (0x228)
+			// Code size: 544 (0x220)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26,
@@ -981,8 +981,7 @@
 				[16] float64,
 				[17] float64,
 				[18] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36,
-				[19] object,
-				[20] float64
+				[19] float64
 			)
 
 			IL_0000: ldarg.2
@@ -995,7 +994,7 @@
 			IL_0013: ldc.r8 2
 			IL_001c: div
 			IL_001d: cgt
-			IL_001f: brfalse IL_0142
+			IL_001f: brfalse IL_013a
 
 			IL_0024: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26::.ctor()
 			IL_0029: stloc.0
@@ -1008,7 +1007,7 @@
 			IL_0038: ldloc.1
 			IL_0039: ldarg.3
 			IL_003a: cgt
-			IL_003c: brfalse IL_0078
+			IL_003c: brfalse IL_0070
 
 			IL_0041: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Block_L57C39::.ctor()
 			IL_0046: stloc.2
@@ -1018,231 +1017,228 @@
 				IL_0049: ldloc.3
 				IL_004a: ldarg.3
 				IL_004b: clt
-				IL_004d: brfalse IL_0076
+				IL_004d: brfalse IL_006e
 
 				IL_0052: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L54C26/Scope_For_L59C9/Block_L59C69::.ctor()
 				IL_0057: stloc.s 4
-				IL_0059: ldloc.3
-				IL_005a: box [System.Runtime]System.Double
-				IL_005f: stloc.s 19
-				IL_0061: ldarg.0
-				IL_0062: ldloc.3
-				IL_0063: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
-				IL_0068: pop
-				IL_0069: ldloc.3
-				IL_006a: ldarg.2
-				IL_006b: add
-				IL_006c: stloc.s 20
-				IL_006e: ldloc.s 20
-				IL_0070: stloc.3
-				IL_0071: br IL_0049
+				IL_0059: ldarg.0
+				IL_005a: ldloc.3
+				IL_005b: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
+				IL_0060: pop
+				IL_0061: ldloc.3
+				IL_0062: ldarg.2
+				IL_0063: add
+				IL_0064: stloc.s 19
+				IL_0066: ldloc.s 19
+				IL_0068: stloc.3
+				IL_0069: br IL_0049
 			// end loop
 
-			IL_0076: ldnull
-			IL_0077: ret
+			IL_006e: ldnull
+			IL_006f: ret
 
-			IL_0078: ldarg.3
-			IL_0079: conv.i4
-			IL_007a: conv.u4
-			IL_007b: ldc.r8 5
-			IL_0084: conv.i4
-			IL_0085: shr.un
-			IL_0086: conv.r.un
-			IL_0087: stloc.s 20
-			IL_0089: ldloc.s 20
-			IL_008b: stloc.s 5
-			IL_008d: ldarg.1
-			IL_008e: stloc.s 6
-			// loop start (head: IL_0090)
-				IL_0090: ldloc.s 6
-				IL_0092: ldloc.1
-				IL_0093: clt
-				IL_0095: brfalse IL_0140
+			IL_0070: ldarg.3
+			IL_0071: conv.i4
+			IL_0072: conv.u4
+			IL_0073: ldc.r8 5
+			IL_007c: conv.i4
+			IL_007d: shr.un
+			IL_007e: conv.r.un
+			IL_007f: stloc.s 19
+			IL_0081: ldloc.s 19
+			IL_0083: stloc.s 5
+			IL_0085: ldarg.1
+			IL_0086: stloc.s 6
+			// loop start (head: IL_0088)
+				IL_0088: ldloc.s 6
+				IL_008a: ldloc.1
+				IL_008b: clt
+				IL_008d: brfalse IL_0138
 
-				IL_009a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
-				IL_009f: stloc.s 7
-				IL_00a1: ldloc.s 6
-				IL_00a3: conv.i4
-				IL_00a4: conv.u4
-				IL_00a5: ldc.r8 5
-				IL_00ae: conv.i4
-				IL_00af: shr.un
-				IL_00b0: conv.r.un
-				IL_00b1: stloc.s 20
-				IL_00b3: ldloc.s 20
-				IL_00b5: stloc.s 8
-				IL_00b7: ldloc.s 6
-				IL_00b9: conv.i4
-				IL_00ba: ldc.r8 31
-				IL_00c3: conv.i4
-				IL_00c4: and
-				IL_00c5: conv.r8
-				IL_00c6: stloc.s 20
-				IL_00c8: ldloc.s 20
-				IL_00ca: stloc.s 9
-				IL_00cc: ldc.r8 1
-				IL_00d5: conv.i4
-				IL_00d6: ldloc.s 9
-				IL_00d8: conv.i4
-				IL_00d9: shl
-				IL_00da: conv.r8
-				IL_00db: stloc.s 20
-				IL_00dd: ldloc.s 20
-				IL_00df: stloc.s 10
-				// loop start (head: IL_00e1)
-					IL_00e1: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75/Block_L70C7::.ctor()
-					IL_00e6: stloc.s 11
-					IL_00e8: ldarg.0
-					IL_00e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_00ee: ldloc.s 8
-					IL_00f0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_00f5: stloc.s 20
-					IL_00f7: ldloc.s 20
-					IL_00f9: stloc.s 20
-					IL_00fb: ldloc.s 20
-					IL_00fd: conv.i4
-					IL_00fe: ldloc.s 10
-					IL_0100: conv.i4
-					IL_0101: or
-					IL_0102: conv.r8
-					IL_0103: stloc.s 20
-					IL_0105: ldarg.0
-					IL_0106: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-					IL_010b: ldloc.s 8
-					IL_010d: ldloc.s 20
-					IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_0114: ldloc.s 8
-					IL_0116: ldarg.2
-					IL_0117: add
-					IL_0118: stloc.s 20
-					IL_011a: ldloc.s 20
-					IL_011c: stloc.s 8
-					IL_011e: ldloc.s 8
-					IL_0120: ldloc.s 5
-					IL_0122: cgt
-					IL_0124: ldc.i4.0
-					IL_0125: ceq
-					IL_0127: brfalse IL_0131
+				IL_0092: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75::.ctor()
+				IL_0097: stloc.s 7
+				IL_0099: ldloc.s 6
+				IL_009b: conv.i4
+				IL_009c: conv.u4
+				IL_009d: ldc.r8 5
+				IL_00a6: conv.i4
+				IL_00a7: shr.un
+				IL_00a8: conv.r.un
+				IL_00a9: stloc.s 19
+				IL_00ab: ldloc.s 19
+				IL_00ad: stloc.s 8
+				IL_00af: ldloc.s 6
+				IL_00b1: conv.i4
+				IL_00b2: ldc.r8 31
+				IL_00bb: conv.i4
+				IL_00bc: and
+				IL_00bd: conv.r8
+				IL_00be: stloc.s 19
+				IL_00c0: ldloc.s 19
+				IL_00c2: stloc.s 9
+				IL_00c4: ldc.r8 1
+				IL_00cd: conv.i4
+				IL_00ce: ldloc.s 9
+				IL_00d0: conv.i4
+				IL_00d1: shl
+				IL_00d2: conv.r8
+				IL_00d3: stloc.s 19
+				IL_00d5: ldloc.s 19
+				IL_00d7: stloc.s 10
+				// loop start (head: IL_00d9)
+					IL_00d9: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Scope_For_L66C8/Block_L66C75/Block_L70C7::.ctor()
+					IL_00de: stloc.s 11
+					IL_00e0: ldarg.0
+					IL_00e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_00e6: ldloc.s 8
+					IL_00e8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00ed: stloc.s 19
+					IL_00ef: ldloc.s 19
+					IL_00f1: stloc.s 19
+					IL_00f3: ldloc.s 19
+					IL_00f5: conv.i4
+					IL_00f6: ldloc.s 10
+					IL_00f8: conv.i4
+					IL_00f9: or
+					IL_00fa: conv.r8
+					IL_00fb: stloc.s 19
+					IL_00fd: ldarg.0
+					IL_00fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+					IL_0103: ldloc.s 8
+					IL_0105: ldloc.s 19
+					IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_010c: ldloc.s 8
+					IL_010e: ldarg.2
+					IL_010f: add
+					IL_0110: stloc.s 19
+					IL_0112: ldloc.s 19
+					IL_0114: stloc.s 8
+					IL_0116: ldloc.s 8
+					IL_0118: ldloc.s 5
+					IL_011a: cgt
+					IL_011c: ldc.i4.0
+					IL_011d: ceq
+					IL_011f: brfalse IL_0129
 
-					IL_012c: br IL_00e1
+					IL_0124: br IL_00d9
 				// end loop
 
-				IL_0131: ldloc.s 6
-				IL_0133: ldarg.2
-				IL_0134: add
-				IL_0135: stloc.s 20
-				IL_0137: ldloc.s 20
-				IL_0139: stloc.s 6
-				IL_013b: br IL_0090
+				IL_0129: ldloc.s 6
+				IL_012b: ldarg.2
+				IL_012c: add
+				IL_012d: stloc.s 19
+				IL_012f: ldloc.s 19
+				IL_0131: stloc.s 6
+				IL_0133: br IL_0088
 			// end loop
 
-			IL_0140: ldnull
-			IL_0141: ret
+			IL_0138: ldnull
+			IL_0139: ret
 
-			IL_0142: ldarg.1
-			IL_0143: stloc.s 12
-			IL_0145: ldloc.s 12
-			IL_0147: conv.i4
-			IL_0148: conv.u4
-			IL_0149: ldc.r8 5
-			IL_0152: conv.i4
-			IL_0153: shr.un
-			IL_0154: conv.r.un
-			IL_0155: stloc.s 20
-			IL_0157: ldloc.s 20
-			IL_0159: stloc.s 13
-			IL_015b: ldarg.0
-			IL_015c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_0161: ldloc.s 13
-			IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0168: stloc.s 20
-			IL_016a: ldloc.s 20
-			IL_016c: stloc.s 14
-			// loop start (head: IL_016e)
-				IL_016e: ldloc.s 12
-				IL_0170: ldarg.3
-				IL_0171: clt
-				IL_0173: brfalse IL_0217
+			IL_013a: ldarg.1
+			IL_013b: stloc.s 12
+			IL_013d: ldloc.s 12
+			IL_013f: conv.i4
+			IL_0140: conv.u4
+			IL_0141: ldc.r8 5
+			IL_014a: conv.i4
+			IL_014b: shr.un
+			IL_014c: conv.r.un
+			IL_014d: stloc.s 19
+			IL_014f: ldloc.s 19
+			IL_0151: stloc.s 13
+			IL_0153: ldarg.0
+			IL_0154: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0159: ldloc.s 13
+			IL_015b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0160: stloc.s 19
+			IL_0162: ldloc.s 19
+			IL_0164: stloc.s 14
+			// loop start (head: IL_0166)
+				IL_0166: ldloc.s 12
+				IL_0168: ldarg.3
+				IL_0169: clt
+				IL_016b: brfalse IL_020f
 
-				IL_0178: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
-				IL_017d: stloc.s 15
-				IL_017f: ldloc.s 12
-				IL_0181: conv.i4
-				IL_0182: ldc.r8 31
-				IL_018b: conv.i4
-				IL_018c: and
-				IL_018d: conv.r8
-				IL_018e: stloc.s 20
-				IL_0190: ldloc.s 20
-				IL_0192: stloc.s 16
-				IL_0194: ldc.r8 1
-				IL_019d: conv.i4
-				IL_019e: ldloc.s 16
-				IL_01a0: conv.i4
-				IL_01a1: shl
-				IL_01a2: conv.r8
-				IL_01a3: stloc.s 20
-				IL_01a5: ldloc.s 14
-				IL_01a7: conv.i4
-				IL_01a8: ldloc.s 20
-				IL_01aa: conv.i4
-				IL_01ab: or
-				IL_01ac: conv.r8
-				IL_01ad: stloc.s 20
-				IL_01af: ldloc.s 20
-				IL_01b1: stloc.s 14
-				IL_01b3: ldloc.s 12
-				IL_01b5: ldarg.2
-				IL_01b6: add
-				IL_01b7: stloc.s 20
-				IL_01b9: ldloc.s 20
-				IL_01bb: stloc.s 12
-				IL_01bd: ldloc.s 12
-				IL_01bf: conv.i4
-				IL_01c0: conv.u4
-				IL_01c1: ldc.r8 5
-				IL_01ca: conv.i4
-				IL_01cb: shr.un
-				IL_01cc: conv.r.un
-				IL_01cd: stloc.s 20
-				IL_01cf: ldloc.s 20
-				IL_01d1: stloc.s 17
-				IL_01d3: ldloc.s 17
-				IL_01d5: ldloc.s 13
-				IL_01d7: ceq
-				IL_01d9: ldc.i4.0
-				IL_01da: ceq
-				IL_01dc: brfalse IL_0212
+				IL_0170: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29::.ctor()
+				IL_0175: stloc.s 15
+				IL_0177: ldloc.s 12
+				IL_0179: conv.i4
+				IL_017a: ldc.r8 31
+				IL_0183: conv.i4
+				IL_0184: and
+				IL_0185: conv.r8
+				IL_0186: stloc.s 19
+				IL_0188: ldloc.s 19
+				IL_018a: stloc.s 16
+				IL_018c: ldc.r8 1
+				IL_0195: conv.i4
+				IL_0196: ldloc.s 16
+				IL_0198: conv.i4
+				IL_0199: shl
+				IL_019a: conv.r8
+				IL_019b: stloc.s 19
+				IL_019d: ldloc.s 14
+				IL_019f: conv.i4
+				IL_01a0: ldloc.s 19
+				IL_01a2: conv.i4
+				IL_01a3: or
+				IL_01a4: conv.r8
+				IL_01a5: stloc.s 19
+				IL_01a7: ldloc.s 19
+				IL_01a9: stloc.s 14
+				IL_01ab: ldloc.s 12
+				IL_01ad: ldarg.2
+				IL_01ae: add
+				IL_01af: stloc.s 19
+				IL_01b1: ldloc.s 19
+				IL_01b3: stloc.s 12
+				IL_01b5: ldloc.s 12
+				IL_01b7: conv.i4
+				IL_01b8: conv.u4
+				IL_01b9: ldc.r8 5
+				IL_01c2: conv.i4
+				IL_01c3: shr.un
+				IL_01c4: conv.r.un
+				IL_01c5: stloc.s 19
+				IL_01c7: ldloc.s 19
+				IL_01c9: stloc.s 17
+				IL_01cb: ldloc.s 17
+				IL_01cd: ldloc.s 13
+				IL_01cf: ceq
+				IL_01d1: ldc.i4.0
+				IL_01d2: ceq
+				IL_01d4: brfalse IL_020a
 
-				IL_01e1: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
-				IL_01e6: stloc.s 18
-				IL_01e8: ldarg.0
-				IL_01e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_01ee: ldloc.s 13
-				IL_01f0: ldloc.s 14
-				IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_01f7: ldloc.s 17
-				IL_01f9: stloc.s 20
-				IL_01fb: ldloc.s 20
-				IL_01fd: stloc.s 13
-				IL_01ff: ldarg.0
-				IL_0200: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-				IL_0205: ldloc.s 13
-				IL_0207: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_020c: stloc.s 20
-				IL_020e: ldloc.s 20
-				IL_0210: stloc.s 14
+				IL_01d9: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/Block_L83C29/Block_L89C36::.ctor()
+				IL_01de: stloc.s 18
+				IL_01e0: ldarg.0
+				IL_01e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_01e6: ldloc.s 13
+				IL_01e8: ldloc.s 14
+				IL_01ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01ef: ldloc.s 17
+				IL_01f1: stloc.s 19
+				IL_01f3: ldloc.s 19
+				IL_01f5: stloc.s 13
+				IL_01f7: ldarg.0
+				IL_01f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+				IL_01fd: ldloc.s 13
+				IL_01ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0204: stloc.s 19
+				IL_0206: ldloc.s 19
+				IL_0208: stloc.s 14
 
-				IL_0212: br IL_016e
+				IL_020a: br IL_0166
 			// end loop
 
-			IL_0217: ldarg.0
-			IL_0218: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
-			IL_021d: ldloc.s 13
-			IL_021f: ldloc.s 14
-			IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_0226: ldnull
-			IL_0227: ret
+			IL_020f: ldarg.0
+			IL_0210: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Compile_Performance_PrimeJavaScript/BitArray::wordArray
+			IL_0215: ldloc.s 13
+			IL_0217: ldloc.s 14
+			IL_0219: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_021e: ldnull
+			IL_021f: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1253,7 +1249,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b5c
+			// Method begins at RVA 0x2b54
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1367,7 +1363,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31e5
+				// Method begins at RVA 0x31d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1387,7 +1383,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31ee
+				// Method begins at RVA 0x31de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1411,7 +1407,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3200
+					// Method begins at RVA 0x31f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1429,7 +1425,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x31f7
+				// Method begins at RVA 0x31e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1449,7 +1445,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3209
+				// Method begins at RVA 0x31f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1477,7 +1473,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3224
+						// Method begins at RVA 0x3214
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1495,7 +1491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x321b
+					// Method begins at RVA 0x320b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1513,7 +1509,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3212
+				// Method begins at RVA 0x3202
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1533,7 +1529,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x322d
+				// Method begins at RVA 0x321d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1557,7 +1553,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x323f
+					// Method begins at RVA 0x322f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1575,7 +1571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3236
+				// Method begins at RVA 0x3226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1599,7 +1595,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3251
+					// Method begins at RVA 0x3241
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1617,7 +1613,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3248
+				// Method begins at RVA 0x3238
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1704,9 +1700,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bb8
+			// Method begins at RVA 0x2bb0
 			// Header size: 12
-			// Code size: 314 (0x13a)
+			// Code size: 306 (0x132)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1716,8 +1712,7 @@
 				[4] float64,
 				[5] float64,
 				[6] object,
-				[7] object,
-				[8] object
+				[7] object
 			)
 
 			IL_0000: ldarg.0
@@ -1739,7 +1734,7 @@
 				IL_0031: ldloc.1
 				IL_0032: ldloc.0
 				IL_0033: clt
-				IL_0035: brfalse IL_0138
+				IL_0035: brfalse IL_0130
 
 				IL_003a: newobj instance void Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_runSieve/Block_L133C2::.ctor()
 				IL_003f: stloc.2
@@ -1767,74 +1762,70 @@
 				IL_0072: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
 				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_007c: stloc.s 7
-				IL_007e: ldloc.s 4
-				IL_0080: box [System.Runtime]System.Double
-				IL_0085: stloc.s 6
-				IL_0087: ldloc.3
-				IL_0088: box [System.Runtime]System.Double
-				IL_008d: stloc.s 8
-				IL_008f: ldloc.s 7
-				IL_0091: isinst Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_0096: dup
-				IL_0097: brfalse IL_00b0
+				IL_007e: ldloc.s 7
+				IL_0080: isinst Modules.Compile_Performance_PrimeJavaScript/BitArray
+				IL_0085: dup
+				IL_0086: brfalse IL_009f
 
-				IL_009c: ldloc.s 4
-				IL_009e: ldloc.3
-				IL_009f: ldarg.0
-				IL_00a0: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
-				IL_00a5: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
-				IL_00aa: pop
-				IL_00ab: br IL_00cd
+				IL_008b: ldloc.s 4
+				IL_008d: ldloc.3
+				IL_008e: ldarg.0
+				IL_008f: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
+				IL_0094: callvirt instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
+				IL_0099: pop
+				IL_009a: br IL_00c5
 
-				IL_00b0: pop
-				IL_00b1: ldloc.s 7
-				IL_00b3: ldstr "setBitsTrue"
-				IL_00b8: ldloc.s 6
-				IL_00ba: ldloc.s 8
-				IL_00bc: ldarg.0
-				IL_00bd: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
-				IL_00c2: box [System.Runtime]System.Double
-				IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_00cc: pop
+				IL_009f: pop
+				IL_00a0: ldloc.s 7
+				IL_00a2: ldstr "setBitsTrue"
+				IL_00a7: ldloc.s 4
+				IL_00a9: box [System.Runtime]System.Double
+				IL_00ae: ldloc.3
+				IL_00af: box [System.Runtime]System.Double
+				IL_00b4: ldarg.0
+				IL_00b5: ldfld float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::sieveSizeInBits
+				IL_00ba: box [System.Runtime]System.Double
+				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_00c4: pop
 
-				IL_00cd: ldarg.0
-				IL_00ce: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
-				IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00d8: stloc.s 7
-				IL_00da: ldloc.s 7
-				IL_00dc: isinst Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_00e1: dup
-				IL_00e2: brfalse IL_0108
+				IL_00c5: ldarg.0
+				IL_00c6: ldfld class Modules.Compile_Performance_PrimeJavaScript/BitArray Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::bitArray
+				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00d0: stloc.s 7
+				IL_00d2: ldloc.s 7
+				IL_00d4: isinst Modules.Compile_Performance_PrimeJavaScript/BitArray
+				IL_00d9: dup
+				IL_00da: brfalse IL_0100
 
-				IL_00e7: ldloc.1
-				IL_00e8: ldc.r8 1
-				IL_00f1: add
-				IL_00f2: box [System.Runtime]System.Double
-				IL_00f7: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(object)
-				IL_00fc: box [System.Runtime]System.Double
-				IL_0101: stloc.s 7
-				IL_0103: br IL_0127
+				IL_00df: ldloc.1
+				IL_00e0: ldc.r8 1
+				IL_00e9: add
+				IL_00ea: box [System.Runtime]System.Double
+				IL_00ef: callvirt instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(object)
+				IL_00f4: box [System.Runtime]System.Double
+				IL_00f9: stloc.s 7
+				IL_00fb: br IL_011f
 
-				IL_0108: pop
-				IL_0109: ldloc.s 7
-				IL_010b: ldstr "searchBitFalse"
-				IL_0110: ldloc.1
-				IL_0111: ldc.r8 1
-				IL_011a: add
-				IL_011b: box [System.Runtime]System.Double
-				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0125: stloc.s 7
+				IL_0100: pop
+				IL_0101: ldloc.s 7
+				IL_0103: ldstr "searchBitFalse"
+				IL_0108: ldloc.1
+				IL_0109: ldc.r8 1
+				IL_0112: add
+				IL_0113: box [System.Runtime]System.Double
+				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_011d: stloc.s 7
 
-				IL_0127: ldloc.s 7
-				IL_0129: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_012e: stloc.s 5
-				IL_0130: ldloc.s 5
-				IL_0132: stloc.1
-				IL_0133: br IL_0031
+				IL_011f: ldloc.s 7
+				IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0126: stloc.s 5
+				IL_0128: ldloc.s 5
+				IL_012a: stloc.1
+				IL_012b: br IL_0031
 			// end loop
 
-			IL_0138: ldarg.0
-			IL_0139: ret
+			IL_0130: ldarg.0
+			IL_0131: ret
 		} // end of method PrimeSieve::runSieve
 
 		.method public hidebysig 
@@ -1843,7 +1834,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2f88
+			// Method begins at RVA 0x2f78
 			// Header size: 12
 			// Code size: 166 (0xa6)
 			.maxstack 8
@@ -1929,7 +1920,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x303c
+			// Method begins at RVA 0x302c
 			// Header size: 12
 			// Code size: 260 (0x104)
 			.maxstack 8
@@ -2047,7 +2038,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d00
+			// Method begins at RVA 0x2cf0
 			// Header size: 12
 			// Code size: 633 (0x279)
 			.maxstack 8
@@ -2294,7 +2285,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x314c
+			// Method begins at RVA 0x313c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2740,7 +2731,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3275
+		// Method begins at RVA 0x3265
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3447
+					// Method begins at RVA 0x3437
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x343e
+				// Method begins at RVA 0x342e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -238,7 +238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3450
+				// Method begins at RVA 0x3440
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -487,7 +487,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3339
+				// Method begins at RVA 0x3329
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -507,7 +507,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3342
+				// Method begins at RVA 0x3332
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -527,7 +527,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x334b
+				// Method begins at RVA 0x333b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -555,7 +555,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3366
+						// Method begins at RVA 0x3356
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -579,7 +579,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3378
+							// Method begins at RVA 0x3368
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -597,7 +597,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x336f
+						// Method begins at RVA 0x335f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -615,7 +615,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x335d
+					// Method begins at RVA 0x334d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -643,7 +643,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3393
+							// Method begins at RVA 0x3383
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -661,7 +661,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x338a
+						// Method begins at RVA 0x337a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -679,7 +679,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3381
+					// Method begins at RVA 0x3371
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -703,7 +703,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33a5
+						// Method begins at RVA 0x3395
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -721,7 +721,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x339c
+					// Method begins at RVA 0x338c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -739,7 +739,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3354
+				// Method begins at RVA 0x3344
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -759,7 +759,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33ae
+				// Method begins at RVA 0x339e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -783,7 +783,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c0
+					// Method begins at RVA 0x33b0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -801,7 +801,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33b7
+				// Method begins at RVA 0x33a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -878,7 +878,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cdc
+			// Method begins at RVA 0x2cd4
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -950,7 +950,7 @@
 			)
 			// Method begins at RVA 0x2aa8
 			// Header size: 12
-			// Code size: 552 (0x228)
+			// Code size: 544 (0x220)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26,
@@ -972,8 +972,7 @@
 				[16] float64,
 				[17] float64,
 				[18] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36,
-				[19] object,
-				[20] float64
+				[19] float64
 			)
 
 			IL_0000: ldarg.2
@@ -986,7 +985,7 @@
 			IL_0013: ldc.r8 2
 			IL_001c: div
 			IL_001d: cgt
-			IL_001f: brfalse IL_0142
+			IL_001f: brfalse IL_013a
 
 			IL_0024: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26::.ctor()
 			IL_0029: stloc.0
@@ -999,7 +998,7 @@
 			IL_0038: ldloc.1
 			IL_0039: ldarg.3
 			IL_003a: cgt
-			IL_003c: brfalse IL_0078
+			IL_003c: brfalse IL_0070
 
 			IL_0041: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Block_L60C39::.ctor()
 			IL_0046: stloc.2
@@ -1009,231 +1008,228 @@
 				IL_0049: ldloc.3
 				IL_004a: ldarg.3
 				IL_004b: clt
-				IL_004d: brfalse IL_0076
+				IL_004d: brfalse IL_006e
 
 				IL_0052: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L57C26/Scope_For_L62C9/Block_L62C69::.ctor()
 				IL_0057: stloc.s 4
-				IL_0059: ldloc.3
-				IL_005a: box [System.Runtime]System.Double
-				IL_005f: stloc.s 19
-				IL_0061: ldarg.0
-				IL_0062: ldloc.3
-				IL_0063: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
-				IL_0068: pop
-				IL_0069: ldloc.3
-				IL_006a: ldarg.2
-				IL_006b: add
-				IL_006c: stloc.s 20
-				IL_006e: ldloc.s 20
-				IL_0070: stloc.3
-				IL_0071: br IL_0049
+				IL_0059: ldarg.0
+				IL_005a: ldloc.3
+				IL_005b: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
+				IL_0060: pop
+				IL_0061: ldloc.3
+				IL_0062: ldarg.2
+				IL_0063: add
+				IL_0064: stloc.s 19
+				IL_0066: ldloc.s 19
+				IL_0068: stloc.3
+				IL_0069: br IL_0049
 			// end loop
 
-			IL_0076: ldnull
-			IL_0077: ret
+			IL_006e: ldnull
+			IL_006f: ret
 
-			IL_0078: ldarg.3
-			IL_0079: conv.i4
-			IL_007a: conv.u4
-			IL_007b: ldc.r8 5
-			IL_0084: conv.i4
-			IL_0085: shr.un
-			IL_0086: conv.r.un
-			IL_0087: stloc.s 20
-			IL_0089: ldloc.s 20
-			IL_008b: stloc.s 5
-			IL_008d: ldarg.1
-			IL_008e: stloc.s 6
-			// loop start (head: IL_0090)
-				IL_0090: ldloc.s 6
-				IL_0092: ldloc.1
-				IL_0093: clt
-				IL_0095: brfalse IL_0140
+			IL_0070: ldarg.3
+			IL_0071: conv.i4
+			IL_0072: conv.u4
+			IL_0073: ldc.r8 5
+			IL_007c: conv.i4
+			IL_007d: shr.un
+			IL_007e: conv.r.un
+			IL_007f: stloc.s 19
+			IL_0081: ldloc.s 19
+			IL_0083: stloc.s 5
+			IL_0085: ldarg.1
+			IL_0086: stloc.s 6
+			// loop start (head: IL_0088)
+				IL_0088: ldloc.s 6
+				IL_008a: ldloc.1
+				IL_008b: clt
+				IL_008d: brfalse IL_0138
 
-				IL_009a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
-				IL_009f: stloc.s 7
-				IL_00a1: ldloc.s 6
-				IL_00a3: conv.i4
-				IL_00a4: conv.u4
-				IL_00a5: ldc.r8 5
-				IL_00ae: conv.i4
-				IL_00af: shr.un
-				IL_00b0: conv.r.un
-				IL_00b1: stloc.s 20
-				IL_00b3: ldloc.s 20
-				IL_00b5: stloc.s 8
-				IL_00b7: ldloc.s 6
-				IL_00b9: conv.i4
-				IL_00ba: ldc.r8 31
-				IL_00c3: conv.i4
-				IL_00c4: and
-				IL_00c5: conv.r8
-				IL_00c6: stloc.s 20
-				IL_00c8: ldloc.s 20
-				IL_00ca: stloc.s 9
-				IL_00cc: ldc.r8 1
-				IL_00d5: conv.i4
-				IL_00d6: ldloc.s 9
-				IL_00d8: conv.i4
-				IL_00d9: shl
-				IL_00da: conv.r8
-				IL_00db: stloc.s 20
-				IL_00dd: ldloc.s 20
-				IL_00df: stloc.s 10
-				// loop start (head: IL_00e1)
-					IL_00e1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75/Block_L73C7::.ctor()
-					IL_00e6: stloc.s 11
-					IL_00e8: ldarg.0
-					IL_00e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_00ee: ldloc.s 8
-					IL_00f0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_00f5: stloc.s 20
-					IL_00f7: ldloc.s 20
-					IL_00f9: stloc.s 20
-					IL_00fb: ldloc.s 20
-					IL_00fd: conv.i4
-					IL_00fe: ldloc.s 10
-					IL_0100: conv.i4
-					IL_0101: or
-					IL_0102: conv.r8
-					IL_0103: stloc.s 20
-					IL_0105: ldarg.0
-					IL_0106: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-					IL_010b: ldloc.s 8
-					IL_010d: ldloc.s 20
-					IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_0114: ldloc.s 8
-					IL_0116: ldarg.2
-					IL_0117: add
-					IL_0118: stloc.s 20
-					IL_011a: ldloc.s 20
-					IL_011c: stloc.s 8
-					IL_011e: ldloc.s 8
-					IL_0120: ldloc.s 5
-					IL_0122: cgt
-					IL_0124: ldc.i4.0
-					IL_0125: ceq
-					IL_0127: brfalse IL_0131
+				IL_0092: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75::.ctor()
+				IL_0097: stloc.s 7
+				IL_0099: ldloc.s 6
+				IL_009b: conv.i4
+				IL_009c: conv.u4
+				IL_009d: ldc.r8 5
+				IL_00a6: conv.i4
+				IL_00a7: shr.un
+				IL_00a8: conv.r.un
+				IL_00a9: stloc.s 19
+				IL_00ab: ldloc.s 19
+				IL_00ad: stloc.s 8
+				IL_00af: ldloc.s 6
+				IL_00b1: conv.i4
+				IL_00b2: ldc.r8 31
+				IL_00bb: conv.i4
+				IL_00bc: and
+				IL_00bd: conv.r8
+				IL_00be: stloc.s 19
+				IL_00c0: ldloc.s 19
+				IL_00c2: stloc.s 9
+				IL_00c4: ldc.r8 1
+				IL_00cd: conv.i4
+				IL_00ce: ldloc.s 9
+				IL_00d0: conv.i4
+				IL_00d1: shl
+				IL_00d2: conv.r8
+				IL_00d3: stloc.s 19
+				IL_00d5: ldloc.s 19
+				IL_00d7: stloc.s 10
+				// loop start (head: IL_00d9)
+					IL_00d9: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Scope_For_L69C8/Block_L69C75/Block_L73C7::.ctor()
+					IL_00de: stloc.s 11
+					IL_00e0: ldarg.0
+					IL_00e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_00e6: ldloc.s 8
+					IL_00e8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_00ed: stloc.s 19
+					IL_00ef: ldloc.s 19
+					IL_00f1: stloc.s 19
+					IL_00f3: ldloc.s 19
+					IL_00f5: conv.i4
+					IL_00f6: ldloc.s 10
+					IL_00f8: conv.i4
+					IL_00f9: or
+					IL_00fa: conv.r8
+					IL_00fb: stloc.s 19
+					IL_00fd: ldarg.0
+					IL_00fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+					IL_0103: ldloc.s 8
+					IL_0105: ldloc.s 19
+					IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_010c: ldloc.s 8
+					IL_010e: ldarg.2
+					IL_010f: add
+					IL_0110: stloc.s 19
+					IL_0112: ldloc.s 19
+					IL_0114: stloc.s 8
+					IL_0116: ldloc.s 8
+					IL_0118: ldloc.s 5
+					IL_011a: cgt
+					IL_011c: ldc.i4.0
+					IL_011d: ceq
+					IL_011f: brfalse IL_0129
 
-					IL_012c: br IL_00e1
+					IL_0124: br IL_00d9
 				// end loop
 
-				IL_0131: ldloc.s 6
-				IL_0133: ldarg.2
-				IL_0134: add
-				IL_0135: stloc.s 20
-				IL_0137: ldloc.s 20
-				IL_0139: stloc.s 6
-				IL_013b: br IL_0090
+				IL_0129: ldloc.s 6
+				IL_012b: ldarg.2
+				IL_012c: add
+				IL_012d: stloc.s 19
+				IL_012f: ldloc.s 19
+				IL_0131: stloc.s 6
+				IL_0133: br IL_0088
 			// end loop
 
-			IL_0140: ldnull
-			IL_0141: ret
+			IL_0138: ldnull
+			IL_0139: ret
 
-			IL_0142: ldarg.1
-			IL_0143: stloc.s 12
-			IL_0145: ldloc.s 12
-			IL_0147: conv.i4
-			IL_0148: conv.u4
-			IL_0149: ldc.r8 5
-			IL_0152: conv.i4
-			IL_0153: shr.un
-			IL_0154: conv.r.un
-			IL_0155: stloc.s 20
-			IL_0157: ldloc.s 20
-			IL_0159: stloc.s 13
-			IL_015b: ldarg.0
-			IL_015c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_0161: ldloc.s 13
-			IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-			IL_0168: stloc.s 20
-			IL_016a: ldloc.s 20
-			IL_016c: stloc.s 14
-			// loop start (head: IL_016e)
-				IL_016e: ldloc.s 12
-				IL_0170: ldarg.3
-				IL_0171: clt
-				IL_0173: brfalse IL_0217
+			IL_013a: ldarg.1
+			IL_013b: stloc.s 12
+			IL_013d: ldloc.s 12
+			IL_013f: conv.i4
+			IL_0140: conv.u4
+			IL_0141: ldc.r8 5
+			IL_014a: conv.i4
+			IL_014b: shr.un
+			IL_014c: conv.r.un
+			IL_014d: stloc.s 19
+			IL_014f: ldloc.s 19
+			IL_0151: stloc.s 13
+			IL_0153: ldarg.0
+			IL_0154: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0159: ldloc.s 13
+			IL_015b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+			IL_0160: stloc.s 19
+			IL_0162: ldloc.s 19
+			IL_0164: stloc.s 14
+			// loop start (head: IL_0166)
+				IL_0166: ldloc.s 12
+				IL_0168: ldarg.3
+				IL_0169: clt
+				IL_016b: brfalse IL_020f
 
-				IL_0178: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
-				IL_017d: stloc.s 15
-				IL_017f: ldloc.s 12
-				IL_0181: conv.i4
-				IL_0182: ldc.r8 31
-				IL_018b: conv.i4
-				IL_018c: and
-				IL_018d: conv.r8
-				IL_018e: stloc.s 20
-				IL_0190: ldloc.s 20
-				IL_0192: stloc.s 16
-				IL_0194: ldc.r8 1
-				IL_019d: conv.i4
-				IL_019e: ldloc.s 16
-				IL_01a0: conv.i4
-				IL_01a1: shl
-				IL_01a2: conv.r8
-				IL_01a3: stloc.s 20
-				IL_01a5: ldloc.s 14
-				IL_01a7: conv.i4
-				IL_01a8: ldloc.s 20
-				IL_01aa: conv.i4
-				IL_01ab: or
-				IL_01ac: conv.r8
-				IL_01ad: stloc.s 20
-				IL_01af: ldloc.s 20
-				IL_01b1: stloc.s 14
-				IL_01b3: ldloc.s 12
-				IL_01b5: ldarg.2
-				IL_01b6: add
-				IL_01b7: stloc.s 20
-				IL_01b9: ldloc.s 20
-				IL_01bb: stloc.s 12
-				IL_01bd: ldloc.s 12
-				IL_01bf: conv.i4
-				IL_01c0: conv.u4
-				IL_01c1: ldc.r8 5
-				IL_01ca: conv.i4
-				IL_01cb: shr.un
-				IL_01cc: conv.r.un
-				IL_01cd: stloc.s 20
-				IL_01cf: ldloc.s 20
-				IL_01d1: stloc.s 17
-				IL_01d3: ldloc.s 17
-				IL_01d5: ldloc.s 13
-				IL_01d7: ceq
-				IL_01d9: ldc.i4.0
-				IL_01da: ceq
-				IL_01dc: brfalse IL_0212
+				IL_0170: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29::.ctor()
+				IL_0175: stloc.s 15
+				IL_0177: ldloc.s 12
+				IL_0179: conv.i4
+				IL_017a: ldc.r8 31
+				IL_0183: conv.i4
+				IL_0184: and
+				IL_0185: conv.r8
+				IL_0186: stloc.s 19
+				IL_0188: ldloc.s 19
+				IL_018a: stloc.s 16
+				IL_018c: ldc.r8 1
+				IL_0195: conv.i4
+				IL_0196: ldloc.s 16
+				IL_0198: conv.i4
+				IL_0199: shl
+				IL_019a: conv.r8
+				IL_019b: stloc.s 19
+				IL_019d: ldloc.s 14
+				IL_019f: conv.i4
+				IL_01a0: ldloc.s 19
+				IL_01a2: conv.i4
+				IL_01a3: or
+				IL_01a4: conv.r8
+				IL_01a5: stloc.s 19
+				IL_01a7: ldloc.s 19
+				IL_01a9: stloc.s 14
+				IL_01ab: ldloc.s 12
+				IL_01ad: ldarg.2
+				IL_01ae: add
+				IL_01af: stloc.s 19
+				IL_01b1: ldloc.s 19
+				IL_01b3: stloc.s 12
+				IL_01b5: ldloc.s 12
+				IL_01b7: conv.i4
+				IL_01b8: conv.u4
+				IL_01b9: ldc.r8 5
+				IL_01c2: conv.i4
+				IL_01c3: shr.un
+				IL_01c4: conv.r.un
+				IL_01c5: stloc.s 19
+				IL_01c7: ldloc.s 19
+				IL_01c9: stloc.s 17
+				IL_01cb: ldloc.s 17
+				IL_01cd: ldloc.s 13
+				IL_01cf: ceq
+				IL_01d1: ldc.i4.0
+				IL_01d2: ceq
+				IL_01d4: brfalse IL_020a
 
-				IL_01e1: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
-				IL_01e6: stloc.s 18
-				IL_01e8: ldarg.0
-				IL_01e9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_01ee: ldloc.s 13
-				IL_01f0: ldloc.s 14
-				IL_01f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-				IL_01f7: ldloc.s 17
-				IL_01f9: stloc.s 20
-				IL_01fb: ldloc.s 20
-				IL_01fd: stloc.s 13
-				IL_01ff: ldarg.0
-				IL_0200: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-				IL_0205: ldloc.s 13
-				IL_0207: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-				IL_020c: stloc.s 20
-				IL_020e: ldloc.s 20
-				IL_0210: stloc.s 14
+				IL_01d9: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/Block_L86C29/Block_L92C36::.ctor()
+				IL_01de: stloc.s 18
+				IL_01e0: ldarg.0
+				IL_01e1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_01e6: ldloc.s 13
+				IL_01e8: ldloc.s 14
+				IL_01ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+				IL_01ef: ldloc.s 17
+				IL_01f1: stloc.s 19
+				IL_01f3: ldloc.s 19
+				IL_01f5: stloc.s 13
+				IL_01f7: ldarg.0
+				IL_01f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+				IL_01fd: ldloc.s 13
+				IL_01ff: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+				IL_0204: stloc.s 19
+				IL_0206: ldloc.s 19
+				IL_0208: stloc.s 14
 
-				IL_0212: br IL_016e
+				IL_020a: br IL_0166
 			// end loop
 
-			IL_0217: ldarg.0
-			IL_0218: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
-			IL_021d: ldloc.s 13
-			IL_021f: ldloc.s 14
-			IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-			IL_0226: ldnull
-			IL_0227: ret
+			IL_020f: ldarg.0
+			IL_0210: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::wordArray
+			IL_0215: ldloc.s 13
+			IL_0217: ldloc.s 14
+			IL_0219: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+			IL_021e: ldnull
+			IL_021f: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -1244,7 +1240,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d40
+			// Method begins at RVA 0x2d38
 			// Header size: 12
 			// Code size: 79 (0x4f)
 			.maxstack 8
@@ -1358,7 +1354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33c9
+				// Method begins at RVA 0x33b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1378,7 +1374,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33d2
+				// Method begins at RVA 0x33c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1402,7 +1398,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33e4
+					// Method begins at RVA 0x33d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1420,7 +1416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33db
+				// Method begins at RVA 0x33cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1440,7 +1436,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33ed
+				// Method begins at RVA 0x33dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1468,7 +1464,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3408
+						// Method begins at RVA 0x33f8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1486,7 +1482,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33ff
+					// Method begins at RVA 0x33ef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1504,7 +1500,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33f6
+				// Method begins at RVA 0x33e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1524,7 +1520,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3411
+				// Method begins at RVA 0x3401
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1548,7 +1544,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3423
+					// Method begins at RVA 0x3413
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1566,7 +1562,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x341a
+				// Method begins at RVA 0x340a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1590,7 +1586,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3435
+					// Method begins at RVA 0x3425
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1608,7 +1604,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x342c
+				// Method begins at RVA 0x341c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1695,9 +1691,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d9c
+			// Method begins at RVA 0x2d94
 			// Header size: 12
-			// Code size: 314 (0x13a)
+			// Code size: 306 (0x132)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -1707,8 +1703,7 @@
 				[4] float64,
 				[5] float64,
 				[6] object,
-				[7] object,
-				[8] object
+				[7] object
 			)
 
 			IL_0000: ldarg.0
@@ -1730,7 +1725,7 @@
 				IL_0031: ldloc.1
 				IL_0032: ldloc.0
 				IL_0033: clt
-				IL_0035: brfalse IL_0138
+				IL_0035: brfalse IL_0130
 
 				IL_003a: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/Block_L136C2::.ctor()
 				IL_003f: stloc.2
@@ -1758,74 +1753,70 @@
 				IL_0072: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
 				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_007c: stloc.s 7
-				IL_007e: ldloc.s 4
-				IL_0080: box [System.Runtime]System.Double
-				IL_0085: stloc.s 6
-				IL_0087: ldloc.3
-				IL_0088: box [System.Runtime]System.Double
-				IL_008d: stloc.s 8
-				IL_008f: ldloc.s 7
-				IL_0091: isinst Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_0096: dup
-				IL_0097: brfalse IL_00b0
+				IL_007e: ldloc.s 7
+				IL_0080: isinst Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+				IL_0085: dup
+				IL_0086: brfalse IL_009f
 
-				IL_009c: ldloc.s 4
-				IL_009e: ldloc.3
-				IL_009f: ldarg.0
-				IL_00a0: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
-				IL_00a5: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
-				IL_00aa: pop
-				IL_00ab: br IL_00cd
+				IL_008b: ldloc.s 4
+				IL_008d: ldloc.3
+				IL_008e: ldarg.0
+				IL_008f: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
+				IL_0094: callvirt instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
+				IL_0099: pop
+				IL_009a: br IL_00c5
 
-				IL_00b0: pop
-				IL_00b1: ldloc.s 7
-				IL_00b3: ldstr "setBitsTrue"
-				IL_00b8: ldloc.s 6
-				IL_00ba: ldloc.s 8
-				IL_00bc: ldarg.0
-				IL_00bd: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
-				IL_00c2: box [System.Runtime]System.Double
-				IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_00cc: pop
+				IL_009f: pop
+				IL_00a0: ldloc.s 7
+				IL_00a2: ldstr "setBitsTrue"
+				IL_00a7: ldloc.s 4
+				IL_00a9: box [System.Runtime]System.Double
+				IL_00ae: ldloc.3
+				IL_00af: box [System.Runtime]System.Double
+				IL_00b4: ldarg.0
+				IL_00b5: ldfld float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::sieveSizeInBits
+				IL_00ba: box [System.Runtime]System.Double
+				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+				IL_00c4: pop
 
-				IL_00cd: ldarg.0
-				IL_00ce: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
-				IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00d8: stloc.s 7
-				IL_00da: ldloc.s 7
-				IL_00dc: isinst Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_00e1: dup
-				IL_00e2: brfalse IL_0108
+				IL_00c5: ldarg.0
+				IL_00c6: ldfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::bitArray
+				IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00d0: stloc.s 7
+				IL_00d2: ldloc.s 7
+				IL_00d4: isinst Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+				IL_00d9: dup
+				IL_00da: brfalse IL_0100
 
-				IL_00e7: ldloc.1
-				IL_00e8: ldc.r8 1
-				IL_00f1: add
-				IL_00f2: box [System.Runtime]System.Double
-				IL_00f7: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(object)
-				IL_00fc: box [System.Runtime]System.Double
-				IL_0101: stloc.s 7
-				IL_0103: br IL_0127
+				IL_00df: ldloc.1
+				IL_00e0: ldc.r8 1
+				IL_00e9: add
+				IL_00ea: box [System.Runtime]System.Double
+				IL_00ef: callvirt instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(object)
+				IL_00f4: box [System.Runtime]System.Double
+				IL_00f9: stloc.s 7
+				IL_00fb: br IL_011f
 
-				IL_0108: pop
-				IL_0109: ldloc.s 7
-				IL_010b: ldstr "searchBitFalse"
-				IL_0110: ldloc.1
-				IL_0111: ldc.r8 1
-				IL_011a: add
-				IL_011b: box [System.Runtime]System.Double
-				IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0125: stloc.s 7
+				IL_0100: pop
+				IL_0101: ldloc.s 7
+				IL_0103: ldstr "searchBitFalse"
+				IL_0108: ldloc.1
+				IL_0109: ldc.r8 1
+				IL_0112: add
+				IL_0113: box [System.Runtime]System.Double
+				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_011d: stloc.s 7
 
-				IL_0127: ldloc.s 7
-				IL_0129: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_012e: stloc.s 5
-				IL_0130: ldloc.s 5
-				IL_0132: stloc.1
-				IL_0133: br IL_0031
+				IL_011f: ldloc.s 7
+				IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0126: stloc.s 5
+				IL_0128: ldloc.s 5
+				IL_012a: stloc.1
+				IL_012b: br IL_0031
 			// end loop
 
-			IL_0138: ldarg.0
-			IL_0139: ret
+			IL_0130: ldarg.0
+			IL_0131: ret
 		} // end of method PrimeSieve::runSieve
 
 		.method public hidebysig 
@@ -1834,7 +1825,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x316c
+			// Method begins at RVA 0x315c
 			// Header size: 12
 			// Code size: 166 (0xa6)
 			.maxstack 8
@@ -1920,7 +1911,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3220
+			// Method begins at RVA 0x3210
 			// Header size: 12
 			// Code size: 260 (0x104)
 			.maxstack 8
@@ -2038,7 +2029,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ee4
+			// Method begins at RVA 0x2ed4
 			// Header size: 12
 			// Code size: 633 (0x279)
 			.maxstack 8
@@ -2282,7 +2273,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3330
+			// Method begins at RVA 0x3320
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2952,7 +2943,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3459
+		// Method begins at RVA 0x3449
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_FreezeSeal_PreventExtensions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_FreezeSeal_PreventExtensions.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d5
+				// Method begins at RVA 0x25d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25de
+				// Method begins at RVA 0x25da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -58,7 +58,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e7
+				// Method begins at RVA 0x25e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -78,7 +78,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f0
+				// Method begins at RVA 0x25ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +98,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f9
+				// Method begins at RVA 0x25f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2602
+				// Method begins at RVA 0x25fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -138,7 +138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260b
+				// Method begins at RVA 0x2607
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2614
+				// Method begins at RVA 0x2610
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25cc
+			// Method begins at RVA 0x25c8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1340 (0x53c)
+		// Code size: 1334 (0x536)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope,
@@ -443,252 +443,248 @@
 			IL_0279: ldstr "x"
 			IL_027e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
 			IL_0283: stloc.s 25
-			IL_0285: ldloc.s 25
-			IL_0287: pop
-			IL_0288: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_028d: ldstr "sealed_delete=ok"
-			IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0297: pop
-			IL_0298: leave IL_0304
+			IL_0285: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_028a: ldstr "sealed_delete=ok"
+			IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0294: pop
+			IL_0295: leave IL_0301
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_029d: stloc.s 9
-			IL_029f: ldloc.s 9
-			IL_02a1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02a6: dup
-			IL_02a7: brtrue IL_02bd
+			IL_029a: stloc.s 9
+			IL_029c: ldloc.s 9
+			IL_029e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_02a3: dup
+			IL_02a4: brtrue IL_02ba
 
-			IL_02ac: pop
-			IL_02ad: ldloc.s 9
-			IL_02af: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02b4: dup
-			IL_02b5: brtrue IL_02c9
+			IL_02a9: pop
+			IL_02aa: ldloc.s 9
+			IL_02ac: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_02b1: dup
+			IL_02b2: brtrue IL_02c6
 
-			IL_02ba: pop
-			IL_02bb: rethrow
+			IL_02b7: pop
+			IL_02b8: rethrow
 
-			IL_02bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02c2: stloc.s 10
-			IL_02c4: br IL_02cb
+			IL_02ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_02bf: stloc.s 10
+			IL_02c1: br IL_02c8
 
-			IL_02c9: stloc.s 10
+			IL_02c6: stloc.s 10
 
-			IL_02cb: ldloc.s 10
-			IL_02cd: stloc.s 28
-			IL_02cf: ldloc.s 28
-			IL_02d1: stloc.s 11
-			IL_02d3: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L26C12::.ctor()
-			IL_02d8: stloc.s 12
-			IL_02da: ldstr "sealed_delete="
-			IL_02df: ldloc.s 11
-			IL_02e1: ldstr "name"
-			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02f0: stloc.s 27
-			IL_02f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02f7: ldloc.s 27
-			IL_02f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02fe: pop
-			IL_02ff: leave IL_0304
+			IL_02c8: ldloc.s 10
+			IL_02ca: stloc.s 28
+			IL_02cc: ldloc.s 28
+			IL_02ce: stloc.s 11
+			IL_02d0: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L26C12::.ctor()
+			IL_02d5: stloc.s 12
+			IL_02d7: ldstr "sealed_delete="
+			IL_02dc: ldloc.s 11
+			IL_02de: ldstr "name"
+			IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ed: stloc.s 27
+			IL_02ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f4: ldloc.s 27
+			IL_02f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02fb: pop
+			IL_02fc: leave IL_0301
 		} // end handler
 
-		IL_0304: ldloc.s 7
-		IL_0306: ldstr "x"
-		IL_030b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0310: stloc.s 25
-		IL_0312: ldloc.s 25
-		IL_0314: box [System.Runtime]System.Boolean
-		IL_0319: stloc.s 26
-		IL_031b: ldstr "sealed_has_x="
-		IL_0320: ldloc.s 26
-		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0327: stloc.s 27
-		IL_0329: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032e: ldloc.s 27
-		IL_0330: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0335: pop
-		IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_033b: dup
-		IL_033c: ldstr "y"
-		IL_0341: ldc.r8 1
-		IL_034a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_034f: stloc.s 13
-		IL_0351: ldloc.s 13
-		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_0358: pop
-		IL_0359: ldloc.s 13
-		IL_035b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_0360: stloc.s 25
-		IL_0362: ldloc.s 25
-		IL_0364: box [System.Runtime]System.Boolean
-		IL_0369: stloc.s 26
-		IL_036b: ldstr "frozen="
-		IL_0370: ldloc.s 26
-		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0377: stloc.s 27
-		IL_0379: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_037e: ldloc.s 27
-		IL_0380: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0385: pop
-		IL_0386: ldloc.s 13
-		IL_0388: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
-		IL_038d: stloc.s 25
-		IL_038f: ldloc.s 25
-		IL_0391: box [System.Runtime]System.Boolean
-		IL_0396: stloc.s 26
-		IL_0398: ldstr "frozen_sealed="
-		IL_039d: ldloc.s 26
-		IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_03a4: stloc.s 27
-		IL_03a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ab: ldloc.s 27
-		IL_03ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03b2: pop
+		IL_0301: ldloc.s 7
+		IL_0303: ldstr "x"
+		IL_0308: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_030d: stloc.s 25
+		IL_030f: ldloc.s 25
+		IL_0311: box [System.Runtime]System.Boolean
+		IL_0316: stloc.s 26
+		IL_0318: ldstr "sealed_has_x="
+		IL_031d: ldloc.s 26
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0324: stloc.s 27
+		IL_0326: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_032b: ldloc.s 27
+		IL_032d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0332: pop
+		IL_0333: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0338: dup
+		IL_0339: ldstr "y"
+		IL_033e: ldc.r8 1
+		IL_0347: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_034c: stloc.s 13
+		IL_034e: ldloc.s 13
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_0355: pop
+		IL_0356: ldloc.s 13
+		IL_0358: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_035d: stloc.s 25
+		IL_035f: ldloc.s 25
+		IL_0361: box [System.Runtime]System.Boolean
+		IL_0366: stloc.s 26
+		IL_0368: ldstr "frozen="
+		IL_036d: ldloc.s 26
+		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0374: stloc.s 27
+		IL_0376: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_037b: ldloc.s 27
+		IL_037d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0382: pop
+		IL_0383: ldloc.s 13
+		IL_0385: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isSealed(object)
+		IL_038a: stloc.s 25
+		IL_038c: ldloc.s 25
+		IL_038e: box [System.Runtime]System.Boolean
+		IL_0393: stloc.s 26
+		IL_0395: ldstr "frozen_sealed="
+		IL_039a: ldloc.s 26
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_03a1: stloc.s 27
+		IL_03a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03a8: ldloc.s 27
+		IL_03aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03af: pop
 		.try
 		{
-			IL_03b3: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L35C4::.ctor()
-			IL_03b8: stloc.s 14
-			IL_03ba: ldloc.s 13
-			IL_03bc: ldstr "y"
-			IL_03c1: ldc.r8 5
-			IL_03ca: ldc.i4.1
-			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_03d0: pop
-			IL_03d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03d6: ldstr "frozen_write=ok"
-			IL_03db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03e0: pop
-			IL_03e1: leave IL_044d
+			IL_03b0: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L35C4::.ctor()
+			IL_03b5: stloc.s 14
+			IL_03b7: ldloc.s 13
+			IL_03b9: ldstr "y"
+			IL_03be: ldc.r8 5
+			IL_03c7: ldc.i4.1
+			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_03cd: pop
+			IL_03ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03d3: ldstr "frozen_write=ok"
+			IL_03d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03dd: pop
+			IL_03de: leave IL_044a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03e6: stloc.s 15
-			IL_03e8: ldloc.s 15
-			IL_03ea: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03ef: dup
-			IL_03f0: brtrue IL_0406
+			IL_03e3: stloc.s 15
+			IL_03e5: ldloc.s 15
+			IL_03e7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03ec: dup
+			IL_03ed: brtrue IL_0403
 
-			IL_03f5: pop
-			IL_03f6: ldloc.s 15
-			IL_03f8: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03fd: dup
-			IL_03fe: brtrue IL_0412
+			IL_03f2: pop
+			IL_03f3: ldloc.s 15
+			IL_03f5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03fa: dup
+			IL_03fb: brtrue IL_040f
 
-			IL_0403: pop
-			IL_0404: rethrow
+			IL_0400: pop
+			IL_0401: rethrow
 
-			IL_0406: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_040b: stloc.s 16
-			IL_040d: br IL_0414
+			IL_0403: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0408: stloc.s 16
+			IL_040a: br IL_0411
 
-			IL_0412: stloc.s 16
+			IL_040f: stloc.s 16
 
-			IL_0414: ldloc.s 16
-			IL_0416: stloc.s 28
-			IL_0418: ldloc.s 28
-			IL_041a: stloc.s 17
-			IL_041c: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L38C12::.ctor()
-			IL_0421: stloc.s 18
-			IL_0423: ldstr "frozen_write="
-			IL_0428: ldloc.s 17
-			IL_042a: ldstr "name"
-			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0439: stloc.s 27
-			IL_043b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0440: ldloc.s 27
-			IL_0442: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0447: pop
-			IL_0448: leave IL_044d
+			IL_0411: ldloc.s 16
+			IL_0413: stloc.s 28
+			IL_0415: ldloc.s 28
+			IL_0417: stloc.s 17
+			IL_0419: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L38C12::.ctor()
+			IL_041e: stloc.s 18
+			IL_0420: ldstr "frozen_write="
+			IL_0425: ldloc.s 17
+			IL_0427: ldstr "name"
+			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0436: stloc.s 27
+			IL_0438: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_043d: ldloc.s 27
+			IL_043f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0444: pop
+			IL_0445: leave IL_044a
 		} // end handler
 
-		IL_044d: ldstr "frozen_value="
-		IL_0452: ldloc.s 13
-		IL_0454: ldstr "y"
-		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0463: stloc.s 27
-		IL_0465: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_046a: ldloc.s 27
-		IL_046c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0471: pop
+		IL_044a: ldstr "frozen_value="
+		IL_044f: ldloc.s 13
+		IL_0451: ldstr "y"
+		IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0460: stloc.s 27
+		IL_0462: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0467: ldloc.s 27
+		IL_0469: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_046e: pop
 		.try
 		{
-			IL_0472: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L42C4::.ctor()
-			IL_0477: stloc.s 19
-			IL_0479: ldloc.s 13
-			IL_047b: ldstr "y"
-			IL_0480: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-			IL_0485: stloc.s 25
-			IL_0487: ldloc.s 25
-			IL_0489: pop
-			IL_048a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_048f: ldstr "frozen_delete=ok"
-			IL_0494: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0499: pop
-			IL_049a: leave IL_0506
+			IL_046f: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L42C4::.ctor()
+			IL_0474: stloc.s 19
+			IL_0476: ldloc.s 13
+			IL_0478: ldstr "y"
+			IL_047d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_0482: stloc.s 25
+			IL_0484: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0489: ldstr "frozen_delete=ok"
+			IL_048e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0493: pop
+			IL_0494: leave IL_0500
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_049f: stloc.s 20
-			IL_04a1: ldloc.s 20
-			IL_04a3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_04a8: dup
-			IL_04a9: brtrue IL_04bf
+			IL_0499: stloc.s 20
+			IL_049b: ldloc.s 20
+			IL_049d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04a2: dup
+			IL_04a3: brtrue IL_04b9
 
-			IL_04ae: pop
-			IL_04af: ldloc.s 20
-			IL_04b1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04b6: dup
-			IL_04b7: brtrue IL_04cb
+			IL_04a8: pop
+			IL_04a9: ldloc.s 20
+			IL_04ab: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04b0: dup
+			IL_04b1: brtrue IL_04c5
 
-			IL_04bc: pop
-			IL_04bd: rethrow
+			IL_04b6: pop
+			IL_04b7: rethrow
 
-			IL_04bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04c4: stloc.s 21
-			IL_04c6: br IL_04cd
+			IL_04b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04be: stloc.s 21
+			IL_04c0: br IL_04c7
 
-			IL_04cb: stloc.s 21
+			IL_04c5: stloc.s 21
 
-			IL_04cd: ldloc.s 21
-			IL_04cf: stloc.s 28
-			IL_04d1: ldloc.s 28
-			IL_04d3: stloc.s 22
-			IL_04d5: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L45C12::.ctor()
-			IL_04da: stloc.s 23
-			IL_04dc: ldstr "frozen_delete="
-			IL_04e1: ldloc.s 22
-			IL_04e3: ldstr "name"
-			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04ed: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04f2: stloc.s 27
-			IL_04f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04f9: ldloc.s 27
-			IL_04fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0500: pop
-			IL_0501: leave IL_0506
+			IL_04c7: ldloc.s 21
+			IL_04c9: stloc.s 28
+			IL_04cb: ldloc.s 28
+			IL_04cd: stloc.s 22
+			IL_04cf: newobj instance void Modules.Object_Integrity_FreezeSeal_PreventExtensions/Scope/Block_L45C12::.ctor()
+			IL_04d4: stloc.s 23
+			IL_04d6: ldstr "frozen_delete="
+			IL_04db: ldloc.s 22
+			IL_04dd: ldstr "name"
+			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04ec: stloc.s 27
+			IL_04ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04f3: ldloc.s 27
+			IL_04f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04fa: pop
+			IL_04fb: leave IL_0500
 		} // end handler
 
-		IL_0506: ldloc.s 13
-		IL_0508: ldstr "y"
-		IL_050d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0512: stloc.s 25
-		IL_0514: ldloc.s 25
-		IL_0516: box [System.Runtime]System.Boolean
-		IL_051b: stloc.s 26
-		IL_051d: ldstr "frozen_has_y="
-		IL_0522: ldloc.s 26
-		IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0529: stloc.s 27
-		IL_052b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0530: ldloc.s 27
-		IL_0532: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0537: pop
-		IL_0538: ldnull
-		IL_0539: stloc.s 24
-		IL_053b: ret
+		IL_0500: ldloc.s 13
+		IL_0502: ldstr "y"
+		IL_0507: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_050c: stloc.s 25
+		IL_050e: ldloc.s 25
+		IL_0510: box [System.Runtime]System.Boolean
+		IL_0515: stloc.s 26
+		IL_0517: ldstr "frozen_has_y="
+		IL_051c: ldloc.s 26
+		IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0523: stloc.s 27
+		IL_0525: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_052a: ldloc.s 27
+		IL_052c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0531: pop
+		IL_0532: ldnull
+		IL_0533: stloc.s 24
+		IL_0535: ret
 	} // end of method Object_Integrity_FreezeSeal_PreventExtensions::__js_module_init__
 
 } // end of class Modules.Object_Integrity_FreezeSeal_PreventExtensions
@@ -700,7 +696,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x261d
+		// Method begins at RVA 0x2619
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
+﻿// IL code: Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a5b
+				// Method begins at RVA 0x2a47
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -38,7 +38,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a64
+				// Method begins at RVA 0x2a50
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a76
+					// Method begins at RVA 0x2a62
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a6d
+				// Method begins at RVA 0x2a59
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a91
+						// Method begins at RVA 0x2a7d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -132,7 +132,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2aa3
+							// Method begins at RVA 0x2a8f
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -150,7 +150,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a9a
+						// Method begins at RVA 0x2a86
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -168,7 +168,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a88
+					// Method begins at RVA 0x2a74
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -196,7 +196,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2abe
+							// Method begins at RVA 0x2aaa
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -214,7 +214,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ab5
+						// Method begins at RVA 0x2aa1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -232,7 +232,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aac
+					// Method begins at RVA 0x2a98
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -250,7 +250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a7f
+				// Method begins at RVA 0x2a6b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ad0
+					// Method begins at RVA 0x2abc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -292,7 +292,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac7
+				// Method begins at RVA 0x2ab3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -312,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad9
+				// Method begins at RVA 0x2ac5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -336,7 +336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2aeb
+					// Method begins at RVA 0x2ad7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -354,7 +354,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ae2
+				// Method begins at RVA 0x2ace
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -431,7 +431,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x296c
+			// Method begins at RVA 0x2958
 			// Header size: 12
 			// Code size: 174 (0xae)
 			.maxstack 8
@@ -542,7 +542,7 @@
 			)
 			// Method begins at RVA 0x2730
 			// Header size: 12
-			// Code size: 450 (0x1c2)
+			// Code size: 433 (0x1b1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28,
@@ -559,8 +559,7 @@
 				[11] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7,
 				[12] float64,
 				[13] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67,
-				[14] float64,
-				[15] object
+				[14] float64
 			)
 
 			IL_0000: ldarg.0
@@ -576,7 +575,7 @@
 			IL_001f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0024: ldloc.s 14
 			IL_0026: cgt
-			IL_0028: brfalse IL_017d
+			IL_0028: brfalse IL_0175
 
 			IL_002d: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28::.ctor()
 			IL_0032: stloc.0
@@ -593,7 +592,7 @@
 			IL_004f: ldarg.3
 			IL_0050: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0055: cgt
-			IL_0057: brfalse IL_00a1
+			IL_0057: brfalse IL_0099
 
 			IL_005c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Block_L22C39::.ctor()
 			IL_0061: stloc.2
@@ -605,159 +604,153 @@
 				IL_006a: ldarg.3
 				IL_006b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0070: clt
-				IL_0072: brfalse IL_009f
+				IL_0072: brfalse IL_0097
 
 				IL_0077: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Block_L20C28/Scope_For_L23C9/Block_L23C69::.ctor()
 				IL_007c: stloc.s 4
-				IL_007e: ldloc.3
-				IL_007f: box [System.Runtime]System.Double
-				IL_0084: stloc.s 15
-				IL_0086: ldarg.0
-				IL_0087: ldloc.3
-				IL_0088: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_008d: pop
-				IL_008e: ldloc.3
-				IL_008f: ldarg.2
-				IL_0090: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_0095: stloc.s 14
-				IL_0097: ldloc.s 14
-				IL_0099: stloc.3
-				IL_009a: br IL_0069
+				IL_007e: ldarg.0
+				IL_007f: ldloc.3
+				IL_0080: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_0085: pop
+				IL_0086: ldloc.3
+				IL_0087: ldarg.2
+				IL_0088: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_008d: stloc.s 14
+				IL_008f: ldloc.s 14
+				IL_0091: stloc.3
+				IL_0092: br IL_0069
 			// end loop
 
-			IL_009f: ldnull
-			IL_00a0: ret
+			IL_0097: ldnull
+			IL_0098: ret
 
-			IL_00a1: ldarg.3
-			IL_00a2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a7: conv.i4
-			IL_00a8: conv.u4
-			IL_00a9: ldc.r8 5
-			IL_00b2: conv.i4
-			IL_00b3: shr.un
-			IL_00b4: conv.r.un
-			IL_00b5: stloc.s 14
-			IL_00b7: ldloc.s 14
-			IL_00b9: stloc.s 5
-			IL_00bb: ldarg.1
-			IL_00bc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c1: stloc.s 6
-			// loop start (head: IL_00c3)
-				IL_00c3: ldloc.s 6
-				IL_00c5: ldloc.1
-				IL_00c6: clt
-				IL_00c8: brfalse IL_017b
+			IL_0099: ldarg.3
+			IL_009a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009f: conv.i4
+			IL_00a0: conv.u4
+			IL_00a1: ldc.r8 5
+			IL_00aa: conv.i4
+			IL_00ab: shr.un
+			IL_00ac: conv.r.un
+			IL_00ad: stloc.s 14
+			IL_00af: ldloc.s 14
+			IL_00b1: stloc.s 5
+			IL_00b3: ldarg.1
+			IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00b9: stloc.s 6
+			// loop start (head: IL_00bb)
+				IL_00bb: ldloc.s 6
+				IL_00bd: ldloc.1
+				IL_00be: clt
+				IL_00c0: brfalse IL_0173
 
-				IL_00cd: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75::.ctor()
-				IL_00d2: stloc.s 7
-				IL_00d4: ldloc.s 6
-				IL_00d6: conv.i4
-				IL_00d7: conv.u4
-				IL_00d8: ldc.r8 5
-				IL_00e1: conv.i4
-				IL_00e2: shr.un
-				IL_00e3: conv.r.un
-				IL_00e4: stloc.s 14
-				IL_00e6: ldloc.s 14
-				IL_00e8: stloc.s 8
-				IL_00ea: ldloc.s 6
-				IL_00ec: conv.i4
-				IL_00ed: ldc.r8 31
-				IL_00f6: conv.i4
-				IL_00f7: and
-				IL_00f8: conv.r8
-				IL_00f9: stloc.s 14
-				IL_00fb: ldloc.s 14
-				IL_00fd: stloc.s 9
-				IL_00ff: ldc.r8 1
-				IL_0108: conv.i4
-				IL_0109: ldloc.s 9
-				IL_010b: conv.i4
-				IL_010c: shl
-				IL_010d: conv.r8
-				IL_010e: stloc.s 14
-				IL_0110: ldloc.s 14
-				IL_0112: stloc.s 10
-				// loop start (head: IL_0114)
-					IL_0114: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7::.ctor()
-					IL_0119: stloc.s 11
-					IL_011b: ldarg.0
-					IL_011c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_0121: ldloc.s 8
-					IL_0123: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
-					IL_0128: stloc.s 14
-					IL_012a: ldloc.s 14
-					IL_012c: stloc.s 14
-					IL_012e: ldloc.s 14
-					IL_0130: conv.i4
-					IL_0131: ldloc.s 10
-					IL_0133: conv.i4
-					IL_0134: or
-					IL_0135: conv.r8
-					IL_0136: stloc.s 14
-					IL_0138: ldarg.0
-					IL_0139: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
-					IL_013e: ldloc.s 8
-					IL_0140: ldloc.s 14
-					IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
-					IL_0147: ldloc.s 8
-					IL_0149: ldarg.2
-					IL_014a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-					IL_014f: stloc.s 14
-					IL_0151: ldloc.s 14
-					IL_0153: stloc.s 8
-					IL_0155: ldloc.s 8
-					IL_0157: ldloc.s 5
-					IL_0159: cgt
-					IL_015b: ldc.i4.0
-					IL_015c: ceq
-					IL_015e: brfalse IL_0168
+				IL_00c5: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75::.ctor()
+				IL_00ca: stloc.s 7
+				IL_00cc: ldloc.s 6
+				IL_00ce: conv.i4
+				IL_00cf: conv.u4
+				IL_00d0: ldc.r8 5
+				IL_00d9: conv.i4
+				IL_00da: shr.un
+				IL_00db: conv.r.un
+				IL_00dc: stloc.s 14
+				IL_00de: ldloc.s 14
+				IL_00e0: stloc.s 8
+				IL_00e2: ldloc.s 6
+				IL_00e4: conv.i4
+				IL_00e5: ldc.r8 31
+				IL_00ee: conv.i4
+				IL_00ef: and
+				IL_00f0: conv.r8
+				IL_00f1: stloc.s 14
+				IL_00f3: ldloc.s 14
+				IL_00f5: stloc.s 9
+				IL_00f7: ldc.r8 1
+				IL_0100: conv.i4
+				IL_0101: ldloc.s 9
+				IL_0103: conv.i4
+				IL_0104: shl
+				IL_0105: conv.r8
+				IL_0106: stloc.s 14
+				IL_0108: ldloc.s 14
+				IL_010a: stloc.s 10
+				// loop start (head: IL_010c)
+					IL_010c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/Scope_For_L30C8/Block_L30C75/Block_L34C7::.ctor()
+					IL_0111: stloc.s 11
+					IL_0113: ldarg.0
+					IL_0114: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_0119: ldloc.s 8
+					IL_011b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::get_Item(float64)
+					IL_0120: stloc.s 14
+					IL_0122: ldloc.s 14
+					IL_0124: stloc.s 14
+					IL_0126: ldloc.s 14
+					IL_0128: conv.i4
+					IL_0129: ldloc.s 10
+					IL_012b: conv.i4
+					IL_012c: or
+					IL_012d: conv.r8
+					IL_012e: stloc.s 14
+					IL_0130: ldarg.0
+					IL_0131: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Int32Array Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::wordArray
+					IL_0136: ldloc.s 8
+					IL_0138: ldloc.s 14
+					IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::set_Item(float64, float64)
+					IL_013f: ldloc.s 8
+					IL_0141: ldarg.2
+					IL_0142: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+					IL_0147: stloc.s 14
+					IL_0149: ldloc.s 14
+					IL_014b: stloc.s 8
+					IL_014d: ldloc.s 8
+					IL_014f: ldloc.s 5
+					IL_0151: cgt
+					IL_0153: ldc.i4.0
+					IL_0154: ceq
+					IL_0156: brfalse IL_0160
 
-					IL_0163: br IL_0114
+					IL_015b: br IL_010c
 				// end loop
 
-				IL_0168: ldloc.s 6
-				IL_016a: ldarg.2
-				IL_016b: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_0170: stloc.s 14
-				IL_0172: ldloc.s 14
-				IL_0174: stloc.s 6
-				IL_0176: br IL_00c3
+				IL_0160: ldloc.s 6
+				IL_0162: ldarg.2
+				IL_0163: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_0168: stloc.s 14
+				IL_016a: ldloc.s 14
+				IL_016c: stloc.s 6
+				IL_016e: br IL_00bb
 			// end loop
 
-			IL_017b: ldnull
-			IL_017c: ret
+			IL_0173: ldnull
+			IL_0174: ret
 
-			IL_017d: ldarg.1
-			IL_017e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0183: stloc.s 12
-			// loop start (head: IL_0185)
-				IL_0185: ldloc.s 12
-				IL_0187: ldarg.3
-				IL_0188: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_018d: clt
-				IL_018f: brfalse IL_01c0
+			IL_0175: ldarg.1
+			IL_0176: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_017b: stloc.s 12
+			// loop start (head: IL_017d)
+				IL_017d: ldloc.s 12
+				IL_017f: ldarg.3
+				IL_0180: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0185: clt
+				IL_0187: brfalse IL_01af
 
-				IL_0194: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67::.ctor()
-				IL_0199: stloc.s 13
-				IL_019b: ldloc.s 12
-				IL_019d: box [System.Runtime]System.Double
-				IL_01a2: stloc.s 15
-				IL_01a4: ldarg.0
-				IL_01a5: ldloc.s 12
-				IL_01a7: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_01ac: pop
-				IL_01ad: ldloc.s 12
-				IL_01af: ldarg.2
-				IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_01b5: stloc.s 14
-				IL_01b7: ldloc.s 14
-				IL_01b9: stloc.s 12
-				IL_01bb: br IL_0185
+				IL_018c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L43C7/Block_L43C67::.ctor()
+				IL_0191: stloc.s 13
+				IL_0193: ldarg.0
+				IL_0194: ldloc.s 12
+				IL_0196: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_019b: pop
+				IL_019c: ldloc.s 12
+				IL_019e: ldarg.2
+				IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_01a4: stloc.s 14
+				IL_01a6: ldloc.s 14
+				IL_01a8: stloc.s 12
+				IL_01aa: br IL_017d
 			// end loop
 
-			IL_01c0: ldnull
-			IL_01c1: ret
+			IL_01af: ldnull
+			IL_01b0: ret
 		} // end of method BitArray::setBitsTrue
 
 		.method public hidebysig 
@@ -770,15 +763,14 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2900
+			// Method begins at RVA 0x28f0
 			// Header size: 12
-			// Code size: 96 (0x60)
+			// Code size: 89 (0x59)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L50C7/Block_L50C67,
-				[2] object,
-				[3] float64
+				[2] float64
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -810,28 +802,25 @@
 				IL_002d: ldarg.3
 				IL_002e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0033: clt
-				IL_0035: brfalse IL_005e
+				IL_0035: brfalse IL_0057
 
 				IL_003a: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_For_L50C7/Block_L50C67::.ctor()
 				IL_003f: stloc.1
-				IL_0040: ldloc.0
-				IL_0041: box [System.Runtime]System.Double
-				IL_0046: stloc.2
-				IL_0047: ldarg.0
+				IL_0040: ldarg.0
+				IL_0041: ldloc.0
+				IL_0042: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_0047: pop
 				IL_0048: ldloc.0
-				IL_0049: callvirt instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_004e: pop
-				IL_004f: ldloc.0
-				IL_0050: ldarg.2
-				IL_0051: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
-				IL_0056: stloc.3
-				IL_0057: ldloc.3
-				IL_0058: stloc.0
-				IL_0059: br IL_002c
+				IL_0049: ldarg.2
+				IL_004a: call float64 [JavaScriptRuntime]JavaScriptRuntime.Operators::AddAndToNumber(float64, object)
+				IL_004f: stloc.2
+				IL_0050: ldloc.2
+				IL_0051: stloc.0
+				IL_0052: br IL_002c
 			// end loop
 
-			IL_005e: ldnull
-			IL_005f: ret
+			IL_0057: ldnull
+			IL_0058: ret
 		} // end of method BitArray::setBitsTrue_Naive
 
 	} // end of class BitArray
@@ -856,7 +845,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b0f
+				// Method begins at RVA 0x2afb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -881,7 +870,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a26
+			// Method begins at RVA 0x2a12
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -921,7 +910,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b06
+					// Method begins at RVA 0x2af2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -939,7 +928,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2afd
+				// Method begins at RVA 0x2ae9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -957,7 +946,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2af4
+			// Method begins at RVA 0x2ae0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1578,7 +1567,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b18
+		// Method begins at RVA 0x2b04
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinus_MemberAndIndexTargets.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinus_MemberAndIndexTargets.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2385
+			// Method begins at RVA 0x2375
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -40,7 +40,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 809 (0x329)
+		// Code size: 793 (0x319)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusMinusMinus_MemberAndIndexTargets/Scope,
@@ -85,198 +85,190 @@
 		IL_0065: ldloc.s 7
 		IL_0067: box [System.Runtime]System.Double
 		IL_006c: stloc.s 8
-		IL_006e: ldloc.s 7
-		IL_0070: ldc.r8 1
-		IL_0079: add
-		IL_007a: stloc.s 7
-		IL_007c: ldloc.s 6
-		IL_007e: ldstr "_nextnid"
-		IL_0083: ldloc.s 7
-		IL_0085: ldc.i4.1
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_008b: pop
-		IL_008c: ldloc.2
-		IL_008d: ldstr "_nid"
-		IL_0092: ldloc.s 8
-		IL_0094: ldc.i4.1
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_009a: pop
-		IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a0: ldloc.2
-		IL_00a1: ldstr "_nid"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b0: pop
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b6: ldloc.2
-		IL_00b7: ldstr "ownerDocument"
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c1: ldstr "_nextnid"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d0: pop
-		IL_00d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00d6: dup
-		IL_00d7: ldstr "a"
-		IL_00dc: ldc.r8 1
-		IL_00e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00ea: stloc.3
-		IL_00eb: ldloc.3
-		IL_00ec: ldstr "a"
-		IL_00f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-		IL_00f6: stloc.s 7
-		IL_00f8: ldloc.s 7
-		IL_00fa: box [System.Runtime]System.Double
-		IL_00ff: stloc.s 8
-		IL_0101: ldloc.s 7
-		IL_0103: ldc.r8 1
-		IL_010c: add
-		IL_010d: stloc.s 7
-		IL_010f: ldloc.3
-		IL_0110: ldstr "a"
-		IL_0115: ldloc.s 7
-		IL_0117: ldc.i4.1
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_011d: pop
-		IL_011e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0123: ldloc.s 8
-		IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_012a: pop
-		IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0130: ldloc.3
-		IL_0131: ldstr "a"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0140: pop
-		IL_0141: ldloc.3
-		IL_0142: ldstr "a"
-		IL_0147: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-		IL_014c: ldc.r8 1
-		IL_0155: add
-		IL_0156: stloc.s 7
-		IL_0158: ldloc.3
-		IL_0159: ldstr "a"
-		IL_015e: ldloc.s 7
-		IL_0160: ldc.i4.1
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-		IL_0166: pop
-		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016c: ldloc.s 7
-		IL_016e: box [System.Runtime]System.Double
-		IL_0173: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0178: pop
-		IL_0179: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017e: ldloc.3
-		IL_017f: ldstr "a"
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0189: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018e: pop
-		IL_018f: ldc.i4.1
-		IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0195: dup
-		IL_0196: ldc.r8 10
-		IL_019f: box [System.Runtime]System.Double
-		IL_01a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_01a9: stloc.s 4
-		IL_01ab: ldloc.s 4
-		IL_01ad: ldc.r8 0.0
-		IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_01bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01c0: stloc.s 7
-		IL_01c2: ldloc.s 7
-		IL_01c4: box [System.Runtime]System.Double
-		IL_01c9: stloc.s 8
-		IL_01cb: ldloc.s 7
-		IL_01cd: ldc.r8 1
-		IL_01d6: add
-		IL_01d7: stloc.s 7
-		IL_01d9: ldloc.s 4
-		IL_01db: ldc.r8 0.0
-		IL_01e4: ldloc.s 7
-		IL_01e6: ldc.i4.1
-		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-		IL_01ec: pop
-		IL_01ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f2: ldloc.s 8
-		IL_01f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f9: pop
-		IL_01fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ff: ldloc.s 4
-		IL_0201: ldc.r8 0.0
-		IL_020a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_020f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0214: pop
-		IL_0215: ldloc.s 4
-		IL_0217: ldc.r8 0.0
-		IL_0220: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0225: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_022a: ldc.r8 1
-		IL_0233: add
-		IL_0234: stloc.s 7
-		IL_0236: ldloc.s 4
-		IL_0238: ldc.r8 0.0
-		IL_0241: ldloc.s 7
-		IL_0243: ldc.i4.1
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-		IL_0249: pop
-		IL_024a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_024f: ldloc.s 7
-		IL_0251: box [System.Runtime]System.Double
-		IL_0256: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_025b: pop
-		IL_025c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0261: ldloc.s 4
-		IL_0263: ldc.r8 0.0
-		IL_026c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0271: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0276: pop
-		IL_0277: ldloc.s 4
-		IL_0279: ldc.r8 0.0
-		IL_0282: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0287: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_028c: ldc.r8 1
-		IL_0295: sub
-		IL_0296: stloc.s 7
-		IL_0298: ldloc.s 4
-		IL_029a: ldc.r8 0.0
-		IL_02a3: ldloc.s 7
-		IL_02a5: ldc.i4.1
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-		IL_02ab: pop
-		IL_02ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b1: ldloc.s 7
-		IL_02b3: box [System.Runtime]System.Double
-		IL_02b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02bd: pop
-		IL_02be: ldloc.s 4
-		IL_02c0: ldc.r8 0.0
-		IL_02c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_02ce: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_02d3: stloc.s 7
-		IL_02d5: ldloc.s 7
-		IL_02d7: box [System.Runtime]System.Double
-		IL_02dc: stloc.s 8
-		IL_02de: ldloc.s 7
-		IL_02e0: ldc.r8 1
-		IL_02e9: sub
-		IL_02ea: stloc.s 7
-		IL_02ec: ldloc.s 4
-		IL_02ee: ldc.r8 0.0
-		IL_02f7: ldloc.s 7
-		IL_02f9: ldc.i4.1
-		IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-		IL_02ff: pop
-		IL_0300: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0305: ldloc.s 8
-		IL_0307: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_030c: pop
-		IL_030d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0312: ldloc.s 4
-		IL_0314: ldc.r8 0.0
-		IL_031d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-		IL_0322: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0327: pop
-		IL_0328: ret
+		IL_006e: ldloc.s 6
+		IL_0070: ldstr "_nextnid"
+		IL_0075: ldloc.s 7
+		IL_0077: ldc.r8 1
+		IL_0080: add
+		IL_0081: ldc.i4.1
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0087: pop
+		IL_0088: ldloc.2
+		IL_0089: ldstr "_nid"
+		IL_008e: ldloc.s 8
+		IL_0090: ldc.i4.1
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0096: pop
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldloc.2
+		IL_009d: ldstr "_nid"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ac: pop
+		IL_00ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b2: ldloc.2
+		IL_00b3: ldstr "ownerDocument"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bd: ldstr "_nextnid"
+		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00cc: pop
+		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00d2: dup
+		IL_00d3: ldstr "a"
+		IL_00d8: ldc.r8 1
+		IL_00e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00e6: stloc.3
+		IL_00e7: ldloc.3
+		IL_00e8: ldstr "a"
+		IL_00ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+		IL_00f2: stloc.s 7
+		IL_00f4: ldloc.s 7
+		IL_00f6: box [System.Runtime]System.Double
+		IL_00fb: stloc.s 8
+		IL_00fd: ldloc.3
+		IL_00fe: ldstr "a"
+		IL_0103: ldloc.s 7
+		IL_0105: ldc.r8 1
+		IL_010e: add
+		IL_010f: ldc.i4.1
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_0115: pop
+		IL_0116: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011b: ldloc.s 8
+		IL_011d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0122: pop
+		IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0128: ldloc.3
+		IL_0129: ldstr "a"
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0138: pop
+		IL_0139: ldloc.3
+		IL_013a: ldstr "a"
+		IL_013f: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+		IL_0144: ldc.r8 1
+		IL_014d: add
+		IL_014e: stloc.s 7
+		IL_0150: ldloc.3
+		IL_0151: ldstr "a"
+		IL_0156: ldloc.s 7
+		IL_0158: ldc.i4.1
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+		IL_015e: pop
+		IL_015f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0164: ldloc.s 7
+		IL_0166: box [System.Runtime]System.Double
+		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0170: pop
+		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0176: ldloc.3
+		IL_0177: ldstr "a"
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0181: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0186: pop
+		IL_0187: ldc.i4.1
+		IL_0188: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_018d: dup
+		IL_018e: ldc.r8 10
+		IL_0197: box [System.Runtime]System.Double
+		IL_019c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_01a1: stloc.s 4
+		IL_01a3: ldloc.s 4
+		IL_01a5: ldc.r8 0.0
+		IL_01ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_01b3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01b8: stloc.s 7
+		IL_01ba: ldloc.s 7
+		IL_01bc: box [System.Runtime]System.Double
+		IL_01c1: stloc.s 8
+		IL_01c3: ldloc.s 4
+		IL_01c5: ldc.r8 0.0
+		IL_01ce: ldloc.s 7
+		IL_01d0: ldc.r8 1
+		IL_01d9: add
+		IL_01da: ldc.i4.1
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+		IL_01e0: pop
+		IL_01e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e6: ldloc.s 8
+		IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ed: pop
+		IL_01ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f3: ldloc.s 4
+		IL_01f5: ldc.r8 0.0
+		IL_01fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0203: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0208: pop
+		IL_0209: ldloc.s 4
+		IL_020b: ldc.r8 0.0
+		IL_0214: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0219: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_021e: ldc.r8 1
+		IL_0227: add
+		IL_0228: stloc.s 7
+		IL_022a: ldloc.s 4
+		IL_022c: ldc.r8 0.0
+		IL_0235: ldloc.s 7
+		IL_0237: ldc.i4.1
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+		IL_023d: pop
+		IL_023e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0243: ldloc.s 7
+		IL_0245: box [System.Runtime]System.Double
+		IL_024a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_024f: pop
+		IL_0250: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0255: ldloc.s 4
+		IL_0257: ldc.r8 0.0
+		IL_0260: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026a: pop
+		IL_026b: ldloc.s 4
+		IL_026d: ldc.r8 0.0
+		IL_0276: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_027b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0280: ldc.r8 1
+		IL_0289: sub
+		IL_028a: stloc.s 7
+		IL_028c: ldloc.s 4
+		IL_028e: ldc.r8 0.0
+		IL_0297: ldloc.s 7
+		IL_0299: ldc.i4.1
+		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+		IL_029f: pop
+		IL_02a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a5: ldloc.s 7
+		IL_02a7: box [System.Runtime]System.Double
+		IL_02ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b1: pop
+		IL_02b2: ldloc.s 4
+		IL_02b4: ldc.r8 0.0
+		IL_02bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_02c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_02c7: stloc.s 7
+		IL_02c9: ldloc.s 7
+		IL_02cb: box [System.Runtime]System.Double
+		IL_02d0: stloc.s 8
+		IL_02d2: ldloc.s 4
+		IL_02d4: ldc.r8 0.0
+		IL_02dd: ldloc.s 7
+		IL_02df: ldc.r8 1
+		IL_02e8: sub
+		IL_02e9: ldc.i4.1
+		IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+		IL_02ef: pop
+		IL_02f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f5: ldloc.s 8
+		IL_02f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02fc: pop
+		IL_02fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0302: ldloc.s 4
+		IL_0304: ldc.r8 0.0
+		IL_030d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+		IL_0312: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0317: pop
+		IL_0318: ret
 	} // end of method UnaryOperator_PlusPlusMinusMinus_MemberAndIndexTargets::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusMinusMinus_MemberAndIndexTargets
@@ -288,7 +280,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x238e
+		// Method begins at RVA 0x237e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- centralizes LIR storage-compatibility checks in `ValueStorageFacts`
- forwards redundant boxed numeric arguments back to typed temps for direct/typed user-class calls when the original value is stable through the call boundary
- removes dead `LIRConvertToObject`/copy materializations more safely and teaches temp allocation about `LIRGetItemAsNumberString`
- updates affected generator snapshots and the Unreleased changelog

## Snapshot impact
- `Prime_SetBitsTrue_LargeStep_OptimizedVsNaive`: `box` 33 -> 30
- `Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes`: `box` 72 -> 71
- `Compile_Performance_PrimeJavaScript`: `box` 52 -> 51
- `Classes_ClassMethod_ForLoop_CallsAnotherMethod`: `box` 5 -> 4

## Validation
- `dotnet build src\Jroc.Core\Jroc.Core.csproj -c Release --nologo`
- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~BinaryOperator|FullyQualifiedName~TypedArray|FullyQualifiedName~Classes|FullyQualifiedName~Math|FullyQualifiedName~Generator_YieldStar_ArrayBasic|FullyQualifiedName~ControlFlow_ForIn_Mutation_DeleteAndAdd|FullyQualifiedName~UnaryOperator_PlusPlusMinusMinus_MemberAndIndexTargets|FullyQualifiedName~Compile_Performance_PrimeJavaScript|FullyQualifiedName~CompoundAssignment_PropertyNullishAssignment|FullyQualifiedName~Object_Integrity_FreezeSeal_PreventExtensions|FullyQualifiedName~Compile_Scripts_Test262MetadataParser" --nologo`
- `dotnet test tests\Jroc.Test262.Tests\Jroc.Test262.Tests.csproj -c Release --filter "FullyQualifiedName~Compile_Scripts_Test262MetadataParser" --nologo`
- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --nologo` (one unrelated HTTPS socket reset flake; `Https_Request_Post_Basic` passed on targeted rerun)
- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~Https_Request_Post_Basic" --nologo`

Refs #451
