### PR TITLE
perf(compiler): Avoid boxed unused item assignment results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-_Nothing yet._
+- perf/compiler/runtime: avoid materializing boxed property/index assignment results when expression-statement assignments discard the value, emitting void item-store helpers for numeric array/object hot paths while preserving normal assignment-expression values.
 
 ## v0.11.25 - 2026-07-14
 

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Collections.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Collections.cs
@@ -551,6 +551,9 @@ internal sealed partial class LIRToILCompiler
                     var valueStorage = GetTempStorage(setItem.Value);
 
                     bool isResultMaterialized = IsMaterialized(setItem.Result, allocation);
+                    var setItemMethodName = isResultMaterialized
+                        ? nameof(JavaScriptRuntime.ObjectRuntime.SetItem)
+                        : nameof(JavaScriptRuntime.ObjectRuntime.SetItemNoResult);
 
                     if (indexStorage.Kind == ValueStorageKind.UnboxedValue && indexStorage.ClrType == typeof(double) &&
                         valueStorage.Kind == ValueStorageKind.UnboxedValue && valueStorage.ClrType == typeof(double))
@@ -562,7 +565,7 @@ internal sealed partial class LIRToILCompiler
                         ilEncoder.LoadConstantI4(setItem.ThrowOnError ? 1 : 0);
                         var setItemMethod = _memberRefRegistry.GetOrAddMethod(
                             typeof(JavaScriptRuntime.ObjectRuntime),
-                            nameof(JavaScriptRuntime.ObjectRuntime.SetItem),
+                            setItemMethodName,
                             parameterTypes: new[] { typeof(object), typeof(double), typeof(double), typeof(bool) });
                         ilEncoder.OpCode(ILOpCode.Call);
                         ilEncoder.Token(setItemMethod);
@@ -577,7 +580,7 @@ internal sealed partial class LIRToILCompiler
                         ilEncoder.LoadConstantI4(setItem.ThrowOnError ? 1 : 0);
                         var setItemMethod = _memberRefRegistry.GetOrAddMethod(
                             typeof(JavaScriptRuntime.ObjectRuntime),
-                            nameof(JavaScriptRuntime.ObjectRuntime.SetItem),
+                            setItemMethodName,
                             parameterTypes: new[] { typeof(object), typeof(string), typeof(double), typeof(bool) });
                         ilEncoder.OpCode(ILOpCode.Call);
                         ilEncoder.Token(setItemMethod);
@@ -591,7 +594,7 @@ internal sealed partial class LIRToILCompiler
                         ilEncoder.LoadConstantI4(setItem.ThrowOnError ? 1 : 0);
                         var setItemMethod = _memberRefRegistry.GetOrAddMethod(
                             typeof(JavaScriptRuntime.ObjectRuntime),
-                            nameof(JavaScriptRuntime.ObjectRuntime.SetItem),
+                            setItemMethodName,
                             parameterTypes: new[] { typeof(object), typeof(string), typeof(object), typeof(bool) });
                         ilEncoder.OpCode(ILOpCode.Call);
                         ilEncoder.Token(setItemMethod);
@@ -605,7 +608,7 @@ internal sealed partial class LIRToILCompiler
                         ilEncoder.LoadConstantI4(setItem.ThrowOnError ? 1 : 0);
                         var setItemMethod = _memberRefRegistry.GetOrAddMethod(
                             typeof(JavaScriptRuntime.ObjectRuntime),
-                            nameof(JavaScriptRuntime.ObjectRuntime.SetItem),
+                            setItemMethodName,
                             parameterTypes: new[] { typeof(object), typeof(object), typeof(object), typeof(bool) });
                         ilEncoder.OpCode(ILOpCode.Call);
                         ilEncoder.Token(setItemMethod);
@@ -614,10 +617,6 @@ internal sealed partial class LIRToILCompiler
                     if (isResultMaterialized)
                     {
                         EmitStoreTemp(setItem.Result, ilEncoder, allocation);
-                    }
-                    else
-                    {
-                        ilEncoder.OpCode(ILOpCode.Pop);
                     }
                     break;
                 }

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAssignments.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.MemberAssignments.cs
@@ -13,7 +13,7 @@ public sealed partial class HIRToLIRLowerer
     private bool UsesStrictAssignmentSemantics()
         => _scope == null || Jroc.Utilities.ArgumentsObjectSemantics.IsStrictScope(_scope);
 
