### PR TITLE
fix(node-process): support process stdout/stderr write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 ## Unreleased
 
 - compiler/runtime/tests/docs/nodejs: fix npm-run-all2 module-id compilation by materializing regular `for (let/const ...)` loop-head scopes for nested closures, resolving nested arrow callable IDs from loop-body scopes, and adding legacy `new Buffer(...)` constructor support required by transitive dependencies such as `memorystream`; update Buffer docs.
+- runtime/tests/docs/nodejs: add `process.stdout` and `process.stderr` writable stream support (including `write(...)`) so CLI-style scripts can report errors through process stdio; add Node Process regressions and update process docs.
 
 ## v0.11.5 - 2026-06-29
 

--- a/docs/nodejs/process.json
+++ b/docs/nodejs/process.json
@@ -31,6 +31,40 @@
       ]
     },
     {
+      "name": "stdout",
+      "kind": "property",
+      "status": "supported",
+      "notes": "Writable stream compatible with `process.stdout.write(...)` for CLI-style output.",
+      "docs": "https://nodejs.org/api/process.html#processstdout",
+      "tests": [
+        {
+          "name": "Jroc.Tests.Node.Process.ExecutionTests.Process_Stdout_Stderr_Write",
+          "file": "tests/Jroc.Tests/Node/Process/ExecutionTests.cs"
+        },
+        {
+          "name": "Jroc.Tests.Node.Process.GeneratorTests.Process_Stdout_Stderr_Write",
+          "file": "tests/Jroc.Tests/Node/Process/GeneratorTests.cs"
+        }
+      ]
+    },
+    {
+      "name": "stderr",
+      "kind": "property",
+      "status": "supported",
+      "notes": "Writable stream compatible with `process.stderr.write(...)` for CLI-style error reporting.",
+      "docs": "https://nodejs.org/api/process.html#processstderr",
+      "tests": [
+        {
+          "name": "Jroc.Tests.Node.Process.ExecutionTests.Process_Stdout_Stderr_Write",
+          "file": "tests/Jroc.Tests/Node/Process/ExecutionTests.cs"
+        },
+        {
+          "name": "Jroc.Tests.Node.Process.GeneratorTests.Process_Stdout_Stderr_Write",
+          "file": "tests/Jroc.Tests/Node/Process/GeneratorTests.cs"
+        }
+      ]
+    },
+    {
       "name": "exit()",
       "kind": "function",
       "status": "supported",

--- a/docs/nodejs/process.md
+++ b/docs/nodejs/process.md
@@ -21,6 +21,8 @@
 | API | Kind | Status | Docs |
 | --- | ---- | ------ | ---- |
 | argv | property | supported | [docs](https://nodejs.org/api/process.html#processargv) |
+| stdout | property | supported | [docs](https://nodejs.org/api/process.html#processstdout) |
+| stderr | property | supported | [docs](https://nodejs.org/api/process.html#processstderr) |
 | exit() | function | supported | [docs](https://nodejs.org/api/process.html#processexitcode) |
 | exit(code) | function | supported | [docs](https://nodejs.org/api/process.html#process_exit_code) |
 | exitCode | property | supported | [docs](https://nodejs.org/api/process.html#processexitcode) |
@@ -44,6 +46,22 @@ argv[0] normalized to current script filename; extra host args trimmed in tests.
 **Tests:**
 - `Jroc.Tests.Node.Process.ExecutionTests.Environment_EnumerateProcessArgV` (`tests/Jroc.Tests/Node/Process/ExecutionTests.cs`)
 - `Jroc.Tests.Node.Process.GeneratorTests.Environment_EnumerateProcessArgV` (`tests/Jroc.Tests/Node/Process/GeneratorTests.cs`)
+
+### stdout
+
+Writable stream compatible with `process.stdout.write(...)` for CLI-style output.
+
+**Tests:**
+- `Jroc.Tests.Node.Process.ExecutionTests.Process_Stdout_Stderr_Write` (`tests/Jroc.Tests/Node/Process/ExecutionTests.cs`)
+- `Jroc.Tests.Node.Process.GeneratorTests.Process_Stdout_Stderr_Write` (`tests/Jroc.Tests/Node/Process/GeneratorTests.cs`)
+
+### stderr
+
+Writable stream compatible with `process.stderr.write(...)` for CLI-style error reporting.
+
+**Tests:**
+- `Jroc.Tests.Node.Process.ExecutionTests.Process_Stdout_Stderr_Write` (`tests/Jroc.Tests/Node/Process/ExecutionTests.cs`)
+- `Jroc.Tests.Node.Process.GeneratorTests.Process_Stdout_Stderr_Write` (`tests/Jroc.Tests/Node/Process/GeneratorTests.cs`)
 
 ### exit()
 

--- a/src/JavaScriptRuntime/IConsoleOutput.cs
+++ b/src/JavaScriptRuntime/IConsoleOutput.cs
@@ -4,6 +4,8 @@ namespace JavaScriptRuntime
 {
     public interface IConsoleOutput
     {
+        void Write(string text);
+
         void WriteLine(string line);
     }
 
@@ -13,6 +15,11 @@ namespace JavaScriptRuntime
         {
             System.Console.WriteLine(line);
         }
+
+        public void Write(string text)
+        {
+            System.Console.Write(text);
+        }
     }
 
     public class DefaultErrorConsoleOutput : IConsoleOutput
@@ -20,6 +27,11 @@ namespace JavaScriptRuntime
         public void WriteLine(string line)
         {
             System.Console.Error.WriteLine(line);
+        }
+
+        public void Write(string text)
+        {
+            System.Console.Error.Write(text);
         }
     }
 }

--- a/src/JavaScriptRuntime/Node/Process.cs
+++ b/src/JavaScriptRuntime/Node/Process.cs
@@ -18,12 +18,16 @@ namespace JavaScriptRuntime.Node
         IEnvironment _environment;
         private readonly Lazy<object> _versions;
         private readonly Lazy<object> _env;
+        private readonly Lazy<Writable> _stdout;
+        private readonly Lazy<Writable> _stderr;
 
-        public Process(IEnvironment environment)
+        public Process(IEnvironment environment, ConsoleOutputSinks consoleOutputSinks)
         {
             _environment = environment;
             _versions = new Lazy<object>(CreateVersions);
             _env = new Lazy<object>(CreateEnvSnapshot);
+            _stdout = new Lazy<Writable>(() => new ProcessStdioStream(consoleOutputSinks.Output ?? new DefaultConsoleOutput()));
+            _stderr = new Lazy<Writable>(() => new ProcessStdioStream(consoleOutputSinks.ErrorOutput ?? new DefaultErrorConsoleOutput()));
 
             if (GlobalThis.ServiceProvider != null
                 && GlobalThis.ServiceProvider.TryResolve<ChildProcessIpcChannel>(out var ipcChannel)
@@ -33,6 +37,11 @@ namespace JavaScriptRuntime.Node
                 ipcChannel.Disconnected += () => emit("disconnect");
                 ipcChannel.Error += ex => emit("error", ex as Error ?? new Error(ex.Message, ex));
             }
+        }
+
+        public Process(IEnvironment environment)
+            : this(environment, new ConsoleOutputSinks())
+        {
         }
 
         /// <summary>
@@ -116,6 +125,10 @@ namespace JavaScriptRuntime.Node
                 return new JavaScriptRuntime.Array(new object[] { "dotnet", JavaScriptRuntime.CommonJS.ModuleContext.CreateModuleContext().__filename });
             }
         }
+
+        public Writable stdout => _stdout.Value;
+
+        public Writable stderr => _stderr.Value;
 
         public string cwd()
         {
@@ -330,6 +343,21 @@ namespace JavaScriptRuntime.Node
             }
 
             return null;
+        }
+
+        private sealed class ProcessStdioStream : Writable
+        {
+            private readonly IConsoleOutput _output;
+
+            public ProcessStdioStream(IConsoleOutput output)
+            {
+                _output = output;
+            }
+
+            protected override void InvokeWrite(object? chunk)
+            {
+                _output.Write(DotNet2JSConversions.ToString(chunk));
+            }
         }
     }
 }

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -1059,6 +1059,7 @@ public class RuntimeServices
     {
         var container = new ServiceContainer();
         container.RegisterInstance(new GlobalThisOptions());
+        container.RegisterInstance(new ConsoleOutputSinks());
         
         // Register default engine dependencies
         container.Register<EngineCore.ITickSource, EngineCore.TickSource>();

--- a/tests/Jroc.Testing/ExecutionTestsBase.cs
+++ b/tests/Jroc.Testing/ExecutionTestsBase.cs
@@ -334,6 +334,7 @@ namespace Jroc.Tests
         private sealed class CapturingConsoleOutput : IConsoleOutput
         {
             private readonly StringBuilder _sb = new();
+            public void Write(string text) => _sb.Append(text);
             public void WriteLine(string line) => _sb.AppendLine(line);
             public string GetOutput() => _sb.ToString();
         }

--- a/tests/Jroc.Testing/InMemoryTestCompiler.cs
+++ b/tests/Jroc.Testing/InMemoryTestCompiler.cs
@@ -154,6 +154,9 @@ public sealed class InMemoryConsoleOutput : IConsoleOutput
 {
     private readonly System.Text.StringBuilder _builder = new();
 
+    public void Write(string text)
+        => _builder.Append(text);
+
     public void WriteLine(string line)
         => _builder.AppendLine(line);
 

--- a/tests/Jroc.Tests/ConsoleTests.cs
+++ b/tests/Jroc.Tests/ConsoleTests.cs
@@ -11,6 +11,11 @@ namespace JavaScriptRuntime.Tests
         private class TestConsoleOutput : IConsoleOutput
         {
             public List<string> Output = new List<string>();
+            public void Write(string text)
+            {
+                Output.Add(text);
+            }
+
             public void WriteLine(string line)
             {
                 Output.Add(line);
@@ -23,6 +28,11 @@ namespace JavaScriptRuntime.Tests
             public List<string> StdErr = new();
             private readonly bool _isErr;
             public DualTestConsoleOutput(bool isErr) { _isErr = isErr; }
+            public void Write(string text)
+            {
+                if (_isErr) StdErr.Add(text); else StdOut.Add(text);
+            }
+
             public void WriteLine(string line)
             {
                 if (_isErr) StdErr.Add(line); else StdOut.Add(line);

--- a/tests/Jroc.Tests/DebugSymbols/JavaScriptErrorStackTraceTests.cs
+++ b/tests/Jroc.Tests/DebugSymbols/JavaScriptErrorStackTraceTests.cs
@@ -178,6 +178,8 @@ public class JavaScriptErrorStackTraceTests
     {
         private readonly List<string> _lines = new();
 
+        public void Write(string text) => _lines.Add(text ?? string.Empty);
+
         public void WriteLine(string line) => _lines.Add(line ?? string.Empty);
 
         public string GetOutput()

--- a/tests/Jroc.Tests/Node/Process/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Node/Process/ExecutionTests.cs
@@ -35,6 +35,10 @@ namespace Jroc.Tests.Node.Process
                 });
 
         [Fact]
+        public Task Process_Stdout_Stderr_Write()
+            => ExecutionTest(nameof(Process_Stdout_Stderr_Write));
+
+        [Fact]
         public Task Process_Exit_Code_Sets_ExitCode()
             => ExecutionTest(
                 nameof(Process_Exit_Code_Sets_ExitCode),

--- a/tests/Jroc.Tests/Node/Process/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Node/Process/GeneratorTests.cs
@@ -11,6 +11,10 @@ namespace Jroc.Tests.Node.Process
             nameof(Environment_EnumerateProcessArgV));
 
         [Fact]
+        public Task Process_Stdout_Stderr_Write() => GenerateTest(
+            nameof(Process_Stdout_Stderr_Write));
+
+        [Fact]
         public Task Process_Exit_NoArg_GeneratesCall() => GenerateTest(
             nameof(Process_Exit_NoArg_GeneratesCall));
 

--- a/tests/Jroc.Tests/Node/Process/JavaScript/Process_Stdout_Stderr_Write.js
+++ b/tests/Jroc.Tests/Node/Process/JavaScript/Process_Stdout_Stderr_Write.js
@@ -1,0 +1,6 @@
+"use strict";
+
+process.stdout.write("stdout");
+process.stdout.write(" ok\n");
+process.stderr.write("stderr");
+process.stderr.write(" ok\n");

--- a/tests/Jroc.Tests/Node/Process/Snapshots/ExecutionTests.Process_Stdout_Stderr_Write.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/ExecutionTests.Process_Stdout_Stderr_Write.verified.txt
@@ -1,0 +1,2 @@
+stdout ok
+stderr ok

--- a/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Stdout_Stderr_Write.verified.txt
+++ b/tests/Jroc.Tests/Node/Process/Snapshots/GeneratorTests.Process_Stdout_Stderr_Write.verified.txt
@@ -1,0 +1,119 @@
+﻿// IL code: Process_Stdout_Stderr_Write
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Process_Stdout_Stderr_Write
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20fb
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 159 (0x9f)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Process_Stdout_Stderr_Write/Scope,
+			[1] object
+		)
+
+		IL_0000: newobj instance void Modules.Process_Stdout_Stderr_Write/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_000b: ldstr "stdout"
+		IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_001a: stloc.1
+		IL_001b: ldloc.1
+		IL_001c: ldstr "write"
+		IL_0021: ldstr "stdout"
+		IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_002b: pop
+		IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0031: ldstr "stdout"
+		IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0040: stloc.1
+		IL_0041: ldloc.1
+		IL_0042: ldstr "write"
+		IL_0047: ldstr " ok\n"
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0051: pop
+		IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_0057: ldstr "stderr"
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0066: stloc.1
+		IL_0067: ldloc.1
+		IL_0068: ldstr "write"
+		IL_006d: ldstr "stderr"
+		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0077: pop
+		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+		IL_007d: ldstr "stderr"
+		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008c: stloc.1
+		IL_008d: ldloc.1
+		IL_008e: ldstr "write"
+		IL_0093: ldstr " ok\n"
+		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_009d: pop
+		IL_009e: ret
+	} // end of method Process_Stdout_Stderr_Write::__js_module_init__
+
+} // end of class Modules.Process_Stdout_Stderr_Write
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x2104
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Process_Stdout_Stderr_Write::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary
- add Node-compatible `process.stdout` and `process.stderr` writable streams with `write(...)` support
- route process stdio writes through console sinks by extending `IConsoleOutput` with raw `Write(...)`
- add Node Process regression coverage for stdout/stderr writes (execution + generator snapshots)
- update `CHANGELOG.md` and `docs/nodejs/process.json` + regenerated `docs/nodejs/process.md`

## Root cause
The failure was not loop lowering or `process.argv`; `process.argv` was already populated correctly. The script crashed in its error path because `process.stderr` was missing, so `process.stderr.write(...)` threw `TypeError: Cannot read properties of null or undefined`.

## Validation
- `dotnet test tests\Jroc.Tests\Jroc.Tests.csproj --no-restore -c Release --filter "FullyQualifiedName~ConsoleTests|FullyQualifiedName~Node.Process" --nologo`
- `dotnet run --project src\Cli\Jroc.csproj -- --pdb --input scripts\summarizePrCiFailures.js -o C:\Temp\jroc-summarize-pr`
- `dotnet C:\Temp\jroc-summarize-pr\summarizePrCiFailures.dll` (prints `Missing pull request number.`)