### PR TITLE
sdk/samples/ci: add Hosting.Picocolors sample

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -176,6 +176,16 @@ jobs:
           echo "$output" | grep -i "title=JROC Domino Sample"
           echo "$output" | grep -i "links=2"
 
+      - name: Build and run Hosting.Picocolors sample
+        run: |
+          set -euo pipefail
+          output=$(dotnet run --project samples/Hosting.Picocolors/Hosting.Picocolors.csproj -c Release -p:JrocRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
+          echo "Program output:"
+          echo "$output"
+          echo "$output" | grep "red="
+          echo "$output" | grep "green="
+          echo "$output" | grep "done"
+
       - name: Build and run Hosting.Basic sample
         run: |
           set -euo pipefail

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -205,6 +205,19 @@ jobs:
           if ($outputText -notmatch 'title=JROC Domino Sample') { throw 'Expected output containing title=JROC Domino Sample' }
           if ($outputText -notmatch 'links=2') { throw 'Expected output containing links=2' }
 
+      - name: Build and run Hosting.Picocolors sample
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $output = dotnet run --project samples/Hosting.Picocolors/Hosting.Picocolors.csproj -c Release -p:JrocRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
+          if ($LASTEXITCODE -ne 0) { $output; exit 1 }
+          "Program output:" | Write-Output
+          $output | Write-Output
+          $outputText = ($output -join "`n")
+          if ($outputText -notmatch 'red=') { throw 'Expected output containing red=' }
+          if ($outputText -notmatch 'green=') { throw 'Expected output containing green=' }
+          if ($outputText -notmatch 'done') { throw 'Expected output containing done' }
+
       - name: Build and run Hosting.Basic sample
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- sdk/samples/ci: add `Hosting.Picocolors` sample — compiles the `picocolors` npm package to a .NET assembly via `Jroc.SDK` and calls color/style functions from C#; add smoke-test steps to `windows-smoke.yml` and `linux-smoke.yml`.
 - runtime/tests/docs/test262: implement `Array.prototype.some` using the existing array-like callback method pipeline, and port 10 failing `built-ins/Array/prototype/some` test262 cases covering primitive wrappers, built-in objects, and arguments-object receivers.
 
 ## v0.11.4 - 2026-06-29

--- a/samples/Hosting.Picocolors/Hosting.Picocolors.csproj
+++ b/samples/Hosting.Picocolors/Hosting.Picocolors.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <ModuleOutputDirectory>obj\$(Configuration)\$(TargetFramework)\jroc\picocolors</ModuleOutputDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Jroc.SDK" Version="$(JrocSdkPackageVersion)" />
+    <PackageReference Include="Jroc.Runtime" Version="$(JrocRuntimePackageVersion)" />
+
+    <JrocCompile Include="picocolors"
+                  OutputDirectory="$(ModuleOutputDirectory)"
+                  CopyToOutputDirectory="true" />
+  </ItemGroup>
+
+  <Target Name="NpmRestore"
+          BeforeTargets="JrocCompile"
+          Condition="'$(SkipNpmRestore)' != 'true'">
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm ci" />
+  </Target>
+
+</Project>

--- a/samples/Hosting.Picocolors/Program.cs
+++ b/samples/Hosting.Picocolors/Program.cs
@@ -1,0 +1,32 @@
+using Jroc.Runtime;
+using System.Reflection;
+
+namespace Hosting.Picocolors;
+
+internal static class Program
+{
+    private static void Main()
+    {
+        var compiledModulePath = Path.Combine(AppContext.BaseDirectory, "picocolors.dll");
+        var asm = Assembly.LoadFrom(compiledModulePath);
+
+        // module.exports from picocolors is the color-functions object itself.
+        using dynamic pc = JsEngine.LoadModule(asm, moduleId: "picocolors");
+
+        // Call a representative selection of picocolors color/style functions.
+        // When ANSI color is supported the strings include ANSI escape codes;
+        // when running without a TTY they are returned as plain text.
+        string red    = Convert.ToString(pc.red("ERROR: something went wrong")) ?? string.Empty;
+        string green  = Convert.ToString(pc.green("OK: all systems go"))        ?? string.Empty;
+        string yellow = Convert.ToString(pc.yellow("WARN: check your config"))  ?? string.Empty;
+        string cyan   = Convert.ToString(pc.cyan("INFO: picocolors via JROC"))  ?? string.Empty;
+        string bold   = Convert.ToString(pc.bold("Bold text"))                  ?? string.Empty;
+
+        Console.WriteLine($"red={red}");
+        Console.WriteLine($"green={green}");
+        Console.WriteLine($"yellow={yellow}");
+        Console.WriteLine($"cyan={cyan}");
+        Console.WriteLine($"bold={bold}");
+        Console.WriteLine("done");
+    }
+}

--- a/samples/Hosting.Picocolors/README.md
+++ b/samples/Hosting.Picocolors/README.md
@@ -1,0 +1,37 @@
+# Hosting.Picocolors
+
+This sample demonstrates compiling and hosting a real npm package: `picocolors`.
+
+[picocolors](https://www.npmjs.com/package/picocolors) is a tiny terminal-color library that wraps strings in ANSI escape codes. The sample compiles the package to a .NET assembly via `Jroc.SDK`, loads it at runtime, and calls several color/style functions from C#.
+
+## Prerequisites
+
+- .NET SDK (see repo root `global.json`)
+- Node.js + npm
+
+## Running the sample
+
+From `samples/Hosting.Picocolors`:
+
+```
+dotnet run -c Release
+```
+
+This will:
+
+1. Run `npm ci` to restore `picocolors` into `node_modules`
+2. Compile `picocolors` to `picocolors.dll` via `Jroc.SDK`
+3. Load the compiled module and call several color functions, printing the results
+
+## Expected output
+
+When a color-capable terminal is detected the strings include ANSI escape codes; when running without a TTY (e.g. piped output) picocolors returns the strings unchanged:
+
+```
+red=ERROR: something went wrong
+green=OK: all systems go
+yellow=WARN: check your config
+cyan=INFO: picocolors via JROC
+bold=Bold text
+done
+```

--- a/samples/Hosting.Picocolors/package-lock.json
+++ b/samples/Hosting.Picocolors/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "jroc-sample-hosting-picocolors",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jroc-sample-hosting-picocolors",
+      "version": "0.0.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "picocolors": "^1.1.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    }
+  }
+}

--- a/samples/Hosting.Picocolors/package.json
+++ b/samples/Hosting.Picocolors/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "jroc-sample-hosting-picocolors",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Dependencies for the JROC Hosting.Picocolors sample",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "picocolors": "^1.1.1"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `Hosting.Picocolors` sample that compiles the [`picocolors`](https://www.npmjs.com/package/picocolors) npm package to a .NET assembly via `Jroc.SDK` and calls color/style functions from C#.

## Changes

### `samples/Hosting.Picocolors/` (new)
- `Hosting.Picocolors.csproj` — flat project layout matching `Hosting.Domino`; uses `JrocCompile Include="picocolors"` and `NpmRestore` target
- `Program.cs` — loads `picocolors.dll`, calls `red`, `green`, `yellow`, `cyan`, and `bold` and prints the results
- `package.json` / `package-lock.json` — pins `picocolors@^1.1.1`
- `README.md` — explains the sample and expected output

### CI smoke tests
- `.github/workflows/windows-smoke.yml` — adds `Build and run Hosting.Picocolors sample` step
- `.github/workflows/linux-smoke.yml` — same

### Changelog
- `CHANGELOG.md` — adds `Unreleased` entry for the new sample