-    private bool TryLowerPropertyAssignmentTarget(HIRExpression objectExpr, string propertyName, TempVariable valueToStore, out TempVariable resultTempVar)
+    private bool TryLowerPropertyAssignmentTarget(HIRExpression objectExpr, string propertyName, TempVariable valueToStore, out TempVariable resultTempVar, bool resultUsed = true)
     {
         resultTempVar = default;
 
@@ -30,7 +30,7 @@ public sealed partial class HIRToLIRLowerer
                 IsPrivateField: false,
                 fieldValueToStore));
 
-            resultTempVar = fieldValueToStore;
+            resultTempVar = resultUsed ? fieldValueToStore : default;
             return true;
         }
 
@@ -39,10 +39,10 @@ public sealed partial class HIRToLIRLowerer
             return false;
         }
 
-        return TryLowerPropertyAssignmentTarget(objTemp, propertyName, valueToStore, out resultTempVar);
+        return TryLowerPropertyAssignmentTarget(objTemp, propertyName, valueToStore, out resultTempVar, resultUsed);
     }
 
-    private bool TryLowerPropertyAssignmentTarget(TempVariable objectTemp, string propertyName, TempVariable valueToStore, out TempVariable resultTempVar)
+    private bool TryLowerPropertyAssignmentTarget(TempVariable objectTemp, string propertyName, TempVariable valueToStore, out TempVariable resultTempVar, bool resultUsed = true)
     {
         resultTempVar = default;
 
@@ -64,11 +64,11 @@ public sealed partial class HIRToLIRLowerer
         var setResult = CreateTempVariable();
         _methodBodyIR.Instructions.Add(new LIRSetItem(objectTemp, boxedKey, valueToStore, setResult, UsesStrictAssignmentSemantics()));
         DefineTempStorage(setResult, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
-        resultTempVar = setResult;
+        resultTempVar = resultUsed ? setResult : default;
         return true;
     }
 
-    private bool TryLowerIndexAssignmentTarget(HIRExpression objectExpr, HIRExpression indexExpr, TempVariable valueToStore, out TempVariable resultTempVar)
+    private bool TryLowerIndexAssignmentTarget(HIRExpression objectExpr, HIRExpression indexExpr, TempVariable valueToStore, out TempVariable resultTempVar, bool resultUsed = true)
     {
         resultTempVar = default;
 
@@ -88,7 +88,7 @@ public sealed partial class HIRToLIRLowerer
                 IsPrivateField: false,
                 fieldValueToStore));
 
-            resultTempVar = fieldValueToStore;
+            resultTempVar = resultUsed ? fieldValueToStore : default;
             return true;
         }
 
@@ -102,10 +102,10 @@ public sealed partial class HIRToLIRLowerer
             return false;
         }
 
-        return TryLowerIndexAssignmentTarget(objTemp, indexTemp, valueToStore, out resultTempVar);
+        return TryLowerIndexAssignmentTarget(objTemp, indexTemp, valueToStore, out resultTempVar, resultUsed);
     }
 
