### PR TITLE
compiler: avoid boxing arith stable numeric return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- compiler/tests: keep stable no-scope zero-arg numeric function returns unboxed (including `NumericInference_ExponentiationLoop_NoBoxing`), threading callable return-type metadata through direct-call lowering and only boxing at object call boundaries.
 
 ## v0.11.3 - 2026-06-28
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
@@ -3,6 +3,7 @@ using Jroc.IR;
 using Jroc.Services;
 using Jroc.Services.ILGenerators;
 using Jroc.Services.TwoPhaseCompilation;
+using Jroc.SymbolTables;
 using Jroc.Utilities;
 using Jroc.Utilities.Ecma335;
 using Microsoft.Extensions.DependencyInjection;
@@ -184,7 +185,7 @@ internal sealed partial class LIRToILCompiler
                         ilEncoder.OpCode(ILOpCode.Ldftn);
                         ilEncoder.Token(methodHandle);
                         ilEncoder.OpCode(ILOpCode.Newobj);
-                        ilEncoder.Token(_bclReferences.GetFuncCtorRef(callableId.JsParamCount, delegateRequiresScopeArray));
+                        ilEncoder.Token(_bclReferences.GetFuncCtorRef(callableId.JsParamCount, delegateRequiresScopeArray, callableSignature?.ReturnClrType));
 
                         if (delegateRequiresScopeArray)
                         {
@@ -209,6 +210,7 @@ internal sealed partial class LIRToILCompiler
 
                         if (IsMaterialized(callFunc.Result, allocation))
                         {
+                            EmitBoxCallResultForObjectTarget(GetDirectFunctionReturnClrType(callableSignature, callFunc.FunctionSymbol.BindingInfo, callableId), callFunc.Result, ilEncoder);
                             EmitStoreTemp(callFunc.Result, ilEncoder, allocation);
                         }
                         else
@@ -262,6 +264,7 @@ internal sealed partial class LIRToILCompiler
 
                     if (IsMaterialized(callFunc.Result, allocation))
                     {
+                        EmitBoxCallResultForObjectTarget(GetDirectFunctionReturnClrType(callableSignature, callFunc.FunctionSymbol.BindingInfo, callableId), callFunc.Result, ilEncoder);
                         EmitStoreTemp(callFunc.Result, ilEncoder, allocation);
                     }
                     else
@@ -385,7 +388,7 @@ internal sealed partial class LIRToILCompiler
                     ilEncoder.OpCode(ILOpCode.Ldftn);
                     ilEncoder.Token(methodHandle);
                     ilEncoder.OpCode(ILOpCode.Newobj);
-                    ilEncoder.Token(_bclReferences.GetFuncCtorRef(jsParamCount, delegateRequiresScopeArray));
+                    ilEncoder.Token(_bclReferences.GetFuncCtorRef(jsParamCount, delegateRequiresScopeArray, callableSignature?.ReturnClrType));
 
                     // Load scopes array
                     EmitLoadTemp(callFuncArray.ScopesArray, ilEncoder, allocation, methodDescriptor);
@@ -1001,6 +1004,7 @@ internal sealed partial class LIRToILCompiler
 
                     if (IsMaterialized(callDeclared.Result, allocation))
                     {
+                        EmitBoxCallResultForObjectTarget(signature?.ReturnClrType, callDeclared.Result, ilEncoder);
                         EmitStoreTemp(callDeclared.Result, ilEncoder, allocation);
                     }
                     else
@@ -1058,7 +1062,7 @@ internal sealed partial class LIRToILCompiler
                     ilEncoder.OpCode(ILOpCode.Ldftn);
                     ilEncoder.Token(methodHandle);
                     ilEncoder.OpCode(ILOpCode.Newobj);
-                    ilEncoder.Token(_bclReferences.GetFuncCtorRef(jsParamCount, delegateRequiresScopeArray));
+                    ilEncoder.Token(_bclReferences.GetFuncCtorRef(jsParamCount, delegateRequiresScopeArray, signature?.ReturnClrType));
 
                     // Bind delegate to scopes array AND lexical 'this': Closure.BindArrow(object, object[], object)
                     EmitLoadTemp(createArrow.ScopesArray, ilEncoder, allocation, methodDescriptor);
@@ -1142,7 +1146,7 @@ internal sealed partial class LIRToILCompiler
                     ilEncoder.OpCode(ILOpCode.Ldftn);
                     ilEncoder.Token(methodHandle);
                     ilEncoder.OpCode(ILOpCode.Newobj);
-                    ilEncoder.Token(_bclReferences.GetFuncCtorRef(jsParamCount, requiresScopes: false));
+                    ilEncoder.Token(_bclReferences.GetFuncCtorRef(jsParamCount, requiresScopes: false, signature?.ReturnClrType));
                     EmitInitializeFunctionInstance(createFunc.CallableId, createFunc.IsAsync, ilEncoder);
                     EmitInitializeGeneratorFunctionSurfaceIfNeeded(callableId, ilEncoder);
 
@@ -1230,5 +1234,75 @@ internal sealed partial class LIRToILCompiler
         }
 
         return true;
+    }
+
+    private void EmitBoxCallResultForObjectTarget(Type? returnClrType, TempVariable result, InstructionEncoder ilEncoder)
+    {
+        if (returnClrType == null)
+        {
+            return;
+        }
+
+        var resultStorage = GetTempStorage(result);
+        if (resultStorage.Kind is not (ValueStorageKind.Reference or ValueStorageKind.BoxedValue)
+            || resultStorage.ClrType != typeof(object))
+        {
+            return;
+        }
+
+        if (returnClrType == typeof(double))
+        {
+            ilEncoder.OpCode(ILOpCode.Box);
+            ilEncoder.Token(_bclReferences.DoubleType);
+        }
+        else if (returnClrType == typeof(bool))
+        {
+            ilEncoder.OpCode(ILOpCode.Box);
+            ilEncoder.Token(_bclReferences.BooleanType);
+        }
+    }
+
+    private static Type? GetDirectFunctionReturnClrType(CallableSignature? signature, BindingInfo symbol, CallableId callableId)
+        => signature?.ReturnClrType ?? GetStableDirectFunctionReturnClrType(symbol, callableId);
+
+    private static Type? GetStableDirectFunctionReturnClrType(BindingInfo symbol, CallableId callableId)
+    {
+        if (symbol.Kind != BindingKind.Function || callableId.JsParamCount != 0)
+        {
+            return null;
+        }
+
+        var functionScope = FindFunctionScope(symbol.DeclaringScope, symbol);
+        if (functionScope == null || functionScope.ReferencesParentScopeVariables)
+        {
+            return null;
+        }
+
+        return functionScope.StableReturnClrType == typeof(double)
+            ? typeof(double)
+            : null;
+    }
+
+    private static Scope? FindFunctionScope(Scope root, BindingInfo symbol)
+    {
+        foreach (var child in root.Children)
+        {
+            if (child.Kind == ScopeKind.Function
+                && (ReferenceEquals(child.AstNode, symbol.DeclarationNode)
+                    || string.Equals(child.Name, symbol.Name, StringComparison.Ordinal)
+                    || (child.AstNode is FunctionDeclaration functionDeclaration
+                        && functionDeclaration.Id?.Name == symbol.Name)))
+            {
+                return child;
+            }
+
+            var descendant = FindFunctionScope(child, symbol);
+            if (descendant != null)
+            {
+                return descendant;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Compiler/IR/LIR/HIRToLIRLower.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.cs
@@ -16,6 +16,8 @@ public sealed partial class HIRToLIRLowerer
     private readonly EnvironmentLayoutBuilder? _environmentLayoutBuilder;
     private readonly Jroc.Services.ClassRegistry? _classRegistry;
     private readonly CallableKind _callableKind;
+    private readonly TwoPhase.CallableRegistry? _callableRegistry;
+    private readonly bool _preserveNonClassDoubleReturn;
     private readonly HIRExpression? _superClassExpression;
     private readonly bool _isAsync;
     private readonly bool _isDerivedConstructor;
@@ -73,17 +75,19 @@ public sealed partial class HIRToLIRLowerer
 
     private readonly bool _isGenerator;
 
-    private HIRToLIRLowerer(Scope? scope, EnvironmentLayout? environmentLayout, EnvironmentLayoutBuilder? environmentLayoutBuilder, Jroc.Services.ClassRegistry? classRegistry, CallableKind callableKind, IReadOnlyList<HIRPattern> parameters, HIRExpression? superClassExpression = null, bool isAsync = false, bool isGenerator = false, bool isDerivedConstructor = false)
+    private HIRToLIRLowerer(Scope? scope, EnvironmentLayout? environmentLayout, EnvironmentLayoutBuilder? environmentLayoutBuilder, Jroc.Services.ClassRegistry? classRegistry, CallableKind callableKind, IReadOnlyList<HIRPattern> parameters, HIRExpression? superClassExpression = null, bool isAsync = false, bool isGenerator = false, bool isDerivedConstructor = false, TwoPhase.CallableRegistry? callableRegistry = null, bool preserveNonClassDoubleReturn = false)
     {
         _scope = scope;
         _environmentLayout = environmentLayout;
         _environmentLayoutBuilder = environmentLayoutBuilder;
         _classRegistry = classRegistry;
         _callableKind = callableKind;
+        _callableRegistry = callableRegistry;
         _superClassExpression = superClassExpression;
         _isAsync = isAsync;
         _isGenerator = isGenerator;
         _isDerivedConstructor = isDerivedConstructor;
+        _preserveNonClassDoubleReturn = preserveNonClassDoubleReturn;
         InitializeParameters(parameters);
     }
 
@@ -116,7 +120,12 @@ public sealed partial class HIRToLIRLowerer
             }
         }
 
-        var lowerer = new HIRToLIRLowerer(scope, environmentLayout, environmentLayoutBuilder, classRegistry, callableKind, hirMethod.Parameters, hirMethod.SuperClassExpression, isAsync, isGenerator, isDerivedConstructor);
+        var preserveNonClassDoubleReturn = scope?.StableReturnClrType == typeof(double)
+            && callableKind == Jroc.Services.ScopesAbi.CallableKind.Function
+            && !hasScopesParameter
+            && callableId?.JsParamCount == 0;
+
+        var lowerer = new HIRToLIRLowerer(scope, environmentLayout, environmentLayoutBuilder, classRegistry, callableKind, hirMethod.Parameters, hirMethod.SuperClassExpression, isAsync, isGenerator, isDerivedConstructor, callableRegistry, preserveNonClassDoubleReturn);
         lowerer.CollectStringBuilderAccumulatorCandidates(hirMethod.Body.Statements);
 
         // If default parameter initialization failed, fall back to legacy emitter

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -519,7 +519,7 @@ public sealed partial class HIRToLIRLowerer
                 DefineTempStorage(constArrowScopesTemp, new ValueStorage(ValueStorageKind.Reference, typeof(object[])));
 
                 _methodBodyIR.Instructions.Add(new LIRCallFunction(symbol, constArrowScopesTemp, constArrowArguments, resultTempVar, constArrowCallableId));
-                DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+                DefineDirectCallResultStorage(resultTempVar, constArrowCallableId, symbol.BindingInfo);
                 return true;
             }
 
@@ -627,7 +627,7 @@ public sealed partial class HIRToLIRLowerer
             // Emit the function call with arguments
             var callableId = TryCreateCallableIdForFunctionDeclaration(symbol);
             _methodBodyIR.Instructions.Add(new LIRCallFunction(symbol, scopesTempVar, arguments, resultTempVar, callableId));
-            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            DefineDirectCallResultStorage(resultTempVar, callableId, symbol.BindingInfo);
 
             return true;
         }
@@ -1287,6 +1287,82 @@ public sealed partial class HIRToLIRLowerer
 
         DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
         return true;
+    }
+
+    private void DefineDirectCallResultStorage(TempVariable resultTempVar, TwoPhase.CallableId? callableId, BindingInfo? symbol)
+    {
+        Type? returnClrType = null;
+        if (callableId != null && _callableRegistry != null)
+        {
+            returnClrType = _callableRegistry.GetSignature(callableId)?.ReturnClrType;
+        }
+
+        returnClrType ??= GetStableDirectFunctionReturnClrType(symbol, callableId);
+
+        if (returnClrType == typeof(double))
+        {
+            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double)));
+        }
+        else if (returnClrType == typeof(bool))
+        {
+            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool)));
+        }
+        else if (returnClrType == typeof(string))
+        {
+            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        }
+        else if (returnClrType == typeof(JavaScriptRuntime.Array))
+        {
+            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(JavaScriptRuntime.Array)));
+        }
+        else
+        {
+            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        }
+    }
+
+    private static Type? GetStableDirectFunctionReturnClrType(BindingInfo? symbol, TwoPhase.CallableId? callableId)
+    {
+        if (symbol?.Kind != BindingKind.Function
+            || callableId?.JsParamCount != 0)
+        {
+            return null;
+        }
+
+        var functionScope = FindFunctionScope(symbol.DeclaringScope, symbol);
+
+        if (functionScope == null
+            || functionScope.ReferencesParentScopeVariables)
+        {
+            return null;
+        }
+
+        return functionScope.StableReturnClrType == typeof(double)
+            ? typeof(double)
+            : null;
+    }
+
+    private static Scope? FindFunctionScope(Scope root, BindingInfo symbol)
+    {
+        foreach (var child in root.Children)
+        {
+            if (child.Kind == ScopeKind.Function
+                && (ReferenceEquals(child.AstNode, symbol.DeclarationNode)
+                    || string.Equals(child.Name, symbol.Name, StringComparison.Ordinal)
+                    || (child.AstNode is FunctionDeclaration functionDeclaration
+                        && functionDeclaration.Id?.Name == symbol.Name)))
+            {
+                return child;
+            }
+
+            var descendant = FindFunctionScope(child, symbol);
+            if (descendant != null)
+            {
+                return descendant;
+            }
+        }
+
+        return null;
     }
 
     private static Type ResolveTypedInstanceCallReturnClrType(Type receiverType, string methodName, int argCount)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementReturn.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.StatementReturn.cs
@@ -84,7 +84,8 @@ public sealed partial class HIRToLIRLowerer
                 {
                     stableReturnClrType = functionScope.StableReturnClrType;
                 }
-                else if (functionScope.StableReturnClrType == typeof(string))
+                else if (functionScope.StableReturnClrType == typeof(string)
+                    || (functionScope.StableReturnClrType == typeof(double) && _preserveNonClassDoubleReturn))
                 {
                     stableReturnClrType = functionScope.StableReturnClrType;
                 }
@@ -399,7 +400,8 @@ public sealed partial class HIRToLIRLowerer
             {
                 stableReturnClrType = functionScope.StableReturnClrType;
             }
-            else if (functionScope.StableReturnClrType == typeof(string))
+            else if (functionScope.StableReturnClrType == typeof(string)
+                || (functionScope.StableReturnClrType == typeof(double) && _preserveNonClassDoubleReturn))
             {
                 stableReturnClrType = functionScope.StableReturnClrType;
             }

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -448,10 +448,20 @@ internal static class LIRIntrinsicNormalization
 
             if (callFunction.Result.Index >= 0 && callFunction.Result.Index < methodBody.TempStorages.Count)
             {
-                methodBody.TempStorages[callFunction.Result.Index] = new ValueStorage(ValueStorageKind.Reference, typeof(object));
+                methodBody.TempStorages[callFunction.Result.Index] = GetDeclaredCallResultStorage(signature?.ReturnClrType);
             }
         }
     }
+
+    private static ValueStorage GetDeclaredCallResultStorage(Type? returnClrType)
+        => returnClrType switch
+        {
+            Type type when type == typeof(double) => new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double)),
+            Type type when type == typeof(bool) => new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool)),
+            Type type when type == typeof(string) => new ValueStorage(ValueStorageKind.Reference, typeof(string)),
+            Type type when type == typeof(JavaScriptRuntime.Array) => new ValueStorage(ValueStorageKind.Reference, typeof(JavaScriptRuntime.Array)),
+            _ => new ValueStorage(ValueStorageKind.Reference, typeof(object))
+        };
 
     /// <summary>
     /// Peephole pass: fuses LIRGetItem(obj, index, result) immediately followed by

--- a/src/Compiler/JsMethodCompiler.cs
+++ b/src/Compiler/JsMethodCompiler.cs
@@ -480,6 +480,10 @@ internal sealed class JsMethodCompiler
                 // returns so generated signatures can expose specialized return types where proven.
                 inferredReturnClrType = scope.StableReturnClrType;
             }
