### PR TITLE
ci: add generator snapshot update workflow

### DIFF
--- a/.github/workflows/update-generator-snapshots.yml
+++ b/.github/workflows/update-generator-snapshots.yml
@@ -1,0 +1,119 @@
+name: Update generator snapshots
+run-name: ${{ github.workflow }} - PR #${{ github.event.inputs.pr_number }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number whose branch should receive updated generator snapshots"
+        required: true
+        type: number
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  update-generator-snapshots:
+    name: Update generator snapshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Resolve PR branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          head_repo="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRepository --jq '.headRepository.nameWithOwner')"
+          head_ref="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName --jq '.headRefName')"
+
+          if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
+            echo "::error::PR #$PR_NUMBER is from $head_repo. This workflow can only push to branches in $GITHUB_REPOSITORY."
+            exit 1
+          fi
+
+          {
+            echo "head_repo=$head_repo"
+            echo "head_ref=$head_ref"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ steps.pr.outputs.head_repo }}
+          ref: ${{ steps.pr.outputs.head_ref }}
+          token: ${{ github.token }}
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Restore dependencies
+        run: |
+          dotnet tool restore
+          dotnet restore
+
+      - name: Run generator tests and update generator snapshots
+        id: update
+        run: |
+          set -euo pipefail
+
+          set +e
+          node scripts/runGeneratorTestsAndUpdateFailures.js
+          test_exit=$?
+          set -e
+
+          echo "Initial generator test exit code: $test_exit"
+          node scripts/updateVerifiedFiles.js --root tests/Jroc.Tests --generator-only
+
+          find tests/Jroc.Tests -name 'GeneratorTests.*.received.txt' -delete
+          find tests/Jroc.Tests -path '*/Snapshots/GeneratorTests.*.verified.txt' -print0 | xargs -r -0 git add --
+
+          if git diff --cached --quiet; then
+            if [ "$test_exit" -ne 0 ]; then
+              echo "::error::Generator tests failed, but no generator snapshot updates were produced."
+              exit "$test_exit"
+            fi
+
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No generator snapshot changes were produced."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify generator tests after snapshot update
+        if: steps.update.outputs.changed == 'true'
+        run: dotnet test tests/Jroc.Tests/Jroc.Tests.csproj -c Debug --filter "FullyQualifiedName~.GeneratorTests." --nologo
+
+      - name: Commit and push generator snapshots
+        if: steps.update.outputs.changed == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git commit -m "test: update generator snapshots for PR #$PR_NUMBER"
+          git push origin "HEAD:$HEAD_REF"
+
+      - name: Report no snapshot changes
+        if: steps.update.outputs.changed != 'true'
+        run: echo "No generator snapshot updates were needed."


### PR DESCRIPTION
## Summary
- Add a manual workflow to update generator snapshot drift for a specified PR
- The workflow runs generator-only tests, promotes generator verified snapshots, commits the updated `*.verified.txt` files, and pushes back to the PR branch
- Fork PRs are rejected because the workflow needs write access to the head branch

## Validation
- Parsed `.github/workflows/update-generator-snapshots.yml` with `js-yaml`
- Confirmed the branch differs from `master` only by the new workflow file
