### PR TITLE
fix(runtime): handle quoted execSync args on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/tooling/tests: fix Windows `child_process.execSync` shell execution to preserve quoted arguments when running through `cmd.exe`, add `child_process.execSync` quoted-command regression coverage, and add a `scripts/release.js` Node-only escape hatch (`--node-only` / `JROC_RELEASE_NODE_ONLY=1`) so releases can proceed even if compiled-script execution regresses.
 - perf/benchmarks/tooling: add `scripts/runCubePhasedGuardrails.js` plus npm scripts (`perf:phased:cube*`) to run only the Dromaeo cube phased scenarios and report `jroc-execute` vs `jint-execute-prepared` vs `okojo-execute` time/allocation counters, with optional generated-IL smell counting for allocation/codegen guardrails; add phased benchmark `--scenario` filtering so script selection happens in benchmark setup instead of via BenchmarkDotNet `--filter`.
 - perf/compiler/runtime: add numeric fast paths for `Math.abs`, `Math.ceil`, `Math.round`, `Math.sqrt`, `Math.sin`, and `Math.cos` when arguments are already unboxed doubles, plus safe `Math.PI` constant lowering (`Math.PI / 180` fold) when the global `Math` binding has not been written; preserve dynamic dispatch when `Math` is written/replaced.
 - perf/compiler/tests: infer stable `JavaScriptRuntime.Array` parameter types for direct function and arrow callsites, including the Dromaeo cube `RotateX`/`RotateY`/`RotateZ` helpers, while keeping escaped callables on the object ABI.

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -33,6 +33,9 @@ function maybeRunCompiledWithJroc() {
   if (process.env.JROC_RELEASE_BOOTSTRAPPED === '1') {
     return;
   }
+  if (process.env.JROC_RELEASE_NODE_ONLY === '1' || process.argv.includes('--node-only')) {
+    return;
+  }
 
   const argv0 = path.basename((process.argv[0] || '').toLowerCase());
   const runningViaNode = argv0 === 'node' || argv0 === 'node.exe';
@@ -139,7 +142,7 @@ function writeStdout(text) {
 }
 
 function usageAndExit(code = 1) {
-  console.error(`\nUsage: node scripts/release.js <patch|minor|major> [--merge] [--skip-empty] [--dry-run] [--repo owner/name] [--base master]\n`);
+  console.error(`\nUsage: node scripts/release.js <patch|minor|major> [--merge] [--skip-empty] [--dry-run] [--repo owner/name] [--base master] [--node-only]\n`);
   process.exit(code);
 }
 
@@ -193,6 +196,9 @@ function parseArgs(argv) {
       case '--help':
       case '-h':
         usageAndExit(0);
+        break;
+      case '--node-only':
+        // Consumed by maybeRunCompiledWithJroc as an escape hatch.
         break;
       default:
         console.error(`Unknown arg: ${a}`);

--- a/src/JavaScriptRuntime/Node/ChildProcess.cs
+++ b/src/JavaScriptRuntime/Node/ChildProcess.cs
@@ -812,8 +812,7 @@ namespace JavaScriptRuntime.Node
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     psi.FileName = "cmd.exe";
-                    psi.ArgumentList.Add("/c");
-                    psi.ArgumentList.Add(full);
+                    psi.Arguments = "/d /s /c " + full;
                 }
                 else
                 {
@@ -836,22 +835,29 @@ namespace JavaScriptRuntime.Node
 
         private static string BuildShellCommand(string command, IReadOnlyList<string> args)
         {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var sb = new StringBuilder();
             sb.Append(command);
             for (int i = 0; i < args.Count; i++)
             {
                 sb.Append(' ');
-                sb.Append(QuoteArg(args[i] ?? string.Empty));
+                sb.Append(QuoteArg(args[i] ?? string.Empty, isWindows));
             }
             return sb.ToString();
         }
 
-        private static string QuoteArg(string arg)
+        private static string QuoteArg(string arg, bool isWindows)
         {
             if (arg.Length == 0) return "\"\"";
             if (arg.IndexOfAny(new[] { ' ', '\t', '"' }) < 0) return arg;
+            if (isWindows)
+            {
+                return "\"" + arg.Replace("\"", "\"\"") + "\"";
+            }
+
             return "\"" + arg.Replace("\"", "\\\"") + "\"";
         }
+
 
         private static List<string> CoerceArgs(object? args)
         {

--- a/tests/Jroc.Tests/Node/ChildProcess/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Node/ChildProcess/ExecutionTests.cs
@@ -47,5 +47,9 @@ namespace Jroc.Tests.Node.ChildProcess
         [Fact]
         public Task Require_ChildProcess_ExecFileSync_Basic()
             => ExecutionTest(nameof(Require_ChildProcess_ExecFileSync_Basic));
+
+        [Fact]
+        public Task Require_ChildProcess_ExecSync_Quoted()
+            => ExecutionTest(nameof(Require_ChildProcess_ExecSync_Quoted));
     }
 }

--- a/tests/Jroc.Tests/Node/ChildProcess/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Node/ChildProcess/GeneratorTests.cs
@@ -47,5 +47,9 @@ namespace Jroc.Tests.Node.ChildProcess
         [Fact]
         public Task Require_ChildProcess_ExecFileSync_Basic()
             => GenerateTest(nameof(Require_ChildProcess_ExecFileSync_Basic));
+
+        [Fact]
+        public Task Require_ChildProcess_ExecSync_Quoted()
+            => GenerateTest(nameof(Require_ChildProcess_ExecSync_Quoted));
     }
 }