+            else if (SupportsNoScopesZeroArgDoubleReturn(callable, effectiveScopeAbiKind, scope.StableReturnClrType))
+            {
+                inferredReturnClrType = scope.StableReturnClrType;
+            }
         }
 
         var methodDescriptor = new MethodDescriptor(ilMethodName, dummyType, parameters)
@@ -639,6 +643,17 @@ internal sealed class JsMethodCompiler
 
         return CreateILCompiler().TryCompile(methodDescriptor, lirMethod!, methodBodyStreamEncoder);
     }
+
+    private static bool SupportsNoScopesZeroArgDoubleReturn(
+        CallableId callable,
+        Jroc.Runtime.CallableScopeAbiKind scopeAbiKind,
+        Type? returnClrType)
+        => returnClrType == typeof(double)
+            && scopeAbiKind == Jroc.Runtime.CallableScopeAbiKind.NoScopes
+            && callable.JsParamCount == 0
+            && callable.Kind is CallableKind.FunctionDeclaration
+                or CallableKind.FunctionExpression
+                or CallableKind.Arrow;
 
     public MethodDefinitionHandle TryCompileArrowFunction(string typeName, string methodName, Node node, Scope scope, MethodBodyStreamEncoder methodBodyStreamEncoder)
     {

--- a/src/Compiler/Services/BaseClassLibraryReferences.cs
+++ b/src/Compiler/Services/BaseClassLibraryReferences.cs
@@ -13,8 +13,15 @@ namespace Jroc.Services
         // With scopes: (object[] scopes, object? newTarget, object? a1..aN) -> object?
         // Without scopes: (object? newTarget, object? a1..aN) -> object?
         // Always use custom JsFunc delegates so the ABI is explicit and stable.
-        internal static Type GetFunctionDelegateType(int jsParamCount, bool requiresScopes = true)
+        internal static Type GetFunctionDelegateType(int jsParamCount, bool requiresScopes = true, Type? returnClrType = null)
         {
+            if (returnClrType == typeof(double) && jsParamCount == 0)
+            {
+                return requiresScopes
+                    ? typeof(JavaScriptRuntime.JsDoubleFunc0)
+                    : typeof(JavaScriptRuntime.JsDoubleFuncNoScopes0);
+            }
+
             if (!requiresScopes)
             {
                 // No-scopes optimized delegates
@@ -149,15 +156,15 @@ namespace Jroc.Services
         public MemberReferenceHandle DebuggerDisplayAttribute_Ctor_Ref =>
             _memberRefRegistry.GetOrAddConstructor(typeof(System.Diagnostics.DebuggerDisplayAttribute), new[] { typeof(string) });
 
-        public MemberReferenceHandle GetFuncCtorRef(int jsParamCount, bool requiresScopes = true)
+        public MemberReferenceHandle GetFuncCtorRef(int jsParamCount, bool requiresScopes = true, Type? returnClrType = null)
         {
-            var delegateType = GetFunctionDelegateType(jsParamCount, requiresScopes);
+            var delegateType = GetFunctionDelegateType(jsParamCount, requiresScopes, returnClrType);
             return _memberRefRegistry.GetOrAddConstructor(delegateType);
         }
 
-        public MemberReferenceHandle GetFuncInvokeRef(int jsParamCount, bool requiresScopes = true)
+        public MemberReferenceHandle GetFuncInvokeRef(int jsParamCount, bool requiresScopes = true, Type? returnClrType = null)
         {
-            var delegateType = GetFunctionDelegateType(jsParamCount, requiresScopes);
+            var delegateType = GetFunctionDelegateType(jsParamCount, requiresScopes, returnClrType);
             return _memberRefRegistry.GetOrAddMethod(delegateType, "Invoke");
         }
 

--- a/src/Compiler/Services/TwoPhaseCompilation/CallableRegistry.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/CallableRegistry.cs
@@ -280,6 +280,7 @@ public sealed class CallableRegistry : ICallableCatalog, ICallableDeclarationWri
             && left.SingleScopeScopeName == right.SingleScopeScopeName
             && left.InvokeShape == right.InvokeShape
             && left.IsInstanceMethod == right.IsInstanceMethod
+            && left.ReturnClrType == right.ReturnClrType
             && left.SignatureBlob == right.SignatureBlob
             && left.ParameterClrTypes.SequenceEqual(right.ParameterClrTypes);
     }

--- a/src/Compiler/Services/TwoPhaseCompilation/CallableSignature.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/CallableSignature.cs
@@ -69,6 +69,12 @@ public sealed record CallableSignature
     /// Null entries keep the default object-typed JavaScript value ABI.
     /// </summary>
     public IReadOnlyList<Type?> ParameterClrTypes { get; init; } = Array.Empty<Type?>();
+
+    /// <summary>
+    /// Optional stable CLR return type for callables whose ABI can expose a typed return.
+    /// Null keeps the default object-typed JavaScript value ABI.
+    /// </summary>
+    public Type? ReturnClrType { get; init; }
     
     /// <summary>
     /// The invoke shape (delegate type) for this callable.

--- a/src/Compiler/Services/TwoPhaseCompilation/TwoPhaseCompilationCoordinator.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/TwoPhaseCompilationCoordinator.cs
@@ -1648,6 +1648,7 @@ public sealed class TwoPhaseCompilationCoordinator
         {
             var (scopeAbiKind, singleScopeScopeName) = ComputeCallableScopeAbi(callable, symbolTable);
             var parameterClrTypes = GetCallableParameterClrTypes(callable, symbolTable);
+            var returnClrType = GetCallableReturnClrType(callable, symbolTable, scopeAbiKind);
 
             // Build CallableSignature from CallableId
             // Placeholder owner type handle (is set during token allocation)
@@ -1658,6 +1659,7 @@ public sealed class TwoPhaseCompilationCoordinator
                 SingleScopeScopeName = singleScopeScopeName,
                 JsParamCount = callable.JsParamCount,
                 ParameterClrTypes = parameterClrTypes,
+                ReturnClrType = returnClrType,
                 InvokeShape = CallableSignature.GetInvokeShape(callable.JsParamCount),
                 IsInstanceMethod = callable.Kind == CallableKind.ClassMethod,
                 ILMethodName = GetILMethodName(callable)
@@ -1779,6 +1781,53 @@ public sealed class TwoPhaseCompilationCoordinator
 
     private static bool IsSupportedStableParameterClrType(Type? type)
         => type == typeof(double) || type == typeof(bool) || type == typeof(string);
+
+    private static Type? GetCallableReturnClrType(
+        CallableId callable,
+        SymbolTable symbolTable,
+        Jroc.Runtime.CallableScopeAbiKind scopeAbiKind)
+    {
+        var scope = callable.AstNode != null
+            ? symbolTable.FindScopeByAstNode(callable.AstNode)
+            : null;
+
+        if (scope == null && callable.AstNode is Acornima.Ast.MethodDefinition methodDefinition)
+        {
+            scope = symbolTable.FindScopeByAstNode(methodDefinition.Value);
+        }
+
+        if (scope == null || scope.Kind != ScopeKind.Function)
+        {
+            return null;
+        }
+
+        if (callable.Kind is CallableKind.ClassMethod or CallableKind.ClassStaticMethod)
+        {
+            return scope.StableReturnClrType;
+        }
+
+        if (scope.StableReturnClrType == typeof(JavaScriptRuntime.Array)
+            || scope.StableReturnClrType == typeof(string))
+        {
+            return scope.StableReturnClrType;
+        }
+
+        if (SupportsNoScopesZeroArgDoubleReturn(callable, scopeAbiKind, scope.StableReturnClrType))
+        {
+            return typeof(double);
+        }
+
+        return null;
+    }
+
+    private static bool SupportsNoScopesZeroArgDoubleReturn(
+        CallableId callable,
+        Jroc.Runtime.CallableScopeAbiKind scopeAbiKind,
+        Type? returnClrType)
+        => returnClrType == typeof(double)
+            && scopeAbiKind == Jroc.Runtime.CallableScopeAbiKind.NoScopes
+            && callable.JsParamCount == 0
+            && callable.Kind is CallableKind.FunctionDeclaration or CallableKind.FunctionExpression or CallableKind.Arrow;
 
     private static bool IsResumableCallable(CallableId callable)
     {

--- a/src/JavaScriptRuntime/JsFuncDelegates.cs
+++ b/src/JavaScriptRuntime/JsFuncDelegates.cs
@@ -23,6 +23,9 @@ internal static class JsFuncDelegates
                 _registeredDelegateTypes.Add(noScopesDelegateType);
             }
         }
+
+        _registeredDelegateTypes.Add(typeof(JsDoubleFunc0));
+        _registeredDelegateTypes.Add(typeof(JsDoubleFuncNoScopes0));
     }
 
     internal static bool IsJsFuncDelegateType(Type type)
@@ -34,6 +37,7 @@ internal static class JsFuncDelegates
 // Custom delegate types used by jroc to bypass System.Func<> arity limits.
 // Signature convention: (object[] scopes, object? newTarget, object? a1..aN) -> object?
 public delegate object? JsFunc0(object[] scopes, object? newTarget);
+public delegate double JsDoubleFunc0(object[] scopes, object? newTarget);
 public delegate object? JsFunc1(object[] scopes, object? newTarget, object? a1);
 public delegate object? JsFunc2(object[] scopes, object? newTarget, object? a1, object? a2);
 public delegate object? JsFunc3(object[] scopes, object? newTarget, object? a1, object? a2, object? a3);
@@ -71,6 +75,7 @@ public delegate object? JsFunc32(object[] scopes, object? newTarget, object? a1,
 // Signature convention: (object? newTarget, object? a1..aN) -> object?
 // newTarget is retained for proper `new` vs call semantics.
 public delegate object? JsFuncNoScopes0(object? newTarget);
+public delegate double JsDoubleFuncNoScopes0(object? newTarget);
 public delegate object? JsFuncNoScopes1(object? newTarget, object? a1);
 public delegate object? JsFuncNoScopes2(object? newTarget, object? a1, object? a2);
 public delegate object? JsFuncNoScopes3(object? newTarget, object? a1, object? a2, object? a3);

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -4805,7 +4805,8 @@
 				[6] bool,
 				[7] object,
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[9] string
+				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[10] string
 			)
 
 			IL_0000: ldarg.s force
@@ -4977,20 +4978,20 @@
 			IL_01e6: ldnull
 			IL_01e7: ldarg.3
 			IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_01ed: stloc.s 7
+			IL_01ed: stloc.s 9
 			IL_01ef: ldloc.s 8
 			IL_01f1: ldc.i4.1
 			IL_01f2: newarr [System.Runtime]System.Object
 			IL_01f7: dup
 			IL_01f8: ldc.i4.0
-			IL_01f9: ldloc.s 7
+			IL_01f9: ldloc.s 9
 			IL_01fb: stelem.ref
 			IL_01fc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-			IL_0201: stloc.s 8
+			IL_0201: stloc.s 9
 			IL_0203: ldarg.0
 			IL_0204: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
 			IL_0209: ldnull
-			IL_020a: ldloc.s 8
+			IL_020a: ldloc.s 9
 			IL_020c: ldarg.2
 			IL_020d: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 			IL_0212: pop
@@ -5015,11 +5016,11 @@
 			IL_0251: ldstr "commit"
 			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_025b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0260: stloc.s 8
+			IL_0260: stloc.s 9
 			IL_0262: ldarg.0
 			IL_0263: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
 			IL_0268: ldnull
-			IL_0269: ldloc.s 8
+			IL_0269: ldloc.s 9
 			IL_026b: ldarg.2
 			IL_026c: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 			IL_0271: pop
@@ -5034,11 +5035,11 @@
 			IL_028e: dup
 			IL_028f: ldstr "FETCH_HEAD"
 			IL_0294: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0299: stloc.s 8
+			IL_0299: stloc.s 9
 			IL_029b: ldarg.0
 			IL_029c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
 			IL_02a1: ldnull
-			IL_02a2: ldloc.s 8
+			IL_02a2: ldloc.s 9
 			IL_02a4: ldarg.2
 			IL_02a5: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 			IL_02aa: pop
@@ -5067,12 +5068,12 @@
 			IL_02e2: ldstr "message"
 			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_02ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f1: stloc.s 9
+			IL_02f1: stloc.s 10
 			IL_02f3: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
-			IL_02f8: ldloc.s 9
+			IL_02f8: ldloc.s 10
 			IL_02fa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ff: stloc.s 9
-			IL_0301: ldloc.s 9
+			IL_02ff: stloc.s 10
+			IL_0301: ldloc.s 10
 			IL_0303: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
 			IL_030d: stloc.s 7

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -7525,7 +7525,7 @@
 			)
 			// Method begins at RVA 0x5660
 			// Header size: 12
-			// Code size: 1497 (0x5d9)
+			// Code size: 1498 (0x5da)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7542,11 +7542,11 @@
 				[11] class Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48,
 				[12] object,
 				[13] class Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49,
-				[14] object,
-				[15] object,
-				[16] object,
-				[17] object,
-				[18] object,
+				[14] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[16] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[17] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[19] object,
 				[20] float64,
 				[21] class Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41,
@@ -7570,8 +7570,7 @@
 				[39] object,
 				[40] object,
 				[41] object,
-				[42] object,
-				[43] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[42] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -7736,8 +7735,8 @@
 			IL_01a0: ldstr "includes"
 			IL_01a5: ldloc.s 4
 			IL_01a7: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01ac: stloc.s 28
-			IL_01ae: ldloc.s 28
+			IL_01ac: stloc.s 32
+			IL_01ae: ldloc.s 32
 			IL_01b0: stloc.s 14
 			IL_01b2: ldloc.s 7
 			IL_01b4: ldstr "flags"
@@ -7750,8 +7749,8 @@
 			IL_01c9: ldstr "flags"
 			IL_01ce: ldloc.s 4
 			IL_01d0: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01d5: stloc.s 28
-			IL_01d7: ldloc.s 28
+			IL_01d5: stloc.s 32
+			IL_01d7: ldloc.s 32
 			IL_01d9: stloc.s 15
 			IL_01db: ldloc.s 7
 			IL_01dd: ldstr "features"
@@ -7764,8 +7763,8 @@
 			IL_01f2: ldstr "features"
 			IL_01f7: ldloc.s 4
 			IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01fe: stloc.s 28
-			IL_0200: ldloc.s 28
+			IL_01fe: stloc.s 32
+			IL_0200: ldloc.s 32
 			IL_0202: stloc.s 16
 			IL_0204: ldloc.s 7
 			IL_0206: ldstr "locale"
@@ -7778,8 +7777,8 @@
 			IL_021b: ldstr "locale"
 			IL_0220: ldloc.s 4
 			IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0227: stloc.s 28
-			IL_0229: ldloc.s 28
+			IL_0227: stloc.s 32
+			IL_0229: ldloc.s 32
 			IL_022b: stloc.s 17
 			IL_022d: ldloc.s 7
 			IL_022f: ldstr "defines"
@@ -7792,8 +7791,8 @@
 			IL_0244: ldstr "defines"
 			IL_0249: ldloc.s 4
 			IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0250: stloc.s 28
-			IL_0252: ldloc.s 28
+			IL_0250: stloc.s 32
+			IL_0252: ldloc.s 32
 			IL_0254: stloc.s 18
 			IL_0256: ldloc.s 7
 			IL_0258: ldstr "negative"
@@ -7813,291 +7812,292 @@
 			// loop start (head: IL_0285)
 				IL_0285: ldloc.s 20
 				IL_0287: ldloc.s 15
-				IL_0289: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_028e: clt
-				IL_0290: brfalse IL_0347
+				IL_0289: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_028e: conv.r8
+				IL_028f: clt
+				IL_0291: brfalse IL_0348
 
-				IL_0295: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
-				IL_029a: stloc.s 21
-				IL_029c: ldarg.0
-				IL_029d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-				IL_02a2: stloc.s 32
-				IL_02a4: ldloc.s 32
-				IL_02a6: ldc.i4.1
-				IL_02a7: newarr [System.Runtime]System.Object
-				IL_02ac: dup
-				IL_02ad: ldc.i4.0
-				IL_02ae: ldloc.s 15
-				IL_02b0: ldloc.s 20
-				IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02b7: stelem.ref
-				IL_02b8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_02bd: stloc.s 30
-				IL_02bf: ldloc.s 30
-				IL_02c1: ldc.r8 0.0
-				IL_02ca: clt
-				IL_02cc: brfalse IL_0334
+				IL_0296: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
+				IL_029b: stloc.s 21
+				IL_029d: ldarg.0
+				IL_029e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+				IL_02a3: stloc.s 32
+				IL_02a5: ldloc.s 32
+				IL_02a7: ldc.i4.1
+				IL_02a8: newarr [System.Runtime]System.Object
+				IL_02ad: dup
+				IL_02ae: ldc.i4.0
+				IL_02af: ldloc.s 15
+				IL_02b1: ldloc.s 20
+				IL_02b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_02b8: stelem.ref
+				IL_02b9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_02be: stloc.s 30
+				IL_02c0: ldloc.s 30
+				IL_02c2: ldc.r8 0.0
+				IL_02cb: clt
+				IL_02cd: brfalse IL_0335
 