-    private bool TryLowerIndexAssignmentTarget(TempVariable objectTemp, TempVariable indexTemp, TempVariable valueToStore, out TempVariable resultTempVar)
+    private bool TryLowerIndexAssignmentTarget(TempVariable objectTemp, TempVariable indexTemp, TempVariable valueToStore, out TempVariable resultTempVar, bool resultUsed = true)
     {
         resultTempVar = default;
 
@@ -129,11 +129,11 @@ public sealed partial class HIRToLIRLowerer
         var setResult = CreateTempVariable();
         _methodBodyIR.Instructions.Add(new LIRSetItem(objectTemp, indexForSet, valueToStore, setResult, UsesStrictAssignmentSemantics()));
         DefineTempStorage(setResult, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
-        resultTempVar = setResult;
+        resultTempVar = resultUsed ? setResult : default;
         return true;
     }
 
-    private bool TryLowerPropertyAssignmentExpression(HIRPropertyAssignmentExpression assignExpr, out TempVariable resultTempVar)
+    private bool TryLowerPropertyAssignmentExpression(HIRPropertyAssignmentExpression assignExpr, out TempVariable resultTempVar, bool resultUsed = true)
     {
         resultTempVar = default;
 
@@ -160,7 +160,6 @@ public sealed partial class HIRToLIRLowerer
             _methodBodyIR.Instructions.Add(new LIRGetItem(objTemp, boxedKey, current));
             DefineTempStorage(current, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
 
-            resultTempVar = CreateTempVariable();
             var evalRightLabel = CreateLabel();
             var endLabel = CreateLabel();
 
@@ -172,7 +171,11 @@ public sealed partial class HIRToLIRLowerer
             DefineTempStorage(isJsNullTemp, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
             _methodBodyIR.Instructions.Add(new LIRBranchIfTrue(isJsNullTemp, evalRightLabel));
 
-            _methodBodyIR.Instructions.Add(new LIRCopyTemp(currentBoxed, resultTempVar));
+            if (resultUsed)
+            {
+                resultTempVar = CreateTempVariable();
+                _methodBodyIR.Instructions.Add(new LIRCopyTemp(currentBoxed, resultTempVar));
+            }
             _methodBodyIR.Instructions.Add(new LIRBranch(endLabel));
 
             _methodBodyIR.Instructions.Add(new LIRLabel(evalRightLabel));
@@ -187,11 +190,17 @@ public sealed partial class HIRToLIRLowerer
             var setResult = CreateTempVariable();
             _methodBodyIR.Instructions.Add(new LIRSetItem(objTemp, boxedKey, rhsValue, setResult, UsesStrictAssignmentSemantics()));
             DefineTempStorage(setResult, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
-            _methodBodyIR.Instructions.Add(new LIRCopyTemp(setResult, resultTempVar));
+            if (resultUsed)
+            {
+                _methodBodyIR.Instructions.Add(new LIRCopyTemp(setResult, resultTempVar));
+            }
 
             _methodBodyIR.Instructions.Add(new LIRLabel(endLabel));
             ClearNumericRefinementsAtLabel();
-            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            if (resultUsed)
+            {
+                DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            }
             return true;
         }
 
@@ -209,7 +218,7 @@ public sealed partial class HIRToLIRLowerer
                     return false;
                 }
 
-                return TryLowerPropertyAssignmentTarget(assignExpr.Object, assignExpr.PropertyName, valueToStore, out resultTempVar);
+                return TryLowerPropertyAssignmentTarget(assignExpr.Object, assignExpr.PropertyName, valueToStore, out resultTempVar, resultUsed);
             }
 
             if (!TryLowerExpression(assignExpr.Object, out var objTemp))
@@ -222,7 +231,7 @@ public sealed partial class HIRToLIRLowerer
                 return false;
             }
 
-            return TryLowerPropertyAssignmentTarget(objTemp, assignExpr.PropertyName, valueToStore, out resultTempVar);
+            return TryLowerPropertyAssignmentTarget(objTemp, assignExpr.PropertyName, valueToStore, out resultTempVar, resultUsed);
         }
         else
         {
@@ -251,7 +260,7 @@ public sealed partial class HIRToLIRLowerer
             }
         }
 
-        return TryLowerPropertyAssignmentTarget(assignExpr.Object, assignExpr.PropertyName, valueToStore, out resultTempVar);
+        return TryLowerPropertyAssignmentTarget(assignExpr.Object, assignExpr.PropertyName, valueToStore, out resultTempVar, resultUsed);
     }
 
     /// <summary>
@@ -343,7 +352,7 @@ public sealed partial class HIRToLIRLowerer
         return true;
     }
 
