### PR TITLE
feat(runtime): add child_process.execFileSync support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/tests/docs/nodejs: add `child_process.execFileSync(file[, args][, options])` support — runs a file directly without a shell, returns stdout as a string, and throws a `ChildProcessError` (with `status`/`code`/`stdout`/`stderr` properties) on non-zero exit; update Node docs.
 - runtime/tests/docs/nodejs: add `string_decoder` support with utf8/utf-8 decoding, `node:` prefix resolution, and a stream-style decoder test; update the node support docs/index for the new module.
 - sdk/samples/ci: add `NpmRunAll2` sample — compiles `npm-run-all2` and its transitive dependencies into a .NET assembly via `Jroc.SDK`, then calls `createHeader` (task-header formatting) and a `filterTasks` glob helper from C#; add smoke-test steps to `windows-smoke.yml` and `linux-smoke.yml`.
 - sdk/samples/ci: add `Picocolors` sample — compiles the `picocolors` npm package to a .NET assembly via `Jroc.SDK` and calls color/style functions from C#; add smoke-test steps to `windows-smoke.yml` and `linux-smoke.yml`.

--- a/docs/nodejs/child_process.json
+++ b/docs/nodejs/child_process.json
@@ -117,6 +117,23 @@
       "docs": "https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options"
     },
     {
+      "name": "execFileSync(file[, args][, options])",
+      "kind": "function",
+      "status": "supported",
+      "notes": "Runs a file directly without an implicit shell, waits for exit, and returns stdout as a string. Throws a ChildProcessError (with status/code/stdout/stderr properties) on non-zero exit. Supports cwd, encoding, and stdio ('pipe'/'inherit'/'ignore'). Node returns a Buffer when no encoding is provided; the current implementation always returns a string.",
+      "docs": "https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options",
+      "tests": [
+        {
+          "name": "Jroc.Tests.Node.ChildProcess.ExecutionTests.Require_ChildProcess_ExecFileSync_Basic",
+          "file": "tests/Jroc.Tests/Node/ChildProcess/ExecutionTests.cs"
+        },
+        {
+          "name": "Jroc.Tests.Node.ChildProcess.GeneratorTests.Require_ChildProcess_ExecFileSync_Basic",
+          "file": "tests/Jroc.Tests/Node/ChildProcess/GeneratorTests.cs"
+        }
+      ]
+    },
+    {
       "name": "execSync(command, options)",
       "kind": "function",
       "status": "supported",

--- a/docs/nodejs/child_process.md
+++ b/docs/nodejs/child_process.md
@@ -26,6 +26,7 @@ Provides synchronous process execution, async spawn/exec/execFile, and a documen
 | execFile(file[, args][, options][, callback]) | function | supported | [docs](https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback) |
 | fork(modulePath[, args][, options]) | function | supported | [docs](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options) |
 | spawnSync(command, args, options) | function | supported | [docs](https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options) |
+| execFileSync(file[, args][, options]) | function | supported | [docs](https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options) |
 | execSync(command, options) | function | supported | [docs](https://nodejs.org/api/child_process.html#child_processexecsynccommand-options) |
 
 ## API Details
@@ -73,6 +74,14 @@ Launches another compiled JROC child from the current assembly, resolves `module
 ### spawnSync(command, args, options)
 
 Supports cwd, shell, environment overrides, and stdio ('pipe'/'inherit'/'ignore' for the first three slots). Returns { status, stdout, stderr }.
+
+### execFileSync(file[, args][, options])
+
+Runs a file directly without an implicit shell, waits for exit, and returns stdout as a string. Throws a ChildProcessError (with status/code/stdout/stderr properties) on non-zero exit. Supports cwd, encoding, and stdio ('pipe'/'inherit'/'ignore'). Node returns a Buffer when no encoding is provided; the current implementation always returns a string.
+
+**Tests:**
+- `Jroc.Tests.Node.ChildProcess.ExecutionTests.Require_ChildProcess_ExecFileSync_Basic` (`tests/Jroc.Tests/Node/ChildProcess/ExecutionTests.cs`)
+- `Jroc.Tests.Node.ChildProcess.GeneratorTests.Require_ChildProcess_ExecFileSync_Basic` (`tests/Jroc.Tests/Node/ChildProcess/GeneratorTests.cs`)
 
 ### execSync(command, options)
 

--- a/src/JavaScriptRuntime/Node/ChildProcess.cs
+++ b/src/JavaScriptRuntime/Node/ChildProcess.cs
@@ -180,6 +180,68 @@ namespace JavaScriptRuntime.Node
             return stdout;
         }
 
+        public object execFileSync(object[] args)
+        {
+            var srcArgs = args ?? System.Array.Empty<object>();
+            if (srcArgs.Length == 0)
+            {
+                throw new TypeError("The \"file\" argument must be a non-empty string");
+            }
+
+            var file = srcArgs[0];
+            object? fileArgs = null;
+            object? options = null;
+
+            if (srcArgs.Length > 1)
+            {
+                if (IsArgumentList(srcArgs[1]))
+                {
+                    fileArgs = srcArgs[1];
+                }
+                else
+                {
+                    options = srcArgs[1];
+                }
+            }
+
+            if (srcArgs.Length > 2)
+            {
+                options = srcArgs[2];
+            }
+
+            return execFileSync(file, fileArgs, options);
+        }
+
+        public object execFileSync(object file, object? args = null, object? options = null)
+        {
+            var fileText = file?.ToString() ?? string.Empty;
+            var argList = CoerceArgs(args);
+            var cwd = TryGetStringOption(options, "cwd");
+            var encoding = TryGetStringOption(options, "encoding");
+            var stdio = ParseStdioConfiguration(TryGetOption(options, "stdio"), StdioConfiguration.SyncDefault, allowIpc: false, apiName: "child_process.execFileSync");
+
+            var psi = BuildStartInfo(fileText, argList, cwd, shell: false, stdio);
+
+            using var p = DiagnosticsProcess.Start(psi) ?? throw new Error("Failed to start process.");
+            if (stdio.StdinMode == StdioMode.Ignore)
+            {
+                p.StandardInput.Close();
+            }
+
+            var completion = WaitForProcessCompletionSync(p, stdio);
+            var stdout = completion.Stdout;
+            var stderr = completion.Stderr;
+
+            if (completion.ExitCode != 0)
+            {
+                throw new ChildProcessError(fileText, completion.ExitCode, stdout, stderr);
+            }
+
+            // For now we only support string output; Node returns Buffer when no encoding is provided.
+            _ = encoding;
+            return stdout;
+        }
+
         public object exec(object[] args)
         {
             var srcArgs = args ?? System.Array.Empty<object>();

--- a/tests/Jroc.Tests/Node/ChildProcess/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Node/ChildProcess/ExecutionTests.cs
@@ -43,5 +43,9 @@ namespace Jroc.Tests.Node.ChildProcess
         [Fact]
         public Task Require_ChildProcess_Fork_Unsupported_Options()
             => ExecutionTest(nameof(Require_ChildProcess_Fork_Unsupported_Options));
+
+        [Fact]
+        public Task Require_ChildProcess_ExecFileSync_Basic()
+            => ExecutionTest(nameof(Require_ChildProcess_ExecFileSync_Basic));
     }
 }

--- a/tests/Jroc.Tests/Node/ChildProcess/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Node/ChildProcess/GeneratorTests.cs
@@ -43,5 +43,9 @@ namespace Jroc.Tests.Node.ChildProcess
         [Fact]
         public Task Require_ChildProcess_Fork_Unsupported_Options()
             => GenerateTest(nameof(Require_ChildProcess_Fork_Unsupported_Options));
+
+        [Fact]
+        public Task Require_ChildProcess_ExecFileSync_Basic()
+            => GenerateTest(nameof(Require_ChildProcess_ExecFileSync_Basic));
     }
 }

--- a/tests/Jroc.Tests/Node/ChildProcess/JavaScript/Require_ChildProcess_ExecFileSync_Basic.js
+++ b/tests/Jroc.Tests/Node/ChildProcess/JavaScript/Require_ChildProcess_ExecFileSync_Basic.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const childProcess = require("child_process");
+
+const isWindows = process.platform === "win32";
+const file = isWindows ? "cmd.exe" : "/bin/sh";
+
+// Test that stdout is returned as a string
+const echoArgs = isWindows ? ["/c", "echo hello"] : ["-c", "printf hello"];
+const output = childProcess.execFileSync(file, echoArgs, { encoding: "utf8" });
+console.log("stdout contains hello:", output.indexOf("hello") >= 0);
+
+// Test that non-zero exit code throws
+try {
+    const failArgs = isWindows ? ["/c", "exit 5"] : ["-c", "exit 5"];
+    childProcess.execFileSync(file, failArgs, { encoding: "utf8" });
+    console.log("expected error not thrown");
+} catch (e) {
+    console.log("throws on non-zero:", true);
+    console.log("status:", e.status);
+    console.log("code:", e.code);
+    console.log("message has exit code:", e.message.indexOf("exit code 5") >= 0);
+}

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/ExecutionTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/ExecutionTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
@@ -1,0 +1,5 @@
+stdout contains hello: true
+throws on non-zero: true
+status: 5
+code: 5
+message has exit code: true

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
@@ -1,0 +1,363 @@
+﻿// IL code: Require_ChildProcess_ExecFileSync_Basic
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Require_ChildProcess_ExecFileSync_Basic
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L14C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2319
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L14C4::.ctor
+
+		} // end of class Block_L14C4
+
+		.class nested public auto ansi beforefieldinit Block_L18C12
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2322
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L18C12::.ctor
+
+		} // end of class Block_L18C12
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x2310
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 675 (0x2a3)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope,
+			[1] object,
+			[2] bool,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] object,
+			[7] object,
+			[8] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L14C4,
+			[9] object,
+			[10] object,
+			[11] class [System.Runtime]System.Exception,
+			[12] object,
+			[13] object,
+			[14] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L18C12,
+			[15] object,
+			[16] object,
+			[17] bool,
+			[18] float64,
+			[19] object
+		)
+
+		IL_0000: newobj instance void Modules.Require_ChildProcess_ExecFileSync_Basic/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "child_process"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.s 16
+		IL_0013: ldloc.s 16
+		IL_0015: stloc.1
+		IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_001b: ldstr "platform"
+		IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0025: ldstr "win32"
+		IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_002f: stloc.s 17
+		IL_0031: ldloc.s 17
+		IL_0033: stloc.2
+		IL_0034: ldloc.2
+		IL_0035: brfalse IL_0045
+
+		IL_003a: ldstr "cmd.exe"
+		IL_003f: stloc.3
+		IL_0040: br IL_004b
+
+		IL_0045: ldstr "/bin/sh"
+		IL_004a: stloc.3
+
+		IL_004b: ldloc.3
+		IL_004c: stloc.s 4
+		IL_004e: ldloc.2
+		IL_004f: brfalse IL_0077
+
+		IL_0054: ldc.i4.2
+		IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_005a: dup
+		IL_005b: ldstr "/c"
+		IL_0060: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0065: dup
+		IL_0066: ldstr "echo hello"
+		IL_006b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0070: stloc.s 5
+		IL_0072: br IL_0095
+
+		IL_0077: ldc.i4.2
+		IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_007d: dup
+		IL_007e: ldstr "-c"
+		IL_0083: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0088: dup
+		IL_0089: ldstr "printf hello"
+		IL_008e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0093: stloc.s 5
+
+		IL_0095: ldloc.s 5
+		IL_0097: stloc.s 6
+		IL_0099: ldloc.1
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009f: stloc.s 16
+		IL_00a1: ldloc.s 16
+		IL_00a3: ldstr "execFileSync"
+		IL_00a8: ldloc.s 4
+		IL_00aa: ldloc.s 6
+		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00b1: dup
+		IL_00b2: ldstr "encoding"
+		IL_00b7: ldstr "utf8"
+		IL_00bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00c6: stloc.s 16
+		IL_00c8: ldloc.s 16
+		IL_00ca: stloc.s 7
+		IL_00cc: ldloc.s 7
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d3: stloc.s 16
+		IL_00d5: ldloc.s 16
+		IL_00d7: ldstr "indexOf"
+		IL_00dc: ldstr "hello"
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00e6: stloc.s 16
+		IL_00e8: ldloc.s 16
+		IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00ef: stloc.s 18
+		IL_00f1: ldloc.s 18
+		IL_00f3: ldc.r8 0.0
+		IL_00fc: clt
+		IL_00fe: ldc.i4.0
+		IL_00ff: ceq
+		IL_0101: stloc.s 17
+		IL_0103: ldloc.s 17
+		IL_0105: box [System.Runtime]System.Boolean
+		IL_010a: stloc.s 19
+		IL_010c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0111: ldstr "stdout contains hello:"
+		IL_0116: ldloc.s 19
+		IL_0118: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_011d: pop
+		.try
+		{
+			IL_011e: newobj instance void Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L14C4::.ctor()
+			IL_0123: stloc.s 8
+			IL_0125: ldloc.2
+			IL_0126: brfalse IL_014e
+
+			IL_012b: ldc.i4.2
+			IL_012c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0131: dup
+			IL_0132: ldstr "/c"
+			IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_013c: dup
+			IL_013d: ldstr "exit 5"
+			IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0147: stloc.s 9
+			IL_0149: br IL_016c
+
+			IL_014e: ldc.i4.2
+			IL_014f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0154: dup
+			IL_0155: ldstr "-c"
+			IL_015a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015f: dup
+			IL_0160: ldstr "exit 5"
+			IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_016a: stloc.s 9
+
+			IL_016c: ldloc.s 9
+			IL_016e: stloc.s 10
+			IL_0170: ldloc.1
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0176: stloc.s 16
+			IL_0178: ldloc.s 16
+			IL_017a: ldstr "execFileSync"
+			IL_017f: ldloc.s 4
+			IL_0181: ldloc.s 10
+			IL_0183: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0188: dup
+			IL_0189: ldstr "encoding"
+			IL_018e: ldstr "utf8"
+			IL_0193: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_019d: pop
+			IL_019e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01a3: ldstr "expected error not thrown"
+			IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01ad: pop
+			IL_01ae: leave IL_029f
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_01b3: stloc.s 11
+			IL_01b5: ldloc.s 11
+			IL_01b7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_01bc: dup
+			IL_01bd: brtrue IL_01d3
+
+			IL_01c2: pop
+			IL_01c3: ldloc.s 11
+			IL_01c5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_01ca: dup
+			IL_01cb: brtrue IL_01df
+
+			IL_01d0: pop
+			IL_01d1: rethrow
+
+			IL_01d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_01d8: stloc.s 12
+			IL_01da: br IL_01e1
+
+			IL_01df: stloc.s 12
+
+			IL_01e1: ldloc.s 12
+			IL_01e3: stloc.s 16
+			IL_01e5: ldloc.s 16
+			IL_01e7: stloc.s 13
+			IL_01e9: newobj instance void Modules.Require_ChildProcess_ExecFileSync_Basic/Scope/Block_L18C12::.ctor()
+			IL_01ee: stloc.s 14
+			IL_01f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01f5: ldstr "throws on non-zero:"
+			IL_01fa: ldc.i4.1
+			IL_01fb: box [System.Runtime]System.Boolean
+			IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0205: pop
+			IL_0206: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_020b: ldstr "status:"
+			IL_0210: ldloc.s 13
+			IL_0212: ldstr "status"
+			IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_021c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0221: pop
+			IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0227: ldstr "code:"
+			IL_022c: ldloc.s 13
+			IL_022e: ldstr "code"
+			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0238: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_023d: pop
+			IL_023e: ldloc.s 13
+			IL_0240: ldstr "message"
+			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024f: stloc.s 16
+			IL_0251: ldloc.s 16
+			IL_0253: ldstr "indexOf"
+			IL_0258: ldstr "exit code 5"
+			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0262: stloc.s 16
+			IL_0264: ldloc.s 16
+			IL_0266: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_026b: stloc.s 18
+			IL_026d: ldloc.s 18
+			IL_026f: ldc.r8 0.0
+			IL_0278: clt
+			IL_027a: ldc.i4.0
+			IL_027b: ceq
+			IL_027d: stloc.s 17
+			IL_027f: ldloc.s 17
+			IL_0281: box [System.Runtime]System.Boolean
+			IL_0286: stloc.s 19
+			IL_0288: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_028d: ldstr "message has exit code:"
+			IL_0292: ldloc.s 19
+			IL_0294: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0299: pop
+			IL_029a: leave IL_029f
+		} // end handler
+
+		IL_029f: ldnull
+		IL_02a0: stloc.s 15
+		IL_02a2: ret
+	} // end of method Require_ChildProcess_ExecFileSync_Basic::__js_module_init__
+
+} // end of class Modules.Require_ChildProcess_ExecFileSync_Basic
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x232b
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Require_ChildProcess_ExecFileSync_Basic::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary

Adds child_process.execFileSync(file[, args][, options]) to the JavaScriptRuntime.

### What it does

- Runs the specified file **directly** (no implicit shell — equivalent to spawn with shell: false)
- Waits synchronously for the process to exit
- Returns stdout as a string on success
- Throws a ChildProcessError with status, code, stdout, and stderr properties on non-zero exit

### Options supported

| Option | Behaviour |
|--------|-----------|
| rgs | Array of arguments passed directly to the executable |
| cwd | Working directory for the child process |
| ncoding | Accepted (currently ignored; always returns a string) |
| stdio | 'pipe' / 'inherit' / 'ignore' for the first three stdio slots |

### Implementation notes

- Reuses the existing BuildStartInfo + WaitForProcessCompletionSync helpers already used by xecSync and spawnSync
- Key difference from xecSync: passes the arg list directly and sets shell: false so the OS resolves the executable without a shell intermediary
- Error format: `Command failed: <file> (exit code <n>)` via the existing ChildProcessError class

### Changes

| File | Change |
|------|--------|
| src/JavaScriptRuntime/Node/ChildProcess.cs | Add xecFileSync(object[]) and xecFileSync(object, object?, object?) overloads |
| 	ests/Jroc.Tests/Node/ChildProcess/ExecutionTests.cs | New Require_ChildProcess_ExecFileSync_Basic execution test |
| 	ests/Jroc.Tests/Node/ChildProcess/GeneratorTests.cs | New Require_ChildProcess_ExecFileSync_Basic generator test |
| docs/nodejs/child_process.json | Document xecFileSync API entry |
| docs/nodejs/child_process.md | Regenerated markdown |
| CHANGELOG.md | Unreleased entry |