-				IL_02d1: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
-				IL_02d6: stloc.s 22
-				IL_02d8: ldloc.s 15
-				IL_02da: ldloc.s 20
-				IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_02e6: stloc.s 31
-				IL_02e8: ldstr "flags:"
-				IL_02ed: ldloc.s 31
-				IL_02ef: call string [System.Runtime]System.String::Concat(string, string)
-				IL_02f4: stloc.s 31
-				IL_02f6: ldloc.s 15
-				IL_02f8: ldloc.s 20
-				IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0304: stloc.s 33
-				IL_0306: ldstr "Unsupported flag '"
-				IL_030b: ldloc.s 33
-				IL_030d: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0312: stloc.s 33
-				IL_0314: ldloc.s 33
-				IL_0316: ldstr "'."
-				IL_031b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0320: stloc.s 33
-				IL_0322: ldnull
-				IL_0323: ldloc.s 4
-				IL_0325: ldstr "unknown-flag"
-				IL_032a: ldloc.s 31
-				IL_032c: ldloc.s 33
-				IL_032e: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_0333: pop
+				IL_02d2: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
+				IL_02d7: stloc.s 22
+				IL_02d9: ldloc.s 15
+				IL_02db: ldloc.s 20
+				IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_02e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_02e7: stloc.s 31
+				IL_02e9: ldstr "flags:"
+				IL_02ee: ldloc.s 31
+				IL_02f0: call string [System.Runtime]System.String::Concat(string, string)
+				IL_02f5: stloc.s 31
+				IL_02f7: ldloc.s 15
+				IL_02f9: ldloc.s 20
+				IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0300: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0305: stloc.s 33
+				IL_0307: ldstr "Unsupported flag '"
+				IL_030c: ldloc.s 33
+				IL_030e: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0313: stloc.s 33
+				IL_0315: ldloc.s 33
+				IL_0317: ldstr "'."
+				IL_031c: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0321: stloc.s 33
+				IL_0323: ldnull
+				IL_0324: ldloc.s 4
+				IL_0326: ldstr "unknown-flag"
+				IL_032b: ldloc.s 31
+				IL_032d: ldloc.s 33
+				IL_032f: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+				IL_0334: pop
 
-				IL_0334: ldloc.s 20
-				IL_0336: ldc.r8 1
-				IL_033f: add
-				IL_0340: stloc.s 20
-				IL_0342: br IL_0285
+				IL_0335: ldloc.s 20
+				IL_0337: ldc.r8 1
+				IL_0340: add
+				IL_0341: stloc.s 20
+				IL_0343: br IL_0285
 			// end loop
 
-			IL_0347: ldarg.0
-			IL_0348: castclass Modules.test262_metadataParser/Scope
-			IL_034d: ldnull
-			IL_034e: ldloc.s 15
-			IL_0350: ldloc.s 14
-			IL_0352: ldloc.2
-			IL_0353: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0358: stloc.s 28
-			IL_035a: ldloc.s 28
-			IL_035c: stloc.s 23
-			IL_035e: ldloc.s 23
-			IL_0360: ldstr "strictMode"
-			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_036a: ldstr "conflicting-flags"
-			IL_036f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0374: stloc.s 25
-			IL_0376: ldloc.s 25
-			IL_0378: brfalse IL_039c
+			IL_0348: ldarg.0
+			IL_0349: castclass Modules.test262_metadataParser/Scope
+			IL_034e: ldnull
+			IL_034f: ldloc.s 15
+			IL_0351: ldloc.s 14
+			IL_0353: ldloc.2
+			IL_0354: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0359: stloc.s 28
+			IL_035b: ldloc.s 28
+			IL_035d: stloc.s 23
+			IL_035f: ldloc.s 23
+			IL_0361: ldstr "strictMode"
+			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036b: ldstr "conflicting-flags"
+			IL_0370: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0375: stloc.s 25
+			IL_0377: ldloc.s 25
+			IL_0379: brfalse IL_039d
 
-			IL_037d: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
-			IL_0382: stloc.s 24
-			IL_0384: ldnull
-			IL_0385: ldloc.s 4
-			IL_0387: ldstr "conflicting-strictness-flags"
-			IL_038c: ldstr "flags"
-			IL_0391: ldstr "Multiple strictness/source-type flags were declared together."
-			IL_0396: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_039b: pop
+			IL_037e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
+			IL_0383: stloc.s 24
+			IL_0385: ldnull
+			IL_0386: ldloc.s 4
+			IL_0388: ldstr "conflicting-strictness-flags"
+			IL_038d: ldstr "flags"
+			IL_0392: ldstr "Multiple strictness/source-type flags were declared together."
+			IL_0397: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
+			IL_039c: pop
 
-			IL_039c: ldloc.1
-			IL_039d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03a2: stloc.s 25
-			IL_03a4: ldloc.s 25
-			IL_03a6: brtrue IL_03b8
+			IL_039d: ldloc.1
+			IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a3: stloc.s 25
+			IL_03a5: ldloc.s 25
+			IL_03a7: brtrue IL_03b9
 
-			IL_03ab: ldc.i4.0
-			IL_03ac: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03b1: stloc.s 34
-			IL_03b3: br IL_03bb
+			IL_03ac: ldc.i4.0
+			IL_03ad: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03b2: stloc.s 34
+			IL_03b4: br IL_03bc
 
-			IL_03b8: ldloc.1
-			IL_03b9: stloc.s 34
+			IL_03b9: ldloc.1
+			IL_03ba: stloc.s 34
 
-			IL_03bb: ldloc.2
-			IL_03bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03c1: stloc.s 25
-			IL_03c3: ldloc.s 25
-			IL_03c5: brtrue IL_03d7
+			IL_03bc: ldloc.2
+			IL_03bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03c2: stloc.s 25
+			IL_03c4: ldloc.s 25
+			IL_03c6: brtrue IL_03d8
 
-			IL_03ca: ldc.i4.0
-			IL_03cb: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03d0: stloc.s 36
-			IL_03d2: br IL_03da
+			IL_03cb: ldc.i4.0
+			IL_03cc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03d1: stloc.s 36
+			IL_03d3: br IL_03db
 
-			IL_03d7: ldloc.2
-			IL_03d8: stloc.s 36
+			IL_03d8: ldloc.2
+			IL_03d9: stloc.s 36
 
-			IL_03da: ldloc.s 7
-			IL_03dc: ldstr "description"
-			IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e6: stloc.s 28
-			IL_03e8: ldarg.0
-			IL_03e9: castclass Modules.test262_metadataParser/Scope
-			IL_03ee: ldnull
-			IL_03ef: ldloc.s 28
-			IL_03f1: ldstr "description"
-			IL_03f6: ldloc.s 4
-			IL_03f8: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_03fd: stloc.s 28
-			IL_03ff: ldloc.s 7
-			IL_0401: ldstr "info"
-			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040b: stloc.s 37
-			IL_040d: ldarg.0
-			IL_040e: castclass Modules.test262_metadataParser/Scope
-			IL_0413: ldnull
-			IL_0414: ldloc.s 37
-			IL_0416: ldstr "info"
-			IL_041b: ldloc.s 4
-			IL_041d: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0422: stloc.s 37
-			IL_0424: ldloc.s 7
-			IL_0426: ldstr "esid"
-			IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0430: stloc.s 38
-			IL_0432: ldarg.0
-			IL_0433: castclass Modules.test262_metadataParser/Scope
-			IL_0438: ldnull
-			IL_0439: ldloc.s 38
-			IL_043b: ldstr "esid"
-			IL_0440: ldloc.s 4
-			IL_0442: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0447: stloc.s 38
-			IL_0449: ldloc.s 7
-			IL_044b: ldstr "es5id"
-			IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0455: stloc.s 39
-			IL_0457: ldarg.0
-			IL_0458: castclass Modules.test262_metadataParser/Scope
-			IL_045d: ldnull
-			IL_045e: ldloc.s 39
-			IL_0460: ldstr "es5id"
-			IL_0465: ldloc.s 4
-			IL_0467: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_046c: stloc.s 39
-			IL_046e: ldloc.s 7
-			IL_0470: ldstr "es6id"
-			IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_047a: stloc.s 40
-			IL_047c: ldarg.0
-			IL_047d: castclass Modules.test262_metadataParser/Scope
-			IL_0482: ldnull
-			IL_0483: ldloc.s 40
-			IL_0485: ldstr "es6id"
-			IL_048a: ldloc.s 4
-			IL_048c: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0491: stloc.s 40
-			IL_0493: ldloc.s 7
-			IL_0495: ldstr "author"
-			IL_049a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_049f: stloc.s 41
-			IL_04a1: ldarg.0
-			IL_04a2: castclass Modules.test262_metadataParser/Scope
-			IL_04a7: ldnull
-			IL_04a8: ldloc.s 41
-			IL_04aa: ldstr "author"
-			IL_04af: ldloc.s 4
-			IL_04b1: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_04b6: stloc.s 41
-			IL_04b8: ldarg.0
-			IL_04b9: castclass Modules.test262_metadataParser/Scope
-			IL_04be: ldnull
-			IL_04bf: ldloc.1
-			IL_04c0: ldloc.s 19
-			IL_04c2: ldloc.s 23
-			IL_04c4: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_04c9: stloc.s 42
-			IL_04cb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04d0: dup
-			IL_04d1: ldstr "filePath"
-			IL_04d6: ldloc.s 34
-			IL_04d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04dd: dup
-			IL_04de: ldstr "fileName"
-			IL_04e3: ldloc.s 36
-			IL_04e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04ea: dup
-			IL_04eb: ldstr "hasFrontmatter"
-			IL_04f0: ldloc.s 5
-			IL_04f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04f7: dup
-			IL_04f8: ldstr "frontmatter"
-			IL_04fd: ldloc.s 7
-			IL_04ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0504: dup
-			IL_0505: ldstr "unknownKeys"
-			IL_050a: ldloc.s 9
-			IL_050c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0511: dup
-			IL_0512: ldstr "description"
-			IL_0517: ldloc.s 28
-			IL_0519: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_051e: dup
-			IL_051f: ldstr "info"
-			IL_0524: ldloc.s 37
-			IL_0526: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_052b: dup
-			IL_052c: ldstr "esid"
-			IL_0531: ldloc.s 38
-			IL_0533: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0538: dup
-			IL_0539: ldstr "es5id"
-			IL_053e: ldloc.s 39
-			IL_0540: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0545: dup
-			IL_0546: ldstr "es6id"
-			IL_054b: ldloc.s 40
-			IL_054d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0552: dup
-			IL_0553: ldstr "author"
-			IL_0558: ldloc.s 41
-			IL_055a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_055f: dup
-			IL_0560: ldstr "includes"
-			IL_0565: ldloc.s 14
-			IL_0567: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_056c: dup
-			IL_056d: ldstr "flags"
-			IL_0572: ldloc.s 15
-			IL_0574: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0579: dup
-			IL_057a: ldstr "features"
-			IL_057f: ldloc.s 16
-			IL_0581: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0586: dup
-			IL_0587: ldstr "locale"
-			IL_058c: ldloc.s 17
-			IL_058e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0593: dup
-			IL_0594: ldstr "defines"
-			IL_0599: ldloc.s 18
-			IL_059b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05a0: dup
-			IL_05a1: ldstr "negative"
-			IL_05a6: ldloc.s 19
-			IL_05a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05ad: dup
-			IL_05ae: ldstr "execution"
-			IL_05b3: ldloc.s 23
-			IL_05b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05ba: dup
-			IL_05bb: ldstr "mvpBlockers"
-			IL_05c0: ldloc.s 42
-			IL_05c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05c7: dup
-			IL_05c8: ldstr "unsupported"
-			IL_05cd: ldloc.s 4
-			IL_05cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05d4: stloc.s 43
-			IL_05d6: ldloc.s 43
-			IL_05d8: ret
+			IL_03db: ldloc.s 7
+			IL_03dd: ldstr "description"
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e7: stloc.s 28
+			IL_03e9: ldarg.0
+			IL_03ea: castclass Modules.test262_metadataParser/Scope
+			IL_03ef: ldnull
+			IL_03f0: ldloc.s 28
+			IL_03f2: ldstr "description"
+			IL_03f7: ldloc.s 4
+			IL_03f9: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_03fe: stloc.s 28
+			IL_0400: ldloc.s 7
+			IL_0402: ldstr "info"
+			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040c: stloc.s 37
+			IL_040e: ldarg.0
+			IL_040f: castclass Modules.test262_metadataParser/Scope
+			IL_0414: ldnull
+			IL_0415: ldloc.s 37
+			IL_0417: ldstr "info"
+			IL_041c: ldloc.s 4
+			IL_041e: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0423: stloc.s 37
+			IL_0425: ldloc.s 7
+			IL_0427: ldstr "esid"
+			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0431: stloc.s 38
+			IL_0433: ldarg.0
+			IL_0434: castclass Modules.test262_metadataParser/Scope
+			IL_0439: ldnull
+			IL_043a: ldloc.s 38
+			IL_043c: ldstr "esid"
+			IL_0441: ldloc.s 4
+			IL_0443: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0448: stloc.s 38
+			IL_044a: ldloc.s 7
+			IL_044c: ldstr "es5id"
+			IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0456: stloc.s 39
+			IL_0458: ldarg.0
+			IL_0459: castclass Modules.test262_metadataParser/Scope
+			IL_045e: ldnull
+			IL_045f: ldloc.s 39
+			IL_0461: ldstr "es5id"
+			IL_0466: ldloc.s 4
+			IL_0468: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_046d: stloc.s 39
+			IL_046f: ldloc.s 7
+			IL_0471: ldstr "es6id"
+			IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_047b: stloc.s 40
+			IL_047d: ldarg.0
+			IL_047e: castclass Modules.test262_metadataParser/Scope
+			IL_0483: ldnull
+			IL_0484: ldloc.s 40
+			IL_0486: ldstr "es6id"
+			IL_048b: ldloc.s 4
+			IL_048d: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_0492: stloc.s 40
+			IL_0494: ldloc.s 7
+			IL_0496: ldstr "author"
+			IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a0: stloc.s 41
+			IL_04a2: ldarg.0
+			IL_04a3: castclass Modules.test262_metadataParser/Scope
+			IL_04a8: ldnull
+			IL_04a9: ldloc.s 41
+			IL_04ab: ldstr "author"
+			IL_04b0: ldloc.s 4
+			IL_04b2: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_04b7: stloc.s 41
+			IL_04b9: ldarg.0
+			IL_04ba: castclass Modules.test262_metadataParser/Scope
+			IL_04bf: ldnull
+			IL_04c0: ldloc.1
+			IL_04c1: ldloc.s 19
+			IL_04c3: ldloc.s 23
+			IL_04c5: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_04ca: stloc.s 32
+			IL_04cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04d1: dup
+			IL_04d2: ldstr "filePath"
+			IL_04d7: ldloc.s 34
+			IL_04d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04de: dup
+			IL_04df: ldstr "fileName"
+			IL_04e4: ldloc.s 36
+			IL_04e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04eb: dup
+			IL_04ec: ldstr "hasFrontmatter"
+			IL_04f1: ldloc.s 5
+			IL_04f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04f8: dup
+			IL_04f9: ldstr "frontmatter"
+			IL_04fe: ldloc.s 7
+			IL_0500: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0505: dup
+			IL_0506: ldstr "unknownKeys"
+			IL_050b: ldloc.s 9
+			IL_050d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0512: dup
+			IL_0513: ldstr "description"
+			IL_0518: ldloc.s 28
+			IL_051a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_051f: dup
+			IL_0520: ldstr "info"
+			IL_0525: ldloc.s 37
+			IL_0527: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_052c: dup
+			IL_052d: ldstr "esid"
+			IL_0532: ldloc.s 38
+			IL_0534: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0539: dup
+			IL_053a: ldstr "es5id"
+			IL_053f: ldloc.s 39
+			IL_0541: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0546: dup
+			IL_0547: ldstr "es6id"
+			IL_054c: ldloc.s 40
+			IL_054e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0553: dup
+			IL_0554: ldstr "author"
+			IL_0559: ldloc.s 41
+			IL_055b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0560: dup
+			IL_0561: ldstr "includes"
+			IL_0566: ldloc.s 14
+			IL_0568: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_056d: dup
+			IL_056e: ldstr "flags"
+			IL_0573: ldloc.s 15
+			IL_0575: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_057a: dup
+			IL_057b: ldstr "features"
+			IL_0580: ldloc.s 16
+			IL_0582: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0587: dup
+			IL_0588: ldstr "locale"
+			IL_058d: ldloc.s 17
+			IL_058f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0594: dup
+			IL_0595: ldstr "defines"
+			IL_059a: ldloc.s 18
+			IL_059c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05a1: dup
+			IL_05a2: ldstr "negative"
+			IL_05a7: ldloc.s 19
+			IL_05a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05ae: dup
+			IL_05af: ldstr "execution"
+			IL_05b4: ldloc.s 23
+			IL_05b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05bb: dup
+			IL_05bc: ldstr "mvpBlockers"
+			IL_05c1: ldloc.s 32
+			IL_05c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05c8: dup
+			IL_05c9: ldstr "unsupported"
+			IL_05ce: ldloc.s 4
+			IL_05d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05d5: stloc.s 42
+			IL_05d7: ldloc.s 42
+			IL_05d9: ret
 		} // end of method parseTest262Metadata::__js_call__
 
 	} // end of class parseTest262Metadata

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ArrowFunction_LexicalThis_ObjectLiteralProperty
+﻿// IL code: ArrowFunction_LexicalThis_ObjectLiteralProperty
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e6
+				// Method begins at RVA 0x21e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -43,14 +43,13 @@
 			)
 			// Method begins at RVA 0x2101
 			// Header size: 1