-    private bool TryLowerIndexAssignmentExpression(HIRIndexAssignmentExpression assignExpr, out TempVariable resultTempVar)
+    private bool TryLowerIndexAssignmentExpression(HIRIndexAssignmentExpression assignExpr, out TempVariable resultTempVar, bool resultUsed = true)
     {
         resultTempVar = default;
 
@@ -377,7 +386,6 @@ public sealed partial class HIRToLIRLowerer
             _methodBodyIR.Instructions.Add(new LIRGetItem(objTemp, indexForGet, current));
             DefineTempStorage(current, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
 
-            resultTempVar = CreateTempVariable();
             var evalRightLabel = CreateLabel();
             var endLabel = CreateLabel();
 
@@ -389,7 +397,11 @@ public sealed partial class HIRToLIRLowerer
             DefineTempStorage(isJsNullTemp, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
             _methodBodyIR.Instructions.Add(new LIRBranchIfTrue(isJsNullTemp, evalRightLabel));
 
-            _methodBodyIR.Instructions.Add(new LIRCopyTemp(currentBoxed, resultTempVar));
+            if (resultUsed)
+            {
+                resultTempVar = CreateTempVariable();
+                _methodBodyIR.Instructions.Add(new LIRCopyTemp(currentBoxed, resultTempVar));
+            }
             _methodBodyIR.Instructions.Add(new LIRBranch(endLabel));
 
             _methodBodyIR.Instructions.Add(new LIRLabel(evalRightLabel));
@@ -410,11 +422,17 @@ public sealed partial class HIRToLIRLowerer
             var setResult = CreateTempVariable();
             _methodBodyIR.Instructions.Add(new LIRSetItem(objTemp, indexForSet, rhsValue, setResult, UsesStrictAssignmentSemantics()));
             DefineTempStorage(setResult, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
-            _methodBodyIR.Instructions.Add(new LIRCopyTemp(setResult, resultTempVar));
+            if (resultUsed)
+            {
+                _methodBodyIR.Instructions.Add(new LIRCopyTemp(setResult, resultTempVar));
+            }
 
             _methodBodyIR.Instructions.Add(new LIRLabel(endLabel));
             ClearNumericRefinementsAtLabel();
-            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            if (resultUsed)
+            {
+                DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+            }
             return true;
         }
 
@@ -435,7 +453,7 @@ public sealed partial class HIRToLIRLowerer
                     return false;
                 }
 
-                return TryLowerIndexAssignmentTarget(assignExpr.Object, assignExpr.Index, valueToStore, out resultTempVar);
+                return TryLowerIndexAssignmentTarget(assignExpr.Object, assignExpr.Index, valueToStore, out resultTempVar, resultUsed);
             }
 
             if (!TryLowerExpression(assignExpr.Object, out var objTemp))
@@ -453,7 +471,7 @@ public sealed partial class HIRToLIRLowerer
                 return false;
             }
 
-            return TryLowerIndexAssignmentTarget(objTemp, indexTemp, valueToStore, out resultTempVar);
+            return TryLowerIndexAssignmentTarget(objTemp, indexTemp, valueToStore, out resultTempVar, resultUsed);
         }
         else
         {
@@ -497,7 +515,7 @@ public sealed partial class HIRToLIRLowerer
             }
         }
 
-        return TryLowerIndexAssignmentTarget(assignExpr.Object, assignExpr.Index, valueToStore, out resultTempVar);
+        return TryLowerIndexAssignmentTarget(assignExpr.Object, assignExpr.Index, valueToStore, out resultTempVar, resultUsed);
     }
 
     private bool TryLowerDestructuringAssignmentExpression(HIRDestructuringAssignmentExpression assignExpr, out TempVariable resultTempVar)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.Lowering.Expressions.cs
@@ -26,6 +26,16 @@ public sealed partial class HIRToLIRLowerer
             return TryLowerAssignmentExpression(assignmentExpr, out _, resultUsed: false);
         }
 
+        if (expression is HIRPropertyAssignmentExpression propertyAssignmentExpr)
+        {
+            return TryLowerPropertyAssignmentExpression(propertyAssignmentExpr, out _, resultUsed: false);
+        }
+
+        if (expression is HIRIndexAssignmentExpression indexAssignmentExpr)
+        {
+            return TryLowerIndexAssignmentExpression(indexAssignmentExpr, out _, resultUsed: false);
+        }
+
         if (expression is HIRSequenceExpression seqExpr)
         {
             for (int i = 0; i < seqExpr.Expressions.Count; i++)

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -1084,6 +1084,9 @@ namespace JavaScriptRuntime
             return SetProperty(obj, propName, value, throwOnError);
         }
 
+        public static void SetItemNoResult(object? obj, object index, object? value, bool throwOnError)
+            => SetItem(obj, index, value, throwOnError);
+
         /// <summary>
         /// Fast-path overload for string key writes.
         /// Avoids boxing at the call site when the compiler has proven the key is a string.