--- a/tests/Jroc.Tests/Node/ChildProcess/JavaScript/Require_ChildProcess_ExecSync_Quoted.js
+++ b/tests/Jroc.Tests/Node/ChildProcess/JavaScript/Require_ChildProcess_ExecSync_Quoted.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const childProcess = require("child_process");
+
+const output = childProcess.execSync(
+    "node -e \"process.stdout.write('quoted-ok')\"",
+    { encoding: "utf8" }
+);
+
+console.log("quoted output ok:", output === "quoted-ok");

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/ExecutionTests.Require_ChildProcess_ExecSync_Quoted.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/ExecutionTests.Require_ChildProcess_ExecSync_Quoted.verified.txt
@@ -1,0 +1,1 @@
+﻿quoted output ok: true

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecSync_Quoted.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecSync_Quoted.verified.txt
@@ -1,0 +1,116 @@
+﻿// IL code: Require_ChildProcess_ExecSync_Quoted
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Require_ChildProcess_ExecSync_Quoted
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Method begins at RVA 0x20c8
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Method begins at RVA 0x2050
+		// Header size: 12
+		// Code size: 108 (0x6c)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Require_ChildProcess_ExecSync_Quoted/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] bool,
+			[5] object
+		)
+
+		IL_0000: newobj instance void Modules.Require_ChildProcess_ExecSync_Quoted/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldarg.1
+		IL_0007: ldstr "child_process"
+		IL_000c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0011: stloc.3
+		IL_0012: ldloc.3
+		IL_0013: stloc.1
+		IL_0014: ldloc.1
+		IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_001a: stloc.3
+		IL_001b: ldloc.3
+		IL_001c: ldstr "execSync"
+		IL_0021: ldstr "node -e \"process.stdout.write('quoted-ok')\""
+		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_002b: dup
+		IL_002c: ldstr "encoding"
+		IL_0031: ldstr "utf8"
+		IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0040: stloc.3
+		IL_0041: ldloc.3
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: ldstr "quoted-ok"
+		IL_0049: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_004e: stloc.s 4
+		IL_0050: ldloc.s 4
+		IL_0052: box [System.Runtime]System.Boolean
+		IL_0057: stloc.s 5
+		IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_005e: ldstr "quoted output ok:"
+		IL_0063: ldloc.s 5
+		IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_006a: pop
+		IL_006b: ret
+	} // end of method Require_ChildProcess_ExecSync_Quoted::__js_module_init__
+
+} // end of class Modules.Require_ChildProcess_ExecSync_Quoted
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Method begins at RVA 0x20d1
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Require_ChildProcess_ExecSync_Quoted::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary
- fix Windows shell execution in `child_process.execSync` by using `cmd.exe` argument-string handling that preserves quoted command arguments
- add `scripts/release.js` escape hatch (`--node-only` and `JROC_RELEASE_NODE_ONLY=1`) to bypass JROC self-bootstrap when needed
- add Node ChildProcess quoted `execSync` execution/generator regression coverage
- update `CHANGELOG.md` under Unreleased

## Validation
- dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --nologo --filter "FullyQualifiedName~Jroc.Tests.Node.ChildProcess"