-			// Code size: 21 (0x15)
+			// Code size: 16 (0x10)
 			.maxstack 8
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
 			IL_0005: ldstr "x"
 			IL_000a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, string)
-			IL_000f: box [System.Runtime]System.Double
-			IL_0014: ret
+			IL_000f: ret
 		} // end of method ArrowFunction_L11C23::__js_call__
 
 	} // end of class ArrowFunction_L11C23
@@ -66,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x21c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d4
+				// Method begins at RVA 0x21d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21dd
+				// Method begins at RVA 0x21d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -133,7 +132,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2118
+			// Method begins at RVA 0x2114
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -160,7 +159,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2144
+			// Method begins at RVA 0x2140
 			// Header size: 12
 			// Code size: 103 (0x67)
 			.maxstack 8
@@ -174,8 +173,8 @@
 			IL_0000: newobj instance void Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/Scope_make::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldnull
-			IL_0007: ldftn object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/ArrowFunction_L11C23::__js_call__(object)
-			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0007: ldftn float64 Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/ArrowFunction_L11C23::__js_call__(object)
+			IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 			IL_0012: ldc.i4.1
 			IL_0013: newarr [System.Runtime]System.Object
 			IL_0018: dup
@@ -228,7 +227,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b7
+			// Method begins at RVA 0x21b3
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -337,7 +336,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ef
+		// Method begins at RVA 0x21eb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_TypeofFunctionStrictEqual
+﻿// IL code: BinaryOperator_TypeofFunctionStrictEqual
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216b
+				// Method begins at RVA 0x2166
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -43,12 +43,11 @@
 			)
 			// Method begins at RVA 0x2152
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 42
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method ArrowFunction_L3C20::__js_call__
 
 	} // end of class ArrowFunction_L3C20
@@ -64,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2174
+				// Method begins at RVA 0x216f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x217d
+				// Method begins at RVA 0x2178
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2186
+				// Method begins at RVA 0x2181
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -124,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x218f
+				// Method begins at RVA 0x218a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +143,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2198
+				// Method begins at RVA 0x2193
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -162,7 +161,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2162
+			// Method begins at RVA 0x215d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -204,8 +203,8 @@
 		IL_0000: newobj instance void Modules.BinaryOperator_TypeofFunctionStrictEqual/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.BinaryOperator_TypeofFunctionStrictEqual/ArrowFunction_L3C20::__js_call__(object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0007: ldftn float64 Modules.BinaryOperator_TypeofFunctionStrictEqual/ArrowFunction_L3C20::__js_call__(object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0012: ldc.i4.1
 		IL_0013: newarr [System.Runtime]System.Object
 		IL_0018: dup
@@ -290,7 +289,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a1
+		// Method begins at RVA 0x219c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x215f
+					// Method begins at RVA 0x215e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2156
+				// Method begins at RVA 0x2155
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,24 +56,23 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2094
+			// Method begins at RVA 0x209c
 			// Header size: 12
-			// Code size: 173 (0xad)
+			// Code size: 164 (0xa4)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
 				[2] class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/Scope/Block_L3C33,
 				[3] float64,
-				[4] float64,
-				[5] object
+				[4] float64
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -134,10 +133,7 @@
 			// end loop
 
 			IL_00a2: ldloc.0
-			IL_00a3: box [System.Runtime]System.Double
-			IL_00a8: stloc.s 5
-			IL_00aa: ldloc.s 5
-			IL_00ac: ret
+			IL_00a3: ret
 		} // end of method arith::__js_call__
 
 	} // end of class arith
@@ -156,7 +152,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214d
+			// Method begins at RVA 0x214c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -182,19 +178,21 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 55 (0x37)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.NumericInference_ExponentiationLoop_NoBoxing/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] float64,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.NumericInference_ExponentiationLoop_NoBoxing/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0007: ldftn float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0012: ldc.i4.0
 		IL_0013: conv.r8
 		IL_0014: ldstr "arith"
@@ -205,13 +203,16 @@
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
 		IL_0023: ldnull
-		IL_0024: call object Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
-		IL_0029: stloc.2
-		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002f: ldloc.2
-		IL_0030: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0035: pop
-		IL_0036: ret
+		IL_0024: call float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
+		IL_0029: stloc.3
+		IL_002a: ldloc.3
+		IL_002b: box [System.Runtime]System.Double
+		IL_0030: stloc.s 4
+		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0037: ldloc.s 4
+		IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method NumericInference_ExponentiationLoop_NoBoxing::__js_module_init__
 
 } // end of class Modules.NumericInference_ExponentiationLoop_NoBoxing
@@ -223,7 +224,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2168
+		// Method begins at RVA 0x2167
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
@@ -320,7 +320,8 @@
 			[3] object,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] object[]
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[7] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/Scope::.ctor()
@@ -382,9 +383,9 @@
 		IL_0097: stloc.s 5
 		IL_0099: ldnull
 		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
-		IL_009f: stloc.s 4
+		IL_009f: stloc.s 6
 		IL_00a1: ldloc.s 5
-		IL_00a3: ldloc.s 4
+		IL_00a3: ldloc.s 6
 		IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
 		IL_00aa: ldnull
 		IL_00ab: ldc.r8 4
@@ -396,7 +397,7 @@
 		IL_00c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_00c9: ldloc.s 5
 		IL_00cb: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_00d0: stloc.s 6
+		IL_00d0: stloc.s 7
 		IL_00d2: ldloc.0
 		IL_00d3: castclass Modules.Function_Call_Spread_EvaluationOrder/Scope
 		IL_00d8: ldftn object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
@@ -407,7 +408,7 @@
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldloc.0
 		IL_00ec: stelem.ref
-		IL_00ed: ldloc.s 6
+		IL_00ed: ldloc.s 7
 		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
 		IL_00f4: pop
 		IL_00f5: ret

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ConstantString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ConstantString_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Constructor_New_ConstantString_Basic
+﻿// IL code: Function_Constructor_New_ConstantString_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20dd
+				// Method begins at RVA 0x20d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -43,12 +43,11 @@
 			)
 			// Method begins at RVA 0x20c4
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method '<>DynamicFunction_L3C11'::__js_call__
 
 	} // end of class <>DynamicFunction_L3C11
@@ -60,7 +59,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20cf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -97,8 +96,8 @@
 		IL_0000: newobj instance void Modules.Function_Constructor_New_ConstantString_Basic/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0007: ldftn float64 Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0012: ldc.i4.0
 		IL_0013: conv.r8
 		IL_0014: ldstr ""
@@ -140,7 +139,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e6
+		// Method begins at RVA 0x20e1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218f
+					// Method begins at RVA 0x2187
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2186
+				// Method begins at RVA 0x217e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 97 (0x61)
 			.maxstack 8
@@ -130,7 +130,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217d
+			// Method begins at RVA 0x2175
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -156,14 +156,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 177 (0xb1)
+		// Code size: 172 (0xac)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithArrayIteration/Scope,
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[3] object,
-			[4] object
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[4] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[6] string
 		)
 
 		IL_0000: newobj instance void Modules.Function_GlobalFunctionWithArrayIteration/Scope::.ctor()
@@ -202,22 +204,23 @@
 		IL_007c: ldnull
 		IL_007d: ldloc.2
 		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, object)
-		IL_0083: stloc.s 4
-		IL_0085: ldloc.s 4
+		IL_0083: stloc.s 5
+		IL_0085: ldloc.s 5
 		IL_0087: stloc.3
 		IL_0088: ldloc.3
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008e: stloc.s 4
-		IL_0090: ldloc.s 4
-		IL_0092: ldstr "join"
-		IL_0097: ldstr ","
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a1: stloc.s 4
-		IL_00a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a8: ldloc.s 4
-		IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00af: pop
-		IL_00b0: ret
+		IL_0089: ldc.i4.1
+		IL_008a: newarr [System.Runtime]System.Object
+		IL_008f: dup
+		IL_0090: ldc.i4.0
+		IL_0091: ldstr ","
+		IL_0096: stelem.ref
+		IL_0097: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+		IL_009c: stloc.s 6
+		IL_009e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a3: ldloc.s 6
+		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00aa: pop
+		IL_00ab: ret
 	} // end of method Function_GlobalFunctionWithArrayIteration::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithArrayIteration
@@ -229,7 +232,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2198
+		// Method begins at RVA 0x2190
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous
+﻿// IL code: Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2108
+				// Method begins at RVA 0x2103
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -43,12 +43,11 @@
 			)
 			// Method begins at RVA 0x20ef
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method DynamicFunction_L12C34::__js_call__
 
 	} // end of class DynamicFunction_L12C34
@@ -69,7 +68,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20ff
+			// Method begins at RVA 0x20fa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -109,8 +108,8 @@
 		IL_0000: newobj instance void Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0007: ldftn float64 Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0012: ldc.i4.0
 		IL_0013: conv.r8
 		IL_0014: ldstr "DynamicFunction_L12C34"
@@ -169,7 +168,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2111
+		// Method begins at RVA 0x210c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20d5
+				// Method begins at RVA 0x20c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,16 +34,16 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ac
+			// Method begins at RVA 0x20a5
 			// Header size: 1
-			// Code size: 31 (0x1f)
+			// Code size: 26 (0x1a)
 			.maxstack 8
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -51,8 +51,7 @@
 			IL_000a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_000f: pop
 			IL_0010: ldc.r8 5
-			IL_0019: box [System.Runtime]System.Double
-			IL_001e: ret
+			IL_0019: ret
 		} // end of method returnsFive::__js_call__
 
 	} // end of class returnsFive
@@ -72,7 +71,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20cc
+			// Method begins at RVA 0x20c0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -98,7 +97,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 80 (0x50)
+		// Code size: 73 (0x49)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnsStaticValueAndLogs/Scope,
@@ -112,8 +111,8 @@
 		IL_0000: newobj instance void Modules.Function_ReturnsStaticValueAndLogs/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0007: ldftn float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0012: ldc.i4.0
 		IL_0013: conv.r8
 		IL_0014: ldstr "returnsFive"
@@ -124,22 +123,19 @@
 		IL_0021: ldloc.3
 		IL_0022: stloc.1
 		IL_0023: ldnull
-		IL_0024: call object Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
-		IL_0029: stloc.3
-		IL_002a: ldloc.3
-		IL_002b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0030: stloc.s 4
-		IL_0032: ldloc.s 4
-		IL_0034: stloc.2
-		IL_0035: ldloc.2
-		IL_0036: box [System.Runtime]System.Double
-		IL_003b: stloc.s 5
-		IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0042: ldstr "Output:"
-		IL_0047: ldloc.s 5
-		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_004e: pop
-		IL_004f: ret
+		IL_0024: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
+		IL_0029: stloc.s 4
+		IL_002b: ldloc.s 4
+		IL_002d: stloc.2
+		IL_002e: ldloc.2
+		IL_002f: box [System.Runtime]System.Double
+		IL_0034: stloc.s 5
+		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_003b: ldstr "Output:"
+		IL_0040: ldloc.s 5
+		IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0047: pop
+		IL_0048: ret
 	} // end of method Function_ReturnsStaticValueAndLogs::__js_module_init__
 
 } // end of class Modules.Function_ReturnsStaticValueAndLogs
@@ -151,7 +147,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20de
+		// Method begins at RVA 0x20d2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ba6
+				// Method begins at RVA 0x4ab6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4baf
+				// Method begins at RVA 0x4abf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bc1
+					// Method begins at RVA 0x4ad1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bb8
+				// Method begins at RVA 0x4ac8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bd3
+					// Method begins at RVA 0x4ae3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bca
+				// Method begins at RVA 0x4ada
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bdc
+				// Method begins at RVA 0x4aec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -349,7 +349,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4bf7
+						// Method begins at RVA 0x4b07
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -369,7 +369,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4c00
+						// Method begins at RVA 0x4b10
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -387,7 +387,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4bee
+					// Method begins at RVA 0x4afe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -405,7 +405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4be5
+				// Method begins at RVA 0x4af5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -446,10 +446,9 @@
 				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L37C48,
 				[7] float64,
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[9] object,
+				[9] string,
 				[10] object,
-				[11] object,
-				[12] string
+				[11] object
 			)
 
 			IL_0000: ldnull
@@ -585,20 +584,20 @@
 					IL_0158: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
 					IL_015d: ldloc.0
 					IL_015e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0163: stloc.s 12
+					IL_0163: stloc.s 9
 					IL_0165: ldloc.s 4
 					IL_0167: box [System.Runtime]System.Double
 					IL_016c: stloc.s 11
-					IL_016e: ldloc.s 12
+					IL_016e: ldloc.s 9
 					IL_0170: ldloc.s 11
 					IL_0172: ldloc.s 4
 					IL_0174: ldc.r8 100
 					IL_017d: add
 					IL_017e: box [System.Runtime]System.Double
 					IL_0183: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-					IL_0188: stloc.s 12
+					IL_0188: stloc.s 9
 					IL_018a: ldarg.0
-					IL_018b: ldloc.s 12
+					IL_018b: ldloc.s 9
 					IL_018d: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
 					IL_0192: ldloc.s 4
 					IL_0194: ldc.r8 100
@@ -642,7 +641,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c09
+				// Method begins at RVA 0x4b19
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -670,11 +669,11 @@
 			)
 			// Method begins at RVA 0x3380
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "(?:)"
@@ -693,10 +692,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L48C5::__js_call__
 
 	} // end of class FunctionExpression_L48C5
@@ -712,7 +710,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c12
+				// Method begins at RVA 0x4b22
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -738,7 +736,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x33cc
+			// Method begins at RVA 0x33c8
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -795,7 +793,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c1b
+				// Method begins at RVA 0x4b2b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -821,13 +819,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3438
+			// Method begins at RVA 0x3434
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "a"
@@ -846,10 +844,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L61C5::__js_call__
 
 	} // end of class FunctionExpression_L61C5
@@ -865,7 +862,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c24
+				// Method begins at RVA 0x4b34
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -891,7 +888,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3484
+			// Method begins at RVA 0x347c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -948,7 +945,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c2d
+				// Method begins at RVA 0x4b3d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -974,13 +971,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x34f0
+			// Method begins at RVA 0x34e8
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr ".*"
@@ -999,10 +996,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L71C5::__js_call__
 
 	} // end of class FunctionExpression_L71C5
@@ -1018,7 +1014,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c36
+				// Method begins at RVA 0x4b46
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1044,7 +1040,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x353c
+			// Method begins at RVA 0x3530
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1101,7 +1097,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c3f
+				// Method begins at RVA 0x4b4f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1127,13 +1123,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x35a8
+			// Method begins at RVA 0x359c
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -1152,10 +1148,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L83C5::__js_call__
 
 	} // end of class FunctionExpression_L83C5
@@ -1171,7 +1166,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c48
+				// Method begins at RVA 0x4b58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1197,7 +1192,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x35f4
+			// Method begins at RVA 0x35e4
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1254,7 +1249,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c51
+				// Method begins at RVA 0x4b61
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1280,12 +1275,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3660
+			// Method begins at RVA 0x3650
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -1297,10 +1292,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L93C5::__js_call__
 
 	} // end of class FunctionExpression_L93C5
