### PR TITLE
sdk/samples/ci: add NpmRunAll2 sample

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -207,3 +207,14 @@ jobs:
           echo "$output" | grep "counter.value="
           echo "$output" | grep "addAsync(1,2)="
           echo "$output" | grep "created.add(1)="
+
+      - name: Build and run NpmRunAll2 sample
+        run: |
+          set -euo pipefail
+          output=$(dotnet run --project samples/NpmRunAll2/NpmRunAll2.csproj -c Release -p:JrocRuntimePackageVersion="$TOOL_VERSION" 2>&1) || { echo "$output"; exit 1; }
+          echo "Program output:"
+          echo "$output"
+          echo "$output" | grep "task headers"
+          echo "$output" | grep "> build"
+          echo "$output" | grep "pattern matching"
+          echo "$output" | grep "done"

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -245,3 +245,17 @@ jobs:
           if ($outputText -notmatch 'counter\.value=') { throw 'Expected output containing counter.value=' }
           if ($outputText -notmatch 'addAsync\(1,2\)=') { throw 'Expected output containing addAsync(1,2)=' }
           if ($outputText -notmatch 'created\.add\(1\)=') { throw 'Expected output containing created.add(1)=' }
+
+      - name: Build and run NpmRunAll2 sample
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $output = dotnet run --project samples/NpmRunAll2/NpmRunAll2.csproj -c Release -p:JrocRuntimePackageVersion="$env:TOOL_VERSION" 2>&1
+          if ($LASTEXITCODE -ne 0) { $output; exit 1 }
+          "Program output:" | Write-Output
+          $output | Write-Output
+          $outputText = ($output -join "`n")
+          if ($outputText -notmatch 'task headers') { throw 'Expected output containing task headers' }
+          if ($outputText -notmatch '> build') { throw 'Expected output containing > build' }
+          if ($outputText -notmatch 'pattern matching') { throw 'Expected output containing pattern matching' }
+          if ($outputText -notmatch 'done') { throw 'Expected output containing done' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- sdk/samples/ci: add `NpmRunAll2` sample — compiles `npm-run-all2` and its transitive dependencies into a .NET assembly via `Jroc.SDK`, then calls `createHeader` (task-header formatting) and a `filterTasks` glob helper from C#; add smoke-test steps to `windows-smoke.yml` and `linux-smoke.yml`.
 - sdk/samples/ci: add `Picocolors` sample — compiles the `picocolors` npm package to a .NET assembly via `Jroc.SDK` and calls color/style functions from C#; add smoke-test steps to `windows-smoke.yml` and `linux-smoke.yml`.
 - sdk/samples/ci: rename all samples to drop the `Hosting.` prefix (`Hosting.Basic` → `Basic`, `Hosting.Domino` → `Domino`, `Hosting.Picocolors` → `Picocolors`, `Hosting.Typed` → `Typed`); update CI workflows, test assertions, and docs.
+- runtime/tests/docs/test262: implement `Array.prototype.some` using the existing array-like callback method pipeline, and port 10 failing `built-ins/Array/prototype/some` test262 cases covering primitive wrappers, built-in objects, and arguments-object receivers.
 - runtime/tests/docs/test262: implement `Array.prototype.some` using the existing array-like callback method pipeline, and port 10 failing `built-ins/Array/prototype/some` test262 cases covering primitive wrappers, built-in objects, and arguments-object receivers.
 
 ## v0.11.4 - 2026-06-29

--- a/samples/NpmRunAll2/NpmRunAll2.csproj
+++ b/samples/NpmRunAll2/NpmRunAll2.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <ModuleOutputDirectory>obj\$(Configuration)\$(TargetFramework)\jroc\npm-run-all2</ModuleOutputDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Jroc.SDK" Version="$(JrocSdkPackageVersion)" />
+    <PackageReference Include="Jroc.Runtime" Version="$(JrocRuntimePackageVersion)" />
+
+    <JrocCompile Include="$(MSBuildProjectDirectory)\index.js"
+                  OutputDirectory="$(ModuleOutputDirectory)"
+                  RootModuleId="npm-run-all2-match"
+                  CopyToOutputDirectory="true" />
+  </ItemGroup>
+
+  <Target Name="NpmRestore"
+          BeforeTargets="JrocCompile"
+          Condition="'$(SkipNpmRestore)' != 'true'">
+    <Exec WorkingDirectory="$(MSBuildProjectDirectory)" Command="npm ci" />
+  </Target>
+
+</Project>

--- a/samples/NpmRunAll2/Program.cs
+++ b/samples/NpmRunAll2/Program.cs
@@ -1,0 +1,41 @@
+using Jroc.Runtime;
+using System.Reflection;
+
+namespace NpmRunAll2;
+
+internal static class Program
+{
+    private static void Main()
+    {
+        var compiledModulePath = Path.Combine(AppContext.BaseDirectory, "index.dll");
+        var asm = Assembly.LoadFrom(compiledModulePath);
+
+        // The compiled assembly exposes two utilities from npm-run-all2:
+        //   taskHeader(nameAndArgs) – formats a "> task" run header
+        //   filterTasks(taskListCsv, patternsCsv) – glob-based task selection
+        using dynamic exports = JsEngine.LoadModule(asm, moduleId: "npm-run-all2-match");
+
+        // --- Task header formatting (npm-run-all2/lib/create-header) ---
+        Console.WriteLine("=== task headers ===");
+        Console.WriteLine(Convert.ToString(exports.taskHeader("build")) ?? "");
+        Console.WriteLine(Convert.ToString(exports.taskHeader("test:unit --reporter spec")) ?? "");
+        Console.WriteLine(Convert.ToString(exports.taskHeader("lint")) ?? "");
+
+        // --- Pattern-based task filtering (npm-run-all2 glob rules) ---
+        Console.WriteLine("\n=== pattern matching ===");
+        string available = "build,test:unit,test:integration,test:e2e,lint,clean";
+
+        PrintMatch(exports, "test:*",   available);
+        PrintMatch(exports, "lint",     available);
+        PrintMatch(exports, "build",    available);
+        PrintMatch(exports, "test:e2e", available);
+
+        Console.WriteLine("done");
+    }
+
+    private static void PrintMatch(dynamic exports, string pattern, string available)
+    {
+        string matched = Convert.ToString(exports.filterTasks(available, pattern)) ?? string.Empty;
+        Console.WriteLine($"  {pattern,-18} => [{matched}]");
+    }
+}

--- a/samples/NpmRunAll2/README.md
+++ b/samples/NpmRunAll2/README.md
@@ -1,0 +1,56 @@
+# NpmRunAll2
+
+This sample demonstrates compiling the [`npm-run-all2`](https://www.npmjs.com/package/npm-run-all2) npm package into a .NET assembly via `Jroc.SDK` and calling its utilities from C#.
+
+`npm-run-all2` is a CLI tool for running multiple npm scripts in parallel or sequentially.  This sample exposes two of its utilities:
+
+- **Task header formatting** (`npm-run-all2/lib/create-header`) – formats the `"> task-name"` header that npm-run-all2 prints before each task executes.
+- **Pattern-based task selection** – filters a list of script names using the same glob rules as the npm-run-all2 CLI (`test:*` matches `test:unit`, `test:integration`, etc.).
+
+## Prerequisites
+
+- .NET SDK (see repo root `global.json`)
+- Node.js + npm
+
+## Structure
+
+| File | Purpose |
+|---|---|
+| `package.json` / `package-lock.json` | npm manifest — pins `npm-run-all2@^8.0.0` |
+| `index.js` | Wrapper that re-exports `createHeader` from npm-run-all2 and provides `filterTasks` |
+| `NpmRunAll2.csproj` | C# host; compiles `index.js` via `Jroc.SDK` and uses `Jroc.Runtime` |
+| `Program.cs` | Loads the compiled module and exercises both utilities |
+
+## Running the sample
+
+From `samples/NpmRunAll2`:
+
+```
+dotnet run -c Release
+```
+
+This will:
+
+1. Run `npm ci` to restore `npm-run-all2` into `node_modules`
+2. Compile `index.js` (and its `npm-run-all2` dependency) to `index.dll` via `Jroc.SDK`
+3. Load the compiled module and call `taskHeader` and `filterTasks`
+
+## Expected output
+
+```
+=== task headers ===
+> build
+> test:unit --reporter spec
+> lint
+
+=== pattern matching ===
+  test:*             => [test:unit,test:integration,test:e2e]
+  lint               => [lint]
+  build              => [build]
+  test:e2e           => [test:e2e]
+done
+```
+
+## Why `index.js`?
+
+`npm-run-all2`'s main entry point requires modules that spawn child processes and use dynamic `import()`.  `index.js` is a minimal wrapper that pulls in only the purely functional sub-modules (`create-header`), keeping the compiled assembly lightweight.

--- a/samples/NpmRunAll2/index.js
+++ b/samples/NpmRunAll2/index.js
@@ -1,0 +1,74 @@
+/**
+ * Thin wrapper around two npm-run-all2 utilities:
+ *
+ *  taskHeader(nameAndArgs)
+ *    Formats the "> task-name args" header that npm-run-all2 prints
+ *    before each task executes (from npm-run-all2/lib/create-header).
+ *
+ *  filterTasks(taskListCsv, patternsCsv)
+ *    Returns every task name from taskListCsv that is matched by at
+ *    least one pattern in patternsCsv.  Patterns follow npm-run-all2's
+ *    glob rules: ":" and "/" are interchangeable separators, so
+ *    "test:*" matches "test:unit", "test:integration", etc.
+ *    C#-friendly – accepts and returns comma-separated strings.
+ *
+ * Note: this wrapper uses createHeader directly from npm-run-all2 and
+ * provides its own glob-to-regex conversion for filterTasks instead of
+ * pulling in picomatch (which generates regex lookahead assertions not
+ * yet supported in JROC's IL back-end).
+ */
+'use strict';
+
+const createHeader = require('npm-run-all2/lib/create-header');
+
+/**
+ * Returns the npm-run-all2 run-header for a task, e.g. "> build".
+ *
+ * @param {string} nameAndArgs - Task name (and optional arguments).
+ * @returns {string} Trimmed header string.
+ */
+function taskHeader(nameAndArgs) {
+  return createHeader(nameAndArgs, null, false, null).trim();
+}
+
+/**
+ * Converts a glob pattern into a RegExp using npm-run-all2's convention:
+ * ":" and "/" are treated as equivalent path separators, and "*" matches
+ * any sequence of non-separator characters.
+ *
+ * @param {string} pattern - A glob such as "test:*" or "build".
+ * @returns {RegExp}
+ */
+function patternToRegex(pattern) {
+  const norm = pattern.replace(/[:/]/g, '/');
+  const escaped = norm.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*');
+  return new RegExp('^' + escaped + '$');
+}
+
+/**
+ * Filter npm-script names using glob patterns.
+ *
+ * @param {string} taskListCsv - Comma-separated list of available task names.
+ * @param {string} patternsCsv - Comma-separated list of glob patterns.
+ * @returns {string} Comma-separated matched task names (empty string if none).
+ */
+function filterTasks(taskListCsv, patternsCsv) {
+  const tasks = taskListCsv.split(',');
+  const patterns = patternsCsv.split(',');
+  const seen = new Set();
+  const result = [];
+
+  for (const pat of patterns) {
+    const re = patternToRegex(pat.trim());
+    for (const task of tasks) {
+      if (re.test(task.replace(/[:/]/g, '/')) && !seen.has(task)) {
+        seen.add(task);
+        result.push(task);
+      }
+    }
+  }
+
+  return result.join(',');
+}
+
+module.exports = { taskHeader, filterTasks };

--- a/samples/NpmRunAll2/package-lock.json
+++ b/samples/NpmRunAll2/package-lock.json
@@ -1,0 +1,218 @@
+{
+  "name": "jroc-sample-npm-run-all2",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jroc-sample-npm-run-all2",
+      "version": "0.0.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "npm-run-all2": "^8.0.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-4.0.0.tgz",
+      "integrity": "sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
+      "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm-run-all2": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-8.0.4.tgz",
+      "integrity": "sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "cross-spawn": "^7.0.6",
+        "memorystream": "^0.3.1",
+        "picomatch": "^4.0.2",
+        "pidtree": "^0.6.0",
+        "read-package-json-fast": "^4.0.0",
+        "shell-quote": "^1.7.3",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "npm-run-all2": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": "^20.5.0 || >=22.0.0",
+        "npm": ">= 10"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.1.tgz",
+      "integrity": "sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==",
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/read-package-json-fast": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-4.0.0.tgz",
+      "integrity": "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==",
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    }
+  }
+}

