### PR TITLE
fix: stabilize Windows/Linux smoke Picocolors step

### DIFF
--- a/samples/Picocolors/Picocolors.csproj
+++ b/samples/Picocolors/Picocolors.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AssemblyName>PicocolorsHost</AssemblyName>
 
     <ModuleOutputDirectory>obj\$(Configuration)\$(TargetFramework)\jroc\picocolors</ModuleOutputDirectory>
   </PropertyGroup>

--- a/samples/Picocolors/Program.cs
+++ b/samples/Picocolors/Program.cs
@@ -9,9 +9,10 @@ internal static class Program
     {
         var compiledModulePath = Path.Combine(AppContext.BaseDirectory, "picocolors.dll");
         var asm = Assembly.LoadFrom(compiledModulePath);
+        var moduleId = ResolvePicocolorsModuleId(asm);
 
         // module.exports from picocolors is the color-functions object itself.
-        using dynamic pc = JsEngine.LoadModule(asm, moduleId: "picocolors");
+        using dynamic pc = JsEngine.LoadModule(asm, moduleId);
 
         // Call a representative selection of picocolors color/style functions.
         // When ANSI color is supported the strings include ANSI escape codes;
@@ -28,5 +29,32 @@ internal static class Program
         Console.WriteLine($"cyan={cyan}");
         Console.WriteLine($"bold={bold}");
         Console.WriteLine("done");
+    }
+
+    private static string ResolvePicocolorsModuleId(Assembly asm)
+    {
+        var moduleIds = JsEngine.GetModuleIds(asm);
+        foreach (var candidate in moduleIds)
+        {
+            if (string.Equals(candidate, "picocolors", StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        foreach (var candidate in moduleIds)
+        {
+            if (string.Equals(candidate, "picocolors/picocolors", StringComparison.Ordinal))
+            {
+                return candidate;
+            }
+        }
+
+        if (moduleIds.Count > 0)
+        {
+            return moduleIds[0];
+        }
+
+        throw new InvalidOperationException("No compiled module IDs were found in picocolors.dll.");
     }
 }


### PR DESCRIPTION
## Summary
- avoid host/module DLL name collision in samples/Picocolors by setting host assembly name to PicocolorsHost
- resolve module id from compiled module manifest instead of hardcoding picocolors
- keep preferred ids (picocolors, picocolors/picocolors) with fallback to first discovered module id

## Why
Release smoke for 0.11.8 failed on both windows-smoke and linux-smoke during the Picocolors sample step.

## Impact
The Picocolors smoke step is now resilient to case-insensitive filesystem collisions and module-id shape differences in emitted metadata.