@@ -1316,7 +1310,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c5a
+				// Method begins at RVA 0x4b6a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1342,7 +1336,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3698
+			// Method begins at RVA 0x3680
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1399,7 +1393,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c63
+				// Method begins at RVA 0x4b73
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1425,12 +1419,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3704
+			// Method begins at RVA 0x36ec
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -1442,10 +1436,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L102C5::__js_call__
 
 	} // end of class FunctionExpression_L102C5
@@ -1461,7 +1454,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c6c
+				// Method begins at RVA 0x4b7c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1487,7 +1480,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x373c
+			// Method begins at RVA 0x371c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1548,7 +1541,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c75
+				// Method begins at RVA 0x4b85
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1574,12 +1567,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x37b0
+			// Method begins at RVA 0x3790
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -1591,10 +1584,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L111C5::__js_call__
 
 	} // end of class FunctionExpression_L111C5
@@ -1610,7 +1602,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c7e
+				// Method begins at RVA 0x4b8e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1636,7 +1628,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x37e8
+			// Method begins at RVA 0x37c0
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1697,7 +1689,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c87
+				// Method begins at RVA 0x4b97
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1723,13 +1715,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x385c
+			// Method begins at RVA 0x3834
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -1748,10 +1740,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L120C5::__js_call__
 
 	} // end of class FunctionExpression_L120C5
@@ -1767,7 +1758,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c90
+				// Method begins at RVA 0x4ba0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1793,7 +1784,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x38a8
+			// Method begins at RVA 0x387c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1850,7 +1841,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c99
+				// Method begins at RVA 0x4ba9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1876,12 +1867,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3914
+			// Method begins at RVA 0x38e8
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -1893,10 +1884,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L130C5::__js_call__
 
 	} // end of class FunctionExpression_L130C5
@@ -1912,7 +1902,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ca2
+				// Method begins at RVA 0x4bb2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1938,7 +1928,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x394c
+			// Method begins at RVA 0x3918
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1995,7 +1985,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cab
+				// Method begins at RVA 0x4bbb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2021,12 +2011,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x39b8
+			// Method begins at RVA 0x3984
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -2038,10 +2028,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L139C5::__js_call__
 
 	} // end of class FunctionExpression_L139C5
@@ -2057,7 +2046,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cb4
+				// Method begins at RVA 0x4bc4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2083,7 +2072,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x39f0
+			// Method begins at RVA 0x39b4
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2144,7 +2133,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cbd
+				// Method begins at RVA 0x4bcd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2170,12 +2159,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a64
+			// Method begins at RVA 0x3a28
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -2187,10 +2176,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L148C5::__js_call__
 
 	} // end of class FunctionExpression_L148C5
@@ -2206,7 +2194,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cc6
+				// Method begins at RVA 0x4bd6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2232,7 +2220,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a9c
+			// Method begins at RVA 0x3a58
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2293,7 +2281,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ccf
+				// Method begins at RVA 0x4bdf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2319,12 +2307,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b10
+			// Method begins at RVA 0x3acc
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -2336,10 +2324,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L157C5::__js_call__
 
 	} // end of class FunctionExpression_L157C5
@@ -2359,7 +2346,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ce1
+					// Method begins at RVA 0x4bf1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2383,7 +2370,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4b46
+				// Method begins at RVA 0x4a56
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -2401,7 +2388,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cd8
+				// Method begins at RVA 0x4be8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2427,7 +2414,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b48
+			// Method begins at RVA 0x3afc
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -2502,7 +2489,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cea
+				// Method begins at RVA 0x4bfa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2528,13 +2515,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3bdc
+			// Method begins at RVA 0x3b90
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "a.*a"
@@ -2553,10 +2540,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L170C5::__js_call__
 
 	} // end of class FunctionExpression_L170C5
@@ -2572,7 +2558,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cf3
+				// Method begins at RVA 0x4c03
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2598,7 +2584,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c28
+			// Method begins at RVA 0x3bd8
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -2655,7 +2641,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cfc
+				// Method begins at RVA 0x4c0c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2681,12 +2667,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c94
+			// Method begins at RVA 0x3c44
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -2698,10 +2684,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L180C5::__js_call__
 
 	} // end of class FunctionExpression_L180C5
@@ -2717,7 +2702,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d05
+				// Method begins at RVA 0x4c15
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2743,7 +2728,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ccc
+			// Method begins at RVA 0x3c74
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -2800,7 +2785,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d0e
+				// Method begins at RVA 0x4c1e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2826,12 +2811,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d38
+			// Method begins at RVA 0x3ce0
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -2843,10 +2828,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L189C5::__js_call__
 
 	} // end of class FunctionExpression_L189C5
@@ -2862,7 +2846,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d17
+				// Method begins at RVA 0x4c27
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2888,7 +2872,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d70
+			// Method begins at RVA 0x3d10
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2949,7 +2933,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d20
+				// Method begins at RVA 0x4c30
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2975,12 +2959,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3de4
+			// Method begins at RVA 0x3d84
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -2992,10 +2976,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L198C5::__js_call__
 
 	} // end of class FunctionExpression_L198C5
@@ -3011,7 +2994,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d29
+				// Method begins at RVA 0x4c39
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3037,7 +3020,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e1c
+			// Method begins at RVA 0x3db4
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3098,7 +3081,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d32
+				// Method begins at RVA 0x4c42
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3124,13 +3107,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e90
+			// Method begins at RVA 0x3e28
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -3149,10 +3132,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L207C5::__js_call__
 
 	} // end of class FunctionExpression_L207C5
@@ -3168,7 +3150,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d3b
+				// Method begins at RVA 0x4c4b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3194,7 +3176,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3edc
+			// Method begins at RVA 0x3e70
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -3251,7 +3233,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d44
+				// Method begins at RVA 0x4c54
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3277,12 +3259,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f48
+			// Method begins at RVA 0x3edc
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -3294,10 +3276,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L217C5::__js_call__
 
 	} // end of class FunctionExpression_L217C5
@@ -3313,7 +3294,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d4d
+				// Method begins at RVA 0x4c5d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3339,7 +3320,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f80
+			// Method begins at RVA 0x3f0c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -3396,7 +3377,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d56
+				// Method begins at RVA 0x4c66
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3422,12 +3403,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3fec
+			// Method begins at RVA 0x3f78
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -3439,10 +3420,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L226C5::__js_call__
 
 	} // end of class FunctionExpression_L226C5
@@ -3458,7 +3438,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d5f
+				// Method begins at RVA 0x4c6f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3484,7 +3464,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4024
+			// Method begins at RVA 0x3fa8
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3545,7 +3525,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d68
+				// Method begins at RVA 0x4c78
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3571,12 +3551,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4098
+			// Method begins at RVA 0x401c
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -3588,10 +3568,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L235C5::__js_call__
 
 	} // end of class FunctionExpression_L235C5
@@ -3607,7 +3586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d71
+				// Method begins at RVA 0x4c81
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3633,7 +3612,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x40d0
+			// Method begins at RVA 0x404c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3694,7 +3673,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d7a
+				// Method begins at RVA 0x4c8a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3720,12 +3699,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4144
+			// Method begins at RVA 0x40c0
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -3737,10 +3716,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L244C5::__js_call__
 
 	} // end of class FunctionExpression_L244C5
@@ -3760,7 +3738,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d8c
+					// Method begins at RVA 0x4c9c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3784,7 +3762,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4b4d
+				// Method begins at RVA 0x4a5d
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -3802,7 +3780,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d83
+				// Method begins at RVA 0x4c93
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3828,7 +3806,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x417c
+			// Method begins at RVA 0x40f0
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -3903,7 +3881,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d95
+				// Method begins at RVA 0x4ca5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3929,13 +3907,13 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4210
+			// Method begins at RVA 0x4184
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 59 (0x3b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] object
+				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldstr "aa(b)aa"
@@ -3954,10 +3932,9 @@
 			IL_0031: stloc.1
 			IL_0032: ldarg.0
 			IL_0033: ldloc.1
-			IL_0034: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0039: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0034: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0039: ldnull
+			IL_003a: ret
 		} // end of method FunctionExpression_L257C5::__js_call__
 
 	} // end of class FunctionExpression_L257C5
@@ -3973,7 +3950,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d9e
+				// Method begins at RVA 0x4cae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3999,7 +3976,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x425c
+			// Method begins at RVA 0x41cc
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -4056,7 +4033,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4da7
+				// Method begins at RVA 0x4cb7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4082,12 +4059,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x42c8
+			// Method begins at RVA 0x4238
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -4099,10 +4076,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L267C5::__js_call__
 
 	} // end of class FunctionExpression_L267C5
@@ -4118,7 +4094,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4db0
+				// Method begins at RVA 0x4cc0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4144,7 +4120,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4300
+			// Method begins at RVA 0x4268
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -4205,7 +4181,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4db9
+				// Method begins at RVA 0x4cc9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4231,12 +4207,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4374
+			// Method begins at RVA 0x42dc
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -4248,10 +4224,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L276C5::__js_call__
 
 	} // end of class FunctionExpression_L276C5
@@ -4267,7 +4242,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dc2
+				// Method begins at RVA 0x4cd2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4293,7 +4268,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x43ac
+			// Method begins at RVA 0x430c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -4354,7 +4329,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dcb
+				// Method begins at RVA 0x4cdb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4380,12 +4355,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4420
+			// Method begins at RVA 0x4380
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -4397,10 +4372,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L285C5::__js_call__
 
 	} // end of class FunctionExpression_L285C5
@@ -4420,7 +4394,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ddd
+					// Method begins at RVA 0x4ced
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4445,7 +4419,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4b54
+				// Method begins at RVA 0x4a64
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -4474,7 +4448,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dd4
+				// Method begins at RVA 0x4ce4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4500,7 +4474,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4458
+			// Method begins at RVA 0x43b0
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -4575,7 +4549,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4de6
+				// Method begins at RVA 0x4cf6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4601,12 +4575,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x44ec
+			// Method begins at RVA 0x4444
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -4618,10 +4592,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L296C5::__js_call__
 
 	} // end of class FunctionExpression_L296C5
@@ -4641,7 +4614,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4df8
+					// Method begins at RVA 0x4d08
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4666,7 +4639,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x4b7c
+				// Method begins at RVA 0x4a8c
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -4694,7 +4667,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4def
+				// Method begins at RVA 0x4cff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4720,7 +4693,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4524
+			// Method begins at RVA 0x4474
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -4795,7 +4768,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e01
+				// Method begins at RVA 0x4d11
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4821,12 +4794,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x45b8
+			// Method begins at RVA 0x4508
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -4838,10 +4811,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L309C5::__js_call__
 
 	} // end of class FunctionExpression_L309C5
@@ -4857,7 +4829,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e0a
+				// Method begins at RVA 0x4d1a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4883,7 +4855,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x45f0
+			// Method begins at RVA 0x4538
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -4944,7 +4916,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e13
+				// Method begins at RVA 0x4d23
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4970,12 +4942,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4668
+			// Method begins at RVA 0x45b0
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -4987,10 +4959,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L318C5::__js_call__
 
 	} // end of class FunctionExpression_L318C5
@@ -5006,7 +4977,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e1c
+				// Method begins at RVA 0x4d2c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5032,7 +5003,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x46a0
+			// Method begins at RVA 0x45e0
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5093,7 +5064,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e25
+				// Method begins at RVA 0x4d35
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5119,12 +5090,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4718
+			// Method begins at RVA 0x4658
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -5136,10 +5107,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L327C5::__js_call__
 
 	} // end of class FunctionExpression_L327C5
@@ -5155,7 +5125,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e2e
+				// Method begins at RVA 0x4d3e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5181,7 +5151,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4750
+			// Method begins at RVA 0x4688
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5243,7 +5213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e37
+				// Method begins at RVA 0x4d47
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5269,12 +5239,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x47cc
+			// Method begins at RVA 0x4704
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -5286,10 +5256,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L336C5::__js_call__
 
 	} // end of class FunctionExpression_L336C5
@@ -5305,7 +5274,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e40
+				// Method begins at RVA 0x4d50
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5331,7 +5300,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4804
+			// Method begins at RVA 0x4734
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5393,7 +5362,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e49
+				// Method begins at RVA 0x4d59
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5419,12 +5388,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4880
+			// Method begins at RVA 0x47b0
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -5436,10 +5405,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L345C5::__js_call__
 
 	} // end of class FunctionExpression_L345C5
@@ -5455,7 +5423,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e52
+				// Method begins at RVA 0x4d62
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5481,7 +5449,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x48b8
+			// Method begins at RVA 0x47e0
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5542,7 +5510,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e5b
+				// Method begins at RVA 0x4d6b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5568,12 +5536,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4930
+			// Method begins at RVA 0x4858
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -5585,10 +5553,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L354C5::__js_call__
 
 	} // end of class FunctionExpression_L354C5
@@ -5604,7 +5571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e64
+				// Method begins at RVA 0x4d74
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5630,7 +5597,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4968
+			// Method begins at RVA 0x4888
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5691,7 +5658,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e6d
+				// Method begins at RVA 0x4d7d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5717,12 +5684,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x49e0
+			// Method begins at RVA 0x4900
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -5734,10 +5701,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L363C5::__js_call__
 
 	} // end of class FunctionExpression_L363C5
@@ -5753,7 +5719,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e76
+				// Method begins at RVA 0x4d86
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5779,7 +5745,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a18
+			// Method begins at RVA 0x4930
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5841,7 +5807,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e7f
+				// Method begins at RVA 0x4d8f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5867,12 +5833,12 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4a94
+			// Method begins at RVA 0x49ac
 			// Header size: 12
-			// Code size: 41 (0x29)
+			// Code size: 36 (0x24)
 			.maxstack 8
 			.locals init (
-				[0] object
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.0
@@ -5884,10 +5850,9 @@
 			IL_001a: stloc.0
 			IL_001b: ldarg.0
 			IL_001c: ldloc.0
-			IL_001d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0022: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0027: ldnull
-			IL_0028: ret
+			IL_001d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0022: ldnull
+			IL_0023: ret
 		} // end of method FunctionExpression_L372C5::__js_call__
 
 	} // end of class FunctionExpression_L372C5
@@ -5903,7 +5868,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e88
+				// Method begins at RVA 0x4d98
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5929,7 +5894,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4acc
+			// Method begins at RVA 0x49dc
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -6010,7 +5975,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4b9d
+			// Method begins at RVA 0x4aad
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -6046,7 +6011,7 @@
 			[4] object,
 			[5] float64,
 			[6] object,
-			[7] object,
+			[7] string,
 			[8] object
 		)
 
@@ -6190,14 +6155,14 @@
 		IL_0182: ldloc.0
 		IL_0183: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
 		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018d: stloc.s 7
-		IL_018f: ldloc.s 7
+		IL_018d: stloc.s 6
+		IL_018f: ldloc.s 6
 		IL_0191: ldstr "join"
 		IL_0196: ldstr ""
 		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a0: stloc.s 7
+		IL_01a0: stloc.s 6
 		IL_01a2: ldloc.0
-		IL_01a3: ldloc.s 7
+		IL_01a3: ldloc.s 6
 		IL_01a5: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
 		IL_01aa: ldloc.0
 		IL_01ab: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
@@ -6234,9 +6199,9 @@
 		IL_0203: ldc.i4.0
 		IL_0204: ldc.i4.1
 		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_020a: stloc.s 7
+		IL_020a: stloc.s 6
 		IL_020c: ldnull
-		IL_020d: ldloc.s 7
+		IL_020d: ldloc.s 6
 		IL_020f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0214: pop
 		IL_0215: ldc.i4.1
@@ -6256,10 +6221,10 @@
 		IL_0238: ldc.i4.0
 		IL_0239: ldc.i4.1
 		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_023f: stloc.s 7
+		IL_023f: stloc.s 6
 		IL_0241: ldnull
 		IL_0242: ldstr "Compiled Object Empty Split"
-		IL_0247: ldloc.s 7
+		IL_0247: ldloc.s 6
 		IL_0249: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_024e: pop
 		IL_024f: ldc.i4.1
@@ -6279,9 +6244,9 @@
 		IL_0272: ldc.i4.0
 		IL_0273: ldc.i4.1
 		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0279: stloc.s 7
+		IL_0279: stloc.s 6
 		IL_027b: ldnull
-		IL_027c: ldloc.s 7
+		IL_027c: ldloc.s 6
 		IL_027e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0283: pop
 		IL_0284: ldc.i4.1
@@ -6301,10 +6266,10 @@
 		IL_02a7: ldc.i4.0
 		IL_02a8: ldc.i4.1
 		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02ae: stloc.s 7
+		IL_02ae: stloc.s 6
 		IL_02b0: ldnull
 		IL_02b1: ldstr "Compiled Object Char Split"