@@ -1174,6 +1177,9 @@ namespace JavaScriptRuntime
             // Generic object: treat as property assignment
             return SetProperty(obj, key, value, throwOnError);
         }
+
+        public static void SetItemNoResult(object? obj, string key, object? value, bool throwOnError)
+            => SetItem(obj, key, value, throwOnError);
 
         /// <summary>
         /// Fast-path overload for string key writes with numeric values.
@@ -1269,6 +1275,87 @@ namespace JavaScriptRuntime
 
             // Generic object: treat as property assignment
             return SetProperty(obj, key, value, throwOnError);
+        }
+
+        public static void SetItemNoResult(object? obj, string key, double value, bool throwOnError)
+        {
+            if (obj is null)
+            {
+                throw new JavaScriptRuntime.TypeError("Cannot set properties of null or undefined");
+            }
+
+            if (obj is JsNull)
+            {
+                throw new JavaScriptRuntime.TypeError("Cannot set properties of null");
+            }
+
+            if (obj is JavaScriptRuntime.Proxy)
+            {
+                SetProperty(obj, key, value, throwOnError);
+                return;
+            }
+
+            if (obj is string)
+            {
+                return;
+            }
+
+            bool isIndex = TryParseCanonicalIndexString(key, out int intIndex);
+
+            if (obj is System.Dynamic.ExpandoObject)
+            {
+                SetProperty(obj, key, value, throwOnError);
+                return;
+            }
+
+            if (obj is Array array)
+            {
+                if (!isIndex)
+                {
+                    if (string.Equals(key, "length", StringComparison.Ordinal))
+                    {
+                        array.length = value;
+                        return;
+                    }
+
+                    SetProperty(array, key, value, throwOnError);
+                    return;
+                }
+
+                if (!array.HasOwnIndex(intIndex)
+                    && JavaScriptRuntime.Object.TrySetPropertyViaPrototypeOrThrow(array, key, value, throwOnError))
+                {
+                    return;
+                }
+
+                array[intIndex] = value;
+                return;
+            }
+
+            if (obj is TypedArrayBase typedArray)
+            {
+                if (!isIndex)
+                {
+                    SetProperty(typedArray, key, value, throwOnError);
+                    return;
+                }
+
+                typedArray[(double)intIndex] = value;
+                return;
+            }
+
+            if (obj is JavaScriptRuntime.Node.Buffer buffer)
+            {
+                if (!isIndex)
+                {
+                    SetProperty(buffer, key, value, throwOnError);
+                    return;
+                }
+                buffer[(double)intIndex] = value;
+                return;
+            }
+
+            SetProperty(obj, key, value, throwOnError);
         }
 
         /// <summary>
@@ -1378,6 +1465,84 @@ namespace JavaScriptRuntime
 
             // Fallback: treat numeric index as a property key string.
             return SetProperty(obj, DotNet2JSConversions.ToString(index), value, throwOnError) ?? value;