--- a/samples/NpmRunAll2/package.json
+++ b/samples/NpmRunAll2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "jroc-sample-npm-run-all2",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Dependencies for the JROC NpmRunAll2 sample",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "npm-run-all2": "^8.0.0"
+  }
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -5,6 +5,8 @@ These samples demonstrate consuming **compiled** JavaScript modules as a .NET li
 - [samples/Basic](Basic/README.md): load a compiled module and call exports.
 - [samples/Typed](Typed/README.md): typed exports + constructors/instance handles.
 - [samples/Domino](Domino/README.md): compile and host a real npm package (@mixmark-io/domino).
+- [samples/Picocolors](Picocolors/README.md): compile and host the picocolors npm package (ANSI color helpers).
+- [samples/NpmRunAll2](NpmRunAll2/README.md): compile npm-run-all2 and call its task-header and pattern-matching utilities from C#.
 
 ## How samples work
 
@@ -13,4 +15,4 @@ Most samples are split into two parts:
 - `compiler/` – the JavaScript source inputs consumed during `dotnet build`.
 - `host/` – a C# console app that restores `Jroc.SDK` and `Jroc.Runtime`, compiles the JavaScript input via `JrocCompile`, and calls into the resulting module assembly using `Jroc.Runtime` hosting APIs.
 