-		IL_02b6: ldloc.s 7
+		IL_02b6: ldloc.s 6
 		IL_02b8: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_02bd: pop
 		IL_02be: ldc.i4.1
@@ -6324,9 +6289,9 @@
 		IL_02e1: ldc.i4.0
 		IL_02e2: ldc.i4.1
 		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02e8: stloc.s 7
+		IL_02e8: stloc.s 6
 		IL_02ea: ldnull
-		IL_02eb: ldloc.s 7
+		IL_02eb: ldloc.s 6
 		IL_02ed: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_02f2: pop
 		IL_02f3: ldc.i4.1
@@ -6346,10 +6311,10 @@
 		IL_0316: ldc.i4.0
 		IL_0317: ldc.i4.1
 		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_031d: stloc.s 7
+		IL_031d: stloc.s 6
 		IL_031f: ldnull
 		IL_0320: ldstr "Compiled Object Variable Split"
-		IL_0325: ldloc.s 7
+		IL_0325: ldloc.s 6
 		IL_0327: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_032c: pop
 		IL_032d: ldc.i4.1
@@ -6369,9 +6334,9 @@
 		IL_0350: ldc.i4.0
 		IL_0351: ldc.i4.1
 		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0357: stloc.s 7
+		IL_0357: stloc.s 6
 		IL_0359: ldnull
-		IL_035a: ldloc.s 7
+		IL_035a: ldloc.s 6
 		IL_035c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0361: pop
 		IL_0362: ldc.i4.1
@@ -6391,10 +6356,10 @@
 		IL_0385: ldc.i4.0
 		IL_0386: ldc.i4.1
 		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_038c: stloc.s 7
+		IL_038c: stloc.s 6
 		IL_038e: ldnull
 		IL_038f: ldstr "Compiled Match"
-		IL_0394: ldloc.s 7
+		IL_0394: ldloc.s 6
 		IL_0396: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_039b: pop
 		IL_039c: ldc.i4.1
@@ -6414,9 +6379,9 @@
 		IL_03bf: ldc.i4.0
 		IL_03c0: ldc.i4.1
 		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03c6: stloc.s 7
+		IL_03c6: stloc.s 6
 		IL_03c8: ldnull
-		IL_03c9: ldloc.s 7
+		IL_03c9: ldloc.s 6
 		IL_03cb: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_03d0: pop
 		IL_03d1: ldc.i4.1
@@ -6436,10 +6401,10 @@
 		IL_03f4: ldc.i4.0
 		IL_03f5: ldc.i4.1
 		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03fb: stloc.s 7
+		IL_03fb: stloc.s 6
 		IL_03fd: ldnull
 		IL_03fe: ldstr "Compiled Test"
-		IL_0403: ldloc.s 7
+		IL_0403: ldloc.s 6
 		IL_0405: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_040a: pop
 		IL_040b: ldc.i4.1
@@ -6459,9 +6424,9 @@
 		IL_042e: ldc.i4.0
 		IL_042f: ldc.i4.1
 		IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0435: stloc.s 7
+		IL_0435: stloc.s 6
 		IL_0437: ldnull
-		IL_0438: ldloc.s 7
+		IL_0438: ldloc.s 6
 		IL_043a: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_043f: pop
 		IL_0440: ldc.i4.1
@@ -6481,10 +6446,10 @@
 		IL_0463: ldc.i4.0
 		IL_0464: ldc.i4.1
 		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_046a: stloc.s 7
+		IL_046a: stloc.s 6
 		IL_046c: ldnull
 		IL_046d: ldstr "Compiled Empty Replace"
-		IL_0472: ldloc.s 7
+		IL_0472: ldloc.s 6
 		IL_0474: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0479: pop
 		IL_047a: ldc.i4.1
@@ -6504,9 +6469,9 @@
 		IL_049d: ldc.i4.0
 		IL_049e: ldc.i4.1
 		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04a4: stloc.s 7
+		IL_04a4: stloc.s 6
 		IL_04a6: ldnull
-		IL_04a7: ldloc.s 7
+		IL_04a7: ldloc.s 6
 		IL_04a9: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_04ae: pop
 		IL_04af: ldc.i4.1
@@ -6526,10 +6491,10 @@
 		IL_04d2: ldc.i4.0
 		IL_04d3: ldc.i4.1
 		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04d9: stloc.s 7
+		IL_04d9: stloc.s 6
 		IL_04db: ldnull
 		IL_04dc: ldstr "Compiled 12 Char Replace"
-		IL_04e1: ldloc.s 7
+		IL_04e1: ldloc.s 6
 		IL_04e3: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_04e8: pop
 		IL_04e9: ldc.i4.1
@@ -6549,9 +6514,9 @@
 		IL_050c: ldc.i4.0
 		IL_050d: ldc.i4.1
 		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0513: stloc.s 7
+		IL_0513: stloc.s 6
 		IL_0515: ldnull
-		IL_0516: ldloc.s 7
+		IL_0516: ldloc.s 6
 		IL_0518: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_051d: pop
 		IL_051e: ldc.i4.1
@@ -6571,10 +6536,10 @@
 		IL_0541: ldc.i4.0
 		IL_0542: ldc.i4.1
 		IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0548: stloc.s 7
+		IL_0548: stloc.s 6
 		IL_054a: ldnull
 		IL_054b: ldstr "Compiled Object Match"
-		IL_0550: ldloc.s 7
+		IL_0550: ldloc.s 6
 		IL_0552: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0557: pop
 		IL_0558: ldc.i4.1
@@ -6594,9 +6559,9 @@
 		IL_057b: ldc.i4.0
 		IL_057c: ldc.i4.1
 		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0582: stloc.s 7
+		IL_0582: stloc.s 6
 		IL_0584: ldnull
-		IL_0585: ldloc.s 7
+		IL_0585: ldloc.s 6
 		IL_0587: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_058c: pop
 		IL_058d: ldc.i4.1
@@ -6616,10 +6581,10 @@
 		IL_05b0: ldc.i4.0
 		IL_05b1: ldc.i4.1
 		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05b7: stloc.s 7
+		IL_05b7: stloc.s 6
 		IL_05b9: ldnull
 		IL_05ba: ldstr "Compiled Object Test"
-		IL_05bf: ldloc.s 7
+		IL_05bf: ldloc.s 6
 		IL_05c1: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_05c6: pop
 		IL_05c7: ldc.i4.1
@@ -6639,9 +6604,9 @@
 		IL_05ea: ldc.i4.0
 		IL_05eb: ldc.i4.1
 		IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05f1: stloc.s 7
+		IL_05f1: stloc.s 6
 		IL_05f3: ldnull
-		IL_05f4: ldloc.s 7
+		IL_05f4: ldloc.s 6
 		IL_05f6: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_05fb: pop
 		IL_05fc: ldc.i4.1
@@ -6661,10 +6626,10 @@
 		IL_061f: ldc.i4.0
 		IL_0620: ldc.i4.1
 		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0626: stloc.s 7
+		IL_0626: stloc.s 6
 		IL_0628: ldnull
 		IL_0629: ldstr "Compiled Object Empty Replace"
-		IL_062e: ldloc.s 7
+		IL_062e: ldloc.s 6
 		IL_0630: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0635: pop
 		IL_0636: ldc.i4.1
@@ -6684,9 +6649,9 @@
 		IL_0659: ldc.i4.0
 		IL_065a: ldc.i4.1
 		IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0660: stloc.s 7
+		IL_0660: stloc.s 6
 		IL_0662: ldnull
-		IL_0663: ldloc.s 7
+		IL_0663: ldloc.s 6
 		IL_0665: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_066a: pop
 		IL_066b: ldc.i4.1
@@ -6706,10 +6671,10 @@
 		IL_068e: ldc.i4.0
 		IL_068f: ldc.i4.1
 		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0695: stloc.s 7
+		IL_0695: stloc.s 6
 		IL_0697: ldnull
 		IL_0698: ldstr "Compiled Object 12 Char Replace"
-		IL_069d: ldloc.s 7
+		IL_069d: ldloc.s 6
 		IL_069f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_06a4: pop
 		IL_06a5: ldc.i4.1
@@ -6729,9 +6694,9 @@
 		IL_06c8: ldc.i4.0
 		IL_06c9: ldc.i4.1
 		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_06cf: stloc.s 7
+		IL_06cf: stloc.s 6
 		IL_06d1: ldnull
-		IL_06d2: ldloc.s 7
+		IL_06d2: ldloc.s 6
 		IL_06d4: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_06d9: pop
 		IL_06da: ldc.i4.1
@@ -6751,10 +6716,10 @@
 		IL_06fd: ldc.i4.0
 		IL_06fe: ldc.i4.1
 		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0704: stloc.s 7
+		IL_0704: stloc.s 6
 		IL_0706: ldnull
 		IL_0707: ldstr "Compiled Object 12 Char Replace Function"
-		IL_070c: ldloc.s 7
+		IL_070c: ldloc.s 6
 		IL_070e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0713: pop
 		IL_0714: ldc.i4.1
@@ -6774,9 +6739,9 @@
 		IL_0737: ldc.i4.0
 		IL_0738: ldc.i4.1
 		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_073e: stloc.s 7
+		IL_073e: stloc.s 6
 		IL_0740: ldnull
-		IL_0741: ldloc.s 7
+		IL_0741: ldloc.s 6
 		IL_0743: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0748: pop
 		IL_0749: ldc.i4.1
@@ -6796,10 +6761,10 @@
 		IL_076c: ldc.i4.0
 		IL_076d: ldc.i4.1
 		IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0773: stloc.s 7
+		IL_0773: stloc.s 6
 		IL_0775: ldnull
 		IL_0776: ldstr "Compiled Variable Match"
-		IL_077b: ldloc.s 7
+		IL_077b: ldloc.s 6
 		IL_077d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0782: pop
 		IL_0783: ldc.i4.1
@@ -6819,9 +6784,9 @@
 		IL_07a6: ldc.i4.0
 		IL_07a7: ldc.i4.1
 		IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_07ad: stloc.s 7
+		IL_07ad: stloc.s 6
 		IL_07af: ldnull
-		IL_07b0: ldloc.s 7
+		IL_07b0: ldloc.s 6
 		IL_07b2: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_07b7: pop
 		IL_07b8: ldc.i4.1
@@ -6841,10 +6806,10 @@
 		IL_07db: ldc.i4.0
 		IL_07dc: ldc.i4.1
 		IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_07e2: stloc.s 7
+		IL_07e2: stloc.s 6
 		IL_07e4: ldnull
 		IL_07e5: ldstr "Compiled Variable Test"
-		IL_07ea: ldloc.s 7
+		IL_07ea: ldloc.s 6
 		IL_07ec: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_07f1: pop
 		IL_07f2: ldc.i4.1
@@ -6864,9 +6829,9 @@
 		IL_0815: ldc.i4.0
 		IL_0816: ldc.i4.1
 		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_081c: stloc.s 7
+		IL_081c: stloc.s 6
 		IL_081e: ldnull
-		IL_081f: ldloc.s 7
+		IL_081f: ldloc.s 6
 		IL_0821: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0826: pop
 		IL_0827: ldc.i4.1
@@ -6886,10 +6851,10 @@
 		IL_084a: ldc.i4.0
 		IL_084b: ldc.i4.1
 		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0851: stloc.s 7
+		IL_0851: stloc.s 6
 		IL_0853: ldnull
 		IL_0854: ldstr "Compiled Variable Empty Replace"
-		IL_0859: ldloc.s 7
+		IL_0859: ldloc.s 6
 		IL_085b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0860: pop
 		IL_0861: ldc.i4.1
@@ -6909,9 +6874,9 @@
 		IL_0884: ldc.i4.0
 		IL_0885: ldc.i4.1
 		IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_088b: stloc.s 7
+		IL_088b: stloc.s 6
 		IL_088d: ldnull
-		IL_088e: ldloc.s 7
+		IL_088e: ldloc.s 6
 		IL_0890: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0895: pop
 		IL_0896: ldc.i4.1
@@ -6931,10 +6896,10 @@
 		IL_08b9: ldc.i4.0
 		IL_08ba: ldc.i4.1
 		IL_08bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_08c0: stloc.s 7
+		IL_08c0: stloc.s 6
 		IL_08c2: ldnull
 		IL_08c3: ldstr "Compiled Variable 12 Char Replace"
-		IL_08c8: ldloc.s 7
+		IL_08c8: ldloc.s 6
 		IL_08ca: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_08cf: pop
 		IL_08d0: ldc.i4.1
@@ -6954,9 +6919,9 @@
 		IL_08f3: ldc.i4.0
 		IL_08f4: ldc.i4.1
 		IL_08f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_08fa: stloc.s 7
+		IL_08fa: stloc.s 6
 		IL_08fc: ldnull
-		IL_08fd: ldloc.s 7
+		IL_08fd: ldloc.s 6
 		IL_08ff: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0904: pop
 		IL_0905: ldc.i4.1
@@ -6976,10 +6941,10 @@
 		IL_0928: ldc.i4.0
 		IL_0929: ldc.i4.1
 		IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_092f: stloc.s 7
+		IL_092f: stloc.s 6
 		IL_0931: ldnull
 		IL_0932: ldstr "Compiled Variable Object Match"
-		IL_0937: ldloc.s 7
+		IL_0937: ldloc.s 6
 		IL_0939: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_093e: pop
 		IL_093f: ldc.i4.1
@@ -6999,9 +6964,9 @@
 		IL_0962: ldc.i4.0
 		IL_0963: ldc.i4.1
 		IL_0964: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0969: stloc.s 7
+		IL_0969: stloc.s 6
 		IL_096b: ldnull
-		IL_096c: ldloc.s 7
+		IL_096c: ldloc.s 6
 		IL_096e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0973: pop
 		IL_0974: ldc.i4.1
@@ -7021,10 +6986,10 @@
 		IL_0997: ldc.i4.0
 		IL_0998: ldc.i4.1
 		IL_0999: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_099e: stloc.s 7
+		IL_099e: stloc.s 6
 		IL_09a0: ldnull
 		IL_09a1: ldstr "Compiled Variable Object Test"
-		IL_09a6: ldloc.s 7
+		IL_09a6: ldloc.s 6
 		IL_09a8: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_09ad: pop
 		IL_09ae: ldc.i4.1
@@ -7044,9 +7009,9 @@
 		IL_09d1: ldc.i4.0
 		IL_09d2: ldc.i4.1
 		IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_09d8: stloc.s 7
+		IL_09d8: stloc.s 6
 		IL_09da: ldnull
-		IL_09db: ldloc.s 7
+		IL_09db: ldloc.s 6
 		IL_09dd: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_09e2: pop
 		IL_09e3: ldc.i4.1
@@ -7066,10 +7031,10 @@
 		IL_0a06: ldc.i4.0
 		IL_0a07: ldc.i4.1
 		IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0a0d: stloc.s 7
+		IL_0a0d: stloc.s 6
 		IL_0a0f: ldnull
 		IL_0a10: ldstr "Compiled Variable Object Empty Replace"
-		IL_0a15: ldloc.s 7
+		IL_0a15: ldloc.s 6
 		IL_0a17: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0a1c: pop
 		IL_0a1d: ldc.i4.1
@@ -7089,9 +7054,9 @@
 		IL_0a40: ldc.i4.0
 		IL_0a41: ldc.i4.1
 		IL_0a42: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0a47: stloc.s 7
+		IL_0a47: stloc.s 6
 		IL_0a49: ldnull
-		IL_0a4a: ldloc.s 7
+		IL_0a4a: ldloc.s 6
 		IL_0a4c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0a51: pop
 		IL_0a52: ldc.i4.1
@@ -7111,10 +7076,10 @@
 		IL_0a75: ldc.i4.0
 		IL_0a76: ldc.i4.1
 		IL_0a77: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0a7c: stloc.s 7
+		IL_0a7c: stloc.s 6
 		IL_0a7e: ldnull
 		IL_0a7f: ldstr "Compiled Variable Object 12 Char Replace"
-		IL_0a84: ldloc.s 7
+		IL_0a84: ldloc.s 6
 		IL_0a86: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0a8b: pop
 		IL_0a8c: ldc.i4.1
@@ -7134,9 +7099,9 @@
 		IL_0aaf: ldc.i4.0
 		IL_0ab0: ldc.i4.1
 		IL_0ab1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ab6: stloc.s 7
+		IL_0ab6: stloc.s 6
 		IL_0ab8: ldnull
-		IL_0ab9: ldloc.s 7
+		IL_0ab9: ldloc.s 6
 		IL_0abb: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0ac0: pop
 		IL_0ac1: ldc.i4.1
