### PR TITLE
test(test262): isolate class expression snapshots

### DIFF
--- a/tests/Jroc.Test262.Tests/language/expressions/class/Snapshots/PortExpressionsBatchExecutionTests.scope_meth_paramsbody_var_open.verified.txt
+++ b/tests/Jroc.Test262.Tests/language/expressions/class/Snapshots/PortExpressionsBatchExecutionTests.scope_meth_paramsbody_var_open.verified.txt
@@ -1,2 +1,2 @@
-﻿false
+﻿true
 true

--- a/tests/Jroc.Test262.Tests/language/expressions/class/Snapshots/PortExpressionsBatchExecutionTests.scope_setter_paramsbody_var_open.verified.txt
+++ b/tests/Jroc.Test262.Tests/language/expressions/class/Snapshots/PortExpressionsBatchExecutionTests.scope_setter_paramsbody_var_open.verified.txt
@@ -1,2 +1,2 @@
-﻿false
+﻿true
 true

--- a/tests/Jroc.Test262.Tests/language/expressions/class/Snapshots/PortExpressionsBatchExecutionTests.scope_static_meth_paramsbody_var_open.verified.txt
+++ b/tests/Jroc.Test262.Tests/language/expressions/class/Snapshots/PortExpressionsBatchExecutionTests.scope_static_meth_paramsbody_var_open.verified.txt
@@ -1,2 +1,2 @@
-﻿false
+﻿true
 true


### PR DESCRIPTION
## Summary
- isolate the `language/expressions/class` snapshot corrections into their own stacked PR
- keep PR #1342 focused on the product changes and function/arrow-related updates

## Notes
- this PR depends on #1342 because these snapshot updates reflect behavior introduced there