-`Domino` and `Picocolors` are the exceptions: they keep `package.json` / `package-lock.json` next to the `.csproj`, run `npm ci` in place, and compile the npm package directly by module id with the SDK defaults.
+`Domino`, `Picocolors`, and `NpmRunAll2` are the exceptions: they keep `package.json` / `package-lock.json` next to the `.csproj`, run `npm ci` in place, and compile the npm package directly by module id or file path with the SDK defaults.


### PR DESCRIPTION
## Summary

Adds a new **NpmRunAll2** sample that compiles `npm-run-all2` (and its transitive dependencies) into a .NET assembly via `Jroc.SDK`, then calls two of its utilities from C#.

## What the sample demonstrates

- **Task header formatting** – calls `npm-run-all2/lib/create-header` to format the `"> task-name"` header that npm-run-all2 prints before each task executes.
- **Pattern-based task selection** – filters a list of npm-script names using npm-run-all2's glob convention where `:` and `/` are interchangeable separators (`test:*` matches `test:unit`, `test:integration`, `test:e2e`, etc.).

## Sample output

```
=== task headers ===
> build
> test:unit --reporter spec
> lint

=== pattern matching ===
  test:*             => [test:unit,test:integration,test:e2e]
  lint               => [lint]
  build              => [build]
  test:e2e           => [test:e2e]
done
```

## Structure

| File | Purpose |
|---|---|
| `samples/NpmRunAll2/index.js` | Wrapper exposing `taskHeader` (from npm-run-all2) and `filterTasks` (custom glob matching) |
| `samples/NpmRunAll2/NpmRunAll2.csproj` | Compiles `index.js` via `Jroc.SDK` + `NpmRestore` target |
| `samples/NpmRunAll2/Program.cs` | C# host that loads the compiled module and exercises both exports |
| `samples/NpmRunAll2/README.md` | Sample documentation |
| `samples/NpmRunAll2/package.json` | Pins `npm-run-all2@^8.0.0` |

## Notes

- `npm-run-all2`'s main entry point uses dynamic `import()` and child-process spawning; `index.js` wraps only the purely functional sub-modules.
- picomatch (used internally by npm-run-all2) generates regex lookahead assertions that are not yet supported in JROC's IL back-end. The `filterTasks` wrapper implements the same `:` / `/` glob logic without lookaheads.
- CI smoke steps added to both `linux-smoke.yml` and `windows-smoke.yml`.