@@ -7156,10 +7121,10 @@
 		IL_0ae4: ldc.i4.0
 		IL_0ae5: ldc.i4.1
 		IL_0ae6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0aeb: stloc.s 7
+		IL_0aeb: stloc.s 6
 		IL_0aed: ldnull
 		IL_0aee: ldstr "Compiled Variable Object 12 Char Replace Function"
-		IL_0af3: ldloc.s 7
+		IL_0af3: ldloc.s 6
 		IL_0af5: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0afa: pop
 		IL_0afb: ldc.i4.1
@@ -7179,9 +7144,9 @@
 		IL_0b1e: ldc.i4.0
 		IL_0b1f: ldc.i4.1
 		IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0b25: stloc.s 7
+		IL_0b25: stloc.s 6
 		IL_0b27: ldnull
-		IL_0b28: ldloc.s 7
+		IL_0b28: ldloc.s 6
 		IL_0b2a: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0b2f: pop
 		IL_0b30: ldc.i4.1
@@ -7201,10 +7166,10 @@
 		IL_0b53: ldc.i4.0
 		IL_0b54: ldc.i4.1
 		IL_0b55: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0b5a: stloc.s 7
+		IL_0b5a: stloc.s 6
 		IL_0b5c: ldnull
 		IL_0b5d: ldstr "Compiled Capture Match"
-		IL_0b62: ldloc.s 7
+		IL_0b62: ldloc.s 6
 		IL_0b64: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0b69: pop
 		IL_0b6a: ldc.i4.1
@@ -7224,9 +7189,9 @@
 		IL_0b8d: ldc.i4.0
 		IL_0b8e: ldc.i4.1
 		IL_0b8f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0b94: stloc.s 7
+		IL_0b94: stloc.s 6
 		IL_0b96: ldnull
-		IL_0b97: ldloc.s 7
+		IL_0b97: ldloc.s 6
 		IL_0b99: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0b9e: pop
 		IL_0b9f: ldc.i4.1
@@ -7246,10 +7211,10 @@
 		IL_0bc2: ldc.i4.0
 		IL_0bc3: ldc.i4.1
 		IL_0bc4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0bc9: stloc.s 7
+		IL_0bc9: stloc.s 6
 		IL_0bcb: ldnull
 		IL_0bcc: ldstr "Compiled Capture Replace"
-		IL_0bd1: ldloc.s 7
+		IL_0bd1: ldloc.s 6
 		IL_0bd3: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0bd8: pop
 		IL_0bd9: ldc.i4.1
@@ -7269,9 +7234,9 @@
 		IL_0bfc: ldc.i4.0
 		IL_0bfd: ldc.i4.1
 		IL_0bfe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0c03: stloc.s 7
+		IL_0c03: stloc.s 6
 		IL_0c05: ldnull
-		IL_0c06: ldloc.s 7
+		IL_0c06: ldloc.s 6
 		IL_0c08: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0c0d: pop
 		IL_0c0e: ldc.i4.1
@@ -7291,10 +7256,10 @@
 		IL_0c31: ldc.i4.0
 		IL_0c32: ldc.i4.1
 		IL_0c33: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0c38: stloc.s 7
+		IL_0c38: stloc.s 6
 		IL_0c3a: ldnull
 		IL_0c3b: ldstr "Compiled Capture Replace with Capture"
-		IL_0c40: ldloc.s 7
+		IL_0c40: ldloc.s 6
 		IL_0c42: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0c47: pop
 		IL_0c48: ldc.i4.1
@@ -7314,9 +7279,9 @@
 		IL_0c6b: ldc.i4.0
 		IL_0c6c: ldc.i4.1
 		IL_0c6d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0c72: stloc.s 7
+		IL_0c72: stloc.s 6
 		IL_0c74: ldnull
-		IL_0c75: ldloc.s 7
+		IL_0c75: ldloc.s 6
 		IL_0c77: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0c7c: pop
 		IL_0c7d: ldc.i4.1
@@ -7336,10 +7301,10 @@
 		IL_0ca0: ldc.i4.0
 		IL_0ca1: ldc.i4.1
 		IL_0ca2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ca7: stloc.s 7
+		IL_0ca7: stloc.s 6
 		IL_0ca9: ldnull
 		IL_0caa: ldstr "Compiled Capture Replace with Capture Function"
-		IL_0caf: ldloc.s 7
+		IL_0caf: ldloc.s 6
 		IL_0cb1: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0cb6: pop
 		IL_0cb7: ldc.i4.1
@@ -7359,9 +7324,9 @@
 		IL_0cda: ldc.i4.0
 		IL_0cdb: ldc.i4.1
 		IL_0cdc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ce1: stloc.s 7
+		IL_0ce1: stloc.s 6
 		IL_0ce3: ldnull
-		IL_0ce4: ldloc.s 7
+		IL_0ce4: ldloc.s 6
 		IL_0ce6: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0ceb: pop
 		IL_0cec: ldc.i4.1
@@ -7381,10 +7346,10 @@
 		IL_0d0f: ldc.i4.0
 		IL_0d10: ldc.i4.1
 		IL_0d11: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0d16: stloc.s 7
+		IL_0d16: stloc.s 6
 		IL_0d18: ldnull
 		IL_0d19: ldstr "Compiled Capture Replace with Upperase Capture Function"
-		IL_0d1e: ldloc.s 7
+		IL_0d1e: ldloc.s 6
 		IL_0d20: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0d25: pop
 		IL_0d26: ldc.i4.1
@@ -7404,9 +7369,9 @@
 		IL_0d49: ldc.i4.0
 		IL_0d4a: ldc.i4.1
 		IL_0d4b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0d50: stloc.s 7
+		IL_0d50: stloc.s 6
 		IL_0d52: ldnull
-		IL_0d53: ldloc.s 7
+		IL_0d53: ldloc.s 6
 		IL_0d55: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0d5a: pop
 		IL_0d5b: ldc.i4.1
@@ -7426,10 +7391,10 @@
 		IL_0d7e: ldc.i4.0
 		IL_0d7f: ldc.i4.1
 		IL_0d80: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0d85: stloc.s 7
+		IL_0d85: stloc.s 6
 		IL_0d87: ldnull
 		IL_0d88: ldstr "Uncompiled Match"
-		IL_0d8d: ldloc.s 7
+		IL_0d8d: ldloc.s 6
 		IL_0d8f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0d94: pop
 		IL_0d95: ldc.i4.1
@@ -7449,9 +7414,9 @@
 		IL_0db8: ldc.i4.0
 		IL_0db9: ldc.i4.1
 		IL_0dba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0dbf: stloc.s 7
+		IL_0dbf: stloc.s 6
 		IL_0dc1: ldnull
-		IL_0dc2: ldloc.s 7
+		IL_0dc2: ldloc.s 6
 		IL_0dc4: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0dc9: pop
 		IL_0dca: ldc.i4.1
@@ -7471,10 +7436,10 @@
 		IL_0ded: ldc.i4.0
 		IL_0dee: ldc.i4.1
 		IL_0def: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0df4: stloc.s 7
+		IL_0df4: stloc.s 6
 		IL_0df6: ldnull
 		IL_0df7: ldstr "Uncompiled Test"
-		IL_0dfc: ldloc.s 7
+		IL_0dfc: ldloc.s 6
 		IL_0dfe: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0e03: pop
 		IL_0e04: ldc.i4.1
@@ -7494,9 +7459,9 @@
 		IL_0e27: ldc.i4.0
 		IL_0e28: ldc.i4.1
 		IL_0e29: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0e2e: stloc.s 7
+		IL_0e2e: stloc.s 6
 		IL_0e30: ldnull
-		IL_0e31: ldloc.s 7
+		IL_0e31: ldloc.s 6
 		IL_0e33: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0e38: pop
 		IL_0e39: ldc.i4.1
@@ -7516,10 +7481,10 @@
 		IL_0e5c: ldc.i4.0
 		IL_0e5d: ldc.i4.1
 		IL_0e5e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0e63: stloc.s 7
+		IL_0e63: stloc.s 6
 		IL_0e65: ldnull
 		IL_0e66: ldstr "Uncompiled Empty Replace"
-		IL_0e6b: ldloc.s 7
+		IL_0e6b: ldloc.s 6
 		IL_0e6d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0e72: pop
 		IL_0e73: ldc.i4.1
@@ -7539,9 +7504,9 @@
 		IL_0e96: ldc.i4.0
 		IL_0e97: ldc.i4.1
 		IL_0e98: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0e9d: stloc.s 7
+		IL_0e9d: stloc.s 6
 		IL_0e9f: ldnull
-		IL_0ea0: ldloc.s 7
+		IL_0ea0: ldloc.s 6
 		IL_0ea2: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0ea7: pop
 		IL_0ea8: ldc.i4.1
@@ -7561,10 +7526,10 @@
 		IL_0ecb: ldc.i4.0
 		IL_0ecc: ldc.i4.1
 		IL_0ecd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ed2: stloc.s 7
+		IL_0ed2: stloc.s 6
 		IL_0ed4: ldnull
 		IL_0ed5: ldstr "Uncompiled 12 Char Replace"
-		IL_0eda: ldloc.s 7
+		IL_0eda: ldloc.s 6
 		IL_0edc: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0ee1: pop
 		IL_0ee2: ldc.i4.1
@@ -7584,9 +7549,9 @@
 		IL_0f05: ldc.i4.0
 		IL_0f06: ldc.i4.1
 		IL_0f07: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0f0c: stloc.s 7
+		IL_0f0c: stloc.s 6
 		IL_0f0e: ldnull
-		IL_0f0f: ldloc.s 7
+		IL_0f0f: ldloc.s 6
 		IL_0f11: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0f16: pop
 		IL_0f17: ldc.i4.1
@@ -7606,10 +7571,10 @@
 		IL_0f3a: ldc.i4.0
 		IL_0f3b: ldc.i4.1
 		IL_0f3c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0f41: stloc.s 7
+		IL_0f41: stloc.s 6
 		IL_0f43: ldnull
 		IL_0f44: ldstr "Uncompiled Object Match"
-		IL_0f49: ldloc.s 7
+		IL_0f49: ldloc.s 6
 		IL_0f4b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0f50: pop
 		IL_0f51: ldc.i4.1
@@ -7629,9 +7594,9 @@
 		IL_0f74: ldc.i4.0
 		IL_0f75: ldc.i4.1
 		IL_0f76: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0f7b: stloc.s 7
+		IL_0f7b: stloc.s 6
 		IL_0f7d: ldnull
-		IL_0f7e: ldloc.s 7
+		IL_0f7e: ldloc.s 6
 		IL_0f80: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0f85: pop
 		IL_0f86: ldc.i4.1
@@ -7651,10 +7616,10 @@
 		IL_0fa9: ldc.i4.0
 		IL_0faa: ldc.i4.1
 		IL_0fab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0fb0: stloc.s 7
+		IL_0fb0: stloc.s 6
 		IL_0fb2: ldnull
 		IL_0fb3: ldstr "Uncompiled Object Test"
-		IL_0fb8: ldloc.s 7
+		IL_0fb8: ldloc.s 6
 		IL_0fba: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_0fbf: pop
 		IL_0fc0: ldc.i4.1
@@ -7674,9 +7639,9 @@
 		IL_0fe3: ldc.i4.0
 		IL_0fe4: ldc.i4.1
 		IL_0fe5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0fea: stloc.s 7
+		IL_0fea: stloc.s 6
 		IL_0fec: ldnull
-		IL_0fed: ldloc.s 7
+		IL_0fed: ldloc.s 6
 		IL_0fef: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_0ff4: pop
 		IL_0ff5: ldc.i4.1
@@ -7696,10 +7661,10 @@
 		IL_1018: ldc.i4.0
 		IL_1019: ldc.i4.1
 		IL_101a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_101f: stloc.s 7
+		IL_101f: stloc.s 6
 		IL_1021: ldnull
 		IL_1022: ldstr "Uncompiled Object Empty Replace"
-		IL_1027: ldloc.s 7
+		IL_1027: ldloc.s 6
 		IL_1029: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_102e: pop
 		IL_102f: ldc.i4.1
@@ -7719,9 +7684,9 @@
 		IL_1052: ldc.i4.0
 		IL_1053: ldc.i4.1
 		IL_1054: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_1059: stloc.s 7
+		IL_1059: stloc.s 6
 		IL_105b: ldnull
-		IL_105c: ldloc.s 7
+		IL_105c: ldloc.s 6
 		IL_105e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 		IL_1063: pop
 		IL_1064: ldc.i4.1
@@ -7741,10 +7706,10 @@
 		IL_1087: ldc.i4.0
 		IL_1088: ldc.i4.1
 		IL_1089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_108e: stloc.s 7
+		IL_108e: stloc.s 6
 		IL_1090: ldnull
 		IL_1091: ldstr "Uncompiled Object 12 Char Replace"
-		IL_1096: ldloc.s 7
+		IL_1096: ldloc.s 6
 		IL_1098: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
 		IL_109d: pop
 		IL_109e: ldnull
@@ -7762,7 +7727,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4e91
+		// Method begins at RVA 0x4da1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -846,9 +846,10 @@
 				[5] string,
 				[6] object,
 				[7] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17,
-				[8] object,
-				[9] string,
-				[10] bool
+				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[9] object,
+				[10] string,
+				[11] bool
 			)
 
 			IL_0000: ldarg.0
@@ -883,14 +884,14 @@
 
 				IL_0045: ldloc.0
 				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_004b: stloc.s 8
-				IL_004d: ldloc.s 8
+				IL_004b: stloc.s 9
+				IL_004d: ldloc.s 9
 				IL_004f: brfalse IL_0065
 
-				IL_0054: ldloc.s 8
+				IL_0054: ldloc.s 9
 				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_005b: stloc.s 8
-				IL_005d: ldloc.s 8
+				IL_005b: stloc.s 9
+				IL_005d: ldloc.s 9
 				IL_005f: stloc.3
 				IL_0060: br IL_0069
 
@@ -905,14 +906,14 @@
 
 				IL_006f: ldloc.0
 				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_0075: stloc.s 8
-				IL_0077: ldloc.s 8
+				IL_0075: stloc.s 9
+				IL_0077: ldloc.s 9
 				IL_0079: brfalse IL_0090
 
-				IL_007e: ldloc.s 8
+				IL_007e: ldloc.s 9
 				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_0085: stloc.s 8
-				IL_0087: ldloc.s 8
+				IL_0085: stloc.s 9
+				IL_0087: ldloc.s 9
 				IL_0089: stloc.s 4
 				IL_008b: br IL_0095
 
@@ -950,16 +951,16 @@
 
 			IL_00bd: ldarg.3
 			IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c3: stloc.s 9
+			IL_00c3: stloc.s 10
 			IL_00c5: ldstr ""
-			IL_00ca: ldloc.s 9
+			IL_00ca: ldloc.s 10
 			IL_00cc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d1: stloc.s 9
-			IL_00d3: ldloc.s 9
+			IL_00d1: stloc.s 10
+			IL_00d3: ldloc.s 10
 			IL_00d5: ldstr ".dll"
 			IL_00da: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00df: stloc.s 9
-			IL_00e1: ldloc.s 9
+			IL_00df: stloc.s 10
+			IL_00e1: ldloc.s 10
 			IL_00e3: stloc.s 5
 			IL_00e5: ldarg.0
 			IL_00e6: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
@@ -967,13 +968,13 @@
 			IL_00ec: ldloc.3
 			IL_00ed: ldloc.s 5
 			IL_00ef: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_00f4: stloc.s 8
-			IL_00f6: ldloc.s 8
+			IL_00f4: stloc.s 9
+			IL_00f6: ldloc.s 9
 			IL_00f8: stloc.s 6
 			IL_00fa: ldloc.s 6
 			IL_00fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0101: stloc.s 10
-			IL_0103: ldloc.s 10
+			IL_0101: stloc.s 11
+			IL_0103: ldloc.s 11
 			IL_0105: brfalse IL_0114
 
 			IL_010a: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17::.ctor()
@@ -1573,7 +1574,7 @@
 			)
 			// Method begins at RVA 0x29a8
 			// Header size: 12