+        }
+
+        public static void SetItemNoResult(object? obj, double index, double value, bool throwOnError)
+        {
+            if (obj is null)
+            {
+                throw new JavaScriptRuntime.TypeError("Cannot set properties of null or undefined");
+            }
+
+            if (obj is JsNull)
+            {
+                throw new JavaScriptRuntime.TypeError("Cannot set properties of null");
+            }
+
+            var isCanonicalArrayIndex = !double.IsNaN(index)
+                && !double.IsInfinity(index)
+                && index % 1.0 == 0.0
+                && index >= 0
+                && index <= int.MaxValue;
+            var intIndex = isCanonicalArrayIndex ? (int)index : 0;
+
+            if (obj is string)
+            {
+                return;
+            }
+
+            if (obj is Array array)
+            {
+                if (!isCanonicalArrayIndex)
+                {
+                    var nonCanonicalIndexKey = DotNet2JSConversions.ToString(index);
+                    SetProperty(array, nonCanonicalIndexKey, value, throwOnError);
+                    return;
+                }
+
+                if (!PropertyDescriptorStore.HasAny(array) && array.HasOwnIndex(intIndex))
+                {
+                    array[intIndex] = value;
+                    return;
+                }
+
+                var canonicalIndexKey = DotNet2JSConversions.ToString(index);
+                if (!array.HasOwnIndex(intIndex)
+                    && JavaScriptRuntime.Object.TrySetPropertyViaPrototypeOrThrow(array, canonicalIndexKey, value, throwOnError))
+                {
+                    return;
+                }
+
+                array[intIndex] = value;
+                return;
+            }
+
+            if (obj is TypedArrayBase typedArray)
+            {
+                if (isCanonicalArrayIndex && intIndex < (int)typedArray.length)
+                {
+                    typedArray.SetFromDouble(intIndex, value);
+                }
+                return;
+            }
+
+            if (obj is JavaScriptRuntime.Node.Buffer buffer)
+            {
+                if (!double.IsNaN(index) && !double.IsInfinity(index) && (index % 1.0 == 0.0))
+                {
+                    if (index >= 0 && index <= int.MaxValue)
+                    {
+                        int bufferIndex = (int)index;
+                        if (bufferIndex < (int)buffer.length)
+                        {
+                            buffer[(double)bufferIndex] = value;
+                        }
+                    }
+                }
+                return;
+            }
+
+            SetProperty(obj, DotNet2JSConversions.ToString(index), value, throwOnError);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- Avoid boxed assignment-expression results when property/index assignment statements discard the value.
- Emit `ObjectRuntime.SetItemNoResult(...)` for dead `LIRSetItem` results, including numeric string-key and numeric-index hot paths.
- Preserve observable assignment-expression values by keeping the existing returning `SetItem(...)` path when the result is materialized.
- Update generator snapshots and `CHANGELOG.md`.

Fixes #1322.

## Cube phased guardrails

Command before implementation:

```powershell
node scripts/runCubePhasedGuardrails.js --dry --output-json C:\Users\fluid\.copilot\session-state\75768726-0cc2-412d-904d-6b822713a5d0\files\issue-1322-before.json
```

Command after implementation:

```powershell
node scripts/runCubePhasedGuardrails.js --dry --il-smells --output-json C:\Users\fluid\.copilot\session-state\75768726-0cc2-412d-904d-6b822713a5d0\files\issue-1322-smells-after.json
```

| Scenario | Runtime | Before mean | After mean | Before alloc | After alloc | Alloc delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| dromaeo-3d-cube | jroc-execute | 486.048 ms | 546.394 ms | 18,220.7 KB | 18,078.7 KB | -142.0 KB |
| dromaeo-3d-cube | jint-execute-prepared | 412.617 ms | 435.365 ms | 5,780.9 KB | 5,780.9 KB | 0.0 KB |
| dromaeo-3d-cube | okojo-execute | 203.486 ms | 286.353 ms | 753.7 KB | 753.7 KB | 0.0 KB |
| dromaeo-3d-cube-modern | jroc-execute | 541.775 ms | 529.669 ms | 18,344.9 KB | 18,122.1 KB | -222.8 KB |
| dromaeo-3d-cube-modern | jint-execute-prepared | 433.318 ms | 478.678 ms | 5,366.0 KB | 5,366.0 KB | 0.0 KB |
| dromaeo-3d-cube-modern | okojo-execute | 364.483 ms | 342.806 ms | 707.9 KB | 707.9 KB | 0.0 KB |

After-run IL smell counters:

| Scenario | IL bytes | newarr object | box | ToNumber | GetItem |
| --- | ---: | ---: | ---: | ---: | ---: |
| dromaeo-3d-cube | 260,939 | 38 | 254 | 72 | 193 |
| dromaeo-3d-cube-modern | 274,514 | 36 | 254 | 72 | 187 |

## Validation

```powershell
dotnet build .\src\Jroc.Core\Jroc.Core.csproj --no-restore --nologo
dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-restore --nologo --filter "FullyQualifiedName~CompoundAssignment|FullyQualifiedName~Variable|FullyQualifiedName~Object|FullyQualifiedName~Array|FullyQualifiedName~TypedArray|FullyQualifiedName~Buffer|FullyQualifiedName~Proxy"
dotnet test .\tests\Jroc.Tests\Jroc.Tests.csproj --no-build --nologo --filter "FullyQualifiedName~GeneratorTests"
```