-			// Code size: 1542 (0x606)
+			// Code size: 1543 (0x607)
 			.maxstack 9
 			.locals init (
 				[0] object,
@@ -1589,7 +1590,7 @@
 				[10] object,
 				[11] object,
 				[12] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21,
-				[13] object,
+				[13] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[14] float64,
 				[15] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54,
 				[16] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6,
@@ -1921,7 +1922,7 @@
 			IL_03f9: ceq
 			IL_03fb: stloc.s 26
 			IL_03fd: ldloc.s 26
-			IL_03ff: brfalse IL_051b
+			IL_03ff: brfalse IL_051c
 
 			IL_0404: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
 			IL_0409: stloc.s 12
@@ -1960,140 +1961,141 @@
 			IL_0473: ldnull
 			IL_0474: ldloc.2
 			IL_0475: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-			IL_047a: stloc.s 22
-			IL_047c: ldloc.s 22
+			IL_047a: stloc.s 25
+			IL_047c: ldloc.s 25
 			IL_047e: stloc.s 13
 			IL_0480: ldc.r8 0.0
 			IL_0489: stloc.s 14
 			// loop start (head: IL_048b)
 				IL_048b: ldloc.s 14
 				IL_048d: ldloc.s 13
-				IL_048f: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-				IL_0494: clt
-				IL_0496: brfalse IL_04e4
+				IL_048f: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0494: conv.r8
+				IL_0495: clt
+				IL_0497: brfalse IL_04e5
 
-				IL_049b: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
-				IL_04a0: stloc.s 15
-				IL_04a2: ldloc.s 13
-				IL_04a4: ldloc.s 14
-				IL_04a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_04ab: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_04b0: stloc.s 23
-				IL_04b2: ldstr "  - "
-				IL_04b7: ldloc.s 23
-				IL_04b9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04be: stloc.s 23
-				IL_04c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_04c5: ldloc.s 23
-				IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_04cc: pop
-				IL_04cd: ldloc.s 14
-				IL_04cf: ldc.r8 1
-				IL_04d8: add
-				IL_04d9: stloc.s 29
-				IL_04db: ldloc.s 29
-				IL_04dd: stloc.s 14
-				IL_04df: br IL_048b
+				IL_049c: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
+				IL_04a1: stloc.s 15
+				IL_04a3: ldloc.s 13
+				IL_04a5: ldloc.s 14
+				IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_04ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_04b1: stloc.s 23
+				IL_04b3: ldstr "  - "
+				IL_04b8: ldloc.s 23
+				IL_04ba: call string [System.Runtime]System.String::Concat(string, string)
+				IL_04bf: stloc.s 23
+				IL_04c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_04c6: ldloc.s 23
+				IL_04c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_04cd: pop
+				IL_04ce: ldloc.s 14
+				IL_04d0: ldc.r8 1
+				IL_04d9: add
+				IL_04da: stloc.s 29
+				IL_04dc: ldloc.s 29
+				IL_04de: stloc.s 14
+				IL_04e0: br IL_048b
 			// end loop
 
-			IL_04e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04e9: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_04ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_04f3: pop
-			IL_04f4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04fe: stloc.s 22
-			IL_0500: ldloc.s 22
-			IL_0502: ldstr "exit"
-			IL_0507: ldc.r8 1
-			IL_0510: box [System.Runtime]System.Double
-			IL_0515: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_051a: pop
+			IL_04e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04ea: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_04ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_04f4: pop
+			IL_04f5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ff: stloc.s 22
+			IL_0501: ldloc.s 22
+			IL_0503: ldstr "exit"
+			IL_0508: ldc.r8 1
+			IL_0511: box [System.Runtime]System.Double
+			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_051b: pop
 
-			IL_051b: ldloc.s 11
-			IL_051d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0522: stloc.s 23
-			IL_0524: ldstr "Found assembly: "
-			IL_0529: ldloc.s 23
-			IL_052b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0530: stloc.s 23
-			IL_0532: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0537: ldloc.s 23
-			IL_0539: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_053e: pop
+			IL_051c: ldloc.s 11
+			IL_051e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0523: stloc.s 23
+			IL_0525: ldstr "Found assembly: "
+			IL_052a: ldloc.s 23
+			IL_052c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0531: stloc.s 23
+			IL_0533: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0538: ldloc.s 23
+			IL_053a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_053f: pop
 			.try
 			{
-				IL_053f: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
-				IL_0544: stloc.s 16
-				IL_0546: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_054b: ldstr "Opening in ILSpy..."
-				IL_0550: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0555: pop
-				IL_0556: ldarg.0
-				IL_0557: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-				IL_055c: ldnull
-				IL_055d: ldloc.s 11
-				IL_055f: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-				IL_0564: pop
-				IL_0565: leave IL_05f0
+				IL_0540: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
+				IL_0545: stloc.s 16
+				IL_0547: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_054c: ldstr "Opening in ILSpy..."
+				IL_0551: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0556: pop
+				IL_0557: ldarg.0
+				IL_0558: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+				IL_055d: ldnull
+				IL_055e: ldloc.s 11
+				IL_0560: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0565: pop
+				IL_0566: leave IL_05f1
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_056a: stloc.s 17
-				IL_056c: ldloc.s 17
-				IL_056e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0573: dup
-				IL_0574: brtrue IL_058a
+				IL_056b: stloc.s 17
+				IL_056d: ldloc.s 17
+				IL_056f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0574: dup
+				IL_0575: brtrue IL_058b
 
-				IL_0579: pop
-				IL_057a: ldloc.s 17
-				IL_057c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0581: dup
-				IL_0582: brtrue IL_0596
+				IL_057a: pop
+				IL_057b: ldloc.s 17
+				IL_057d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0582: dup
+				IL_0583: brtrue IL_0597
 
-				IL_0587: pop
-				IL_0588: rethrow
+				IL_0588: pop
+				IL_0589: rethrow
 
-				IL_058a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_058f: stloc.s 18
-				IL_0591: br IL_0598
+				IL_058b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0590: stloc.s 18
+				IL_0592: br IL_0599
 
-				IL_0596: stloc.s 18
+				IL_0597: stloc.s 18
 
-				IL_0598: ldloc.s 18
-				IL_059a: stloc.s 22
-				IL_059c: ldloc.s 22
-				IL_059e: stloc.s 19
-				IL_05a0: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
-				IL_05a5: stloc.s 20
-				IL_05a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_05ac: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_05b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_05b6: pop
-				IL_05b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_05bc: ldloc.s 19
-				IL_05be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_05c3: pop
-				IL_05c4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-				IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_05ce: stloc.s 22
-				IL_05d0: ldloc.s 22
-				IL_05d2: ldstr "exit"
-				IL_05d7: ldc.r8 1
-				IL_05e0: box [System.Runtime]System.Double
-				IL_05e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_05ea: pop
-				IL_05eb: leave IL_05f0
+				IL_0599: ldloc.s 18
+				IL_059b: stloc.s 22
+				IL_059d: ldloc.s 22
+				IL_059f: stloc.s 19
+				IL_05a1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
+				IL_05a6: stloc.s 20
+				IL_05a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05ad: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_05b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05b7: pop
+				IL_05b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05bd: ldloc.s 19
+				IL_05bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05c4: pop
+				IL_05c5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+				IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_05cf: stloc.s 22
+				IL_05d1: ldloc.s 22
+				IL_05d3: ldstr "exit"
+				IL_05d8: ldc.r8 1
+				IL_05e1: box [System.Runtime]System.Double
+				IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_05eb: pop
+				IL_05ec: leave IL_05f1
 			} // end handler
 
-			IL_05f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05f5: ldstr "Done!"
-			IL_05fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05ff: pop
-			IL_0600: ldnull
-			IL_0601: stloc.s 21
-			IL_0603: ldloc.s 21
-			IL_0605: ret
+			IL_05f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05f6: ldstr "Done!"
+			IL_05fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0600: pop
+			IL_0601: ldnull
+			IL_0602: stloc.s 21
+			IL_0604: ldloc.s 21
+			IL_0606: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
@@ -1,4 +1,4 @@
-// IL code: ObjectLiteral_AccessorDefinitions
+﻿// IL code: ObjectLiteral_AccessorDefinitions
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2397
+				// Method begins at RVA 0x238d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -72,7 +72,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a0
+				// Method begins at RVA 0x2396
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23a9
+				// Method begins at RVA 0x239f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -183,7 +183,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b2
+				// Method begins at RVA 0x23a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +199,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -208,12 +208,11 @@
 			)
 			// Method begins at RVA 0x236e
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method FunctionExpression_overwritten::__js_call__
 
 	} // end of class FunctionExpression_overwritten
@@ -229,7 +228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23bb
+				// Method begins at RVA 0x23b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -245,21 +244,20 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x237e
+			// Method begins at RVA 0x2379
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method FunctionExpression_spreadOverwrite::__js_call__
 
 	} // end of class FunctionExpression_spreadOverwrite
@@ -271,7 +269,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x238e
+			// Method begins at RVA 0x2384
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -448,8 +446,8 @@
 		IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_01c0: stloc.s 5
 		IL_01c2: ldnull
-		IL_01c3: ldftn object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten::__js_call__(object)
-		IL_01c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01c3: ldftn float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten::__js_call__(object)
+		IL_01c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_01ce: ldc.i4.0
 		IL_01cf: conv.r8
 		IL_01d0: ldstr ""
@@ -479,8 +477,8 @@
 		IL_021d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0222: stloc.s 5
 		IL_0224: ldnull
-		IL_0225: ldftn object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite::__js_call__(object)
-		IL_022b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0225: ldftn float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite::__js_call__(object)
+		IL_022b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0230: ldc.i4.0
 		IL_0231: conv.r8
 		IL_0232: ldstr ""
@@ -522,7 +520,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23c4
+		// Method begins at RVA 0x23ba
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x277e
+				// Method begins at RVA 0x277a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -43,12 +43,11 @@
 			)
 			// Method begins at RVA 0x2710
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 17
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method getter::__js_call__
 
 	} // end of class getter
@@ -64,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2787
+				// Method begins at RVA 0x2783
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -91,7 +90,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2720
+			// Method begins at RVA 0x271c
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -128,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2790
+				// Method begins at RVA 0x278c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -155,7 +154,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x274c
+			// Method begins at RVA 0x2748
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -199,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2799
+				// Method begins at RVA 0x2795
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -219,7 +218,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a2
+				// Method begins at RVA 0x279e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +238,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ab
+				// Method begins at RVA 0x27a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -259,7 +258,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b4
+				// Method begins at RVA 0x27b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -279,7 +278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27bd
+				// Method begins at RVA 0x27b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -299,7 +298,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27c6
+				// Method begins at RVA 0x27c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -319,7 +318,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27cf
+				// Method begins at RVA 0x27cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -339,7 +338,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d8
+				// Method begins at RVA 0x27d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -363,7 +362,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2775
+			// Method begins at RVA 0x2771
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -435,8 +434,8 @@
 		IL_0000: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope::.ctor()
 		IL_0005: stloc.0
 		IL_0006: ldnull
-		IL_0007: ldftn object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
-		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0007: ldftn float64 Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
+		IL_000d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0012: ldc.i4.0
 		IL_0013: conv.r8
 		IL_0014: ldstr "getter"
@@ -1000,7 +999,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27e1
+		// Method begins at RVA 0x27dd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2615
+				// Method begins at RVA 0x2610
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -34,7 +34,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -43,12 +43,11 @@
 			)
 			// Method begins at RVA 0x25b4
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 7
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method FunctionExpression_L49C7::__js_call__
 
 	} // end of class FunctionExpression_L49C7
@@ -64,7 +63,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25cd
+				// Method begins at RVA 0x25c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25d6
+				// Method begins at RVA 0x25d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,7 +103,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25df
+				// Method begins at RVA 0x25da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -124,7 +123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25e8
+				// Method begins at RVA 0x25e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -144,7 +143,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25f1
+				// Method begins at RVA 0x25ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -164,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25fa
+				// Method begins at RVA 0x25f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -184,7 +183,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2603
+				// Method begins at RVA 0x25fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x260c
+				// Method begins at RVA 0x2607
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,7 +223,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x261e
+				// Method begins at RVA 0x2619
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -244,7 +243,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2627
+				// Method begins at RVA 0x2622
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -262,7 +261,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x25c4
+			// Method begins at RVA 0x25bf
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -675,8 +674,8 @@
 		IL_03f4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_03f9: stloc.s 25
 		IL_03fb: ldnull
-		IL_03fc: ldftn object Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
-		IL_0402: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_03fc: ldftn float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
+		IL_0402: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0407: ldc.i4.0
 		IL_0408: conv.r8
 		IL_0409: ldstr ""
@@ -785,7 +784,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2630
+		// Method begins at RVA 0x262b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b4
+					// Method begins at RVA 0x29ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29bd
+					// Method begins at RVA 0x29b5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ab
+				// Method begins at RVA 0x29a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c6
+				// Method begins at RVA 0x29be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -251,7 +251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29cf
+				// Method begins at RVA 0x29c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -307,7 +307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29d8
+				// Method begins at RVA 0x29d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -360,7 +360,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29e1
+				// Method begins at RVA 0x29d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -416,7 +416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ea
+				// Method begins at RVA 0x29e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -461,7 +461,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29f3
+				// Method begins at RVA 0x29eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -522,7 +522,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29fc
+				// Method begins at RVA 0x29f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -574,7 +574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a05
+				// Method begins at RVA 0x29fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -638,7 +638,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a0e
+				// Method begins at RVA 0x2a06
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -691,7 +691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a17
+				// Method begins at RVA 0x2a0f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -707,7 +707,7 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
@@ -716,12 +716,11 @@
 			)
 			// Method begins at RVA 0x2826
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method FunctionExpression_badConstructResultProxy::__js_call__
 
 	} // end of class FunctionExpression_badConstructResultProxy
@@ -737,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a20
+				// Method begins at RVA 0x2a18
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +762,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2838
+			// Method begins at RVA 0x2834
 			// Header size: 12
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -794,7 +793,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a29
+				// Method begins at RVA 0x2a21
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -817,7 +816,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2858
+			// Method begins at RVA 0x2854
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -840,7 +839,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a32
+				// Method begins at RVA 0x2a2a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -856,21 +855,20 @@
 
 		// Methods
 		.method public hidebysig static 
-			object __js_call__ (
+			float64 __js_call__ (
 				object newTarget
 			) cil managed 
 		{
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2860
+			// Method begins at RVA 0x285c
 			// Header size: 1
-			// Code size: 15 (0xf)
+			// Code size: 10 (0xa)
 			.maxstack 8
 
 			IL_0000: ldc.r8 1
-			IL_0009: box [System.Runtime]System.Double
-			IL_000e: ret
+			IL_0009: ret
 		} // end of method FunctionExpression_badGetPrototypeProxy::__js_call__
 
 	} // end of class FunctionExpression_badGetPrototypeProxy
@@ -886,7 +884,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a3b
+				// Method begins at RVA 0x2a33
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -912,7 +910,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2870
+			// Method begins at RVA 0x2868
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -941,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a44
+				// Method begins at RVA 0x2a3c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -967,7 +965,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x288a
+			// Method begins at RVA 0x2882
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -1001,7 +999,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a4d
+				// Method begins at RVA 0x2a45
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1027,7 +1025,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28c8
+			// Method begins at RVA 0x28c0
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -1070,7 +1068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a56
+				// Method begins at RVA 0x2a4e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1093,7 +1091,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2917
+			// Method begins at RVA 0x290f
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1115,7 +1113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a5f
+				// Method begins at RVA 0x2a57
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1141,7 +1139,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2920
+			// Method begins at RVA 0x2918
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1178,7 +1176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a68
+				// Method begins at RVA 0x2a60
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1201,7 +1199,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2952
+			// Method begins at RVA 0x294a
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -1228,7 +1226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a71
+				// Method begins at RVA 0x2a69
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1254,7 +1252,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2970
+			// Method begins at RVA 0x2968
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1314,7 +1312,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29a2
+			// Method begins at RVA 0x299a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1567,8 +1565,8 @@
 		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 		IL_0238: stloc.s 5
 		IL_023a: ldnull
-		IL_023b: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
-		IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_023b: ldftn float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
+		IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0246: ldc.i4.0
 		IL_0247: conv.r8
 		IL_0248: ldstr ""
@@ -1656,8 +1654,8 @@
 		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0334: stloc.s 7
 		IL_0336: ldnull
-		IL_0337: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
-		IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0337: ldftn float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
+		IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
 		IL_0342: ldc.i4.0
 		IL_0343: conv.r8
 		IL_0344: ldstr ""
@@ -1909,7 +1907,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a7a
+		// Method begins at RVA 0x2a72
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- keep NumericInference_ExponentiationLoop_NoBoxing function return typed as float64
- wire typed callable return metadata through two-phase signatures and direct-call lowering
- add typed no-scope zero-arg double delegate path and update call emission/storage to box only at object boundaries
- update the generator snapshot for the coercion optimization regression

## Validation
- `dotnet test .\\tests\\Jroc.Tests\\Jroc.Tests.csproj -c Release --filter "FullyQualifiedName~CoercionOptimization" --nologo`