### PR TITLE
test(test262): split language/function-code snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - compiler/runtime/tests/test262: fix the newly ported language test262 cases by aligning strict/bound `this`, destructuring default function-name inference, class field data-property descriptors, computed/private class element handling, derived constructor primitive returns, and generator/async-generator parameter initialization timing.
 - compiler/tests/docs/test262: fix assignment-expression evaluation order for computed member targets, add explicit strict-mode prologues for the strict-only assignment ports that rely on read-only-property TypeErrors, and refresh the ECMA-262 assignment-operator coverage notes.
 - runtime/tests/docs/test262: align `Array.prototype.at` with spec `ToIntegerOrInfinity` coercion and builtin callable metadata so object indexes coerce via `valueOf()`, `Symbol()` indexes throw `TypeError`, and the method exposes the expected `name` descriptor.
+- compiler/tests/docs/test262: preserve strict bare-call `this` semantics by routing strict direct function calls through the normal function-value invocation path, fixing the newly split `language/function-code` strict nested function cases.
 
 ## v0.11.8 - 2026-07-02
 

--- a/docs/ECMA262/15/Section15_2.json
+++ b/docs/ECMA262/15/Section15_2.json
@@ -75,12 +75,18 @@
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-functionbodycontainsusestrict",
         "testScripts": [
+          "tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-27-s.js",
+          "tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-28-s.js",
+          "tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-29-s.js",
           "tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-35-s.js"
         ],
         "test262Paths": [
+          "test/language/function-code/10.4.3-1-27-s.js",
+          "test/language/function-code/10.4.3-1-28-s.js",
+          "test/language/function-code/10.4.3-1-29-s.js",
           "test/language/function-code/10.4.3-1-35-s.js"
         ],
-        "notes": "JROC parses directive prologues and preserves strict function `this` for bare calls in the covered function-code case. This clause remains limited because full strict-mode semantics and early errors across the language still need a broader dedicated test matrix."
+        "notes": "JROC parses directive prologues and preserves strict function `this` for bare calls, including nested function declarations and function expressions reached through direct-call lowering. This clause remains limited because full strict-mode semantics and early errors across the language still need a broader dedicated test matrix."
       },
       {
         "clause": "15.2",

--- a/docs/ECMA262/15/Section15_2.md
+++ b/docs/ECMA262/15/Section15_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section15](Section15.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-02T19:23:04Z
+> Last generated (UTC): 2026-07-02T22:55:30Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -37,5 +37,5 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| directive prologue / strict mode ("use strict") semantics | Supported with Limitations | [`10.4.3-1-35-s.js`](../../../tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-35-s.js) | `test/language/function-code/10.4.3-1-35-s.js` | JROC parses directive prologues and preserves strict function `this` for bare calls in the covered function-code case. This clause remains limited because full strict-mode semantics and early errors across the language still need a broader dedicated test matrix. |
+| directive prologue / strict mode ("use strict") semantics | Supported with Limitations | [`10.4.3-1-27-s.js`](../../../tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-27-s.js)<br>[`10.4.3-1-28-s.js`](../../../tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-28-s.js)<br>[`10.4.3-1-29-s.js`](../../../tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-29-s.js)<br>[`10.4.3-1-35-s.js`](../../../tests/Jroc.Test262.Tests/language/function-code/JavaScript/10.4.3-1-35-s.js) | `test/language/function-code/10.4.3-1-27-s.js`<br>`test/language/function-code/10.4.3-1-28-s.js`<br>`test/language/function-code/10.4.3-1-29-s.js`<br>`test/language/function-code/10.4.3-1-35-s.js` | JROC parses directive prologues and preserves strict function `this` for bare calls, including nested function declarations and function expressions reached through direct-call lowering. This clause remains limited because full strict-mode semantics and early errors across the language still need a broader dedicated test matrix. |
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -523,9 +523,13 @@ public sealed partial class HIRToLIRLowerer
                 return true;
             }
 
-            // If the callee is not a direct function binding (e.g., it's a local/const holding a closure),
-            // invoke via runtime dispatch (Closure.InvokeWithArgs).
-            if (symbol.Kind != BindingKind.Function)
+            var callableId = TryCreateCallableIdForFunctionDeclaration(symbol);
+
+            // Strict bare calls must preserve undefined `this`; route them through the function-value
+            // dispatch path instead of the direct static-call fast path.
+            // Non-function bindings also use runtime dispatch (e.g., locals/consts holding closures).
+            if (symbol.Kind != BindingKind.Function
+                || callableId?.HasRestrictedFunctionProperties == true)
             {
                 // Lower callee value
                 if (!TryLowerExpression(funcVarExpr, out var calleeTemp))
@@ -598,8 +602,7 @@ public sealed partial class HIRToLIRLowerer
                 }
                 DefineTempStorage(scopesTempForSpread, new ValueStorage(ValueStorageKind.Reference, typeof(object[])));
 
-                var callableIdForSpread = TryCreateCallableIdForFunctionDeclaration(symbol);
-                _methodBodyIR.Instructions.Add(new LIRCallFunctionWithArgsArray(symbol, scopesTempForSpread, argsArrayTemp, resultTempVar, callableIdForSpread));
+                _methodBodyIR.Instructions.Add(new LIRCallFunctionWithArgsArray(symbol, scopesTempForSpread, argsArrayTemp, resultTempVar, callableId));
                 DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
                 return true;
             }
@@ -625,7 +628,6 @@ public sealed partial class HIRToLIRLowerer
             DefineTempStorage(scopesTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object[])));
 
             // Emit the function call with arguments
-            var callableId = TryCreateCallableIdForFunctionDeclaration(symbol);
             _methodBodyIR.Instructions.Add(new LIRCallFunction(symbol, scopesTempVar, arguments, resultTempVar, callableId));
             DefineDirectCallResultStorage(resultTempVar, callableId, symbol.BindingInfo);
 

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d49
+				// Method begins at RVA 0x50bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d64
+						// Method begins at RVA 0x50d7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d6d
+						// Method begins at RVA 0x50e0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d76
+						// Method begins at RVA 0x50e9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d7f
+						// Method begins at RVA 0x50f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -126,7 +126,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d88
+						// Method begins at RVA 0x50fb
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -146,7 +146,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4d91
+						// Method begins at RVA 0x5104
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -164,7 +164,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4d5b
+					// Method begins at RVA 0x50ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -182,7 +182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d52
+				// Method begins at RVA 0x50c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -503,7 +503,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d9a
+				// Method begins at RVA 0x510d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -604,7 +604,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4da3
+				// Method begins at RVA 0x5116
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4db5
+					// Method begins at RVA 0x5128
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -712,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dac
+				// Method begins at RVA 0x511f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -815,7 +815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dbe
+				// Method begins at RVA 0x5131
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -878,7 +878,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dc7
+				// Method begins at RVA 0x513a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -907,45 +907,55 @@
 			)
 			// Method begins at RVA 0x2be0
 			// Header size: 12
-			// Code size: 92 (0x5c)
+			// Code size: 109 (0x6d)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[0] object[],
+				[1] object,
+				[2] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.2
-			IL_0002: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_0007: stloc.0
-			IL_0008: ldloc.0
-			IL_0009: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000e: stloc.0
-			IL_000f: ldstr "^\\/+"
-			IL_0014: ldstr ""
-			IL_0019: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_001e: stloc.1
-			IL_001f: ldloc.0
-			IL_0020: ldstr "replace"
-			IL_0025: ldloc.1
-			IL_0026: ldstr ""
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0030: stloc.0
-			IL_0031: ldloc.0
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0037: stloc.0
-			IL_0038: ldstr "\\/+$"
-			IL_003d: ldstr ""
-			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0047: stloc.1
-			IL_0048: ldloc.0
-			IL_0049: ldstr "replace"
-			IL_004e: ldloc.1
-			IL_004f: ldstr ""
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0059: stloc.0
-			IL_005a: ldloc.0
-			IL_005b: ret
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.0
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+			IL_0011: ldloc.0
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: stloc.1
+			IL_0019: ldloc.1
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001f: stloc.1
+			IL_0020: ldstr "^\\/+"
+			IL_0025: ldstr ""
+			IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_002f: stloc.2
+			IL_0030: ldloc.1
+			IL_0031: ldstr "replace"
+			IL_0036: ldloc.2
+			IL_0037: ldstr ""
+			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0041: stloc.1
+			IL_0042: ldloc.1
+			IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0048: stloc.1
+			IL_0049: ldstr "\\/+$"
+			IL_004e: ldstr ""
+			IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0058: stloc.2
+			IL_0059: ldloc.1
+			IL_005a: ldstr "replace"
+			IL_005f: ldloc.2
+			IL_0060: ldstr ""
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_006a: stloc.1
+			IL_006b: ldloc.1
+			IL_006c: ret
 		} // end of method normalizeSpecPath::__js_call__
 
 	} // end of class normalizeSpecPath
@@ -965,7 +975,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4dd9
+					// Method begins at RVA 0x514c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -983,7 +993,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4dd0
+				// Method begins at RVA 0x5143
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1008,7 +1018,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c48
+			// Method begins at RVA 0x2c5c
 			// Header size: 12
 			// Code size: 188 (0xbc)
 			.maxstack 8
@@ -1117,7 +1127,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4deb
+					// Method begins at RVA 0x515e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1135,7 +1145,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4de2
+				// Method begins at RVA 0x5155
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1163,7 +1173,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4e06
+						// Method begins at RVA 0x5179
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1181,7 +1191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4dfd
+					// Method begins at RVA 0x5170
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1199,7 +1209,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4df4
+				// Method begins at RVA 0x5167
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1224,7 +1234,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d10
+			// Method begins at RVA 0x2d24
 			// Header size: 12
 			// Code size: 501 (0x1f5)
 			.maxstack 8
@@ -1461,7 +1471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e0f
+				// Method begins at RVA 0x5182
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1489,7 +1499,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4e2a
+						// Method begins at RVA 0x519d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1507,7 +1517,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e21
+					// Method begins at RVA 0x5194
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1525,7 +1535,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e18
+				// Method begins at RVA 0x518b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1552,9 +1562,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2f30
+			// Method begins at RVA 0x2f44
 			// Header size: 12
-			// Code size: 207 (0xcf)
+			// Code size: 226 (0xe2)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -1564,103 +1574,113 @@
 				[4] class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29,
 				[5] class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29/Block_L117C42,
 				[6] object,
-				[7] object,
-				[8] bool
+				[7] object[],
+				[8] object,
+				[9] bool
 			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.2
-			IL_0002: ldstr "excludedFromMvp"
-			IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_000c: pop
-			IL_000d: ldarg.2
-			IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_0013: stloc.0
-			IL_0014: ldc.i4.0
-			IL_0015: stloc.1
-			IL_0016: ldc.i4.0
-			IL_0017: stloc.2
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 7
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0012: ldloc.s 7
+			IL_0014: ldarg.2
+			IL_0015: ldstr "excludedFromMvp"
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_001f: pop
+			IL_0020: ldarg.2
+			IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0026: stloc.0
+			IL_0027: ldc.i4.0
+			IL_0028: stloc.1
+			IL_0029: ldc.i4.0
+			IL_002a: stloc.2
 			.try
 			{
-				// loop start (head: IL_0018)
-					IL_0018: ldloc.0
-					IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_001e: stloc.s 7
-					IL_0020: ldloc.s 7
-					IL_0022: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_0027: stloc.s 8
-					IL_0029: ldloc.s 8
-					IL_002b: brtrue IL_00b3
+				// loop start (head: IL_002b)
+					IL_002b: ldloc.0
+					IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_0031: stloc.s 8
+					IL_0033: ldloc.s 8
+					IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_003a: stloc.s 9
+					IL_003c: ldloc.s 9
+					IL_003e: brtrue IL_00c6
 
-					IL_0030: ldloc.s 7
-					IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_0037: stloc.s 7
-					IL_0039: ldloc.s 7
-					IL_003b: stloc.3
-					IL_003c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29::.ctor()
-					IL_0041: stloc.s 4
-					IL_0043: ldloc.3
-					IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0049: stloc.s 7
-					IL_004b: ldloc.s 7
-					IL_004d: ldstr "startsWith"
-					IL_0052: ldstr "frontmatter:"
-					IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_005c: stloc.s 7
-					IL_005e: ldloc.s 7
-					IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0065: stloc.s 8
-					IL_0067: ldloc.s 8
-					IL_0069: brfalse IL_00a1
+					IL_0043: ldloc.s 8
+					IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_004a: stloc.s 8
+					IL_004c: ldloc.s 8
+					IL_004e: stloc.3
+					IL_004f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29::.ctor()
+					IL_0054: stloc.s 4
+					IL_0056: ldloc.3
+					IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_005c: stloc.s 8
+					IL_005e: ldloc.s 8
+					IL_0060: ldstr "startsWith"
+					IL_0065: ldstr "frontmatter:"
+					IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_006f: stloc.s 8
+					IL_0071: ldloc.s 8
+					IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0078: stloc.s 9
+					IL_007a: ldloc.s 9
+					IL_007c: brfalse IL_00b4
 
-					IL_006e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29/Block_L117C42::.ctor()
-					IL_0073: stloc.s 5
-					IL_0075: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
-					IL_007a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_007f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0084: stloc.s 7
-					IL_0086: ldloc.s 7
-					IL_0088: stloc.s 6
-					IL_008a: ldloc.s 6
-					IL_008c: isinst [System.Runtime]System.Exception
-					IL_0091: dup
-					IL_0092: brtrue IL_00a0
+					IL_0081: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/Scope_ForOf_L116C7/Block_L116C29/Block_L117C42::.ctor()
+					IL_0086: stloc.s 5
+					IL_0088: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
+					IL_008d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0097: stloc.s 8
+					IL_0099: ldloc.s 8
+					IL_009b: stloc.s 6
+					IL_009d: ldloc.s 6
+					IL_009f: isinst [System.Runtime]System.Exception
+					IL_00a4: dup
+					IL_00a5: brtrue IL_00b3
 
-					IL_0097: pop
-					IL_0098: ldloc.s 6
-					IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_009f: throw
+					IL_00aa: pop
+					IL_00ab: ldloc.s 6
+					IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_00b2: throw
 
-					IL_00a0: throw
+					IL_00b3: throw
 
-					IL_00a1: br IL_0018
+					IL_00b4: br IL_002b
 				// end loop
-				IL_00a6: ldloc.0
-				IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_00ac: ldc.i4.1
-				IL_00ad: stloc.2
-				IL_00ae: leave IL_00cd
+				IL_00b9: ldloc.0
+				IL_00ba: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_00bf: ldc.i4.1
+				IL_00c0: stloc.2
+				IL_00c1: leave IL_00e0
 
-				IL_00b3: ldc.i4.1
-				IL_00b4: stloc.1
-				IL_00b5: leave IL_00cd
+				IL_00c6: ldc.i4.1
+				IL_00c7: stloc.1
+				IL_00c8: leave IL_00e0
 			} // end .try
 			finally
 			{
-				IL_00ba: ldloc.1
-				IL_00bb: brtrue IL_00cc
+				IL_00cd: ldloc.1
+				IL_00ce: brtrue IL_00df
 
-				IL_00c0: ldloc.2
-				IL_00c1: brtrue IL_00cc
+				IL_00d3: ldloc.2
+				IL_00d4: brtrue IL_00df
 
-				IL_00c6: ldloc.0
-				IL_00c7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_00d9: ldloc.0
+				IL_00da: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00cc: endfinally
+				IL_00df: endfinally
 			} // end handler
 
-			IL_00cd: ldnull
-			IL_00ce: ret
+			IL_00e0: ldnull
+			IL_00e1: ret
 		} // end of method validateExcludedFromMvp::__js_call__
 
 	} // end of class validateExcludedFromMvp
@@ -1680,7 +1700,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e3c
+					// Method begins at RVA 0x51af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1700,7 +1720,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e45
+					// Method begins at RVA 0x51b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1720,7 +1740,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e4e
+					// Method begins at RVA 0x51c1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1738,7 +1758,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e33
+				// Method begins at RVA 0x51a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1765,9 +1785,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x301c
+			// Method begins at RVA 0x3044
 			// Header size: 12
-			// Code size: 914 (0x392)
+			// Code size: 1272 (0x4f8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L124C39,
@@ -1783,7 +1803,9 @@
 				[10] object,
 				[11] object,
 				[12] object,
-				[13] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[13] object[],
+				[14] object,
+				[15] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
 			IL_0000: ldarg.2
@@ -1900,207 +1922,379 @@
 
 			IL_0129: throw
 
-			IL_012a: ldarg.2
-			IL_012b: ldstr "upstream"
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0135: ldstr "owner"
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013f: stloc.s 11
-			IL_0141: ldnull
-			IL_0142: ldloc.s 11
-			IL_0144: ldstr "upstream.owner"
-			IL_0149: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_014e: pop
-			IL_014f: ldarg.2
-			IL_0150: ldstr "upstream"
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015a: ldstr "repo"
-			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0164: stloc.s 11
-			IL_0166: ldnull
-			IL_0167: ldloc.s 11
-			IL_0169: ldstr "upstream.repo"
-			IL_016e: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_0173: pop
-			IL_0174: ldarg.2
-			IL_0175: ldstr "upstream"
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_017f: ldstr "cloneUrl"
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0189: stloc.s 11
-			IL_018b: ldnull
-			IL_018c: ldloc.s 11
-			IL_018e: ldstr "upstream.cloneUrl"
-			IL_0193: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_0198: pop
-			IL_0199: ldarg.2
-			IL_019a: ldstr "upstream"
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a4: ldstr "commit"
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ae: stloc.s 11
-			IL_01b0: ldnull
-			IL_01b1: ldloc.s 11
-			IL_01b3: ldstr "upstream.commit"
-			IL_01b8: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_01bd: pop
-			IL_01be: ldarg.2
-			IL_01bf: ldstr "upstream"
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c9: ldstr "packageVersion"
-			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d3: stloc.s 11
-			IL_01d5: ldnull
-			IL_01d6: ldloc.s 11
-			IL_01d8: ldstr "upstream.packageVersion"
-			IL_01dd: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_01e2: pop
-			IL_01e3: ldarg.2
-			IL_01e4: ldstr "localOverrideEnvVar"
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ee: stloc.s 11
-			IL_01f0: ldnull
-			IL_01f1: ldloc.s 11
-			IL_01f3: ldstr "localOverrideEnvVar"
-			IL_01f8: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_01fd: pop
-			IL_01fe: ldarg.2
-			IL_01ff: ldstr "managedRoot"
-			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0209: stloc.s 11
-			IL_020b: ldnull
-			IL_020c: ldloc.s 11
-			IL_020e: ldstr "managedRoot"
-			IL_0213: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_0218: pop
-			IL_0219: ldarg.2
-			IL_021a: ldstr "lineEndings"
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0224: stloc.s 11
-			IL_0226: ldnull
-			IL_0227: ldloc.s 11
-			IL_0229: ldstr "lineEndings"
-			IL_022e: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_0233: pop
-			IL_0234: ldarg.2
-			IL_0235: ldstr "updateStrategy"
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023f: stloc.s 11
-			IL_0241: ldnull
-			IL_0242: ldloc.s 11
-			IL_0244: ldstr "updateStrategy"
-			IL_0249: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, object)
-			IL_024e: pop
-			IL_024f: ldarg.2
-			IL_0250: ldstr "includeFiles"
-			IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025a: stloc.s 11
-			IL_025c: ldnull
-			IL_025d: ldloc.s 11
-			IL_025f: ldstr "includeFiles"
-			IL_0264: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_0269: pop
+			IL_012a: ldarg.0
+			IL_012b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0130: stloc.s 11
+			IL_0132: ldc.i4.1
+			IL_0133: newarr [System.Runtime]System.Object
+			IL_0138: dup
+			IL_0139: ldc.i4.0
+			IL_013a: ldarg.0
+			IL_013b: stelem.ref
+			IL_013c: stloc.s 13
+			IL_013e: ldarg.2
+			IL_013f: ldstr "upstream"
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0149: ldstr "owner"
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0153: stloc.s 14
+			IL_0155: ldloc.s 11
+			IL_0157: ldloc.s 13
+			IL_0159: ldloc.s 14
+			IL_015b: ldstr "upstream.owner"
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0165: pop
+			IL_0166: ldarg.0
+			IL_0167: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_016c: stloc.s 14
+			IL_016e: ldc.i4.1
+			IL_016f: newarr [System.Runtime]System.Object
+			IL_0174: dup
+			IL_0175: ldc.i4.0
+			IL_0176: ldarg.0
+			IL_0177: stelem.ref
+			IL_0178: stloc.s 13
+			IL_017a: ldarg.2
+			IL_017b: ldstr "upstream"
+			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0185: ldstr "repo"
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_018f: stloc.s 11
+			IL_0191: ldloc.s 14
+			IL_0193: ldloc.s 13
+			IL_0195: ldloc.s 11
+			IL_0197: ldstr "upstream.repo"
+			IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01a1: pop
+			IL_01a2: ldarg.0
+			IL_01a3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_01a8: stloc.s 11
+			IL_01aa: ldc.i4.1
+			IL_01ab: newarr [System.Runtime]System.Object
+			IL_01b0: dup
+			IL_01b1: ldc.i4.0
+			IL_01b2: ldarg.0
+			IL_01b3: stelem.ref
+			IL_01b4: stloc.s 13
+			IL_01b6: ldarg.2
+			IL_01b7: ldstr "upstream"
+			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c1: ldstr "cloneUrl"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cb: stloc.s 14
+			IL_01cd: ldloc.s 11
+			IL_01cf: ldloc.s 13
+			IL_01d1: ldloc.s 14
+			IL_01d3: ldstr "upstream.cloneUrl"
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01dd: pop
+			IL_01de: ldarg.0
+			IL_01df: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_01e4: stloc.s 14
+			IL_01e6: ldc.i4.1
+			IL_01e7: newarr [System.Runtime]System.Object
+			IL_01ec: dup
+			IL_01ed: ldc.i4.0
+			IL_01ee: ldarg.0
+			IL_01ef: stelem.ref
+			IL_01f0: stloc.s 13
+			IL_01f2: ldarg.2
+			IL_01f3: ldstr "upstream"
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01fd: ldstr "commit"
+			IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0207: stloc.s 11
+			IL_0209: ldloc.s 14
+			IL_020b: ldloc.s 13
+			IL_020d: ldloc.s 11
+			IL_020f: ldstr "upstream.commit"
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0219: pop
+			IL_021a: ldarg.0
+			IL_021b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_0220: stloc.s 11
+			IL_0222: ldc.i4.1
+			IL_0223: newarr [System.Runtime]System.Object
+			IL_0228: dup
+			IL_0229: ldc.i4.0
+			IL_022a: ldarg.0
+			IL_022b: stelem.ref
+			IL_022c: stloc.s 13
+			IL_022e: ldarg.2
+			IL_022f: ldstr "upstream"
+			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0239: ldstr "packageVersion"
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0243: stloc.s 14
+			IL_0245: ldloc.s 11
+			IL_0247: ldloc.s 13
+			IL_0249: ldloc.s 14
+			IL_024b: ldstr "upstream.packageVersion"
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0255: pop
+			IL_0256: ldarg.0
+			IL_0257: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_025c: stloc.s 14
+			IL_025e: ldc.i4.1
+			IL_025f: newarr [System.Runtime]System.Object
+			IL_0264: dup
+			IL_0265: ldc.i4.0
+			IL_0266: ldarg.0
+			IL_0267: stelem.ref
+			IL_0268: stloc.s 13
 			IL_026a: ldarg.2
-			IL_026b: ldstr "includeDirectories"
+			IL_026b: ldstr "localOverrideEnvVar"
 			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0275: stloc.s 11
-			IL_0277: ldnull
-			IL_0278: ldloc.s 11
-			IL_027a: ldstr "includeDirectories"
-			IL_027f: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_0284: pop
-			IL_0285: ldarg.2
-			IL_0286: ldstr "requiredFiles"
-			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0290: stloc.s 11
-			IL_0292: ldnull
-			IL_0293: ldloc.s 11
-			IL_0295: ldstr "requiredFiles"
-			IL_029a: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_029f: pop
-			IL_02a0: ldarg.2
-			IL_02a1: ldstr "requiredDirectories"
-			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ab: stloc.s 11
-			IL_02ad: ldnull
-			IL_02ae: ldloc.s 11
-			IL_02b0: ldstr "requiredDirectories"
-			IL_02b5: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_02ba: pop
-			IL_02bb: ldarg.2
-			IL_02bc: ldstr "defaultHarnessFiles"
-			IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c6: stloc.s 11
-			IL_02c8: ldnull
-			IL_02c9: ldloc.s 11
-			IL_02cb: ldstr "defaultHarnessFiles"
-			IL_02d0: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_02d5: pop
-			IL_02d6: ldarg.2
-			IL_02d7: ldstr "excludedFromMvp"
-			IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e1: stloc.s 11
-			IL_02e3: ldarg.0
-			IL_02e4: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_02e9: ldnull
-			IL_02ea: ldloc.s 11
-			IL_02ec: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_02f1: pop
-			IL_02f2: ldarg.2
-			IL_02f3: ldstr "attributionFiles"
-			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02fd: stloc.s 11
-			IL_02ff: ldnull
-			IL_0300: ldloc.s 11
-			IL_0302: ldstr "attributionFiles"
-			IL_0307: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, object)
-			IL_030c: pop
-			IL_030d: ldstr "^[0-9a-f]{40}$"
-			IL_0312: ldstr "i"
-			IL_0317: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_031c: stloc.s 13
-			IL_031e: ldloc.s 13
-			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0325: stloc.s 11
-			IL_0327: ldloc.s 11
-			IL_0329: ldstr "test"
-			IL_032e: ldarg.2
-			IL_032f: ldstr "upstream"
-			IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0339: ldstr "commit"
-			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0348: stloc.s 11
-			IL_034a: ldloc.s 11
-			IL_034c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0351: ldc.i4.0
-			IL_0352: ceq
-			IL_0354: stloc.s 6
-			IL_0356: ldloc.s 6
-			IL_0358: brfalse IL_0390
+			IL_0277: ldloc.s 14
+			IL_0279: ldloc.s 13
+			IL_027b: ldloc.s 11
+			IL_027d: ldstr "localOverrideEnvVar"
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0287: pop
+			IL_0288: ldarg.0
+			IL_0289: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_028e: stloc.s 11
+			IL_0290: ldc.i4.1
+			IL_0291: newarr [System.Runtime]System.Object
+			IL_0296: dup
+			IL_0297: ldc.i4.0
+			IL_0298: ldarg.0
+			IL_0299: stelem.ref
+			IL_029a: stloc.s 13
+			IL_029c: ldarg.2
+			IL_029d: ldstr "managedRoot"
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a7: stloc.s 14
+			IL_02a9: ldloc.s 11
+			IL_02ab: ldloc.s 13
+			IL_02ad: ldloc.s 14
+			IL_02af: ldstr "managedRoot"
+			IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02b9: pop
+			IL_02ba: ldarg.0
+			IL_02bb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_02c0: stloc.s 14
+			IL_02c2: ldc.i4.1
+			IL_02c3: newarr [System.Runtime]System.Object
+			IL_02c8: dup
+			IL_02c9: ldc.i4.0
+			IL_02ca: ldarg.0
+			IL_02cb: stelem.ref
+			IL_02cc: stloc.s 13
+			IL_02ce: ldarg.2
+			IL_02cf: ldstr "lineEndings"
+			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d9: stloc.s 11
+			IL_02db: ldloc.s 14
+			IL_02dd: ldloc.s 13
+			IL_02df: ldloc.s 11
+			IL_02e1: ldstr "lineEndings"
+			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02eb: pop
+			IL_02ec: ldarg.0
+			IL_02ed: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureString
+			IL_02f2: stloc.s 11
+			IL_02f4: ldc.i4.1
+			IL_02f5: newarr [System.Runtime]System.Object
+			IL_02fa: dup
+			IL_02fb: ldc.i4.0
+			IL_02fc: ldarg.0
+			IL_02fd: stelem.ref
+			IL_02fe: stloc.s 13
+			IL_0300: ldarg.2
+			IL_0301: ldstr "updateStrategy"
+			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_030b: stloc.s 14
+			IL_030d: ldloc.s 11
+			IL_030f: ldloc.s 13
+			IL_0311: ldloc.s 14
+			IL_0313: ldstr "updateStrategy"
+			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_031d: pop
+			IL_031e: ldarg.0
+			IL_031f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0324: stloc.s 14
+			IL_0326: ldc.i4.1
+			IL_0327: newarr [System.Runtime]System.Object
+			IL_032c: dup
+			IL_032d: ldc.i4.0
+			IL_032e: ldarg.0
+			IL_032f: stelem.ref
+			IL_0330: stloc.s 13
+			IL_0332: ldarg.2
+			IL_0333: ldstr "includeFiles"
+			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033d: stloc.s 11
+			IL_033f: ldloc.s 14
+			IL_0341: ldloc.s 13
+			IL_0343: ldloc.s 11
+			IL_0345: ldstr "includeFiles"
+			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_034f: pop
+			IL_0350: ldarg.0
+			IL_0351: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0356: stloc.s 11
+			IL_0358: ldc.i4.1
+			IL_0359: newarr [System.Runtime]System.Object
+			IL_035e: dup
+			IL_035f: ldc.i4.0
+			IL_0360: ldarg.0
+			IL_0361: stelem.ref
+			IL_0362: stloc.s 13
+			IL_0364: ldarg.2
+			IL_0365: ldstr "includeDirectories"
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036f: stloc.s 14
+			IL_0371: ldloc.s 11
+			IL_0373: ldloc.s 13
+			IL_0375: ldloc.s 14
+			IL_0377: ldstr "includeDirectories"
+			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0381: pop
+			IL_0382: ldarg.0
+			IL_0383: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0388: stloc.s 14
+			IL_038a: ldc.i4.1
+			IL_038b: newarr [System.Runtime]System.Object
+			IL_0390: dup
+			IL_0391: ldc.i4.0
+			IL_0392: ldarg.0
+			IL_0393: stelem.ref
+			IL_0394: stloc.s 13
+			IL_0396: ldarg.2
+			IL_0397: ldstr "requiredFiles"
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a1: stloc.s 11
+			IL_03a3: ldloc.s 14
+			IL_03a5: ldloc.s 13
+			IL_03a7: ldloc.s 11
+			IL_03a9: ldstr "requiredFiles"
+			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03b3: pop
+			IL_03b4: ldarg.0
+			IL_03b5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_03ba: stloc.s 11
+			IL_03bc: ldc.i4.1
+			IL_03bd: newarr [System.Runtime]System.Object
+			IL_03c2: dup
+			IL_03c3: ldc.i4.0
+			IL_03c4: ldarg.0
+			IL_03c5: stelem.ref
+			IL_03c6: stloc.s 13
+			IL_03c8: ldarg.2
+			IL_03c9: ldstr "requiredDirectories"
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d3: stloc.s 14
+			IL_03d5: ldloc.s 11
+			IL_03d7: ldloc.s 13
+			IL_03d9: ldloc.s 14
+			IL_03db: ldstr "requiredDirectories"
+			IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03e5: pop
+			IL_03e6: ldarg.0
+			IL_03e7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_03ec: stloc.s 14
+			IL_03ee: ldc.i4.1
+			IL_03ef: newarr [System.Runtime]System.Object
+			IL_03f4: dup
+			IL_03f5: ldc.i4.0
+			IL_03f6: ldarg.0
+			IL_03f7: stelem.ref
+			IL_03f8: stloc.s 13
+			IL_03fa: ldarg.2
+			IL_03fb: ldstr "defaultHarnessFiles"
+			IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0405: stloc.s 11
+			IL_0407: ldloc.s 14
+			IL_0409: ldloc.s 13
+			IL_040b: ldloc.s 11
+			IL_040d: ldstr "defaultHarnessFiles"
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0417: pop
+			IL_0418: ldarg.0
+			IL_0419: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateExcludedFromMvp
+			IL_041e: stloc.s 11
+			IL_0420: ldc.i4.1
+			IL_0421: newarr [System.Runtime]System.Object
+			IL_0426: dup
+			IL_0427: ldc.i4.0
+			IL_0428: ldarg.0
+			IL_0429: stelem.ref
+			IL_042a: stloc.s 13
+			IL_042c: ldloc.s 11
+			IL_042e: ldloc.s 13
+			IL_0430: ldarg.2
+			IL_0431: ldstr "excludedFromMvp"
+			IL_0436: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0440: pop
+			IL_0441: ldarg.0
+			IL_0442: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureStringArray
+			IL_0447: stloc.s 11
+			IL_0449: ldc.i4.1
+			IL_044a: newarr [System.Runtime]System.Object
+			IL_044f: dup
+			IL_0450: ldc.i4.0
+			IL_0451: ldarg.0
+			IL_0452: stelem.ref
+			IL_0453: stloc.s 13
+			IL_0455: ldarg.2
+			IL_0456: ldstr "attributionFiles"
+			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0460: stloc.s 14
+			IL_0462: ldloc.s 11
+			IL_0464: ldloc.s 13
+			IL_0466: ldloc.s 14
+			IL_0468: ldstr "attributionFiles"
+			IL_046d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0472: pop
+			IL_0473: ldstr "^[0-9a-f]{40}$"
+			IL_0478: ldstr "i"
+			IL_047d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0482: stloc.s 15
+			IL_0484: ldloc.s 15
+			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_048b: stloc.s 14
+			IL_048d: ldloc.s 14
+			IL_048f: ldstr "test"
+			IL_0494: ldarg.2
+			IL_0495: ldstr "upstream"
+			IL_049a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_049f: ldstr "commit"
+			IL_04a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04ae: stloc.s 14
+			IL_04b0: ldloc.s 14
+			IL_04b2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04b7: ldc.i4.0
+			IL_04b8: ceq
+			IL_04ba: stloc.s 6
+			IL_04bc: ldloc.s 6
+			IL_04be: brfalse IL_04f6
 
-			IL_035d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L149C52::.ctor()
-			IL_0362: stloc.s 4
-			IL_0364: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
-			IL_0369: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_036e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0373: stloc.s 11
-			IL_0375: ldloc.s 11
-			IL_0377: stloc.s 5
-			IL_0379: ldloc.s 5
-			IL_037b: isinst [System.Runtime]System.Exception
-			IL_0380: dup
-			IL_0381: brtrue IL_038f
+			IL_04c3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/Scope/Block_L149C52::.ctor()
+			IL_04c8: stloc.s 4
+			IL_04ca: ldstr "Invalid pin file: 'upstream.commit' must be a 40-character git SHA."
+			IL_04cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_04d9: stloc.s 14
+			IL_04db: ldloc.s 14
+			IL_04dd: stloc.s 5
+			IL_04df: ldloc.s 5
+			IL_04e1: isinst [System.Runtime]System.Exception
+			IL_04e6: dup
+			IL_04e7: brtrue IL_04f5
 
-			IL_0386: pop
-			IL_0387: ldloc.s 5
-			IL_0389: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_038e: throw
+			IL_04ec: pop
+			IL_04ed: ldloc.s 5
+			IL_04ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_04f4: throw
 
-			IL_038f: throw
+			IL_04f5: throw
 
-			IL_0390: ldnull
-			IL_0391: ret
+			IL_04f6: ldnull
+			IL_04f7: ret
 		} // end of method validatePin::__js_call__
 
 	} // end of class validatePin
@@ -2116,7 +2310,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e57
+				// Method begins at RVA 0x51ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2143,9 +2337,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x33bc
+			// Method begins at RVA 0x3548
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 66 (0x42)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2171,13 +2365,18 @@
 			IL_0027: ldloc.2
 			IL_0028: stloc.1
 			IL_0029: ldarg.0
-			IL_002a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_002f: ldnull
-			IL_0030: ldloc.1
-			IL_0031: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0036: pop
-			IL_0037: ldloc.1
-			IL_0038: ret
+			IL_002a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validatePin
+			IL_002f: ldc.i4.1
+			IL_0030: newarr [System.Runtime]System.Object
+			IL_0035: dup
+			IL_0036: ldc.i4.0
+			IL_0037: ldarg.0
+			IL_0038: stelem.ref
+			IL_0039: ldloc.1
+			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003f: pop
+			IL_0040: ldloc.1
+			IL_0041: ret
 		} // end of method loadPin::__js_call__
 
 	} // end of class loadPin
@@ -2193,7 +2392,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e60
+				// Method begins at RVA 0x51d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2221,7 +2420,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3404
+			// Method begins at RVA 0x3598
 			// Header size: 12
 			// Code size: 88 (0x58)
 			.maxstack 8
@@ -2278,7 +2477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e69
+				// Method begins at RVA 0x51dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2305,9 +2504,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3468
+			// Method begins at RVA 0x35fc
 			// Header size: 12
-			// Code size: 105 (0x69)
+			// Code size: 116 (0x74)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2321,41 +2520,48 @@
 			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0015: stloc.0
-			IL_0016: ldarg.2
-			IL_0017: ldstr "managedRoot"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0021: stloc.1
-			IL_0022: ldarg.0
-			IL_0023: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0028: ldnull
-			IL_0029: ldloc.1
-			IL_002a: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_002f: stloc.1
-			IL_0030: ldloc.0
-			IL_0031: ldstr "join"
-			IL_0036: ldloc.1
-			IL_0037: ldarg.2
-			IL_0038: ldstr "upstream"
-			IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0042: ldstr "commit"
-			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0051: stloc.1
-			IL_0052: ldc.i4.1
-			IL_0053: newarr [System.Runtime]System.Object
-			IL_0058: dup
-			IL_0059: ldc.i4.0
-			IL_005a: ldarg.0
-			IL_005b: stelem.ref
-			IL_005c: stloc.2
-			IL_005d: ldnull
-			IL_005e: ldloc.1
-			IL_005f: tail.
-			IL_0061: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_0066: ret
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+			IL_001c: stloc.1
+			IL_001d: ldc.i4.1
+			IL_001e: newarr [System.Runtime]System.Object
+			IL_0023: dup
+			IL_0024: ldc.i4.0
+			IL_0025: ldarg.0
+			IL_0026: stelem.ref
+			IL_0027: stloc.2
+			IL_0028: ldloc.1
+			IL_0029: ldloc.2
+			IL_002a: ldarg.2
+			IL_002b: ldstr "managedRoot"
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003a: stloc.1
+			IL_003b: ldloc.0
+			IL_003c: ldstr "join"
+			IL_0041: ldloc.1
+			IL_0042: ldarg.2
+			IL_0043: ldstr "upstream"
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_004d: ldstr "commit"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_005c: stloc.1
+			IL_005d: ldc.i4.1
+			IL_005e: newarr [System.Runtime]System.Object
+			IL_0063: dup
+			IL_0064: ldc.i4.0
+			IL_0065: ldarg.0
+			IL_0066: stelem.ref
+			IL_0067: stloc.2
+			IL_0068: ldnull
+			IL_0069: ldloc.1
+			IL_006a: tail.
+			IL_006c: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+			IL_0071: ret
 
-			IL_0067: ldnull
-			IL_0068: ret
+			IL_0072: ldnull
+			IL_0073: ret
 		} // end of method resolveManagedCheckoutLabel::__js_call__
 
 	} // end of class resolveManagedCheckoutLabel
@@ -2375,7 +2581,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e7b
+					// Method begins at RVA 0x51ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2393,7 +2599,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e72
+				// Method begins at RVA 0x51e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2421,9 +2627,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x34e0
+			// Method begins at RVA 0x367c
 			// Header size: 12
-			// Code size: 230 (0xe6)
+			// Code size: 239 (0xef)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2507,23 +2713,28 @@
 			IL_00b5: stloc.2
 
 			IL_00b6: ldarg.0
-			IL_00b7: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00bc: ldnull
-			IL_00bd: ldloc.0
-			IL_00be: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00c3: stloc.3
-			IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00c9: dup
-			IL_00ca: ldstr "source"
-			IL_00cf: ldloc.2
-			IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00d5: dup
-			IL_00d6: ldstr "rootPath"
-			IL_00db: ldloc.3
-			IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00e1: stloc.s 9
-			IL_00e3: ldloc.s 9
-			IL_00e5: ret
+			IL_00b7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
+			IL_00bc: ldc.i4.1
+			IL_00bd: newarr [System.Runtime]System.Object
+			IL_00c2: dup
+			IL_00c3: ldc.i4.0
+			IL_00c4: ldarg.0
+			IL_00c5: stelem.ref
+			IL_00c6: ldloc.0
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00cc: stloc.3
+			IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00d2: dup
+			IL_00d3: ldstr "source"
+			IL_00d8: ldloc.2
+			IL_00d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00de: dup
+			IL_00df: ldstr "rootPath"
+			IL_00e4: ldloc.3
+			IL_00e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00ea: stloc.s 9
+			IL_00ec: ldloc.s 9
+			IL_00ee: ret
 		} // end of method resolveOverrideRoot::__js_call__
 
 	} // end of class resolveOverrideRoot
@@ -2543,7 +2754,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4e8d
+					// Method begins at RVA 0x5200
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2561,7 +2772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e84
+				// Method begins at RVA 0x51f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2589,9 +2800,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x35d4
+			// Method begins at RVA 0x3778
 			// Header size: 12
-			// Code size: 1058 (0x422)
+			// Code size: 1109 (0x455)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2603,7 +2814,7 @@
 				[6] string,
 				[7] string,
 				[8] object,
-				[9] string,
+				[9] object[],
 				[10] string,
 				[11] string,
 				[12] string,
@@ -2615,7 +2826,8 @@
 				[18] string,
 				[19] string,
 				[20] string,
-				[21] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[21] string,
+				[22] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.3
@@ -2671,285 +2883,310 @@
 			IL_00a9: ldloc.s 7
 			IL_00ab: call string [System.Runtime]System.String::Concat(string, string)
 			IL_00b0: stloc.s 7
-			IL_00b2: ldarg.2
-			IL_00b3: ldstr "managedRoot"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00bd: stloc.s 8
-			IL_00bf: ldnull
-			IL_00c0: ldloc.s 8
-			IL_00c2: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_00c7: stloc.s 8
-			IL_00c9: ldloc.s 8
-			IL_00cb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldstr "managedRoot "
-			IL_00d7: ldloc.s 9
-			IL_00d9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00de: stloc.s 9
-			IL_00e0: ldarg.0
-			IL_00e1: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00e6: ldnull
-			IL_00e7: ldarg.2
-			IL_00e8: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00ed: stloc.s 8
-			IL_00ef: ldloc.s 8
-			IL_00f1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00f6: stloc.s 10
-			IL_00f8: ldstr "checkoutDir "
-			IL_00fd: ldloc.s 10
-			IL_00ff: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0104: stloc.s 10
-			IL_0106: ldarg.2
-			IL_0107: ldstr "localOverrideEnvVar"
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b2: ldarg.0
+			IL_00b3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+			IL_00b8: stloc.s 8
+			IL_00ba: ldc.i4.1
+			IL_00bb: newarr [System.Runtime]System.Object
+			IL_00c0: dup
+			IL_00c1: ldc.i4.0
+			IL_00c2: ldarg.0
+			IL_00c3: stelem.ref
+			IL_00c4: stloc.s 9
+			IL_00c6: ldloc.s 8
+			IL_00c8: ldloc.s 9
+			IL_00ca: ldarg.2
+			IL_00cb: ldstr "managedRoot"
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00da: stloc.s 8
+			IL_00dc: ldloc.s 8
+			IL_00de: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e3: stloc.s 10
+			IL_00e5: ldstr "managedRoot "
+			IL_00ea: ldloc.s 10
+			IL_00ec: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00f1: stloc.s 10
+			IL_00f3: ldc.i4.1
+			IL_00f4: newarr [System.Runtime]System.Object
+			IL_00f9: dup
+			IL_00fa: ldc.i4.0
+			IL_00fb: ldarg.0
+			IL_00fc: stelem.ref
+			IL_00fd: stloc.s 9
+			IL_00ff: ldarg.0
+			IL_0100: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutLabel
+			IL_0105: ldloc.s 9
+			IL_0107: ldarg.2
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_010d: stloc.s 8
+			IL_010f: ldloc.s 8
 			IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0116: stloc.s 11
-			IL_0118: ldstr "overrideEnv "
+			IL_0118: ldstr "checkoutDir "
 			IL_011d: ldloc.s 11
 			IL_011f: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0124: stloc.s 11
 			IL_0126: ldarg.2
-			IL_0127: ldstr "lineEndings"
+			IL_0127: ldstr "localOverrideEnvVar"
 			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0136: stloc.s 12
-			IL_0138: ldstr "lineEndings "
+			IL_0138: ldstr "overrideEnv "
 			IL_013d: ldloc.s 12
 			IL_013f: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0144: stloc.s 12
 			IL_0146: ldarg.2
-			IL_0147: ldstr "updateStrategy"
+			IL_0147: ldstr "lineEndings"
 			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0151: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0156: stloc.s 13
-			IL_0158: ldstr "updateStrategy "
+			IL_0158: ldstr "lineEndings "
 			IL_015d: ldloc.s 13
 			IL_015f: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0164: stloc.s 13
 			IL_0166: ldarg.2
-			IL_0167: ldstr "includeFiles"
+			IL_0167: ldstr "updateStrategy"
 			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0176: stloc.s 8
-			IL_0178: ldloc.s 8
-			IL_017a: ldstr "join"
-			IL_017f: ldstr ", "
-			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0189: stloc.s 8
-			IL_018b: ldloc.s 8
-			IL_018d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0192: stloc.s 14
-			IL_0194: ldstr "includeFiles "
-			IL_0199: ldloc.s 14
-			IL_019b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a0: stloc.s 14
-			IL_01a2: ldarg.2
-			IL_01a3: ldstr "includeDirectories"
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01b2: stloc.s 8
-			IL_01b4: ldloc.s 8
-			IL_01b6: ldstr "join"
-			IL_01bb: ldstr ", "
-			IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01c5: stloc.s 8
-			IL_01c7: ldloc.s 8
-			IL_01c9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ce: stloc.s 15
-			IL_01d0: ldstr "includeDirectories "
-			IL_01d5: ldloc.s 15
-			IL_01d7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01dc: stloc.s 15
-			IL_01de: ldarg.2
-			IL_01df: ldstr "requiredFiles"
-			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ee: stloc.s 8
-			IL_01f0: ldloc.s 8
-			IL_01f2: ldstr "join"
-			IL_01f7: ldstr ", "
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0201: stloc.s 8
-			IL_0203: ldloc.s 8
-			IL_0205: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_020a: stloc.s 16
-			IL_020c: ldstr "requiredFiles "
-			IL_0211: ldloc.s 16
-			IL_0213: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0218: stloc.s 16
-			IL_021a: ldarg.2
-			IL_021b: ldstr "requiredDirectories"
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_022a: stloc.s 8
-			IL_022c: ldloc.s 8
-			IL_022e: ldstr "join"
-			IL_0233: ldstr ", "
-			IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_023d: stloc.s 8
-			IL_023f: ldloc.s 8
-			IL_0241: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0246: stloc.s 17
-			IL_0248: ldstr "requiredDirectories "
-			IL_024d: ldloc.s 17
-			IL_024f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0254: stloc.s 17
-			IL_0256: ldarg.2
-			IL_0257: ldstr "defaultHarnessFiles"
-			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0266: stloc.s 8
-			IL_0268: ldloc.s 8
-			IL_026a: ldstr "join"
-			IL_026f: ldstr ", "
-			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0279: stloc.s 8
-			IL_027b: ldloc.s 8
-			IL_027d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0282: stloc.s 18
-			IL_0284: ldstr "defaultHarnessFiles "
-			IL_0289: ldloc.s 18
-			IL_028b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0290: stloc.s 18
-			IL_0292: ldarg.2
-			IL_0293: ldstr "excludedFromMvp"
-			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a2: stloc.s 8
-			IL_02a4: ldloc.s 8
-			IL_02a6: ldstr "join"
-			IL_02ab: ldstr "; "
-			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02b5: stloc.s 8
-			IL_02b7: ldloc.s 8
-			IL_02b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02be: stloc.s 19
-			IL_02c0: ldstr "excludedFromMvp "
-			IL_02c5: ldloc.s 19
-			IL_02c7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02cc: stloc.s 19
-			IL_02ce: ldarg.2
-			IL_02cf: ldstr "attributionFiles"
-			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02de: stloc.s 8
-			IL_02e0: ldloc.s 8
-			IL_02e2: ldstr "join"
-			IL_02e7: ldstr ", "
-			IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_02f1: stloc.s 8
-			IL_02f3: ldloc.s 8
-			IL_02f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02fa: stloc.s 20
-			IL_02fc: ldstr "attributionFiles "
-			IL_0301: ldloc.s 20
-			IL_0303: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0308: stloc.s 20
-			IL_030a: ldc.i4.s 16
-			IL_030c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0311: dup
-			IL_0312: ldloc.s 4
-			IL_0314: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0319: dup
-			IL_031a: ldloc.s 5
-			IL_031c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0321: dup
-			IL_0322: ldloc.s 6
-			IL_0324: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0329: dup
-			IL_032a: ldloc.s 7
-			IL_032c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0171: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0176: stloc.s 14
+			IL_0178: ldstr "updateStrategy "
+			IL_017d: ldloc.s 14
+			IL_017f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0184: stloc.s 14
+			IL_0186: ldarg.2
+			IL_0187: ldstr "includeFiles"
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0196: stloc.s 8
+			IL_0198: ldloc.s 8
+			IL_019a: ldstr "join"
+			IL_019f: ldstr ", "
+			IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01a9: stloc.s 8
+			IL_01ab: ldloc.s 8
+			IL_01ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b2: stloc.s 15
+			IL_01b4: ldstr "includeFiles "
+			IL_01b9: ldloc.s 15
+			IL_01bb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01c0: stloc.s 15
+			IL_01c2: ldarg.2
+			IL_01c3: ldstr "includeDirectories"
+			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d2: stloc.s 8
+			IL_01d4: ldloc.s 8
+			IL_01d6: ldstr "join"
+			IL_01db: ldstr ", "
+			IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01e5: stloc.s 8
+			IL_01e7: ldloc.s 8
+			IL_01e9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01ee: stloc.s 16
+			IL_01f0: ldstr "includeDirectories "
+			IL_01f5: ldloc.s 16
+			IL_01f7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fc: stloc.s 16
+			IL_01fe: ldarg.2
+			IL_01ff: ldstr "requiredFiles"
+			IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_020e: stloc.s 8
+			IL_0210: ldloc.s 8
+			IL_0212: ldstr "join"
+			IL_0217: ldstr ", "
+			IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0221: stloc.s 8
+			IL_0223: ldloc.s 8
+			IL_0225: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_022a: stloc.s 17
+			IL_022c: ldstr "requiredFiles "
+			IL_0231: ldloc.s 17
+			IL_0233: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0238: stloc.s 17
+			IL_023a: ldarg.2
+			IL_023b: ldstr "requiredDirectories"
+			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_024a: stloc.s 8
+			IL_024c: ldloc.s 8
+			IL_024e: ldstr "join"
+			IL_0253: ldstr ", "
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_025d: stloc.s 8
+			IL_025f: ldloc.s 8
+			IL_0261: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0266: stloc.s 18
+			IL_0268: ldstr "requiredDirectories "
+			IL_026d: ldloc.s 18
+			IL_026f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0274: stloc.s 18
+			IL_0276: ldarg.2
+			IL_0277: ldstr "defaultHarnessFiles"
+			IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0286: stloc.s 8
+			IL_0288: ldloc.s 8
+			IL_028a: ldstr "join"
+			IL_028f: ldstr ", "
+			IL_0294: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0299: stloc.s 8
+			IL_029b: ldloc.s 8
+			IL_029d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02a2: stloc.s 19
+			IL_02a4: ldstr "defaultHarnessFiles "
+			IL_02a9: ldloc.s 19
+			IL_02ab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b0: stloc.s 19
+			IL_02b2: ldarg.2
+			IL_02b3: ldstr "excludedFromMvp"
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c2: stloc.s 8
+			IL_02c4: ldloc.s 8
+			IL_02c6: ldstr "join"
+			IL_02cb: ldstr "; "
+			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02d5: stloc.s 8
+			IL_02d7: ldloc.s 8
+			IL_02d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02de: stloc.s 20
+			IL_02e0: ldstr "excludedFromMvp "
+			IL_02e5: ldloc.s 20
+			IL_02e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02ec: stloc.s 20
+			IL_02ee: ldarg.2
+			IL_02ef: ldstr "attributionFiles"
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02fe: stloc.s 8
+			IL_0300: ldloc.s 8
+			IL_0302: ldstr "join"
+			IL_0307: ldstr ", "
+			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0311: stloc.s 8
+			IL_0313: ldloc.s 8
+			IL_0315: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_031a: stloc.s 21
+			IL_031c: ldstr "attributionFiles "
+			IL_0321: ldloc.s 21
+			IL_0323: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0328: stloc.s 21
+			IL_032a: ldc.i4.s 16
+			IL_032c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0331: dup
-			IL_0332: ldloc.s 9
+			IL_0332: ldloc.s 4
 			IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0339: dup
-			IL_033a: ldloc.s 10
+			IL_033a: ldloc.s 5
 			IL_033c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0341: dup
-			IL_0342: ldloc.s 11
+			IL_0342: ldloc.s 6
 			IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0349: dup
-			IL_034a: ldloc.s 12
+			IL_034a: ldloc.s 7
 			IL_034c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0351: dup
-			IL_0352: ldloc.s 13
+			IL_0352: ldloc.s 10
 			IL_0354: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0359: dup
-			IL_035a: ldloc.s 14
+			IL_035a: ldloc.s 11
 			IL_035c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0361: dup
-			IL_0362: ldloc.s 15
+			IL_0362: ldloc.s 12
 			IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0369: dup
-			IL_036a: ldloc.s 16
+			IL_036a: ldloc.s 13
 			IL_036c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0371: dup
-			IL_0372: ldloc.s 17
+			IL_0372: ldloc.s 14
 			IL_0374: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0379: dup
-			IL_037a: ldloc.s 18
+			IL_037a: ldloc.s 15
 			IL_037c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0381: dup
-			IL_0382: ldloc.s 19
+			IL_0382: ldloc.s 16
 			IL_0384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0389: dup
-			IL_038a: ldloc.s 20
+			IL_038a: ldloc.s 17
 			IL_038c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0391: stloc.s 21
-			IL_0393: ldloc.s 21
-			IL_0395: stloc.1
-			IL_0396: ldarg.3
-			IL_0397: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_039c: stloc.3
-			IL_039d: ldloc.3
-			IL_039e: brfalse IL_0409
+			IL_0391: dup
+			IL_0392: ldloc.s 18
+			IL_0394: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0399: dup
+			IL_039a: ldloc.s 19
+			IL_039c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03a1: dup
+			IL_03a2: ldloc.s 20
+			IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03a9: dup
+			IL_03aa: ldloc.s 21
+			IL_03ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03b1: stloc.s 22
+			IL_03b3: ldloc.s 22
+			IL_03b5: stloc.1
+			IL_03b6: ldarg.3
+			IL_03b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03bc: stloc.3
+			IL_03bd: ldloc.3
+			IL_03be: brfalse IL_043c
 
-			IL_03a3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/Scope/Block_L202C16::.ctor()
-			IL_03a8: stloc.2
-			IL_03a9: ldarg.3
-			IL_03aa: ldstr "source"
-			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03b9: stloc.s 20
-			IL_03bb: ldstr "overrideSource "
-			IL_03c0: ldloc.s 20
-			IL_03c2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03c7: stloc.s 20
-			IL_03c9: ldloc.1
-			IL_03ca: ldloc.s 20
-			IL_03cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03d1: pop
-			IL_03d2: ldarg.3
-			IL_03d3: ldstr "rootPath"
-			IL_03d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03dd: stloc.s 8
-			IL_03df: ldnull
-			IL_03e0: ldloc.s 8
-			IL_03e2: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_03e7: stloc.s 8
-			IL_03e9: ldloc.s 8
-			IL_03eb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03f0: stloc.s 20
-			IL_03f2: ldstr "overrideRoot "
-			IL_03f7: ldloc.s 20
-			IL_03f9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03fe: stloc.s 20
-			IL_0400: ldloc.1
-			IL_0401: ldloc.s 20
-			IL_0403: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0408: pop
+			IL_03c3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/Scope/Block_L202C16::.ctor()
+			IL_03c8: stloc.2
+			IL_03c9: ldarg.3
+			IL_03ca: ldstr "source"
+			IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03d9: stloc.s 21
+			IL_03db: ldstr "overrideSource "
+			IL_03e0: ldloc.s 21
+			IL_03e2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03e7: stloc.s 21
+			IL_03e9: ldloc.1
+			IL_03ea: ldloc.s 21
+			IL_03ec: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03f1: pop
+			IL_03f2: ldarg.0
+			IL_03f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+			IL_03f8: stloc.s 8
+			IL_03fa: ldc.i4.1
+			IL_03fb: newarr [System.Runtime]System.Object
+			IL_0400: dup
+			IL_0401: ldc.i4.0
+			IL_0402: ldarg.0
+			IL_0403: stelem.ref
+			IL_0404: stloc.s 9
+			IL_0406: ldloc.s 8
+			IL_0408: ldloc.s 9
+			IL_040a: ldarg.3
+			IL_040b: ldstr "rootPath"
+			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_041a: stloc.s 8
+			IL_041c: ldloc.s 8
+			IL_041e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0423: stloc.s 21
+			IL_0425: ldstr "overrideRoot "
+			IL_042a: ldloc.s 21
+			IL_042c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0431: stloc.s 21
+			IL_0433: ldloc.1
+			IL_0434: ldloc.s 21
+			IL_0436: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_043b: pop
 
-			IL_0409: ldloc.1
-			IL_040a: ldc.i4.1
-			IL_040b: newarr [System.Runtime]System.Object
-			IL_0410: dup
-			IL_0411: ldc.i4.0
-			IL_0412: ldstr "\n"
-			IL_0417: stelem.ref
-			IL_0418: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_041d: stloc.s 20
-			IL_041f: ldloc.s 20
-			IL_0421: ret
+			IL_043c: ldloc.1
+			IL_043d: ldc.i4.1
+			IL_043e: newarr [System.Runtime]System.Object
+			IL_0443: dup
+			IL_0444: ldc.i4.0
+			IL_0445: ldstr "\n"
+			IL_044a: stelem.ref
+			IL_044b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0450: stloc.s 21
+			IL_0452: ldloc.s 21
+			IL_0454: ret
 		} // end of method describePlan::__js_call__
 
 	} // end of class describePlan
@@ -2965,7 +3202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e96
+				// Method begins at RVA 0x5209
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2992,7 +3229,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3a04
+			// Method begins at RVA 0x3bdc
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -3035,7 +3272,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ea8
+					// Method begins at RVA 0x521b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3053,7 +3290,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4e9f
+				// Method begins at RVA 0x5212
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3080,7 +3317,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3a3c
+			// Method begins at RVA 0x3c14
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -3151,7 +3388,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4eba
+					// Method begins at RVA 0x522d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3171,7 +3408,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ec3
+					// Method begins at RVA 0x5236
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3189,7 +3426,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4eb1
+				// Method begins at RVA 0x5224
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3217,7 +3454,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3ab4
+			// Method begins at RVA 0x3c8c
 			// Header size: 12
 			// Code size: 678 (0x2a6)
 			.maxstack 8
@@ -3494,7 +3731,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ecc
+				// Method begins at RVA 0x523f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3518,7 +3755,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ede
+					// Method begins at RVA 0x5251
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3536,7 +3773,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ed5
+				// Method begins at RVA 0x5248
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3560,7 +3797,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ef0
+					// Method begins at RVA 0x5263
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3578,7 +3815,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ee7
+				// Method begins at RVA 0x525a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3605,9 +3842,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3d68
+			// Method begins at RVA 0x3f40
 			// Header size: 12
-			// Code size: 397 (0x18d)
+			// Code size: 415 (0x19f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3649,7 +3886,7 @@
 					IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_002b: stloc.s 13
 					IL_002d: ldloc.s 13
-					IL_002f: brtrue IL_008a
+					IL_002f: brtrue IL_0093
 
 					IL_0034: ldloc.s 12
 					IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -3659,142 +3896,152 @@
 					IL_0041: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L247C7/Block_L247C43::.ctor()
 					IL_0046: stloc.s 5
 					IL_0048: ldarg.0
-					IL_0049: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_004e: ldnull
-					IL_004f: ldloc.s 4
-					IL_0051: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_0056: stloc.s 12
-					IL_0058: ldloc.s 12
-					IL_005a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_005f: stloc.s 14
-					IL_0061: ldstr "/"
-					IL_0066: ldloc.s 14
-					IL_0068: call string [System.Runtime]System.String::Concat(string, string)
-					IL_006d: stloc.s 14
-					IL_006f: ldloc.0
-					IL_0070: ldloc.s 14
-					IL_0072: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0077: pop
-					IL_0078: br IL_001c
+					IL_0049: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_004e: ldc.i4.1
+					IL_004f: newarr [System.Runtime]System.Object
+					IL_0054: dup
+					IL_0055: ldc.i4.0
+					IL_0056: ldarg.0
+					IL_0057: stelem.ref
+					IL_0058: ldloc.s 4
+					IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_005f: stloc.s 12
+					IL_0061: ldloc.s 12
+					IL_0063: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0068: stloc.s 14
+					IL_006a: ldstr "/"
+					IL_006f: ldloc.s 14
+					IL_0071: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0076: stloc.s 14
+					IL_0078: ldloc.0
+					IL_0079: ldloc.s 14
+					IL_007b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0080: pop
+					IL_0081: br IL_001c
 				// end loop
-				IL_007d: ldloc.1
-				IL_007e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0083: ldc.i4.1
-				IL_0084: stloc.3
-				IL_0085: leave IL_00a4
+				IL_0086: ldloc.1
+				IL_0087: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_008c: ldc.i4.1
+				IL_008d: stloc.3
+				IL_008e: leave IL_00ad
 
-				IL_008a: ldc.i4.1
-				IL_008b: stloc.2
-				IL_008c: leave IL_00a4
+				IL_0093: ldc.i4.1
+				IL_0094: stloc.2
+				IL_0095: leave IL_00ad
 			} // end .try
 			finally
 			{
-				IL_0091: ldloc.2
-				IL_0092: brtrue IL_00a3
+				IL_009a: ldloc.2
+				IL_009b: brtrue IL_00ac
 
-				IL_0097: ldloc.3
-				IL_0098: brtrue IL_00a3
+				IL_00a0: ldloc.3
+				IL_00a1: brtrue IL_00ac
 
-				IL_009d: ldloc.1
-				IL_009e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_00a6: ldloc.1
+				IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00a3: endfinally
+				IL_00ac: endfinally
 			} // end handler
 
-			IL_00a4: ldarg.2
-			IL_00a5: ldstr "includeDirectories"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_00b4: stloc.s 6
-			IL_00b6: ldc.i4.0
-			IL_00b7: stloc.s 7
-			IL_00b9: ldc.i4.0
-			IL_00ba: stloc.s 8
+			IL_00ad: ldarg.2
+			IL_00ae: ldstr "includeDirectories"
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00bd: stloc.s 6
+			IL_00bf: ldc.i4.0
+			IL_00c0: stloc.s 7
+			IL_00c2: ldc.i4.0
+			IL_00c3: stloc.s 8
 			.try
 			{
-				// loop start (head: IL_00bc)
-					IL_00bc: ldloc.s 6
-					IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_00c3: stloc.s 12
-					IL_00c5: ldloc.s 12
-					IL_00c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_00cc: stloc.s 13
-					IL_00ce: ldloc.s 13
-					IL_00d0: brtrue IL_016d
+				// loop start (head: IL_00c5)
+					IL_00c5: ldloc.s 6
+					IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_00cc: stloc.s 12
+					IL_00ce: ldloc.s 12
+					IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_00d5: stloc.s 13
+					IL_00d7: ldloc.s 13
+					IL_00d9: brtrue IL_017f
 
-					IL_00d5: ldloc.s 12
-					IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_00dc: stloc.s 12
 					IL_00de: ldloc.s 12
-					IL_00e0: stloc.s 9
-					IL_00e2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54::.ctor()
-					IL_00e7: stloc.s 10
-					IL_00e9: ldarg.0
-					IL_00ea: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_00ef: ldnull
-					IL_00f0: ldloc.s 9
-					IL_00f2: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_00f7: stloc.s 12
-					IL_00f9: ldloc.s 12
-					IL_00fb: stloc.s 11
-					IL_00fd: ldloc.s 11
-					IL_00ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0104: stloc.s 14
-					IL_0106: ldstr "/"
-					IL_010b: ldloc.s 14
-					IL_010d: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0112: stloc.s 14
-					IL_0114: ldloc.s 14
-					IL_0116: ldstr "/"
-					IL_011b: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0120: stloc.s 14
-					IL_0122: ldloc.0
-					IL_0123: ldloc.s 14
-					IL_0125: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_012a: pop
-					IL_012b: ldloc.s 11
-					IL_012d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_00e5: stloc.s 12
+					IL_00e7: ldloc.s 12
+					IL_00e9: stloc.s 9
+					IL_00eb: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/Scope_ForOf_L251C7/Block_L251C54::.ctor()
+					IL_00f0: stloc.s 10
+					IL_00f2: ldarg.0
+					IL_00f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_00f8: ldc.i4.1
+					IL_00f9: newarr [System.Runtime]System.Object
+					IL_00fe: dup
+					IL_00ff: ldc.i4.0
+					IL_0100: ldarg.0
+					IL_0101: stelem.ref
+					IL_0102: ldloc.s 9
+					IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0109: stloc.s 12
+					IL_010b: ldloc.s 12
+					IL_010d: stloc.s 11
+					IL_010f: ldloc.s 11
+					IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0116: stloc.s 14
+					IL_0118: ldstr "/"
+					IL_011d: ldloc.s 14
+					IL_011f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0124: stloc.s 14
+					IL_0126: ldloc.s 14
+					IL_0128: ldstr "/"
+					IL_012d: call string [System.Runtime]System.String::Concat(string, string)
 					IL_0132: stloc.s 14
-					IL_0134: ldstr "/"
-					IL_0139: ldloc.s 14
-					IL_013b: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0140: stloc.s 14
-					IL_0142: ldloc.s 14
-					IL_0144: ldstr "/**"
-					IL_0149: call string [System.Runtime]System.String::Concat(string, string)
-					IL_014e: stloc.s 14
-					IL_0150: ldloc.0
-					IL_0151: ldloc.s 14
-					IL_0153: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0158: pop
-					IL_0159: br IL_00bc
+					IL_0134: ldloc.0
+					IL_0135: ldloc.s 14
+					IL_0137: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_013c: pop
+					IL_013d: ldloc.s 11
+					IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0144: stloc.s 14
+					IL_0146: ldstr "/"
+					IL_014b: ldloc.s 14
+					IL_014d: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0152: stloc.s 14
+					IL_0154: ldloc.s 14
+					IL_0156: ldstr "/**"
+					IL_015b: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0160: stloc.s 14
+					IL_0162: ldloc.0
+					IL_0163: ldloc.s 14
+					IL_0165: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_016a: pop
+					IL_016b: br IL_00c5
 				// end loop
-				IL_015e: ldloc.s 6
-				IL_0160: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0165: ldc.i4.1
-				IL_0166: stloc.s 8
-				IL_0168: leave IL_018b
+				IL_0170: ldloc.s 6
+				IL_0172: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0177: ldc.i4.1
+				IL_0178: stloc.s 8
+				IL_017a: leave IL_019d
 
-				IL_016d: ldc.i4.1
-				IL_016e: stloc.s 7
-				IL_0170: leave IL_018b
+				IL_017f: ldc.i4.1
+				IL_0180: stloc.s 7
+				IL_0182: leave IL_019d
 			} // end .try
 			finally
 			{
-				IL_0175: ldloc.s 7
-				IL_0177: brtrue IL_018a
+				IL_0187: ldloc.s 7
+				IL_0189: brtrue IL_019c
 
-				IL_017c: ldloc.s 8
-				IL_017e: brtrue IL_018a
+				IL_018e: ldloc.s 8
+				IL_0190: brtrue IL_019c
 
-				IL_0183: ldloc.s 6
-				IL_0185: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0195: ldloc.s 6
+				IL_0197: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_018a: endfinally
+				IL_019c: endfinally
 			} // end handler
 
-			IL_018b: ldloc.0
-			IL_018c: ret
+			IL_019d: ldloc.0
+			IL_019e: ret
 		} // end of method buildSparsePatterns::__js_call__
 
 	} // end of class buildSparsePatterns
@@ -3818,7 +4065,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f41
+						// Method begins at RVA 0x52b4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3838,7 +4085,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f4a
+						// Method begins at RVA 0x52bd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3856,7 +4103,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f38
+					// Method begins at RVA 0x52ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3876,7 +4123,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f53
+					// Method begins at RVA 0x52c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3894,7 +4141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ef9
+				// Method begins at RVA 0x526c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3922,7 +4169,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f14
+						// Method begins at RVA 0x5287
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3940,7 +4187,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f0b
+					// Method begins at RVA 0x527e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3958,7 +4205,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f02
+				// Method begins at RVA 0x5275
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3986,7 +4233,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f2f
+						// Method begins at RVA 0x52a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4004,7 +4251,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f26
+					// Method begins at RVA 0x5299
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4022,7 +4269,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f1d
+				// Method begins at RVA 0x5290
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4050,9 +4297,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x3f20
+			// Method begins at RVA 0x4108
 			// Header size: 12
-			// Code size: 1603 (0x643)
+			// Code size: 1621 (0x655)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -4122,7 +4369,7 @@
 					IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0033: stloc.s 25
 					IL_0035: ldloc.s 25
-					IL_0037: brtrue IL_0189
+					IL_0037: brtrue IL_0192
 
 					IL_003c: ldloc.s 24
 					IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -4142,547 +4389,557 @@
 					IL_0065: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 					IL_006a: stloc.s 26
 					IL_006c: ldarg.0
-					IL_006d: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_0072: ldnull
-					IL_0073: ldloc.s 5
-					IL_0075: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_007a: stloc.s 27
-					IL_007c: ldloc.s 27
-					IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_006d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_0072: ldc.i4.1
+					IL_0073: newarr [System.Runtime]System.Object
+					IL_0078: dup
+					IL_0079: ldc.i4.0
+					IL_007a: ldarg.0
+					IL_007b: stelem.ref
+					IL_007c: ldloc.s 5
+					IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 					IL_0083: stloc.s 27
 					IL_0085: ldloc.s 27
-					IL_0087: ldstr "split"
-					IL_008c: ldstr "/"
-					IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0096: stloc.s 27
-					IL_0098: ldloc.s 26
-					IL_009a: ldloc.s 27
-					IL_009c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_008c: stloc.s 27
+					IL_008e: ldloc.s 27
+					IL_0090: ldstr "split"
+					IL_0095: ldstr "/"
+					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_009f: stloc.s 27
 					IL_00a1: ldloc.s 26
-					IL_00a3: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_00a8: stloc.s 28
-					IL_00aa: ldloc.s 24
-					IL_00ac: ldstr "join"
-					IL_00b1: ldloc.s 28
-					IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_00b8: stloc.s 24
-					IL_00ba: ldloc.s 24
-					IL_00bc: stloc.s 7
-					IL_00be: ldarg.0
-					IL_00bf: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_00c9: stloc.s 24
-					IL_00cb: ldloc.s 24
-					IL_00cd: ldstr "existsSync"
-					IL_00d2: ldloc.s 7
-					IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_00d9: stloc.s 24
-					IL_00db: ldloc.s 24
-					IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_00e2: ldc.i4.0
-					IL_00e3: ceq
-					IL_00e5: stloc.s 25
-					IL_00e7: ldloc.s 25
-					IL_00e9: box [System.Runtime]System.Boolean
-					IL_00ee: stloc.s 29
-					IL_00f0: ldloc.s 29
-					IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00f7: stloc.s 25
-					IL_00f9: ldloc.s 25
-					IL_00fb: brtrue IL_0152
+					IL_00a3: ldloc.s 27
+					IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_00aa: ldloc.s 26
+					IL_00ac: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_00b1: stloc.s 28
+					IL_00b3: ldloc.s 24
+					IL_00b5: ldstr "join"
+					IL_00ba: ldloc.s 28
+					IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_00c1: stloc.s 24
+					IL_00c3: ldloc.s 24
+					IL_00c5: stloc.s 7
+					IL_00c7: ldarg.0
+					IL_00c8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_00d2: stloc.s 24
+					IL_00d4: ldloc.s 24
+					IL_00d6: ldstr "existsSync"
+					IL_00db: ldloc.s 7
+					IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_00e2: stloc.s 24
+					IL_00e4: ldloc.s 24
+					IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_00eb: ldc.i4.0
+					IL_00ec: ceq
+					IL_00ee: stloc.s 25
+					IL_00f0: ldloc.s 25
+					IL_00f2: box [System.Runtime]System.Boolean
+					IL_00f7: stloc.s 29
+					IL_00f9: ldloc.s 29
+					IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0100: stloc.s 25
+					IL_0102: ldloc.s 25
+					IL_0104: brtrue IL_015b
 
-					IL_0100: ldarg.0
-					IL_0101: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_010b: stloc.s 24
-					IL_010d: ldloc.s 24
-					IL_010f: ldstr "statSync"
-					IL_0114: ldloc.s 7
-					IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_011b: stloc.s 24
-					IL_011d: ldloc.s 24
-					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0109: ldarg.0
+					IL_010a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0114: stloc.s 24
+					IL_0116: ldloc.s 24
+					IL_0118: ldstr "statSync"
+					IL_011d: ldloc.s 7
+					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 					IL_0124: stloc.s 24
 					IL_0126: ldloc.s 24
-					IL_0128: ldstr "isFile"
-					IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_0132: stloc.s 24
-					IL_0134: ldloc.s 24
-					IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_013b: ldc.i4.0
-					IL_013c: ceq
-					IL_013e: stloc.s 25
-					IL_0140: ldloc.s 25
-					IL_0142: box [System.Runtime]System.Boolean
-					IL_0147: stloc.s 30
-					IL_0149: ldloc.s 30
-					IL_014b: stloc.s 32
-					IL_014d: br IL_0156
-
-					IL_0152: ldloc.s 29
+					IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_012d: stloc.s 24
+					IL_012f: ldloc.s 24
+					IL_0131: ldstr "isFile"
+					IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_013b: stloc.s 24
+					IL_013d: ldloc.s 24
+					IL_013f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_0144: ldc.i4.0
+					IL_0145: ceq
+					IL_0147: stloc.s 25
+					IL_0149: ldloc.s 25
+					IL_014b: box [System.Runtime]System.Boolean
+					IL_0150: stloc.s 30
+					IL_0152: ldloc.s 30
 					IL_0154: stloc.s 32
+					IL_0156: br IL_015f
 
-					IL_0156: ldloc.s 32
-					IL_0158: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_015d: stloc.s 25
-					IL_015f: ldloc.s 25
-					IL_0161: brfalse IL_0176
+					IL_015b: ldloc.s 29
+					IL_015d: stloc.s 32
 
-					IL_0166: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
-					IL_016b: stloc.s 8
-					IL_016d: ldloc.0
-					IL_016e: ldloc.s 5
-					IL_0170: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0175: pop
+					IL_015f: ldloc.s 32
+					IL_0161: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0166: stloc.s 25
+					IL_0168: ldloc.s 25
+					IL_016a: brfalse IL_017f
 
-					IL_0176: br IL_0024
+					IL_016f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L264C7/Block_L264C44/Block_L266C69::.ctor()
+					IL_0174: stloc.s 8
+					IL_0176: ldloc.0
+					IL_0177: ldloc.s 5
+					IL_0179: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_017e: pop
+
+					IL_017f: br IL_0024
 				// end loop
-				IL_017b: ldloc.2
-				IL_017c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0181: ldc.i4.1
-				IL_0182: stloc.s 4
-				IL_0184: leave IL_01a4
+				IL_0184: ldloc.2
+				IL_0185: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_018a: ldc.i4.1
+				IL_018b: stloc.s 4
+				IL_018d: leave IL_01ad
 
-				IL_0189: ldc.i4.1
-				IL_018a: stloc.3
-				IL_018b: leave IL_01a4
+				IL_0192: ldc.i4.1
+				IL_0193: stloc.3
+				IL_0194: leave IL_01ad
 			} // end .try
 			finally
 			{
-				IL_0190: ldloc.3
-				IL_0191: brtrue IL_01a3
+				IL_0199: ldloc.3
+				IL_019a: brtrue IL_01ac
 
-				IL_0196: ldloc.s 4
-				IL_0198: brtrue IL_01a3
+				IL_019f: ldloc.s 4
+				IL_01a1: brtrue IL_01ac
 
-				IL_019d: ldloc.2
-				IL_019e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_01a6: ldloc.2
+				IL_01a7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_01a3: endfinally
+				IL_01ac: endfinally
 			} // end handler
 
-			IL_01a4: ldarg.3
-			IL_01a5: ldstr "requiredDirectories"
-			IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_01b4: stloc.s 9
-			IL_01b6: ldc.i4.0
-			IL_01b7: stloc.s 10
-			IL_01b9: ldc.i4.0
-			IL_01ba: stloc.s 11
+			IL_01ad: ldarg.3
+			IL_01ae: ldstr "requiredDirectories"
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_01bd: stloc.s 9
+			IL_01bf: ldc.i4.0
+			IL_01c0: stloc.s 10
+			IL_01c2: ldc.i4.0
+			IL_01c3: stloc.s 11
 			.try
 			{
-				// loop start (head: IL_01bc)
-					IL_01bc: ldloc.s 9
-					IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-					IL_01c3: stloc.s 24
-					IL_01c5: ldloc.s 24
-					IL_01c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-					IL_01cc: stloc.s 25
-					IL_01ce: ldloc.s 25
-					IL_01d0: brtrue IL_0323
+				// loop start (head: IL_01c5)
+					IL_01c5: ldloc.s 9
+					IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+					IL_01cc: stloc.s 24
+					IL_01ce: ldloc.s 24
+					IL_01d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+					IL_01d5: stloc.s 25
+					IL_01d7: ldloc.s 25
+					IL_01d9: brtrue IL_0335
 
-					IL_01d5: ldloc.s 24
-					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-					IL_01dc: stloc.s 24
 					IL_01de: ldloc.s 24
-					IL_01e0: stloc.s 12
-					IL_01e2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
-					IL_01e7: stloc.s 13
-					IL_01e9: ldarg.0
-					IL_01ea: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-					IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_01f4: stloc.s 24
-					IL_01f6: ldc.i4.1
-					IL_01f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_01fc: dup
-					IL_01fd: ldarg.2
-					IL_01fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-					IL_0203: stloc.s 26
-					IL_0205: ldarg.0
-					IL_0206: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-					IL_020b: ldnull
-					IL_020c: ldloc.s 12
-					IL_020e: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-					IL_0213: stloc.s 27
-					IL_0215: ldloc.s 27
-					IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_021c: stloc.s 27
-					IL_021e: ldloc.s 27
-					IL_0220: ldstr "split"
-					IL_0225: ldstr "/"
-					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_022f: stloc.s 27
-					IL_0231: ldloc.s 26
-					IL_0233: ldloc.s 27
-					IL_0235: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-					IL_023a: ldloc.s 26
-					IL_023c: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-					IL_0241: stloc.s 28
-					IL_0243: ldloc.s 24
-					IL_0245: ldstr "join"
-					IL_024a: ldloc.s 28
-					IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-					IL_0251: stloc.s 24
-					IL_0253: ldloc.s 24
-					IL_0255: stloc.s 14
-					IL_0257: ldarg.0
-					IL_0258: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0262: stloc.s 24
-					IL_0264: ldloc.s 24
-					IL_0266: ldstr "existsSync"
-					IL_026b: ldloc.s 14
-					IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_0272: stloc.s 24
-					IL_0274: ldloc.s 24
-					IL_0276: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_027b: ldc.i4.0
-					IL_027c: ceq
-					IL_027e: stloc.s 25
-					IL_0280: ldloc.s 25
-					IL_0282: box [System.Runtime]System.Boolean
-					IL_0287: stloc.s 29
-					IL_0289: ldloc.s 29
-					IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+					IL_01e5: stloc.s 24
+					IL_01e7: ldloc.s 24
+					IL_01e9: stloc.s 12
+					IL_01eb: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55::.ctor()
+					IL_01f0: stloc.s 13
+					IL_01f2: ldarg.0
+					IL_01f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+					IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_01fd: stloc.s 24
+					IL_01ff: ldc.i4.1
+					IL_0200: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0205: dup
+					IL_0206: ldarg.2
+					IL_0207: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+					IL_020c: stloc.s 26
+					IL_020e: ldarg.0
+					IL_020f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::normalizeSpecPath
+					IL_0214: ldc.i4.1
+					IL_0215: newarr [System.Runtime]System.Object
+					IL_021a: dup
+					IL_021b: ldc.i4.0
+					IL_021c: ldarg.0
+					IL_021d: stelem.ref
+					IL_021e: ldloc.s 12
+					IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0225: stloc.s 27
+					IL_0227: ldloc.s 27
+					IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_022e: stloc.s 27
+					IL_0230: ldloc.s 27
+					IL_0232: ldstr "split"
+					IL_0237: ldstr "/"
+					IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0241: stloc.s 27
+					IL_0243: ldloc.s 26
+					IL_0245: ldloc.s 27
+					IL_0247: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+					IL_024c: ldloc.s 26
+					IL_024e: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+					IL_0253: stloc.s 28
+					IL_0255: ldloc.s 24
+					IL_0257: ldstr "join"
+					IL_025c: ldloc.s 28
+					IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+					IL_0263: stloc.s 24
+					IL_0265: ldloc.s 24
+					IL_0267: stloc.s 14
+					IL_0269: ldarg.0
+					IL_026a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0274: stloc.s 24
+					IL_0276: ldloc.s 24
+					IL_0278: ldstr "existsSync"
+					IL_027d: ldloc.s 14
+					IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_0284: stloc.s 24
+					IL_0286: ldloc.s 24
+					IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_028d: ldc.i4.0
+					IL_028e: ceq
 					IL_0290: stloc.s 25
 					IL_0292: ldloc.s 25
-					IL_0294: brtrue IL_02eb
+					IL_0294: box [System.Runtime]System.Boolean
+					IL_0299: stloc.s 29
+					IL_029b: ldloc.s 29
+					IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a2: stloc.s 25
+					IL_02a4: ldloc.s 25
+					IL_02a6: brtrue IL_02fd
 
-					IL_0299: ldarg.0
-					IL_029a: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-					IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02a4: stloc.s 24
-					IL_02a6: ldloc.s 24
-					IL_02a8: ldstr "statSync"
-					IL_02ad: ldloc.s 14
-					IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_02b4: stloc.s 24
-					IL_02b6: ldloc.s 24
-					IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02bd: stloc.s 24
-					IL_02bf: ldloc.s 24
-					IL_02c1: ldstr "isDirectory"
-					IL_02c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02cb: stloc.s 24
-					IL_02cd: ldloc.s 24
-					IL_02cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-					IL_02d4: ldc.i4.0
-					IL_02d5: ceq
-					IL_02d7: stloc.s 25
-					IL_02d9: ldloc.s 25
-					IL_02db: box [System.Runtime]System.Boolean
-					IL_02e0: stloc.s 30
-					IL_02e2: ldloc.s 30
-					IL_02e4: stloc.s 33
-					IL_02e6: br IL_02ef
+					IL_02ab: ldarg.0
+					IL_02ac: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+					IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02b6: stloc.s 24
+					IL_02b8: ldloc.s 24
+					IL_02ba: ldstr "statSync"
+					IL_02bf: ldloc.s 14
+					IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_02c6: stloc.s 24
+					IL_02c8: ldloc.s 24
+					IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02cf: stloc.s 24
+					IL_02d1: ldloc.s 24
+					IL_02d3: ldstr "isDirectory"
+					IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_02dd: stloc.s 24
+					IL_02df: ldloc.s 24
+					IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+					IL_02e6: ldc.i4.0
+					IL_02e7: ceq
+					IL_02e9: stloc.s 25
+					IL_02eb: ldloc.s 25
+					IL_02ed: box [System.Runtime]System.Boolean
+					IL_02f2: stloc.s 30
+					IL_02f4: ldloc.s 30
+					IL_02f6: stloc.s 33
+					IL_02f8: br IL_0301
 
-					IL_02eb: ldloc.s 29
-					IL_02ed: stloc.s 33
+					IL_02fd: ldloc.s 29
+					IL_02ff: stloc.s 33
 
-					IL_02ef: ldloc.s 33
-					IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02f6: stloc.s 25
-					IL_02f8: ldloc.s 25
-					IL_02fa: brfalse IL_030f
+					IL_0301: ldloc.s 33
+					IL_0303: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0308: stloc.s 25
+					IL_030a: ldloc.s 25
+					IL_030c: brfalse IL_0321
 
-					IL_02ff: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
-					IL_0304: stloc.s 15
-					IL_0306: ldloc.1
-					IL_0307: ldloc.s 12
-					IL_0309: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_030e: pop
+					IL_0311: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope_ForOf_L271C7/Block_L271C55/Block_L273C74::.ctor()
+					IL_0316: stloc.s 15
+					IL_0318: ldloc.1
+					IL_0319: ldloc.s 12
+					IL_031b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0320: pop
 
-					IL_030f: br IL_01bc
+					IL_0321: br IL_01c5
 				// end loop
-				IL_0314: ldloc.s 9
-				IL_0316: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_031b: ldc.i4.1
-				IL_031c: stloc.s 11
-				IL_031e: leave IL_0341
+				IL_0326: ldloc.s 9
+				IL_0328: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_032d: ldc.i4.1
+				IL_032e: stloc.s 11
+				IL_0330: leave IL_0353
 
-				IL_0323: ldc.i4.1
-				IL_0324: stloc.s 10
-				IL_0326: leave IL_0341
+				IL_0335: ldc.i4.1
+				IL_0336: stloc.s 10
+				IL_0338: leave IL_0353
 			} // end .try
 			finally
 			{
-				IL_032b: ldloc.s 10
-				IL_032d: brtrue IL_0340
+				IL_033d: ldloc.s 10
+				IL_033f: brtrue IL_0352
 
-				IL_0332: ldloc.s 11
-				IL_0334: brtrue IL_0340
+				IL_0344: ldloc.s 11
+				IL_0346: brtrue IL_0352
 
-				IL_0339: ldloc.s 9
-				IL_033b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_034b: ldloc.s 9
+				IL_034d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_0340: endfinally
+				IL_0352: endfinally
 			} // end handler
 
-			IL_0341: ldloc.0
-			IL_0342: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0347: conv.r8
-			IL_0348: ldc.r8 0.0
-			IL_0351: cgt
-			IL_0353: box [System.Runtime]System.Boolean
-			IL_0358: stloc.s 29
-			IL_035a: ldloc.s 29
-			IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0361: stloc.s 25
-			IL_0363: ldloc.s 25
-			IL_0365: brtrue IL_0388
+			IL_0353: ldloc.0
+			IL_0354: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0359: conv.r8
+			IL_035a: ldc.r8 0.0
+			IL_0363: cgt
+			IL_0365: box [System.Runtime]System.Boolean
+			IL_036a: stloc.s 29
+			IL_036c: ldloc.s 29
+			IL_036e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0373: stloc.s 25
+			IL_0375: ldloc.s 25
+			IL_0377: brtrue IL_039a
 
-			IL_036a: ldloc.1
-			IL_036b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0370: conv.r8
-			IL_0371: ldc.r8 0.0
-			IL_037a: cgt
-			IL_037c: box [System.Runtime]System.Boolean
-			IL_0381: stloc.s 34
-			IL_0383: br IL_038c
+			IL_037c: ldloc.1
+			IL_037d: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0382: conv.r8
+			IL_0383: ldc.r8 0.0
+			IL_038c: cgt
+			IL_038e: box [System.Runtime]System.Boolean
+			IL_0393: stloc.s 34
+			IL_0395: br IL_039e
 
-			IL_0388: ldloc.s 29
-			IL_038a: stloc.s 34
+			IL_039a: ldloc.s 29
+			IL_039c: stloc.s 34
 
-			IL_038c: ldloc.s 34
-			IL_038e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0393: stloc.s 25
-			IL_0395: ldloc.s 25
-			IL_0397: brfalse IL_048f
+			IL_039e: ldloc.s 34
+			IL_03a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a5: stloc.s 25
+			IL_03a7: ldloc.s 25
+			IL_03a9: brfalse IL_04a1
 
-			IL_039c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
-			IL_03a1: stloc.s 16
-			IL_03a3: ldc.i4.0
-			IL_03a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03a9: stloc.s 17
-			IL_03ab: ldloc.0
-			IL_03ac: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_03b1: conv.r8
-			IL_03b2: ldc.r8 0.0
-			IL_03bb: cgt
-			IL_03bd: brfalse IL_0400
+			IL_03ae: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64::.ctor()
+			IL_03b3: stloc.s 16
+			IL_03b5: ldc.i4.0
+			IL_03b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03bb: stloc.s 17
+			IL_03bd: ldloc.0
+			IL_03be: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_03c3: conv.r8
+			IL_03c4: ldc.r8 0.0
+			IL_03cd: cgt
+			IL_03cf: brfalse IL_0412
 
-			IL_03c2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
-			IL_03c7: stloc.s 18
-			IL_03c9: ldloc.0
-			IL_03ca: ldc.i4.1
-			IL_03cb: newarr [System.Runtime]System.Object
-			IL_03d0: dup
-			IL_03d1: ldc.i4.0
-			IL_03d2: ldstr ", "
-			IL_03d7: stelem.ref
-			IL_03d8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_03dd: stloc.s 35
-			IL_03df: ldloc.s 35
-			IL_03e1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03e6: stloc.s 35
-			IL_03e8: ldstr "missing files: "
-			IL_03ed: ldloc.s 35
-			IL_03ef: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03f4: stloc.s 35
-			IL_03f6: ldloc.s 17
-			IL_03f8: ldloc.s 35
-			IL_03fa: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03ff: pop
+			IL_03d4: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L280C33::.ctor()
+			IL_03d9: stloc.s 18
+			IL_03db: ldloc.0
+			IL_03dc: ldc.i4.1
+			IL_03dd: newarr [System.Runtime]System.Object
+			IL_03e2: dup
+			IL_03e3: ldc.i4.0
+			IL_03e4: ldstr ", "
+			IL_03e9: stelem.ref
+			IL_03ea: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_03ef: stloc.s 35
+			IL_03f1: ldloc.s 35
+			IL_03f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03f8: stloc.s 35
+			IL_03fa: ldstr "missing files: "
+			IL_03ff: ldloc.s 35
+			IL_0401: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0406: stloc.s 35
+			IL_0408: ldloc.s 17
+			IL_040a: ldloc.s 35
+			IL_040c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0411: pop
 
-			IL_0400: ldloc.1
-			IL_0401: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0406: conv.r8
-			IL_0407: ldc.r8 0.0
-			IL_0410: cgt
-			IL_0412: brfalse IL_0455
+			IL_0412: ldloc.1
+			IL_0413: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_0418: conv.r8
+			IL_0419: ldc.r8 0.0
+			IL_0422: cgt
+			IL_0424: brfalse IL_0467
 
-			IL_0417: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
-			IL_041c: stloc.s 19
-			IL_041e: ldloc.1
-			IL_041f: ldc.i4.1
-			IL_0420: newarr [System.Runtime]System.Object
-			IL_0425: dup
-			IL_0426: ldc.i4.0
-			IL_0427: ldstr ", "
-			IL_042c: stelem.ref
-			IL_042d: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0432: stloc.s 35
-			IL_0434: ldloc.s 35
-			IL_0436: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_043b: stloc.s 35
-			IL_043d: ldstr "missing directories: "
-			IL_0442: ldloc.s 35
-			IL_0444: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0449: stloc.s 35
-			IL_044b: ldloc.s 17
-			IL_044d: ldloc.s 35
-			IL_044f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0454: pop
+			IL_0429: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L278C64/Block_L283C39::.ctor()
+			IL_042e: stloc.s 19
+			IL_0430: ldloc.1
+			IL_0431: ldc.i4.1
+			IL_0432: newarr [System.Runtime]System.Object
+			IL_0437: dup
+			IL_0438: ldc.i4.0
+			IL_0439: ldstr ", "
+			IL_043e: stelem.ref
+			IL_043f: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0444: stloc.s 35
+			IL_0446: ldloc.s 35
+			IL_0448: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_044d: stloc.s 35
+			IL_044f: ldstr "missing directories: "
+			IL_0454: ldloc.s 35
+			IL_0456: call string [System.Runtime]System.String::Concat(string, string)
+			IL_045b: stloc.s 35
+			IL_045d: ldloc.s 17
+			IL_045f: ldloc.s 35
+			IL_0461: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0466: pop
 
-			IL_0455: ldloc.s 17
-			IL_0457: ldc.i4.1
-			IL_0458: newarr [System.Runtime]System.Object
-			IL_045d: dup
-			IL_045e: ldc.i4.0
-			IL_045f: ldstr "; "
-			IL_0464: stelem.ref
-			IL_0465: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_046a: stloc.s 35
-			IL_046c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0471: dup
-			IL_0472: ldstr "ok"
-			IL_0477: ldc.i4.0
-			IL_0478: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_047d: dup
-			IL_047e: ldstr "message"
-			IL_0483: ldloc.s 35
-			IL_0485: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_048a: stloc.s 36
-			IL_048c: ldloc.s 36
-			IL_048e: ret
+			IL_0467: ldloc.s 17
+			IL_0469: ldc.i4.1
+			IL_046a: newarr [System.Runtime]System.Object
+			IL_046f: dup
+			IL_0470: ldc.i4.0
+			IL_0471: ldstr "; "
+			IL_0476: stelem.ref
+			IL_0477: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_047c: stloc.s 35
+			IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0483: dup
+			IL_0484: ldstr "ok"
+			IL_0489: ldc.i4.0
+			IL_048a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_048f: dup
+			IL_0490: ldstr "message"
+			IL_0495: ldloc.s 35
+			IL_0497: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_049c: stloc.s 36
+			IL_049e: ldloc.s 36
+			IL_04a0: ret
 
-			IL_048f: ldarg.0
-			IL_0490: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
-			IL_0495: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_049a: stloc.s 24
-			IL_049c: ldloc.s 24
-			IL_049e: ldstr "join"
-			IL_04a3: ldarg.2
-			IL_04a4: ldstr "package.json"
-			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04ae: stloc.s 24
-			IL_04b0: ldloc.s 24
-			IL_04b2: stloc.s 20
-			IL_04b4: ldarg.0
-			IL_04b5: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
-			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04bf: stloc.s 24
-			IL_04c1: ldloc.s 24
-			IL_04c3: ldstr "readFileSync"
-			IL_04c8: ldloc.s 20
-			IL_04ca: ldstr "utf8"
-			IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_04d4: stloc.s 24
-			IL_04d6: ldloc.s 24
-			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
-			IL_04dd: stloc.s 24
-			IL_04df: ldloc.s 24
-			IL_04e1: stloc.s 21
-			IL_04e3: ldloc.s 21
-			IL_04e5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04ea: ldc.i4.0
-			IL_04eb: ceq
-			IL_04ed: stloc.s 25
-			IL_04ef: ldloc.s 25
-			IL_04f1: box [System.Runtime]System.Boolean
-			IL_04f6: stloc.s 29
-			IL_04f8: ldloc.s 29
-			IL_04fa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04a1: ldarg.0
+			IL_04a2: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::path
+			IL_04a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04ac: stloc.s 24
+			IL_04ae: ldloc.s 24
+			IL_04b0: ldstr "join"
+			IL_04b5: ldarg.2
+			IL_04b6: ldstr "package.json"
+			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04c0: stloc.s 24
+			IL_04c2: ldloc.s 24
+			IL_04c4: stloc.s 20
+			IL_04c6: ldarg.0
+			IL_04c7: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::fs
+			IL_04cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04d1: stloc.s 24
+			IL_04d3: ldloc.s 24
+			IL_04d5: ldstr "readFileSync"
+			IL_04da: ldloc.s 20
+			IL_04dc: ldstr "utf8"
+			IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04e6: stloc.s 24
+			IL_04e8: ldloc.s 24
+			IL_04ea: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Parse(object)
+			IL_04ef: stloc.s 24
+			IL_04f1: ldloc.s 24
+			IL_04f3: stloc.s 21
+			IL_04f5: ldloc.s 21
+			IL_04f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_04fc: ldc.i4.0
+			IL_04fd: ceq
 			IL_04ff: stloc.s 25
 			IL_0501: ldloc.s 25
-			IL_0503: brtrue IL_0546
+			IL_0503: box [System.Runtime]System.Boolean
+			IL_0508: stloc.s 29
+			IL_050a: ldloc.s 29
+			IL_050c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0511: stloc.s 25
+			IL_0513: ldloc.s 25
+			IL_0515: brtrue IL_0558
 
-			IL_0508: ldloc.s 21
-			IL_050a: ldstr "version"
-			IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0514: stloc.s 24
-			IL_0516: ldloc.s 24
-			IL_0518: ldarg.3
-			IL_0519: ldstr "upstream"
-			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0523: ldstr "packageVersion"
-			IL_0528: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_052d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0532: stloc.s 25
-			IL_0534: ldloc.s 25
-			IL_0536: box [System.Runtime]System.Boolean
-			IL_053b: stloc.s 30
-			IL_053d: ldloc.s 30
-			IL_053f: stloc.s 37
-			IL_0541: br IL_054a
+			IL_051a: ldloc.s 21
+			IL_051c: ldstr "version"
+			IL_0521: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0526: stloc.s 24
+			IL_0528: ldloc.s 24
+			IL_052a: ldarg.3
+			IL_052b: ldstr "upstream"
+			IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0535: ldstr "packageVersion"
+			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_053f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0544: stloc.s 25
+			IL_0546: ldloc.s 25
+			IL_0548: box [System.Runtime]System.Boolean
+			IL_054d: stloc.s 30
+			IL_054f: ldloc.s 30
+			IL_0551: stloc.s 37
+			IL_0553: br IL_055c
 
-			IL_0546: ldloc.s 29
-			IL_0548: stloc.s 37
+			IL_0558: ldloc.s 29
+			IL_055a: stloc.s 37
 
-			IL_054a: ldloc.s 37
-			IL_054c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0551: stloc.s 25
-			IL_0553: ldloc.s 25
-			IL_0555: brfalse IL_0621
+			IL_055c: ldloc.s 37
+			IL_055e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0563: stloc.s 25
+			IL_0565: ldloc.s 25
+			IL_0567: brfalse IL_0633
 
-			IL_055a: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
-			IL_055f: stloc.s 22
-			IL_0561: ldarg.3
-			IL_0562: ldstr "upstream"
-			IL_0567: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_056c: ldstr "packageVersion"
-			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0576: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_057b: stloc.s 35
-			IL_057d: ldstr "package.json version mismatch: expected "
-			IL_0582: ldloc.s 35
-			IL_0584: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0589: stloc.s 35
-			IL_058b: ldloc.s 35
-			IL_058d: ldstr ", got "
-			IL_0592: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0597: stloc.s 35
-			IL_0599: ldloc.s 21
-			IL_059b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05a0: stloc.s 25
-			IL_05a2: ldloc.s 25
-			IL_05a4: brfalse IL_05bc
+			IL_056c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/Scope/Block_L291C75::.ctor()
+			IL_0571: stloc.s 22
+			IL_0573: ldarg.3
+			IL_0574: ldstr "upstream"
+			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057e: ldstr "packageVersion"
+			IL_0583: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0588: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_058d: stloc.s 35
+			IL_058f: ldstr "package.json version mismatch: expected "
+			IL_0594: ldloc.s 35
+			IL_0596: call string [System.Runtime]System.String::Concat(string, string)
+			IL_059b: stloc.s 35
+			IL_059d: ldloc.s 35
+			IL_059f: ldstr ", got "
+			IL_05a4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_05a9: stloc.s 35
+			IL_05ab: ldloc.s 21
+			IL_05ad: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05b2: stloc.s 25
+			IL_05b4: ldloc.s 25
+			IL_05b6: brfalse IL_05ce
 
-			IL_05a9: ldloc.s 21
-			IL_05ab: ldstr "version"
-			IL_05b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05b5: stloc.s 38
-			IL_05b7: br IL_05c0
+			IL_05bb: ldloc.s 21
+			IL_05bd: ldstr "version"
+			IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c7: stloc.s 38
+			IL_05c9: br IL_05d2
 
-			IL_05bc: ldloc.s 21
-			IL_05be: stloc.s 38
+			IL_05ce: ldloc.s 21
+			IL_05d0: stloc.s 38
 
-			IL_05c0: ldloc.s 38
-			IL_05c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05c7: stloc.s 25
-			IL_05c9: ldloc.s 25
-			IL_05cb: brfalse IL_05e3
+			IL_05d2: ldloc.s 38
+			IL_05d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05d9: stloc.s 25
+			IL_05db: ldloc.s 25
+			IL_05dd: brfalse IL_05f5
 
-			IL_05d0: ldloc.s 21
-			IL_05d2: ldstr "version"
-			IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05dc: stloc.s 23
-			IL_05de: br IL_05ea
+			IL_05e2: ldloc.s 21
+			IL_05e4: ldstr "version"
+			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05ee: stloc.s 23
+			IL_05f0: br IL_05fc
 
-			IL_05e3: ldstr "<missing>"
-			IL_05e8: stloc.s 23
+			IL_05f5: ldstr "<missing>"
+			IL_05fa: stloc.s 23
 
-			IL_05ea: ldloc.s 23
-			IL_05ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05f1: stloc.s 39
-			IL_05f3: ldloc.s 35
-			IL_05f5: ldloc.s 39
-			IL_05f7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05fc: stloc.s 39
-			IL_05fe: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0603: dup
-			IL_0604: ldstr "ok"
-			IL_0609: ldc.i4.0
-			IL_060a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_060f: dup
-			IL_0610: ldstr "message"
-			IL_0615: ldloc.s 39
-			IL_0617: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_061c: stloc.s 36
-			IL_061e: ldloc.s 36
-			IL_0620: ret
+			IL_05fc: ldloc.s 23
+			IL_05fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0603: stloc.s 39
+			IL_0605: ldloc.s 35
+			IL_0607: ldloc.s 39
+			IL_0609: call string [System.Runtime]System.String::Concat(string, string)
+			IL_060e: stloc.s 39
+			IL_0610: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0615: dup
+			IL_0616: ldstr "ok"
+			IL_061b: ldc.i4.0
+			IL_061c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0621: dup
+			IL_0622: ldstr "message"
+			IL_0627: ldloc.s 39
+			IL_0629: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_062e: stloc.s 36
+			IL_0630: ldloc.s 36
+			IL_0632: ret
 
-			IL_0621: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0626: dup
-			IL_0627: ldstr "ok"
-			IL_062c: ldc.i4.1
-			IL_062d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0632: dup
-			IL_0633: ldstr "message"
-			IL_0638: ldstr ""
-			IL_063d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0642: ret
+			IL_0633: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0638: dup
+			IL_0639: ldstr "ok"
+			IL_063e: ldc.i4.1
+			IL_063f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0644: dup
+			IL_0645: ldstr "message"
+			IL_064a: ldstr ""
+			IL_064f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0654: ret
 		} // end of method validateResolvedRoot::__js_call__
 
 	} // end of class validateResolvedRoot
@@ -4706,7 +4963,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f6e
+						// Method begins at RVA 0x52e1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4724,7 +4981,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f65
+					// Method begins at RVA 0x52d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4744,7 +5001,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f77
+					// Method begins at RVA 0x52ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4762,7 +5019,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f5c
+				// Method begins at RVA 0x52cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4791,9 +5048,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x45a4
+			// Method begins at RVA 0x47a0
 			// Header size: 12
-			// Code size: 856 (0x358)
+			// Code size: 1057 (0x421)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14,
@@ -4803,10 +5060,12 @@
 				[4] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22,
 				[5] object,
 				[6] bool,
-				[7] object,
-				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[7] object[],
+				[8] object,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[10] string
+				[10] object[],
+				[11] object,
+				[12] string
 			)
 
 			IL_0000: ldarg.s force
@@ -4815,296 +5074,403 @@
 			IL_0008: ceq
 			IL_000a: stloc.s 6
 			IL_000c: ldloc.s 6
-			IL_000e: brfalse IL_0079
+			IL_000e: brfalse IL_0086
 
 			IL_0013: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14::.ctor()
 			IL_0018: stloc.0
-			IL_0019: ldarg.0
-			IL_001a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_001f: ldnull
-			IL_0020: ldarg.2
-			IL_0021: ldarg.3
-			IL_0022: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0027: stloc.s 7
-			IL_0029: ldloc.s 7
-			IL_002b: stloc.1
-			IL_002c: ldloc.1
-			IL_002d: ldstr "ok"
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_003c: stloc.s 6
-			IL_003e: ldloc.s 6
-			IL_0040: brfalse IL_0079
+			IL_0019: ldc.i4.1
+			IL_001a: newarr [System.Runtime]System.Object
+			IL_001f: dup
+			IL_0020: ldc.i4.0
+			IL_0021: ldarg.0
+			IL_0022: stelem.ref
+			IL_0023: stloc.s 7
+			IL_0025: ldarg.0
+			IL_0026: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_002b: ldloc.s 7
+			IL_002d: ldarg.2
+			IL_002e: ldarg.3
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0034: stloc.s 8
+			IL_0036: ldloc.s 8
+			IL_0038: stloc.1
+			IL_0039: ldloc.1
+			IL_003a: ldstr "ok"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0049: stloc.s 6
+			IL_004b: ldloc.s 6
+			IL_004d: brfalse IL_0086
 
-			IL_0045: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14/Block_L304C20::.ctor()
-			IL_004a: stloc.2
-			IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0050: dup
-			IL_0051: ldstr "source"
-			IL_0056: ldstr "managed-cache"
-			IL_005b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0060: dup
-			IL_0061: ldstr "rootPath"
-			IL_0066: ldarg.2
-			IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_006c: dup
-			IL_006d: ldstr "reused"
-			IL_0072: ldc.i4.1
-			IL_0073: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0078: ret
+			IL_0052: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L302C14/Block_L304C20::.ctor()
+			IL_0057: stloc.2
+			IL_0058: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_005d: dup
+			IL_005e: ldstr "source"
+			IL_0063: ldstr "managed-cache"
+			IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_006d: dup
+			IL_006e: ldstr "rootPath"
+			IL_0073: ldarg.2
+			IL_0074: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0079: dup
+			IL_007a: ldstr "reused"
+			IL_007f: ldc.i4.1
+			IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0085: ret
 
-			IL_0079: ldarg.0
-			IL_007a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_007f: ldnull
-			IL_0080: ldarg.2
-			IL_0081: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0086: pop
-			IL_0087: ldarg.0
-			IL_0088: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_008d: ldnull
-			IL_008e: ldarg.2
-			IL_008f: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0094: pop
-			IL_0095: ldc.i4.1
-			IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_009b: dup
-			IL_009c: ldstr "init"
-			IL_00a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00a6: stloc.s 8
-			IL_00a8: ldarg.0
-			IL_00a9: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00ae: ldnull
-			IL_00af: ldloc.s 8
-			IL_00b1: ldarg.2
-			IL_00b2: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_00b7: pop
-			IL_00b8: ldc.i4.3
-			IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00be: dup
-			IL_00bf: ldstr "config"
-			IL_00c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00c9: dup
-			IL_00ca: ldstr "core.autocrlf"
-			IL_00cf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00d4: dup
-			IL_00d5: ldstr "false"
-			IL_00da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00df: stloc.s 8
-			IL_00e1: ldarg.0
-			IL_00e2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00e7: ldnull
-			IL_00e8: ldloc.s 8
-			IL_00ea: ldarg.2
-			IL_00eb: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_00f0: pop
-			IL_00f1: ldc.i4.3
-			IL_00f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00f7: dup
-			IL_00f8: ldstr "config"
-			IL_00fd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0102: dup
-			IL_0103: ldstr "core.eol"
-			IL_0108: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_010d: dup
-			IL_010e: ldstr "lf"
-			IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0118: stloc.s 8
-			IL_011a: ldarg.0
-			IL_011b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0120: ldnull
-			IL_0121: ldloc.s 8
-			IL_0123: ldarg.2
-			IL_0124: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0129: pop
-			IL_012a: ldc.i4.4
-			IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0130: dup
-			IL_0131: ldstr "remote"
-			IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_013b: dup
-			IL_013c: ldstr "add"
-			IL_0141: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0146: dup
-			IL_0147: ldstr "origin"
-			IL_014c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0151: dup
-			IL_0152: ldarg.3
-			IL_0153: ldstr "upstream"
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015d: ldstr "cloneUrl"
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0167: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_016c: stloc.s 8
-			IL_016e: ldarg.0
-			IL_016f: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0174: ldnull
-			IL_0175: ldloc.s 8
-			IL_0177: ldarg.2
-			IL_0178: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_017d: pop
-			IL_017e: ldc.i4.3
-			IL_017f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0184: dup
-			IL_0185: ldstr "sparse-checkout"
-			IL_018a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_018f: dup
-			IL_0190: ldstr "init"
-			IL_0195: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_019a: dup
-			IL_019b: ldstr "--no-cone"
-			IL_01a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01a5: stloc.s 8
-			IL_01a7: ldarg.0
-			IL_01a8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_01ad: ldnull
-			IL_01ae: ldloc.s 8
-			IL_01b0: ldarg.2
-			IL_01b1: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_01b6: pop
-			IL_01b7: ldc.i4.3
-			IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01bd: dup
-			IL_01be: ldstr "sparse-checkout"
-			IL_01c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01c8: dup
-			IL_01c9: ldstr "set"
-			IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01d3: dup
-			IL_01d4: ldstr "--no-cone"
-			IL_01d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01de: stloc.s 8
-			IL_01e0: ldarg.0
-			IL_01e1: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_01e6: ldnull
-			IL_01e7: ldarg.3
-			IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_01ed: stloc.s 9
-			IL_01ef: ldloc.s 8
+			IL_0086: ldc.i4.1
+			IL_0087: newarr [System.Runtime]System.Object
+			IL_008c: dup
+			IL_008d: ldc.i4.0
+			IL_008e: ldarg.0
+			IL_008f: stelem.ref
+			IL_0090: stloc.s 7
+			IL_0092: ldarg.0
+			IL_0093: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::removeDir
+			IL_0098: ldloc.s 7
+			IL_009a: ldarg.2
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a0: pop
+			IL_00a1: ldc.i4.1
+			IL_00a2: newarr [System.Runtime]System.Object
+			IL_00a7: dup
+			IL_00a8: ldc.i4.0
+			IL_00a9: ldarg.0
+			IL_00aa: stelem.ref
+			IL_00ab: stloc.s 7
+			IL_00ad: ldarg.0
+			IL_00ae: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::ensureDir
+			IL_00b3: ldloc.s 7
+			IL_00b5: ldarg.2
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00bb: pop
+			IL_00bc: ldarg.0
+			IL_00bd: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_00c2: stloc.s 8
+			IL_00c4: ldc.i4.1
+			IL_00c5: newarr [System.Runtime]System.Object
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
+			IL_00cc: ldarg.0
+			IL_00cd: stelem.ref
+			IL_00ce: stloc.s 7
+			IL_00d0: ldc.i4.1
+			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d6: dup
+			IL_00d7: ldstr "init"
+			IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_00e1: stloc.s 9
+			IL_00e3: ldloc.s 8
+			IL_00e5: ldloc.s 7
+			IL_00e7: ldloc.s 9
+			IL_00e9: ldarg.2
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00ef: pop
+			IL_00f0: ldarg.0
+			IL_00f1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_00f6: stloc.s 8
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: ldarg.0
+			IL_0101: stelem.ref
+			IL_0102: stloc.s 7
+			IL_0104: ldc.i4.3
+			IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_010a: dup
+			IL_010b: ldstr "config"
+			IL_0110: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0115: dup
+			IL_0116: ldstr "core.autocrlf"
+			IL_011b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0120: dup
+			IL_0121: ldstr "false"
+			IL_0126: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012b: stloc.s 9
+			IL_012d: ldloc.s 8
+			IL_012f: ldloc.s 7
+			IL_0131: ldloc.s 9
+			IL_0133: ldarg.2
+			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0139: pop
+			IL_013a: ldarg.0
+			IL_013b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0140: stloc.s 8
+			IL_0142: ldc.i4.1
+			IL_0143: newarr [System.Runtime]System.Object
+			IL_0148: dup
+			IL_0149: ldc.i4.0
+			IL_014a: ldarg.0
+			IL_014b: stelem.ref
+			IL_014c: stloc.s 7
+			IL_014e: ldc.i4.3
+			IL_014f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0154: dup
+			IL_0155: ldstr "config"
+			IL_015a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_015f: dup
+			IL_0160: ldstr "core.eol"
+			IL_0165: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_016a: dup
+			IL_016b: ldstr "lf"
+			IL_0170: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0175: stloc.s 9
+			IL_0177: ldloc.s 8
+			IL_0179: ldloc.s 7
+			IL_017b: ldloc.s 9
+			IL_017d: ldarg.2
+			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0183: pop
+			IL_0184: ldarg.0
+			IL_0185: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_018a: stloc.s 8
+			IL_018c: ldc.i4.1
+			IL_018d: newarr [System.Runtime]System.Object
+			IL_0192: dup
+			IL_0193: ldc.i4.0
+			IL_0194: ldarg.0
+			IL_0195: stelem.ref
+			IL_0196: stloc.s 7
+			IL_0198: ldc.i4.4
+			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_019e: dup
+			IL_019f: ldstr "remote"
+			IL_01a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a9: dup
+			IL_01aa: ldstr "add"
+			IL_01af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01b4: dup
+			IL_01b5: ldstr "origin"
+			IL_01ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01bf: dup
+			IL_01c0: ldarg.3
+			IL_01c1: ldstr "upstream"
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01cb: ldstr "cloneUrl"
+			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01da: stloc.s 9
+			IL_01dc: ldloc.s 8
+			IL_01de: ldloc.s 7
+			IL_01e0: ldloc.s 9
+			IL_01e2: ldarg.2
+			IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01e8: pop
+			IL_01e9: ldarg.0
+			IL_01ea: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_01ef: stloc.s 8
 			IL_01f1: ldc.i4.1
 			IL_01f2: newarr [System.Runtime]System.Object
 			IL_01f7: dup
 			IL_01f8: ldc.i4.0
-			IL_01f9: ldloc.s 9
-			IL_01fb: stelem.ref
-			IL_01fc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
-			IL_0201: stloc.s 9
-			IL_0203: ldarg.0
-			IL_0204: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0209: ldnull
-			IL_020a: ldloc.s 9
-			IL_020c: ldarg.2
-			IL_020d: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0212: pop
-			IL_0213: ldc.i4.5
-			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01f9: ldarg.0
+			IL_01fa: stelem.ref
+			IL_01fb: stloc.s 7
+			IL_01fd: ldc.i4.3
+			IL_01fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0203: dup
+			IL_0204: ldstr "sparse-checkout"
+			IL_0209: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_020e: dup
+			IL_020f: ldstr "init"
+			IL_0214: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0219: dup
-			IL_021a: ldstr "fetch"
+			IL_021a: ldstr "--no-cone"
 			IL_021f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0224: dup
-			IL_0225: ldstr "--depth"
-			IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_022f: dup
-			IL_0230: ldstr "1"
-			IL_0235: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_023a: dup
-			IL_023b: ldstr "origin"
-			IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0245: dup
-			IL_0246: ldarg.3
-			IL_0247: ldstr "upstream"
-			IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0251: ldstr "commit"
-			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0260: stloc.s 9
-			IL_0262: ldarg.0
-			IL_0263: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0268: ldnull
-			IL_0269: ldloc.s 9
-			IL_026b: ldarg.2
-			IL_026c: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0271: pop
-			IL_0272: ldc.i4.3
-			IL_0273: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0278: dup
-			IL_0279: ldstr "checkout"
-			IL_027e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0283: dup
-			IL_0284: ldstr "--detach"
-			IL_0289: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_028e: dup
-			IL_028f: ldstr "FETCH_HEAD"
-			IL_0294: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0299: stloc.s 9
-			IL_029b: ldarg.0
-			IL_029c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_02a1: ldnull
-			IL_02a2: ldloc.s 9
-			IL_02a4: ldarg.2
-			IL_02a5: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_02aa: pop
-			IL_02ab: ldarg.0
-			IL_02ac: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_02b1: ldnull
-			IL_02b2: ldarg.2
-			IL_02b3: ldarg.3
-			IL_02b4: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_02b9: stloc.s 7
-			IL_02bb: ldloc.s 7
-			IL_02bd: stloc.3
-			IL_02be: ldloc.3
-			IL_02bf: ldstr "ok"
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02ce: ldc.i4.0
-			IL_02cf: ceq
-			IL_02d1: stloc.s 6
-			IL_02d3: ldloc.s 6
-			IL_02d5: brfalse IL_032a
+			IL_0224: stloc.s 9
+			IL_0226: ldloc.s 8
+			IL_0228: ldloc.s 7
+			IL_022a: ldloc.s 9
+			IL_022c: ldarg.2
+			IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0232: pop
+			IL_0233: ldarg.0
+			IL_0234: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0239: stloc.s 8
+			IL_023b: ldc.i4.1
+			IL_023c: newarr [System.Runtime]System.Object
+			IL_0241: dup
+			IL_0242: ldc.i4.0
+			IL_0243: ldarg.0
+			IL_0244: stelem.ref
+			IL_0245: stloc.s 7
+			IL_0247: ldc.i4.3
+			IL_0248: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_024d: dup
+			IL_024e: ldstr "sparse-checkout"
+			IL_0253: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0258: dup
+			IL_0259: ldstr "set"
+			IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0263: dup
+			IL_0264: ldstr "--no-cone"
+			IL_0269: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_026e: stloc.s 9
+			IL_0270: ldc.i4.1
+			IL_0271: newarr [System.Runtime]System.Object
+			IL_0276: dup
+			IL_0277: ldc.i4.0
+			IL_0278: ldarg.0
+			IL_0279: stelem.ref
+			IL_027a: stloc.s 10
+			IL_027c: ldarg.0
+			IL_027d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::buildSparsePatterns
+			IL_0282: ldloc.s 10
+			IL_0284: ldarg.3
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_028a: stloc.s 11
+			IL_028c: ldloc.s 9
+			IL_028e: ldc.i4.1
+			IL_028f: newarr [System.Runtime]System.Object
+			IL_0294: dup
+			IL_0295: ldc.i4.0
+			IL_0296: ldloc.s 11
+			IL_0298: stelem.ref
+			IL_0299: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::concat(object[])
+			IL_029e: stloc.s 9
+			IL_02a0: ldloc.s 8
+			IL_02a2: ldloc.s 7
+			IL_02a4: ldloc.s 9
+			IL_02a6: ldarg.2
+			IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02ac: pop
+			IL_02ad: ldarg.0
+			IL_02ae: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_02b3: stloc.s 8
+			IL_02b5: ldc.i4.1
+			IL_02b6: newarr [System.Runtime]System.Object
+			IL_02bb: dup
+			IL_02bc: ldc.i4.0
+			IL_02bd: ldarg.0
+			IL_02be: stelem.ref
+			IL_02bf: stloc.s 7
+			IL_02c1: ldc.i4.5
+			IL_02c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02c7: dup
+			IL_02c8: ldstr "fetch"
+			IL_02cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02d2: dup
+			IL_02d3: ldstr "--depth"
+			IL_02d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02dd: dup
+			IL_02de: ldstr "1"
+			IL_02e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e8: dup
+			IL_02e9: ldstr "origin"
+			IL_02ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f3: dup
+			IL_02f4: ldarg.3
+			IL_02f5: ldstr "upstream"
+			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ff: ldstr "commit"
+			IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0309: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_030e: stloc.s 9
+			IL_0310: ldloc.s 8
+			IL_0312: ldloc.s 7
+			IL_0314: ldloc.s 9
+			IL_0316: ldarg.2
+			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_031c: pop
+			IL_031d: ldarg.0
+			IL_031e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::runGit
+			IL_0323: stloc.s 8
+			IL_0325: ldc.i4.1
+			IL_0326: newarr [System.Runtime]System.Object
+			IL_032b: dup
+			IL_032c: ldc.i4.0
+			IL_032d: ldarg.0
+			IL_032e: stelem.ref
+			IL_032f: stloc.s 7
+			IL_0331: ldc.i4.3
+			IL_0332: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0337: dup
+			IL_0338: ldstr "checkout"
+			IL_033d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0342: dup
+			IL_0343: ldstr "--detach"
+			IL_0348: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_034d: dup
+			IL_034e: ldstr "FETCH_HEAD"
+			IL_0353: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0358: stloc.s 9
+			IL_035a: ldloc.s 8
+			IL_035c: ldloc.s 7
+			IL_035e: ldloc.s 9
+			IL_0360: ldarg.2
+			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0366: pop
+			IL_0367: ldc.i4.1
+			IL_0368: newarr [System.Runtime]System.Object
+			IL_036d: dup
+			IL_036e: ldc.i4.0
+			IL_036f: ldarg.0
+			IL_0370: stelem.ref
+			IL_0371: stloc.s 7
+			IL_0373: ldarg.0
+			IL_0374: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_0379: ldloc.s 7
+			IL_037b: ldarg.2
+			IL_037c: ldarg.3
+			IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0382: stloc.s 8
+			IL_0384: ldloc.s 8
+			IL_0386: stloc.3
+			IL_0387: ldloc.3
+			IL_0388: ldstr "ok"
+			IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0392: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0397: ldc.i4.0
+			IL_0398: ceq
+			IL_039a: stloc.s 6
+			IL_039c: ldloc.s 6
+			IL_039e: brfalse IL_03f3
 
-			IL_02da: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22::.ctor()
-			IL_02df: stloc.s 4
-			IL_02e1: ldloc.3
-			IL_02e2: ldstr "message"
-			IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ec: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f1: stloc.s 10
-			IL_02f3: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
-			IL_02f8: ldloc.s 10
-			IL_02fa: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02ff: stloc.s 10
-			IL_0301: ldloc.s 10
-			IL_0303: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0308: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_030d: stloc.s 7
-			IL_030f: ldloc.s 7
-			IL_0311: stloc.s 5
-			IL_0313: ldloc.s 5
-			IL_0315: isinst [System.Runtime]System.Exception
-			IL_031a: dup
-			IL_031b: brtrue IL_0329
+			IL_03a3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/Scope/Block_L322C22::.ctor()
+			IL_03a8: stloc.s 4
+			IL_03aa: ldloc.3
+			IL_03ab: ldstr "message"
+			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03ba: stloc.s 12
+			IL_03bc: ldstr "Pinned test262 checkout is incomplete after bootstrap: "
+			IL_03c1: ldloc.s 12
+			IL_03c3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03c8: stloc.s 12
+			IL_03ca: ldloc.s 12
+			IL_03cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_03d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_03d6: stloc.s 8
+			IL_03d8: ldloc.s 8
+			IL_03da: stloc.s 5
+			IL_03dc: ldloc.s 5
+			IL_03de: isinst [System.Runtime]System.Exception
+			IL_03e3: dup
+			IL_03e4: brtrue IL_03f2
 
-			IL_0320: pop
-			IL_0321: ldloc.s 5
-			IL_0323: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0328: throw
+			IL_03e9: pop
+			IL_03ea: ldloc.s 5
+			IL_03ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_03f1: throw
 
-			IL_0329: throw
+			IL_03f2: throw
 
-			IL_032a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_032f: dup
-			IL_0330: ldstr "source"
-			IL_0335: ldstr "managed-cache"
-			IL_033a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_033f: dup
-			IL_0340: ldstr "rootPath"
-			IL_0345: ldarg.2
-			IL_0346: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_034b: dup
-			IL_034c: ldstr "reused"
-			IL_0351: ldc.i4.0
-			IL_0352: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0357: ret
+			IL_03f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03f8: dup
+			IL_03f9: ldstr "source"
+			IL_03fe: ldstr "managed-cache"
+			IL_0403: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0408: dup
+			IL_0409: ldstr "rootPath"
+			IL_040e: ldarg.2
+			IL_040f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0414: dup
+			IL_0415: ldstr "reused"
+			IL_041a: ldc.i4.0
+			IL_041b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0420: ret
 		} // end of method ensureManagedCheckout::__js_call__
 
 	} // end of class ensureManagedCheckout
@@ -5128,7 +5494,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4f92
+						// Method begins at RVA 0x5305
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5146,7 +5512,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4f89
+					// Method begins at RVA 0x52fc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5164,7 +5530,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f80
+				// Method begins at RVA 0x52f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5193,9 +5559,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4908
+			// Method begins at RVA 0x4bd0
 			// Header size: 12
-			// Code size: 346 (0x15a)
+			// Code size: 389 (0x185)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5203,141 +5569,165 @@
 				[2] object,
 				[3] class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24,
 				[4] object,
-				[5] object,
-				[6] bool,
-				[7] string,
-				[8] string,
-				[9] object
+				[5] object[],
+				[6] object,
+				[7] bool,
+				[8] object,
+				[9] string,
+				[10] string
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0006: ldnull
-			IL_0007: ldarg.s args
-			IL_0009: ldarg.3
-			IL_000a: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_000f: stloc.s 5
-			IL_0011: ldloc.s 5
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_001a: stloc.s 6
-			IL_001c: ldloc.s 6
-			IL_001e: brfalse IL_0126
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 5
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+			IL_0012: ldloc.s 5
+			IL_0014: ldarg.s args
+			IL_0016: ldarg.3
+			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_001c: stloc.s 6
+			IL_001e: ldloc.s 6
+			IL_0020: stloc.0
+			IL_0021: ldloc.0
+			IL_0022: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0027: stloc.s 7
+			IL_0029: ldloc.s 7
+			IL_002b: brfalse IL_0144
 
-			IL_0023: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16::.ctor()
-			IL_0028: stloc.1
-			IL_0029: ldloc.0
-			IL_002a: ldstr "rootPath"
-			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0034: stloc.s 5
+			IL_0030: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16::.ctor()
+			IL_0035: stloc.1
 			IL_0036: ldarg.0
-			IL_0037: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_003c: ldnull
-			IL_003d: ldloc.s 5
-			IL_003f: ldarg.3
-			IL_0040: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0045: stloc.s 5
-			IL_0047: ldloc.s 5
-			IL_0049: stloc.2
-			IL_004a: ldloc.2
-			IL_004b: ldstr "ok"
+			IL_0037: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::validateResolvedRoot
+			IL_003c: stloc.s 6
+			IL_003e: ldc.i4.1
+			IL_003f: newarr [System.Runtime]System.Object
+			IL_0044: dup
+			IL_0045: ldc.i4.0
+			IL_0046: ldarg.0
+			IL_0047: stelem.ref
+			IL_0048: stloc.s 5
+			IL_004a: ldloc.0
+			IL_004b: ldstr "rootPath"
 			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_005a: ldc.i4.0
-			IL_005b: ceq
-			IL_005d: stloc.s 6
-			IL_005f: ldloc.s 6
-			IL_0061: brfalse IL_00e0
+			IL_0055: stloc.s 8
+			IL_0057: ldloc.s 6
+			IL_0059: ldloc.s 5
+			IL_005b: ldloc.s 8
+			IL_005d: ldarg.3
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0063: stloc.s 8
+			IL_0065: ldloc.s 8
+			IL_0067: stloc.2
+			IL_0068: ldloc.2
+			IL_0069: ldstr "ok"
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0078: ldc.i4.0
+			IL_0079: ceq
+			IL_007b: stloc.s 7
+			IL_007d: ldloc.s 7
+			IL_007f: brfalse IL_00fe
 
-			IL_0066: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24::.ctor()
-			IL_006b: stloc.3
-			IL_006c: ldloc.0
-			IL_006d: ldstr "rootPath"
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0077: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_007c: stloc.s 7
-			IL_007e: ldstr "Override test262 root '"
-			IL_0083: ldloc.s 7
-			IL_0085: call string [System.Runtime]System.String::Concat(string, string)
-			IL_008a: stloc.s 7
-			IL_008c: ldloc.s 7
-			IL_008e: ldstr "' is invalid: "
-			IL_0093: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0098: stloc.s 7
-			IL_009a: ldloc.2
-			IL_009b: ldstr "message"
-			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00aa: stloc.s 8
-			IL_00ac: ldloc.s 7
-			IL_00ae: ldloc.s 8
-			IL_00b0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b5: stloc.s 8
-			IL_00b7: ldloc.s 8
-			IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00c3: stloc.s 5
-			IL_00c5: ldloc.s 5
-			IL_00c7: stloc.s 4
-			IL_00c9: ldloc.s 4
-			IL_00cb: isinst [System.Runtime]System.Exception
-			IL_00d0: dup
-			IL_00d1: brtrue IL_00df
+			IL_0084: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/Scope/Block_L331C16/Block_L333C24::.ctor()
+			IL_0089: stloc.3
+			IL_008a: ldloc.0
+			IL_008b: ldstr "rootPath"
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0095: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009a: stloc.s 9
+			IL_009c: ldstr "Override test262 root '"
+			IL_00a1: ldloc.s 9
+			IL_00a3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00a8: stloc.s 9
+			IL_00aa: ldloc.s 9
+			IL_00ac: ldstr "' is invalid: "
+			IL_00b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b6: stloc.s 9
+			IL_00b8: ldloc.2
+			IL_00b9: ldstr "message"
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c8: stloc.s 10
+			IL_00ca: ldloc.s 9
+			IL_00cc: ldloc.s 10
+			IL_00ce: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d3: stloc.s 10
+			IL_00d5: ldloc.s 10
+			IL_00d7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00dc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00e1: stloc.s 8
+			IL_00e3: ldloc.s 8
+			IL_00e5: stloc.s 4
+			IL_00e7: ldloc.s 4
+			IL_00e9: isinst [System.Runtime]System.Exception
+			IL_00ee: dup
+			IL_00ef: brtrue IL_00fd
 
-			IL_00d6: pop
-			IL_00d7: ldloc.s 4
-			IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00de: throw
+			IL_00f4: pop
+			IL_00f5: ldloc.s 4
+			IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00fc: throw
 
-			IL_00df: throw
+			IL_00fd: throw
 
-			IL_00e0: ldloc.0
-			IL_00e1: ldstr "source"
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00eb: stloc.s 5
-			IL_00ed: ldloc.0
-			IL_00ee: ldstr "rootPath"
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f8: stloc.s 9
-			IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00ff: dup
-			IL_0100: ldstr "source"
-			IL_0105: ldloc.s 5
-			IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_010c: dup
-			IL_010d: ldstr "rootPath"
-			IL_0112: ldloc.s 9
-			IL_0114: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0119: dup
-			IL_011a: ldstr "reused"
-			IL_011f: ldc.i4.1
-			IL_0120: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0125: ret
+			IL_00fe: ldloc.0
+			IL_00ff: ldstr "source"
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0109: stloc.s 8
+			IL_010b: ldloc.0
+			IL_010c: ldstr "rootPath"
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0116: stloc.s 6
+			IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_011d: dup
+			IL_011e: ldstr "source"
+			IL_0123: ldloc.s 8
+			IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_012a: dup
+			IL_012b: ldstr "rootPath"
+			IL_0130: ldloc.s 6
+			IL_0132: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0137: dup
+			IL_0138: ldstr "reused"
+			IL_013d: ldc.i4.1
+			IL_013e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0143: ret
 
-			IL_0126: ldarg.0
-			IL_0127: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_012c: ldnull
-			IL_012d: ldarg.2
-			IL_012e: ldarg.3
-			IL_012f: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_0134: stloc.s 9
-			IL_0136: ldarg.s args
-			IL_0138: ldstr "force"
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0142: stloc.s 5
-			IL_0144: ldarg.0
-			IL_0145: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_014a: ldnull
-			IL_014b: ldloc.s 9
-			IL_014d: ldarg.3
-			IL_014e: ldloc.s 5
-			IL_0150: tail.
-			IL_0152: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_0157: ret
+			IL_0144: ldc.i4.1
+			IL_0145: newarr [System.Runtime]System.Object
+			IL_014a: dup
+			IL_014b: ldc.i4.0
+			IL_014c: ldarg.0
+			IL_014d: stelem.ref
+			IL_014e: stloc.s 5
+			IL_0150: ldarg.0
+			IL_0151: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveManagedCheckoutRoot
+			IL_0156: ldloc.s 5
+			IL_0158: ldarg.2
+			IL_0159: ldarg.3
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_015f: stloc.s 6
+			IL_0161: ldarg.s args
+			IL_0163: ldstr "force"
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016d: stloc.s 8
+			IL_016f: ldarg.0
+			IL_0170: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
+			IL_0175: ldnull
+			IL_0176: ldloc.s 6
+			IL_0178: ldarg.3
+			IL_0179: ldloc.s 8
+			IL_017b: tail.
+			IL_017d: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+			IL_0182: ret
 
-			IL_0158: ldnull
-			IL_0159: ret
+			IL_0183: ldnull
+			IL_0184: ret
 		} // end of method resolveBootstrapRoot::__js_call__
 
 	} // end of class resolveBootstrapRoot
@@ -5357,7 +5747,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fa4
+					// Method begins at RVA 0x5317
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5375,7 +5765,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4f9b
+				// Method begins at RVA 0x530e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5404,9 +5794,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4a70
+			// Method begins at RVA 0x4d64
 			// Header size: 12
-			// Code size: 356 (0x164)
+			// Code size: 375 (0x177)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/Scope/Block_L344C21,
@@ -5415,11 +5805,12 @@
 				[3] bool,
 				[4] string,
 				[5] object,
-				[6] string,
+				[6] object[],
 				[7] string,
 				[8] string,
 				[9] string,
-				[10] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[10] string,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldarg.s printRootOnly
@@ -5465,83 +5856,92 @@
 			IL_006d: ldloc.s 4
 			IL_006f: call string [System.Runtime]System.String::Concat(string, string)
 			IL_0074: stloc.s 4
-			IL_0076: ldarg.2
-			IL_0077: ldstr "rootPath"
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0081: stloc.s 5
-			IL_0083: ldnull
-			IL_0084: ldloc.s 5
-			IL_0086: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-			IL_008b: stloc.s 5
-			IL_008d: ldloc.s 5
-			IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0094: stloc.s 6
-			IL_0096: ldstr "root "
-			IL_009b: ldloc.s 6
-			IL_009d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00a2: stloc.s 6
-			IL_00a4: ldarg.3
-			IL_00a5: ldstr "upstream"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00af: ldstr "commit"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00b9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00be: stloc.s 7
-			IL_00c0: ldstr "commit "
-			IL_00c5: ldloc.s 7
-			IL_00c7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00cc: stloc.s 7
-			IL_00ce: ldarg.3
-			IL_00cf: ldstr "upstream"
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d9: ldstr "packageVersion"
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00e8: stloc.s 8
-			IL_00ea: ldstr "packageVersion "
-			IL_00ef: ldloc.s 8
-			IL_00f1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00f6: stloc.s 8
-			IL_00f8: ldloc.2
-			IL_00f9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00fe: stloc.s 9
-			IL_0100: ldstr "status "
-			IL_0105: ldloc.s 9
-			IL_0107: call string [System.Runtime]System.String::Concat(string, string)
-			IL_010c: stloc.s 9
-			IL_010e: ldc.i4.5
-			IL_010f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0114: dup
-			IL_0115: ldloc.s 4
-			IL_0117: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011c: dup
-			IL_011d: ldloc.s 6
-			IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0124: dup
-			IL_0125: ldloc.s 7
-			IL_0127: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_012c: dup
-			IL_012d: ldloc.s 8
-			IL_012f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0134: dup
-			IL_0135: ldloc.s 9
-			IL_0137: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_013c: stloc.s 10
-			IL_013e: ldloc.s 10
-			IL_0140: ldc.i4.1
-			IL_0141: newarr [System.Runtime]System.Object
-			IL_0146: dup
-			IL_0147: ldc.i4.0
-			IL_0148: ldstr "\n"
-			IL_014d: stelem.ref
-			IL_014e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0153: stloc.s 9
-			IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_015a: ldloc.s 9
-			IL_015c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0161: pop
-			IL_0162: ldnull
-			IL_0163: ret
+			IL_0076: ldarg.0
+			IL_0077: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::toPortablePath
+			IL_007c: stloc.s 5
+			IL_007e: ldc.i4.1
+			IL_007f: newarr [System.Runtime]System.Object
+			IL_0084: dup
+			IL_0085: ldc.i4.0
+			IL_0086: ldarg.0
+			IL_0087: stelem.ref
+			IL_0088: stloc.s 6
+			IL_008a: ldloc.s 5
+			IL_008c: ldloc.s 6
+			IL_008e: ldarg.2
+			IL_008f: ldstr "rootPath"
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_009e: stloc.s 5
+			IL_00a0: ldloc.s 5
+			IL_00a2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00a7: stloc.s 7
+			IL_00a9: ldstr "root "
+			IL_00ae: ldloc.s 7
+			IL_00b0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b5: stloc.s 7
+			IL_00b7: ldarg.3
+			IL_00b8: ldstr "upstream"
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00c2: ldstr "commit"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00d1: stloc.s 8
+			IL_00d3: ldstr "commit "
+			IL_00d8: ldloc.s 8
+			IL_00da: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00df: stloc.s 8
+			IL_00e1: ldarg.3
+			IL_00e2: ldstr "upstream"
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ec: ldstr "packageVersion"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00fb: stloc.s 9
+			IL_00fd: ldstr "packageVersion "
+			IL_0102: ldloc.s 9
+			IL_0104: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0109: stloc.s 9
+			IL_010b: ldloc.2
+			IL_010c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0111: stloc.s 10
+			IL_0113: ldstr "status "
+			IL_0118: ldloc.s 10
+			IL_011a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_011f: stloc.s 10
+			IL_0121: ldc.i4.5
+			IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0127: dup
+			IL_0128: ldloc.s 4
+			IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012f: dup
+			IL_0130: ldloc.s 7
+			IL_0132: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0137: dup
+			IL_0138: ldloc.s 8
+			IL_013a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_013f: dup
+			IL_0140: ldloc.s 9
+			IL_0142: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0147: dup
+			IL_0148: ldloc.s 10
+			IL_014a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_014f: stloc.s 11
+			IL_0151: ldloc.s 11
+			IL_0153: ldc.i4.1
+			IL_0154: newarr [System.Runtime]System.Object
+			IL_0159: dup
+			IL_015a: ldc.i4.0
+			IL_015b: ldstr "\n"
+			IL_0160: stelem.ref
+			IL_0161: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0166: stloc.s 10
+			IL_0168: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_016d: ldloc.s 10
+			IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0174: pop
+			IL_0175: ldnull
+			IL_0176: ret
 		} // end of method printResolvedRoot::__js_call__
 
 	} // end of class printResolvedRoot
@@ -5561,7 +5961,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fb6
+					// Method begins at RVA 0x5329
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5581,7 +5981,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fbf
+					// Method begins at RVA 0x5332
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5599,7 +5999,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fad
+				// Method begins at RVA 0x5320
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5625,9 +6025,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x4be0
+			// Method begins at RVA 0x4ee8
 			// Header size: 12
-			// Code size: 340 (0x154)
+			// Code size: 447 (0x1bf)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5638,142 +6038,201 @@
 				[5] class Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L372C21,
 				[6] object,
 				[7] object,
-				[8] bool,
+				[8] object[],
 				[9] object,
-				[10] object,
-				[11] object
+				[10] bool,
+				[11] object,
+				[12] object,
+				[13] object
 			)
 
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0005: ldstr "argv"
-			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_000f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0014: stloc.s 7
-			IL_0016: ldloc.s 7
-			IL_0018: ldstr "slice"
-			IL_001d: ldc.r8 2
-			IL_0026: box [System.Runtime]System.Double
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0030: stloc.s 7
-			IL_0032: ldarg.0
-			IL_0033: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0038: ldnull
-			IL_0039: ldloc.s 7
-			IL_003b: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_0040: stloc.s 7
-			IL_0042: ldloc.s 7
-			IL_0044: stloc.0
-			IL_0045: ldloc.0
-			IL_0046: ldstr "help"
-			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0055: stloc.s 8
-			IL_0057: ldloc.s 8
-			IL_0059: brfalse IL_006d
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
+			IL_0006: stloc.s 7
+			IL_0008: ldc.i4.1
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: stloc.s 8
+			IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0019: ldstr "argv"
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0028: stloc.s 9
+			IL_002a: ldloc.s 9
+			IL_002c: ldstr "slice"
+			IL_0031: ldc.r8 2
+			IL_003a: box [System.Runtime]System.Double
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0044: stloc.s 9
+			IL_0046: ldloc.s 7
+			IL_0048: ldloc.s 8
+			IL_004a: ldloc.s 9
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0051: stloc.s 9
+			IL_0053: ldloc.s 9
+			IL_0055: stloc.0
+			IL_0056: ldloc.0
+			IL_0057: ldstr "help"
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0066: stloc.s 10
+			IL_0068: ldloc.s 10
+			IL_006a: brfalse IL_008d
 
-			IL_005e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L363C17::.ctor()
-			IL_0063: stloc.1
-			IL_0064: ldnull
-			IL_0065: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
-			IL_006a: pop
-			IL_006b: ldnull
-			IL_006c: ret
+			IL_006f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L363C17::.ctor()
+			IL_0074: stloc.1
+			IL_0075: ldarg.0
+			IL_0076: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
+			IL_007b: ldc.i4.1
+			IL_007c: newarr [System.Runtime]System.Object
+			IL_0081: dup
+			IL_0082: ldc.i4.0
+			IL_0083: ldarg.0
+			IL_0084: stelem.ref
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_008a: pop
+			IL_008b: ldnull
+			IL_008c: ret
 
-			IL_006d: ldloc.0
-			IL_006e: ldstr "pin"
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0078: stloc.s 7
-			IL_007a: ldloc.s 7
-			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0081: stloc.s 8
-			IL_0083: ldloc.s 8
-			IL_0085: brtrue IL_00a1
+			IL_008d: ldarg.0
+			IL_008e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
+			IL_0093: stloc.s 9
+			IL_0095: ldc.i4.1
+			IL_0096: newarr [System.Runtime]System.Object
+			IL_009b: dup
+			IL_009c: ldc.i4.0
+			IL_009d: ldarg.0
+			IL_009e: stelem.ref
+			IL_009f: stloc.s 8
+			IL_00a1: ldloc.0
+			IL_00a2: ldstr "pin"
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ac: stloc.s 7
+			IL_00ae: ldloc.s 7
+			IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00b5: stloc.s 10
+			IL_00b7: ldloc.s 10
+			IL_00b9: brtrue IL_00de
 
-			IL_008a: ldarg.0
-			IL_008b: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0090: ldnull
-			IL_0091: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-			IL_0096: stloc.s 9
-			IL_0098: ldloc.s 9
-			IL_009a: stloc.s 11
-			IL_009c: br IL_00a5
+			IL_00be: ldarg.0
+			IL_00bf: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
+			IL_00c4: ldc.i4.1
+			IL_00c5: newarr [System.Runtime]System.Object
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
+			IL_00cc: ldarg.0
+			IL_00cd: stelem.ref
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00d3: stloc.s 11
+			IL_00d5: ldloc.s 11
+			IL_00d7: stloc.s 13
+			IL_00d9: br IL_00e2
 
-			IL_00a1: ldloc.s 7
-			IL_00a3: stloc.s 11
+			IL_00de: ldloc.s 7
+			IL_00e0: stloc.s 13
 
-			IL_00a5: ldarg.0
-			IL_00a6: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00ab: ldnull
-			IL_00ac: ldloc.s 11
-			IL_00ae: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00b3: stloc.s 7
-			IL_00b5: ldloc.s 7
-			IL_00b7: stloc.2
-			IL_00b8: ldarg.0
-			IL_00b9: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00be: ldnull
-			IL_00bf: ldloc.2
-			IL_00c0: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-			IL_00c5: stloc.s 7
-			IL_00c7: ldloc.s 7
-			IL_00c9: stloc.3
-			IL_00ca: ldarg.0
-			IL_00cb: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_00d0: ldnull
-			IL_00d1: ldloc.0
-			IL_00d2: ldloc.3
-			IL_00d3: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_00d8: stloc.s 7
-			IL_00da: ldloc.s 7
-			IL_00dc: stloc.s 4
-			IL_00de: ldloc.0
-			IL_00df: ldstr "describe"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00ee: stloc.s 8
-			IL_00f0: ldloc.s 8
-			IL_00f2: brfalse IL_011e
+			IL_00e2: ldloc.s 9
+			IL_00e4: ldloc.s 8
+			IL_00e6: ldloc.s 13
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00ed: stloc.s 9
+			IL_00ef: ldloc.s 9
+			IL_00f1: stloc.2
+			IL_00f2: ldarg.0
+			IL_00f3: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: ldarg.0
+			IL_0101: stelem.ref
+			IL_0102: ldloc.2
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0108: stloc.s 9
+			IL_010a: ldloc.s 9
+			IL_010c: stloc.3
+			IL_010d: ldarg.0
+			IL_010e: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+			IL_0113: ldc.i4.1
+			IL_0114: newarr [System.Runtime]System.Object
+			IL_0119: dup
+			IL_011a: ldc.i4.0
+			IL_011b: ldarg.0
+			IL_011c: stelem.ref
+			IL_011d: ldloc.0
+			IL_011e: ldloc.3
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0124: stloc.s 9
+			IL_0126: ldloc.s 9
+			IL_0128: stloc.s 4
+			IL_012a: ldloc.0
+			IL_012b: ldstr "describe"
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0135: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_013a: stloc.s 10
+			IL_013c: ldloc.s 10
+			IL_013e: brfalse IL_0173
 
-			IL_00f7: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L372C21::.ctor()
-			IL_00fc: stloc.s 5
-			IL_00fe: ldarg.0
-			IL_00ff: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0104: ldnull
-			IL_0105: ldloc.3
-			IL_0106: ldloc.s 4
-			IL_0108: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-			IL_010d: stloc.s 7
-			IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0114: ldloc.s 7
-			IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_011b: pop
-			IL_011c: ldnull
-			IL_011d: ret
+			IL_0143: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/Scope/Block_L372C21::.ctor()
+			IL_0148: stloc.s 5
+			IL_014a: ldarg.0
+			IL_014b: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+			IL_0150: ldc.i4.1
+			IL_0151: newarr [System.Runtime]System.Object
+			IL_0156: dup
+			IL_0157: ldc.i4.0
+			IL_0158: ldarg.0
+			IL_0159: stelem.ref
+			IL_015a: ldloc.3
+			IL_015b: ldloc.s 4
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0162: stloc.s 9
+			IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0169: ldloc.s 9
+			IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0170: pop
+			IL_0171: ldnull
+			IL_0172: ret
 
-			IL_011e: ldarg.0
-			IL_011f: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0124: ldnull
-			IL_0125: ldloc.2
-			IL_0126: ldloc.3
-			IL_0127: ldloc.0
-			IL_0128: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_012d: stloc.s 7
-			IL_012f: ldloc.s 7
-			IL_0131: stloc.s 6
-			IL_0133: ldloc.0
-			IL_0134: ldstr "printRoot"
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013e: stloc.s 7
-			IL_0140: ldarg.0
-			IL_0141: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_0146: ldnull
-			IL_0147: ldloc.s 6
-			IL_0149: ldloc.3
-			IL_014a: ldloc.s 7
-			IL_014c: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-			IL_0151: pop
-			IL_0152: ldnull
-			IL_0153: ret
+			IL_0173: ldarg.0
+			IL_0174: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+			IL_0179: ldc.i4.1
+			IL_017a: newarr [System.Runtime]System.Object
+			IL_017f: dup
+			IL_0180: ldc.i4.0
+			IL_0181: ldarg.0
+			IL_0182: stelem.ref
+			IL_0183: ldloc.2
+			IL_0184: ldloc.3
+			IL_0185: ldloc.0
+			IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_018b: stloc.s 9
+			IL_018d: ldloc.s 9
+			IL_018f: stloc.s 6
+			IL_0191: ldarg.0
+			IL_0192: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
+			IL_0197: stloc.s 9
+			IL_0199: ldc.i4.1
+			IL_019a: newarr [System.Runtime]System.Object
+			IL_019f: dup
+			IL_01a0: ldc.i4.0
+			IL_01a1: ldarg.0
+			IL_01a2: stelem.ref
+			IL_01a3: stloc.s 8
+			IL_01a5: ldloc.s 9
+			IL_01a7: ldloc.s 8
+			IL_01a9: ldloc.s 6
+			IL_01ab: ldloc.3
+			IL_01ac: ldloc.0
+			IL_01ad: ldstr "printRoot"
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01bc: pop
+			IL_01bd: ldnull
+			IL_01be: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -5809,7 +6268,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fd1
+					// Method begins at RVA 0x5344
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5829,7 +6288,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4fda
+					// Method begins at RVA 0x534d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5847,7 +6306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4fc8
+				// Method begins at RVA 0x533b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5895,7 +6354,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4d40
+			// Method begins at RVA 0x50b3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5921,7 +6380,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1736 (0x6c8)
+		// Code size: 1735 (0x6c7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
@@ -6528,7 +6987,7 @@
 		IL_05d4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_05d9: stloc.s 20
 		IL_05db: ldloc.s 20
-		IL_05dd: brfalse IL_06c4
+		IL_05dd: brfalse IL_06c3
 
 		IL_05e2: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29::.ctor()
 		IL_05e7: stloc.2
@@ -6536,93 +6995,92 @@
 		{
 			IL_05e8: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L395C6::.ctor()
 			IL_05ed: stloc.3
-			IL_05ee: ldloc.0
-			IL_05ef: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-			IL_05f4: ldnull
-			IL_05f5: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-			IL_05fa: pop
-			IL_05fb: leave IL_06c4
+			IL_05ee: ldloc.1
+			IL_05ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_05f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_05f9: pop
+			IL_05fa: leave IL_06c3
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0600: stloc.s 4
-			IL_0602: ldloc.s 4
-			IL_0604: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0609: dup
-			IL_060a: brtrue IL_0620
+			IL_05ff: stloc.s 4
+			IL_0601: ldloc.s 4
+			IL_0603: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0608: dup
+			IL_0609: brtrue IL_061f
 
-			IL_060f: pop
-			IL_0610: ldloc.s 4
-			IL_0612: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0617: dup
-			IL_0618: brtrue IL_062c
+			IL_060e: pop
+			IL_060f: ldloc.s 4
+			IL_0611: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0616: dup
+			IL_0617: brtrue IL_062b
 
-			IL_061d: pop
-			IL_061e: rethrow
+			IL_061c: pop
+			IL_061d: rethrow
 
-			IL_0620: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0625: stloc.s 5
-			IL_0627: br IL_062e
+			IL_061f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0624: stloc.s 5
+			IL_0626: br IL_062d
 
-			IL_062c: stloc.s 5
+			IL_062b: stloc.s 5
 
-			IL_062e: ldloc.s 5
-			IL_0630: stloc.s 18
-			IL_0632: ldloc.s 18
-			IL_0634: stloc.s 6
-			IL_0636: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L397C18::.ctor()
-			IL_063b: stloc.s 7
-			IL_063d: ldloc.s 6
-			IL_063f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0644: stloc.s 20
-			IL_0646: ldloc.s 20
-			IL_0648: brfalse IL_0660
+			IL_062d: ldloc.s 5
+			IL_062f: stloc.s 18
+			IL_0631: ldloc.s 18
+			IL_0633: stloc.s 6
+			IL_0635: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/Scope/Block_L394C29/Block_L397C18::.ctor()
+			IL_063a: stloc.s 7
+			IL_063c: ldloc.s 6
+			IL_063e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0643: stloc.s 20
+			IL_0645: ldloc.s 20
+			IL_0647: brfalse IL_065f
 
-			IL_064d: ldloc.s 6
-			IL_064f: ldstr "message"
-			IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0659: stloc.s 22
-			IL_065b: br IL_0664
+			IL_064c: ldloc.s 6
+			IL_064e: ldstr "message"
+			IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0658: stloc.s 22
+			IL_065a: br IL_0663
 
-			IL_0660: ldloc.s 6
-			IL_0662: stloc.s 22
+			IL_065f: ldloc.s 6
+			IL_0661: stloc.s 22
 
-			IL_0664: ldloc.s 22
-			IL_0666: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_066b: stloc.s 20
-			IL_066d: ldloc.s 20
-			IL_066f: brfalse IL_0687
+			IL_0663: ldloc.s 22
+			IL_0665: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_066a: stloc.s 20
+			IL_066c: ldloc.s 20
+			IL_066e: brfalse IL_0686
 
-			IL_0674: ldloc.s 6
-			IL_0676: ldstr "message"
-			IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0680: stloc.s 8
-			IL_0682: br IL_0694
+			IL_0673: ldloc.s 6
+			IL_0675: ldstr "message"
+			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_067f: stloc.s 8
+			IL_0681: br IL_0693
 
-			IL_0687: ldloc.s 6
-			IL_0689: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_068e: stloc.s 23
-			IL_0690: ldloc.s 23
-			IL_0692: stloc.s 8
+			IL_0686: ldloc.s 6
+			IL_0688: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_068d: stloc.s 23
+			IL_068f: ldloc.s 23
+			IL_0691: stloc.s 8
 
-			IL_0694: ldloc.s 8
-			IL_0696: stloc.s 9
-			IL_0698: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_069d: ldloc.s 9
-			IL_069f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_06a4: pop
-			IL_06a5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_06aa: ldstr "exitCode"
-			IL_06af: ldc.r8 1
-			IL_06b8: ldc.i4.1
-			IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_06be: pop
-			IL_06bf: leave IL_06c4
+			IL_0693: ldloc.s 8
+			IL_0695: stloc.s 9
+			IL_0697: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_069c: ldloc.s 9
+			IL_069e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_06a3: pop
+			IL_06a4: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_06a9: ldstr "exitCode"
+			IL_06ae: ldc.r8 1
+			IL_06b7: ldc.i4.1
+			IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_06bd: pop
+			IL_06be: leave IL_06c3
 		} // end handler
 
-		IL_06c4: ldnull
-		IL_06c5: stloc.s 10
-		IL_06c7: ret
+		IL_06c3: ldnull
+		IL_06c4: stloc.s 10
+		IL_06c6: ret
 	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262Bootstrap
@@ -6634,7 +7092,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4fe3
+		// Method begins at RVA 0x5356
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ca6
+				// Method begins at RVA 0x64ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28c0
+			// Method begins at RVA 0x28cc
 			// Header size: 12
 			// Code size: 190 (0xbe)
 			.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cb8
+					// Method begins at RVA 0x64c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -153,7 +153,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cc1
+					// Method begins at RVA 0x64c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -173,7 +173,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cca
+					// Method begins at RVA 0x64d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -191,7 +191,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5caf
+				// Method begins at RVA 0x64b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -218,7 +218,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x298c
+			// Method begins at RVA 0x2998
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -303,7 +303,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cdc
+					// Method begins at RVA 0x64e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -321,7 +321,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cd3
+				// Method begins at RVA 0x64db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -348,15 +348,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2a10
+			// Method begins at RVA 0x2a1c
 			// Header size: 12
-			// Code size: 126 (0x7e)
+			// Code size: 156 (0x9c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/Scope/Block_L30C17,
 				[1] bool,
 				[2] object,
-				[3] object
+				[3] object[],
+				[4] object
 			)
 
 			IL_0000: ldarg.2
@@ -372,44 +373,58 @@
 			IL_0016: ldstr "null"
 			IL_001b: ret
 
-			IL_001c: ldarg.2
-			IL_001d: ldstr "phase"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0027: stloc.2
-			IL_0028: ldarg.0
-			IL_0029: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_002e: ldnull
-			IL_002f: ldloc.2
-			IL_0030: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0035: stloc.2
-			IL_0036: ldstr "{ phase: "
-			IL_003b: ldloc.2
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0041: stloc.3
-			IL_0042: ldloc.3
-			IL_0043: ldstr ", type: "
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_004d: stloc.3
-			IL_004e: ldarg.2
-			IL_004f: ldstr "type"
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0059: stloc.2
-			IL_005a: ldarg.0
-			IL_005b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0060: ldnull
-			IL_0061: ldloc.2
-			IL_0062: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0067: stloc.2
-			IL_0068: ldloc.3
-			IL_0069: ldloc.2
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006f: stloc.3
-			IL_0070: ldloc.3
-			IL_0071: ldstr " }"
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_007b: stloc.3
-			IL_007c: ldloc.3
-			IL_007d: ret
+			IL_001c: ldarg.0
+			IL_001d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0022: stloc.2
+			IL_0023: ldc.i4.1
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldarg.0
+			IL_002c: stelem.ref
+			IL_002d: stloc.3
+			IL_002e: ldloc.2
+			IL_002f: ldloc.3
+			IL_0030: ldarg.2
+			IL_0031: ldstr "phase"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0040: stloc.2
+			IL_0041: ldstr "{ phase: "
+			IL_0046: ldloc.2
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004c: stloc.s 4
+			IL_004e: ldloc.s 4
+			IL_0050: ldstr ", type: "
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005a: stloc.s 4
+			IL_005c: ldarg.0
+			IL_005d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0062: stloc.2
+			IL_0063: ldc.i4.1
+			IL_0064: newarr [System.Runtime]System.Object
+			IL_0069: dup
+			IL_006a: ldc.i4.0
+			IL_006b: ldarg.0
+			IL_006c: stelem.ref
+			IL_006d: stloc.3
+			IL_006e: ldloc.2
+			IL_006f: ldloc.3
+			IL_0070: ldarg.2
+			IL_0071: ldstr "type"
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0080: stloc.2
+			IL_0081: ldloc.s 4
+			IL_0083: ldloc.2
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0089: stloc.s 4
+			IL_008b: ldloc.s 4
+			IL_008d: ldstr " }"
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0097: stloc.s 4
+			IL_0099: ldloc.s 4
+			IL_009b: ret
 		} // end of method formatNegative::__js_call__
 
 	} // end of class formatNegative
@@ -429,7 +444,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5cee
+					// Method begins at RVA 0x64f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -447,7 +462,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ce5
+				// Method begins at RVA 0x64ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -474,15 +489,16 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2a9c
+			// Method begins at RVA 0x2ac4
 			// Header size: 12
-			// Code size: 172 (0xac)
+			// Code size: 217 (0xd9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/Scope/Block_L40C14,
 				[1] bool,
 				[2] object,
-				[3] object
+				[3] object[],
+				[4] object
 			)
 
 			IL_0000: ldarg.2
@@ -498,62 +514,83 @@
 			IL_0016: ldstr "null"
 			IL_001b: ret
 
-			IL_001c: ldarg.2
-			IL_001d: ldstr "code"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0027: stloc.2
-			IL_0028: ldarg.0
-			IL_0029: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_002e: ldnull
-			IL_002f: ldloc.2
-			IL_0030: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0035: stloc.2
-			IL_0036: ldstr "{ code: "
-			IL_003b: ldloc.2
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0041: stloc.3
-			IL_0042: ldloc.3
-			IL_0043: ldstr ", source: "
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_004d: stloc.3
-			IL_004e: ldarg.2
-			IL_004f: ldstr "source"
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0059: stloc.2
-			IL_005a: ldarg.0
-			IL_005b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0060: ldnull
-			IL_0061: ldloc.2
-			IL_0062: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0067: stloc.2
-			IL_0068: ldloc.3
-			IL_0069: ldloc.2
-			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_006f: stloc.3
-			IL_0070: ldloc.3
-			IL_0071: ldstr ", reason: "
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_007b: stloc.3
-			IL_007c: ldarg.2
-			IL_007d: ldstr "reason"
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0087: stloc.2
-			IL_0088: ldarg.0
-			IL_0089: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_008e: ldnull
-			IL_008f: ldloc.2
-			IL_0090: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0095: stloc.2
-			IL_0096: ldloc.3
-			IL_0097: ldloc.2
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_009d: stloc.3
-			IL_009e: ldloc.3
-			IL_009f: ldstr " }"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a9: stloc.3
-			IL_00aa: ldloc.3
-			IL_00ab: ret
+			IL_001c: ldarg.0
+			IL_001d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0022: stloc.2
+			IL_0023: ldc.i4.1
+			IL_0024: newarr [System.Runtime]System.Object
+			IL_0029: dup
+			IL_002a: ldc.i4.0
+			IL_002b: ldarg.0
+			IL_002c: stelem.ref
+			IL_002d: stloc.3
+			IL_002e: ldloc.2
+			IL_002f: ldloc.3
+			IL_0030: ldarg.2
+			IL_0031: ldstr "code"
+			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0040: stloc.2
+			IL_0041: ldstr "{ code: "
+			IL_0046: ldloc.2
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_004c: stloc.s 4
+			IL_004e: ldloc.s 4
+			IL_0050: ldstr ", source: "
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005a: stloc.s 4
+			IL_005c: ldarg.0
+			IL_005d: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0062: stloc.2
+			IL_0063: ldc.i4.1
+			IL_0064: newarr [System.Runtime]System.Object
+			IL_0069: dup
+			IL_006a: ldc.i4.0
+			IL_006b: ldarg.0
+			IL_006c: stelem.ref
+			IL_006d: stloc.3
+			IL_006e: ldloc.2
+			IL_006f: ldloc.3
+			IL_0070: ldarg.2
+			IL_0071: ldstr "source"
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0080: stloc.2
+			IL_0081: ldloc.s 4
+			IL_0083: ldloc.2
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0089: stloc.s 4
+			IL_008b: ldloc.s 4
+			IL_008d: ldstr ", reason: "
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0097: stloc.s 4
+			IL_0099: ldarg.0
+			IL_009a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_009f: stloc.2
+			IL_00a0: ldc.i4.1
+			IL_00a1: newarr [System.Runtime]System.Object
+			IL_00a6: dup
+			IL_00a7: ldc.i4.0
+			IL_00a8: ldarg.0
+			IL_00a9: stelem.ref
+			IL_00aa: stloc.3
+			IL_00ab: ldloc.2
+			IL_00ac: ldloc.3
+			IL_00ad: ldarg.2
+			IL_00ae: ldstr "reason"
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00bd: stloc.2
+			IL_00be: ldloc.s 4
+			IL_00c0: ldloc.2
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00c6: stloc.s 4
+			IL_00c8: ldloc.s 4
+			IL_00ca: ldstr " }"
+			IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00d4: stloc.s 4
+			IL_00d6: ldloc.s 4
+			IL_00d8: ret
 		} // end of method formatIssue::__js_call__
 
 	} // end of class formatIssue
@@ -569,7 +606,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5cf7
+				// Method begins at RVA 0x64ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -597,1071 +634,1443 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1f 00 00 02
 			)
-			// Method begins at RVA 0x2b54
+			// Method begins at RVA 0x2bac
 			// Header size: 12
-			// Code size: 3248 (0xcb0)
+			// Code size: 3831 (0xef7)
 			.maxstack 8
 			.locals init (
-				[0] object,
-				[1] object
+				[0] object[],
+				[1] object,
+				[2] object
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0006: ldnull
-			IL_0007: ldarg.2
-			IL_0008: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_000d: stloc.0
-			IL_000e: ldstr "name: "
-			IL_0013: ldloc.0
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0019: stloc.1
-			IL_001a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_001f: ldloc.1
-			IL_0020: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0025: pop
-			IL_0026: ldarg.3
-			IL_0027: ldstr "filePath"
-			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0031: stloc.0
-			IL_0032: ldarg.0
-			IL_0033: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0038: ldnull
-			IL_0039: ldloc.0
-			IL_003a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_003f: stloc.0
-			IL_0040: ldstr "filePath: "
-			IL_0045: ldloc.0
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_004b: stloc.1
-			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0051: ldloc.1
-			IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0057: pop
-			IL_0058: ldarg.3
-			IL_0059: ldstr "fileName"
-			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0063: stloc.0
-			IL_0064: ldarg.0
-			IL_0065: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_006a: ldnull
-			IL_006b: ldloc.0
-			IL_006c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0071: stloc.0
-			IL_0072: ldstr "fileName: "
-			IL_0077: ldloc.0
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_007d: stloc.1
-			IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0083: ldloc.1
-			IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0089: pop
-			IL_008a: ldarg.3
-			IL_008b: ldstr "hasFrontmatter"
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0095: stloc.0
-			IL_0096: ldarg.0
-			IL_0097: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_009c: ldnull
-			IL_009d: ldloc.0
-			IL_009e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_00a3: stloc.0
-			IL_00a4: ldstr "hasFrontmatter: "
-			IL_00a9: ldloc.0
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00af: stloc.1
-			IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00b5: ldloc.1
-			IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bb: pop
-			IL_00bc: ldarg.3
-			IL_00bd: ldstr "unknownKeys"
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c7: ldstr "length"
-			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d1: stloc.0
-			IL_00d2: ldarg.0
-			IL_00d3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_00d8: ldnull
-			IL_00d9: ldloc.0
-			IL_00da: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_00df: stloc.0
-			IL_00e0: ldstr "unknownKeys.length: "
-			IL_00e5: ldloc.0
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00eb: stloc.1
-			IL_00ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00f1: ldloc.1
-			IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00f7: pop
-			IL_00f8: ldarg.3
-			IL_00f9: ldstr "unknownKeys"
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0103: ldc.r8 0.0
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0111: stloc.0
-			IL_0112: ldarg.0
-			IL_0113: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0118: ldnull
-			IL_0119: ldloc.0
-			IL_011a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_011f: stloc.0
-			IL_0120: ldstr "unknownKeys[0]: "
-			IL_0125: ldloc.0
-			IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_012b: stloc.1
-			IL_012c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0131: ldloc.1
-			IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0137: pop
-			IL_0138: ldarg.3
-			IL_0139: ldstr "description"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0143: stloc.0
-			IL_0144: ldarg.0
-			IL_0145: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_014a: ldnull
-			IL_014b: ldloc.0
-			IL_014c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0151: stloc.0
-			IL_0152: ldstr "description: "
-			IL_0157: ldloc.0
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_015d: stloc.1
-			IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0163: ldloc.1
-			IL_0164: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0169: pop
-			IL_016a: ldarg.3
-			IL_016b: ldstr "info"
-			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0175: stloc.0
-			IL_0176: ldarg.0
-			IL_0177: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_017c: ldnull
-			IL_017d: ldloc.0
-			IL_017e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0183: stloc.0
-			IL_0184: ldstr "info: "
-			IL_0189: ldloc.0
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_018f: stloc.1
-			IL_0190: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0195: ldloc.1
-			IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_019b: pop
-			IL_019c: ldarg.3
-			IL_019d: ldstr "esid"
-			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a7: stloc.0
-			IL_01a8: ldarg.0
-			IL_01a9: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_01ae: ldnull
-			IL_01af: ldloc.0
-			IL_01b0: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_01b5: stloc.0
-			IL_01b6: ldstr "esid: "
-			IL_01bb: ldloc.0
-			IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01c1: stloc.1
-			IL_01c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01c7: ldloc.1
-			IL_01c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01cd: pop
-			IL_01ce: ldarg.3
-			IL_01cf: ldstr "es5id"
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d9: stloc.0
-			IL_01da: ldarg.0
-			IL_01db: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_01e0: ldnull
-			IL_01e1: ldloc.0
-			IL_01e2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_01e7: stloc.0
-			IL_01e8: ldstr "es5id: "
-			IL_01ed: ldloc.0
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01f3: stloc.1
-			IL_01f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01f9: ldloc.1
-			IL_01fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01ff: pop
-			IL_0200: ldarg.3
-			IL_0201: ldstr "includes"
-			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_020b: ldstr "length"
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0215: stloc.0
-			IL_0216: ldarg.0
-			IL_0217: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_021c: ldnull
-			IL_021d: ldloc.0
-			IL_021e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0223: stloc.0
-			IL_0224: ldstr "includes.length: "
-			IL_0229: ldloc.0
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_022f: stloc.1
-			IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0235: ldloc.1
-			IL_0236: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_023b: pop
-			IL_023c: ldarg.3
-			IL_023d: ldstr "includes"
-			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0247: ldc.r8 0.0
-			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0255: stloc.0
-			IL_0256: ldarg.0
-			IL_0257: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_025c: ldnull
-			IL_025d: ldloc.0
-			IL_025e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0263: stloc.0
-			IL_0264: ldstr "includes[0]: "
-			IL_0269: ldloc.0
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_026f: stloc.1
-			IL_0270: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0275: ldloc.1
-			IL_0276: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_027b: pop
-			IL_027c: ldarg.3
-			IL_027d: ldstr "includes"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0287: ldc.r8 1
-			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0295: stloc.0
-			IL_0296: ldarg.0
-			IL_0297: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_029c: ldnull
-			IL_029d: ldloc.0
-			IL_029e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_02a3: stloc.0
-			IL_02a4: ldstr "includes[1]: "
-			IL_02a9: ldloc.0
-			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02af: stloc.1
-			IL_02b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02b5: ldloc.1
-			IL_02b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02bb: pop
-			IL_02bc: ldarg.3
-			IL_02bd: ldstr "flags"
-			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02c7: ldstr "length"
-			IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02d1: stloc.0
-			IL_02d2: ldarg.0
-			IL_02d3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_02d8: ldnull
-			IL_02d9: ldloc.0
-			IL_02da: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_02df: stloc.0
-			IL_02e0: ldstr "flags.length: "
-			IL_02e5: ldloc.0
-			IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02eb: stloc.1
-			IL_02ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02f1: ldloc.1
-			IL_02f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02f7: pop
-			IL_02f8: ldarg.3
-			IL_02f9: ldstr "flags"
-			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0303: ldc.r8 0.0
-			IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.0
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0011: ldloc.0
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: stloc.1
+			IL_0019: ldstr "name: "
+			IL_001e: ldloc.1
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0024: stloc.2
+			IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_002a: ldloc.2
+			IL_002b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0030: pop
+			IL_0031: ldarg.0
+			IL_0032: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0037: stloc.1
+			IL_0038: ldc.i4.1
+			IL_0039: newarr [System.Runtime]System.Object
+			IL_003e: dup
+			IL_003f: ldc.i4.0
+			IL_0040: ldarg.0
+			IL_0041: stelem.ref
+			IL_0042: stloc.0
+			IL_0043: ldloc.1
+			IL_0044: ldloc.0
+			IL_0045: ldarg.3
+			IL_0046: ldstr "filePath"
+			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0055: stloc.1
+			IL_0056: ldstr "filePath: "
+			IL_005b: ldloc.1
+			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0061: stloc.2
+			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0067: ldloc.2
+			IL_0068: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_006d: pop
+			IL_006e: ldarg.0
+			IL_006f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0074: stloc.1
+			IL_0075: ldc.i4.1
+			IL_0076: newarr [System.Runtime]System.Object
+			IL_007b: dup
+			IL_007c: ldc.i4.0
+			IL_007d: ldarg.0
+			IL_007e: stelem.ref
+			IL_007f: stloc.0
+			IL_0080: ldloc.1
+			IL_0081: ldloc.0
+			IL_0082: ldarg.3
+			IL_0083: ldstr "fileName"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0092: stloc.1
+			IL_0093: ldstr "fileName: "
+			IL_0098: ldloc.1
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_009e: stloc.2
+			IL_009f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00a4: ldloc.2
+			IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00aa: pop
+			IL_00ab: ldarg.0
+			IL_00ac: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_00b1: stloc.1
+			IL_00b2: ldc.i4.1
+			IL_00b3: newarr [System.Runtime]System.Object
+			IL_00b8: dup
+			IL_00b9: ldc.i4.0
+			IL_00ba: ldarg.0
+			IL_00bb: stelem.ref
+			IL_00bc: stloc.0
+			IL_00bd: ldloc.1
+			IL_00be: ldloc.0
+			IL_00bf: ldarg.3
+			IL_00c0: ldstr "hasFrontmatter"
+			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00cf: stloc.1
+			IL_00d0: ldstr "hasFrontmatter: "
+			IL_00d5: ldloc.1
+			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00db: stloc.2
+			IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00e1: ldloc.2
+			IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00e7: pop
+			IL_00e8: ldarg.0
+			IL_00e9: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_00ee: stloc.1
+			IL_00ef: ldc.i4.1
+			IL_00f0: newarr [System.Runtime]System.Object
+			IL_00f5: dup
+			IL_00f6: ldc.i4.0
+			IL_00f7: ldarg.0
+			IL_00f8: stelem.ref
+			IL_00f9: stloc.0
+			IL_00fa: ldloc.1
+			IL_00fb: ldloc.0
+			IL_00fc: ldarg.3
+			IL_00fd: ldstr "unknownKeys"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0107: ldstr "length"
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0116: stloc.1
+			IL_0117: ldstr "unknownKeys.length: "
+			IL_011c: ldloc.1
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0122: stloc.2
+			IL_0123: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0128: ldloc.2
+			IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_012e: pop
+			IL_012f: ldarg.0
+			IL_0130: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0135: stloc.1
+			IL_0136: ldc.i4.1
+			IL_0137: newarr [System.Runtime]System.Object
+			IL_013c: dup
+			IL_013d: ldc.i4.0
+			IL_013e: ldarg.0
+			IL_013f: stelem.ref
+			IL_0140: stloc.0
+			IL_0141: ldloc.1
+			IL_0142: ldloc.0
+			IL_0143: ldarg.3
+			IL_0144: ldstr "unknownKeys"
+			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014e: ldc.r8 0.0
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0161: stloc.1
+			IL_0162: ldstr "unknownKeys[0]: "
+			IL_0167: ldloc.1
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_016d: stloc.2
+			IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0173: ldloc.2
+			IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0179: pop
+			IL_017a: ldarg.0
+			IL_017b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0180: stloc.1
+			IL_0181: ldc.i4.1
+			IL_0182: newarr [System.Runtime]System.Object
+			IL_0187: dup
+			IL_0188: ldc.i4.0
+			IL_0189: ldarg.0
+			IL_018a: stelem.ref
+			IL_018b: stloc.0
+			IL_018c: ldloc.1
+			IL_018d: ldloc.0
+			IL_018e: ldarg.3
+			IL_018f: ldstr "description"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_019e: stloc.1
+			IL_019f: ldstr "description: "
+			IL_01a4: ldloc.1
+			IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01aa: stloc.2
+			IL_01ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01b0: ldloc.2
+			IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01b6: pop
+			IL_01b7: ldarg.0
+			IL_01b8: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_01bd: stloc.1
+			IL_01be: ldc.i4.1
+			IL_01bf: newarr [System.Runtime]System.Object
+			IL_01c4: dup
+			IL_01c5: ldc.i4.0
+			IL_01c6: ldarg.0
+			IL_01c7: stelem.ref
+			IL_01c8: stloc.0
+			IL_01c9: ldloc.1
+			IL_01ca: ldloc.0
+			IL_01cb: ldarg.3
+			IL_01cc: ldstr "info"
+			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_01db: stloc.1
+			IL_01dc: ldstr "info: "
+			IL_01e1: ldloc.1
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01e7: stloc.2
+			IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01ed: ldloc.2
+			IL_01ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01f3: pop
+			IL_01f4: ldarg.0
+			IL_01f5: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_01fa: stloc.1
+			IL_01fb: ldc.i4.1
+			IL_01fc: newarr [System.Runtime]System.Object
+			IL_0201: dup
+			IL_0202: ldc.i4.0
+			IL_0203: ldarg.0
+			IL_0204: stelem.ref
+			IL_0205: stloc.0
+			IL_0206: ldloc.1
+			IL_0207: ldloc.0
+			IL_0208: ldarg.3
+			IL_0209: ldstr "esid"
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0218: stloc.1
+			IL_0219: ldstr "esid: "
+			IL_021e: ldloc.1
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0224: stloc.2
+			IL_0225: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_022a: ldloc.2
+			IL_022b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0230: pop
+			IL_0231: ldarg.0
+			IL_0232: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0237: stloc.1
+			IL_0238: ldc.i4.1
+			IL_0239: newarr [System.Runtime]System.Object
+			IL_023e: dup
+			IL_023f: ldc.i4.0
+			IL_0240: ldarg.0
+			IL_0241: stelem.ref
+			IL_0242: stloc.0
+			IL_0243: ldloc.1
+			IL_0244: ldloc.0
+			IL_0245: ldarg.3
+			IL_0246: ldstr "es5id"
+			IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0255: stloc.1
+			IL_0256: ldstr "es5id: "
+			IL_025b: ldloc.1
+			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0261: stloc.2
+			IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0267: ldloc.2
+			IL_0268: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_026d: pop
+			IL_026e: ldarg.0
+			IL_026f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0274: stloc.1
+			IL_0275: ldc.i4.1
+			IL_0276: newarr [System.Runtime]System.Object
+			IL_027b: dup
+			IL_027c: ldc.i4.0
+			IL_027d: ldarg.0
+			IL_027e: stelem.ref
+			IL_027f: stloc.0
+			IL_0280: ldloc.1
+			IL_0281: ldloc.0
+			IL_0282: ldarg.3
+			IL_0283: ldstr "includes"
+			IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028d: ldstr "length"
+			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_029c: stloc.1
+			IL_029d: ldstr "includes.length: "
+			IL_02a2: ldloc.1
+			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02a8: stloc.2
+			IL_02a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02ae: ldloc.2
+			IL_02af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02b4: pop
+			IL_02b5: ldarg.0
+			IL_02b6: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_02bb: stloc.1
+			IL_02bc: ldc.i4.1
+			IL_02bd: newarr [System.Runtime]System.Object
+			IL_02c2: dup
+			IL_02c3: ldc.i4.0
+			IL_02c4: ldarg.0
+			IL_02c5: stelem.ref
+			IL_02c6: stloc.0
+			IL_02c7: ldloc.1
+			IL_02c8: ldloc.0
+			IL_02c9: ldarg.3
+			IL_02ca: ldstr "includes"
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02d4: ldc.r8 0.0
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_02e7: stloc.1
+			IL_02e8: ldstr "includes[0]: "
+			IL_02ed: ldloc.1
+			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02f3: stloc.2
+			IL_02f4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f9: ldloc.2
+			IL_02fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02ff: pop
+			IL_0300: ldarg.0
+			IL_0301: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0306: stloc.1
+			IL_0307: ldc.i4.1
+			IL_0308: newarr [System.Runtime]System.Object
+			IL_030d: dup
+			IL_030e: ldc.i4.0
+			IL_030f: ldarg.0
+			IL_0310: stelem.ref
 			IL_0311: stloc.0
-			IL_0312: ldarg.0
-			IL_0313: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0318: ldnull
-			IL_0319: ldloc.0
-			IL_031a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_031f: stloc.0
-			IL_0320: ldstr "flags[0]: "
-			IL_0325: ldloc.0
-			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_032b: stloc.1
-			IL_032c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0331: ldloc.1
-			IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0337: pop
-			IL_0338: ldarg.3
-			IL_0339: ldstr "flags"
-			IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0343: ldc.r8 1
-			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0351: stloc.0
-			IL_0352: ldarg.0
-			IL_0353: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0358: ldnull
-			IL_0359: ldloc.0
-			IL_035a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_035f: stloc.0
-			IL_0360: ldstr "flags[1]: "
-			IL_0365: ldloc.0
-			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_036b: stloc.1
-			IL_036c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0371: ldloc.1
-			IL_0372: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0377: pop
-			IL_0378: ldarg.3
-			IL_0379: ldstr "flags"
-			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0383: ldc.r8 2
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0391: stloc.0
+			IL_0312: ldloc.1
+			IL_0313: ldloc.0
+			IL_0314: ldarg.3
+			IL_0315: ldstr "includes"
+			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_031f: ldc.r8 1
+			IL_0328: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0332: stloc.1
+			IL_0333: ldstr "includes[1]: "
+			IL_0338: ldloc.1
+			IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_033e: stloc.2
+			IL_033f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0344: ldloc.2
+			IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_034a: pop
+			IL_034b: ldarg.0
+			IL_034c: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0351: stloc.1
+			IL_0352: ldc.i4.1
+			IL_0353: newarr [System.Runtime]System.Object
+			IL_0358: dup
+			IL_0359: ldc.i4.0
+			IL_035a: ldarg.0
+			IL_035b: stelem.ref
+			IL_035c: stloc.0
+			IL_035d: ldloc.1
+			IL_035e: ldloc.0
+			IL_035f: ldarg.3
+			IL_0360: ldstr "flags"
+			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036a: ldstr "length"
+			IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0379: stloc.1
+			IL_037a: ldstr "flags.length: "
+			IL_037f: ldloc.1
+			IL_0380: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0385: stloc.2
+			IL_0386: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_038b: ldloc.2
+			IL_038c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0391: pop
 			IL_0392: ldarg.0
-			IL_0393: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0398: ldnull
-			IL_0399: ldloc.0
-			IL_039a: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_039f: stloc.0
-			IL_03a0: ldstr "flags[2]: "
+			IL_0393: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0398: stloc.1
+			IL_0399: ldc.i4.1
+			IL_039a: newarr [System.Runtime]System.Object
+			IL_039f: dup
+			IL_03a0: ldc.i4.0
+			IL_03a1: ldarg.0
+			IL_03a2: stelem.ref
+			IL_03a3: stloc.0
+			IL_03a4: ldloc.1
 			IL_03a5: ldloc.0
-			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03ab: stloc.1
-			IL_03ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03b1: ldloc.1
-			IL_03b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03b7: pop
-			IL_03b8: ldarg.3
-			IL_03b9: ldstr "features"
-			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c3: ldstr "length"
-			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03cd: stloc.0
-			IL_03ce: ldarg.0
-			IL_03cf: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_03d4: ldnull
-			IL_03d5: ldloc.0
-			IL_03d6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_03db: stloc.0
-			IL_03dc: ldstr "features.length: "
-			IL_03e1: ldloc.0
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03e7: stloc.1
-			IL_03e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03ed: ldloc.1
-			IL_03ee: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03f3: pop
-			IL_03f4: ldarg.3
-			IL_03f5: ldstr "features"
-			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ff: ldc.r8 0.0
-			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_040d: stloc.0
-			IL_040e: ldarg.0
-			IL_040f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0414: ldnull
-			IL_0415: ldloc.0
-			IL_0416: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_041b: stloc.0
-			IL_041c: ldstr "features[0]: "
-			IL_0421: ldloc.0
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0427: stloc.1
-			IL_0428: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_042d: ldloc.1
-			IL_042e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0433: pop
-			IL_0434: ldarg.3
-			IL_0435: ldstr "features"
-			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_043f: ldc.r8 1
-			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_044d: stloc.0
-			IL_044e: ldarg.0
-			IL_044f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0454: ldnull
-			IL_0455: ldloc.0
-			IL_0456: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_045b: stloc.0
-			IL_045c: ldstr "features[1]: "
-			IL_0461: ldloc.0
-			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0467: stloc.1
-			IL_0468: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_046d: ldloc.1
-			IL_046e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0473: pop
-			IL_0474: ldarg.3
-			IL_0475: ldstr "locale"
-			IL_047a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_047f: ldstr "length"
-			IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0489: stloc.0
-			IL_048a: ldarg.0
-			IL_048b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0490: ldnull
-			IL_0491: ldloc.0
-			IL_0492: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0497: stloc.0
-			IL_0498: ldstr "locale.length: "
-			IL_049d: ldloc.0
-			IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04a3: stloc.1
-			IL_04a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04a9: ldloc.1
-			IL_04aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04af: pop
-			IL_04b0: ldarg.3
-			IL_04b1: ldstr "locale"
-			IL_04b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04bb: ldc.r8 0.0
-			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_04c9: stloc.0
-			IL_04ca: ldarg.0
-			IL_04cb: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_04d0: ldnull
-			IL_04d1: ldloc.0
-			IL_04d2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_04d7: stloc.0
-			IL_04d8: ldstr "locale[0]: "
-			IL_04dd: ldloc.0
-			IL_04de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04e3: stloc.1
-			IL_04e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04e9: ldloc.1
-			IL_04ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04ef: pop
-			IL_04f0: ldarg.3
-			IL_04f1: ldstr "defines"
-			IL_04f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04fb: ldstr "length"
-			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0505: stloc.0
-			IL_0506: ldarg.0
-			IL_0507: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_050c: ldnull
-			IL_050d: ldloc.0
-			IL_050e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0513: stloc.0
-			IL_0514: ldstr "defines.length: "
-			IL_0519: ldloc.0
-			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_051f: stloc.1
-			IL_0520: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0525: ldloc.1
-			IL_0526: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_052b: pop
-			IL_052c: ldarg.3
-			IL_052d: ldstr "defines"
-			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0537: ldc.r8 0.0
-			IL_0540: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0545: stloc.0
-			IL_0546: ldarg.0
-			IL_0547: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_054c: ldnull
-			IL_054d: ldloc.0
-			IL_054e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0553: stloc.0
-			IL_0554: ldstr "defines[0]: "
-			IL_0559: ldloc.0
-			IL_055a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_055f: stloc.1
-			IL_0560: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0565: ldloc.1
-			IL_0566: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_056b: pop
-			IL_056c: ldarg.3
-			IL_056d: ldstr "negative"
-			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0577: stloc.0
-			IL_0578: ldarg.0
-			IL_0579: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_057e: ldnull
-			IL_057f: ldloc.0
-			IL_0580: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0585: stloc.0
-			IL_0586: ldstr "negative: "
-			IL_058b: ldloc.0
-			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0591: stloc.1
-			IL_0592: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0597: ldloc.1
-			IL_0598: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_059d: pop
-			IL_059e: ldarg.3
-			IL_059f: ldstr "execution"
-			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05a9: ldstr "sourceType"
-			IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05b3: stloc.0
-			IL_05b4: ldarg.0
-			IL_05b5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_05ba: ldnull
-			IL_05bb: ldloc.0
-			IL_05bc: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_05c1: stloc.0
-			IL_05c2: ldstr "execution.sourceType: "
-			IL_05c7: ldloc.0
-			IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_05cd: stloc.1
-			IL_05ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05d3: ldloc.1
-			IL_05d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05d9: pop
-			IL_05da: ldarg.3
-			IL_05db: ldstr "execution"
-			IL_05e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e5: ldstr "strictMode"
-			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05ef: stloc.0
-			IL_05f0: ldarg.0
-			IL_05f1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_05f6: ldnull
-			IL_05f7: ldloc.0
-			IL_05f8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_05fd: stloc.0
-			IL_05fe: ldstr "execution.strictMode: "
-			IL_0603: ldloc.0
-			IL_0604: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0609: stloc.1
-			IL_060a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_060f: ldloc.1
-			IL_0610: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0615: pop
-			IL_0616: ldarg.3
-			IL_0617: ldstr "execution"
-			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0621: ldstr "defaultHarnessIncludes"
-			IL_0626: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_062b: ldstr "length"
-			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0635: stloc.0
-			IL_0636: ldarg.0
-			IL_0637: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_063c: ldnull
-			IL_063d: ldloc.0
-			IL_063e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0643: stloc.0
-			IL_0644: ldstr "execution.defaultHarnessIncludes.length: "
-			IL_0649: ldloc.0
-			IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_064f: stloc.1
-			IL_0650: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0655: ldloc.1
-			IL_0656: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_065b: pop
-			IL_065c: ldarg.3
-			IL_065d: ldstr "execution"
-			IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0667: ldstr "defaultHarnessIncludes"
-			IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0671: ldc.r8 0.0
-			IL_067a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_067f: stloc.0
-			IL_0680: ldarg.0
-			IL_0681: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0686: ldnull
+			IL_03a6: ldarg.3
+			IL_03a7: ldstr "flags"
+			IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03b1: ldc.r8 0.0
+			IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03c4: stloc.1
+			IL_03c5: ldstr "flags[0]: "
+			IL_03ca: ldloc.1
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_03d0: stloc.2
+			IL_03d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03d6: ldloc.2
+			IL_03d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03dc: pop
+			IL_03dd: ldarg.0
+			IL_03de: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_03e3: stloc.1
+			IL_03e4: ldc.i4.1
+			IL_03e5: newarr [System.Runtime]System.Object
+			IL_03ea: dup
+			IL_03eb: ldc.i4.0
+			IL_03ec: ldarg.0
+			IL_03ed: stelem.ref
+			IL_03ee: stloc.0
+			IL_03ef: ldloc.1
+			IL_03f0: ldloc.0
+			IL_03f1: ldarg.3
+			IL_03f2: ldstr "flags"
+			IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fc: ldc.r8 1
+			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_040a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_040f: stloc.1
+			IL_0410: ldstr "flags[1]: "
+			IL_0415: ldloc.1
+			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_041b: stloc.2
+			IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0421: ldloc.2
+			IL_0422: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0427: pop
+			IL_0428: ldarg.0
+			IL_0429: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_042e: stloc.1
+			IL_042f: ldc.i4.1
+			IL_0430: newarr [System.Runtime]System.Object
+			IL_0435: dup
+			IL_0436: ldc.i4.0
+			IL_0437: ldarg.0
+			IL_0438: stelem.ref
+			IL_0439: stloc.0
+			IL_043a: ldloc.1
+			IL_043b: ldloc.0
+			IL_043c: ldarg.3
+			IL_043d: ldstr "flags"
+			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0447: ldc.r8 2
+			IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0455: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_045a: stloc.1
+			IL_045b: ldstr "flags[2]: "
+			IL_0460: ldloc.1
+			IL_0461: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0466: stloc.2
+			IL_0467: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_046c: ldloc.2
+			IL_046d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0472: pop
+			IL_0473: ldarg.0
+			IL_0474: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0479: stloc.1
+			IL_047a: ldc.i4.1
+			IL_047b: newarr [System.Runtime]System.Object
+			IL_0480: dup
+			IL_0481: ldc.i4.0
+			IL_0482: ldarg.0
+			IL_0483: stelem.ref
+			IL_0484: stloc.0
+			IL_0485: ldloc.1
+			IL_0486: ldloc.0
+			IL_0487: ldarg.3
+			IL_0488: ldstr "features"
+			IL_048d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0492: ldstr "length"
+			IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_04a1: stloc.1
+			IL_04a2: ldstr "features.length: "
+			IL_04a7: ldloc.1
+			IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04ad: stloc.2
+			IL_04ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04b3: ldloc.2
+			IL_04b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04b9: pop
+			IL_04ba: ldarg.0
+			IL_04bb: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_04c0: stloc.1
+			IL_04c1: ldc.i4.1
+			IL_04c2: newarr [System.Runtime]System.Object
+			IL_04c7: dup
+			IL_04c8: ldc.i4.0
+			IL_04c9: ldarg.0
+			IL_04ca: stelem.ref
+			IL_04cb: stloc.0
+			IL_04cc: ldloc.1
+			IL_04cd: ldloc.0
+			IL_04ce: ldarg.3
+			IL_04cf: ldstr "features"
+			IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04d9: ldc.r8 0.0
+			IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_04ec: stloc.1
+			IL_04ed: ldstr "features[0]: "
+			IL_04f2: ldloc.1
+			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04f8: stloc.2
+			IL_04f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04fe: ldloc.2
+			IL_04ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0504: pop
+			IL_0505: ldarg.0
+			IL_0506: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_050b: stloc.1
+			IL_050c: ldc.i4.1
+			IL_050d: newarr [System.Runtime]System.Object
+			IL_0512: dup
+			IL_0513: ldc.i4.0
+			IL_0514: ldarg.0
+			IL_0515: stelem.ref
+			IL_0516: stloc.0
+			IL_0517: ldloc.1
+			IL_0518: ldloc.0
+			IL_0519: ldarg.3
+			IL_051a: ldstr "features"
+			IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0524: ldc.r8 1
+			IL_052d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0537: stloc.1
+			IL_0538: ldstr "features[1]: "
+			IL_053d: ldloc.1
+			IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0543: stloc.2
+			IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0549: ldloc.2
+			IL_054a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_054f: pop
+			IL_0550: ldarg.0
+			IL_0551: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0556: stloc.1
+			IL_0557: ldc.i4.1
+			IL_0558: newarr [System.Runtime]System.Object
+			IL_055d: dup
+			IL_055e: ldc.i4.0
+			IL_055f: ldarg.0
+			IL_0560: stelem.ref
+			IL_0561: stloc.0
+			IL_0562: ldloc.1
+			IL_0563: ldloc.0
+			IL_0564: ldarg.3
+			IL_0565: ldstr "locale"
+			IL_056a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_056f: ldstr "length"
+			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_057e: stloc.1
+			IL_057f: ldstr "locale.length: "
+			IL_0584: ldloc.1
+			IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_058a: stloc.2
+			IL_058b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0590: ldloc.2
+			IL_0591: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0596: pop
+			IL_0597: ldarg.0
+			IL_0598: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_059d: stloc.1
+			IL_059e: ldc.i4.1
+			IL_059f: newarr [System.Runtime]System.Object
+			IL_05a4: dup
+			IL_05a5: ldc.i4.0
+			IL_05a6: ldarg.0
+			IL_05a7: stelem.ref
+			IL_05a8: stloc.0
+			IL_05a9: ldloc.1
+			IL_05aa: ldloc.0
+			IL_05ab: ldarg.3
+			IL_05ac: ldstr "locale"
+			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b6: ldc.r8 0.0
+			IL_05bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_05c9: stloc.1
+			IL_05ca: ldstr "locale[0]: "
+			IL_05cf: ldloc.1
+			IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05d5: stloc.2
+			IL_05d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_05db: ldloc.2
+			IL_05dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05e1: pop
+			IL_05e2: ldarg.0
+			IL_05e3: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_05e8: stloc.1
+			IL_05e9: ldc.i4.1
+			IL_05ea: newarr [System.Runtime]System.Object
+			IL_05ef: dup
+			IL_05f0: ldc.i4.0
+			IL_05f1: ldarg.0
+			IL_05f2: stelem.ref
+			IL_05f3: stloc.0
+			IL_05f4: ldloc.1
+			IL_05f5: ldloc.0
+			IL_05f6: ldarg.3
+			IL_05f7: ldstr "defines"
+			IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0601: ldstr "length"
+			IL_0606: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_060b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0610: stloc.1
+			IL_0611: ldstr "defines.length: "
+			IL_0616: ldloc.1
+			IL_0617: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_061c: stloc.2
+			IL_061d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0622: ldloc.2
+			IL_0623: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0628: pop
+			IL_0629: ldarg.0
+			IL_062a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_062f: stloc.1
+			IL_0630: ldc.i4.1
+			IL_0631: newarr [System.Runtime]System.Object
+			IL_0636: dup
+			IL_0637: ldc.i4.0
+			IL_0638: ldarg.0
+			IL_0639: stelem.ref
+			IL_063a: stloc.0
+			IL_063b: ldloc.1
+			IL_063c: ldloc.0
+			IL_063d: ldarg.3
+			IL_063e: ldstr "defines"
+			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0648: ldc.r8 0.0
+			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_065b: stloc.1
+			IL_065c: ldstr "defines[0]: "
+			IL_0661: ldloc.1
+			IL_0662: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0667: stloc.2
+			IL_0668: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_066d: ldloc.2
+			IL_066e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0673: pop
+			IL_0674: ldarg.0
+			IL_0675: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatNegative
+			IL_067a: stloc.1
+			IL_067b: ldc.i4.1
+			IL_067c: newarr [System.Runtime]System.Object
+			IL_0681: dup
+			IL_0682: ldc.i4.0
+			IL_0683: ldarg.0
+			IL_0684: stelem.ref
+			IL_0685: stloc.0
+			IL_0686: ldloc.1
 			IL_0687: ldloc.0
-			IL_0688: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_068d: stloc.0
-			IL_068e: ldstr "execution.defaultHarnessIncludes[0]: "
-			IL_0693: ldloc.0
-			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0699: stloc.1
-			IL_069a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_069f: ldloc.1
-			IL_06a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06a5: pop
-			IL_06a6: ldarg.3
-			IL_06a7: ldstr "execution"
-			IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06b1: ldstr "defaultHarnessIncludes"
-			IL_06b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06bb: ldc.r8 1
-			IL_06c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_06c9: stloc.0
-			IL_06ca: ldarg.0
-			IL_06cb: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_06d0: ldnull
-			IL_06d1: ldloc.0
-			IL_06d2: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_06d7: stloc.0
-			IL_06d8: ldstr "execution.defaultHarnessIncludes[1]: "
-			IL_06dd: ldloc.0
-			IL_06de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06e3: stloc.1
-			IL_06e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06e9: ldloc.1
-			IL_06ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06ef: pop
-			IL_06f0: ldarg.3
-			IL_06f1: ldstr "execution"
-			IL_06f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06fb: ldstr "harnessIncludes"
-			IL_0700: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0705: ldstr "length"
-			IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_070f: stloc.0
-			IL_0710: ldarg.0
-			IL_0711: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0716: ldnull
-			IL_0717: ldloc.0
-			IL_0718: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_071d: stloc.0
-			IL_071e: ldstr "execution.harnessIncludes.length: "
-			IL_0723: ldloc.0
-			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0729: stloc.1
-			IL_072a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_072f: ldloc.1
-			IL_0730: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0735: pop
-			IL_0736: ldarg.3
-			IL_0737: ldstr "execution"
-			IL_073c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0741: ldstr "harnessIncludes"
-			IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_074b: ldc.r8 0.0
-			IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0759: stloc.0
-			IL_075a: ldarg.0
-			IL_075b: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0760: ldnull
-			IL_0761: ldloc.0
-			IL_0762: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0767: stloc.0
-			IL_0768: ldstr "execution.harnessIncludes[0]: "
-			IL_076d: ldloc.0
-			IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0773: stloc.1
-			IL_0774: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0779: ldloc.1
-			IL_077a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_077f: pop
-			IL_0780: ldarg.3
-			IL_0781: ldstr "execution"
-			IL_0786: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_078b: ldstr "harnessIncludes"
-			IL_0790: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0795: ldc.r8 1
-			IL_079e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_07a3: stloc.0
-			IL_07a4: ldarg.0
-			IL_07a5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_07aa: ldnull
-			IL_07ab: ldloc.0
-			IL_07ac: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_07b1: stloc.0
-			IL_07b2: ldstr "execution.harnessIncludes[1]: "
-			IL_07b7: ldloc.0
-			IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_07bd: stloc.1
-			IL_07be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07c3: ldloc.1
-			IL_07c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07c9: pop
-			IL_07ca: ldarg.3
-			IL_07cb: ldstr "execution"
-			IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07d5: ldstr "harnessIncludes"
-			IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07df: ldc.r8 2
-			IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_07ed: stloc.0
-			IL_07ee: ldarg.0
-			IL_07ef: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_07f4: ldnull
-			IL_07f5: ldloc.0
-			IL_07f6: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_07fb: stloc.0
-			IL_07fc: ldstr "execution.harnessIncludes[2]: "
-			IL_0801: ldloc.0
-			IL_0802: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0807: stloc.1
-			IL_0808: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_080d: ldloc.1
-			IL_080e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0813: pop
-			IL_0814: ldarg.3
-			IL_0815: ldstr "execution"
-			IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_081f: ldstr "harnessIncludes"
-			IL_0824: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0829: ldc.r8 3
-			IL_0832: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0837: stloc.0
-			IL_0838: ldarg.0
-			IL_0839: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_083e: ldnull
-			IL_083f: ldloc.0
-			IL_0840: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0845: stloc.0
-			IL_0846: ldstr "execution.harnessIncludes[3]: "
-			IL_084b: ldloc.0
-			IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0851: stloc.1
-			IL_0852: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0857: ldloc.1
-			IL_0858: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_085d: pop
-			IL_085e: ldarg.3
-			IL_085f: ldstr "execution"
-			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0869: ldstr "requiresDefaultHarness"
-			IL_086e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0873: stloc.0
-			IL_0874: ldarg.0
-			IL_0875: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_087a: ldnull
-			IL_087b: ldloc.0
-			IL_087c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0881: stloc.0
-			IL_0882: ldstr "execution.requiresDefaultHarness: "
-			IL_0887: ldloc.0
-			IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_088d: stloc.1
-			IL_088e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0893: ldloc.1
-			IL_0894: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0899: pop
-			IL_089a: ldarg.3
-			IL_089b: ldstr "execution"
-			IL_08a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08a5: ldstr "requiresAsyncHarness"
-			IL_08aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08af: stloc.0
-			IL_08b0: ldarg.0
-			IL_08b1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_08b6: ldnull
-			IL_08b7: ldloc.0
-			IL_08b8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_08bd: stloc.0
-			IL_08be: ldstr "execution.requiresAsyncHarness: "
-			IL_08c3: ldloc.0
-			IL_08c4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_08c9: stloc.1
-			IL_08ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_08cf: ldloc.1
-			IL_08d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_08d5: pop
-			IL_08d6: ldarg.3
-			IL_08d7: ldstr "execution"
-			IL_08dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08e1: ldstr "requiresAgent"
-			IL_08e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08eb: stloc.0
-			IL_08ec: ldarg.0
-			IL_08ed: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_08f2: ldnull
+			IL_0688: ldarg.3
+			IL_0689: ldstr "negative"
+			IL_068e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0698: stloc.1
+			IL_0699: ldstr "negative: "
+			IL_069e: ldloc.1
+			IL_069f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06a4: stloc.2
+			IL_06a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06aa: ldloc.2
+			IL_06ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06b0: pop
+			IL_06b1: ldarg.0
+			IL_06b2: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_06b7: stloc.1
+			IL_06b8: ldc.i4.1
+			IL_06b9: newarr [System.Runtime]System.Object
+			IL_06be: dup
+			IL_06bf: ldc.i4.0
+			IL_06c0: ldarg.0
+			IL_06c1: stelem.ref
+			IL_06c2: stloc.0
+			IL_06c3: ldloc.1
+			IL_06c4: ldloc.0
+			IL_06c5: ldarg.3
+			IL_06c6: ldstr "execution"
+			IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06d0: ldstr "sourceType"
+			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_06df: stloc.1
+			IL_06e0: ldstr "execution.sourceType: "
+			IL_06e5: ldloc.1
+			IL_06e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06eb: stloc.2
+			IL_06ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06f1: ldloc.2
+			IL_06f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06f7: pop
+			IL_06f8: ldarg.0
+			IL_06f9: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_06fe: stloc.1
+			IL_06ff: ldc.i4.1
+			IL_0700: newarr [System.Runtime]System.Object
+			IL_0705: dup
+			IL_0706: ldc.i4.0
+			IL_0707: ldarg.0
+			IL_0708: stelem.ref
+			IL_0709: stloc.0
+			IL_070a: ldloc.1
+			IL_070b: ldloc.0
+			IL_070c: ldarg.3
+			IL_070d: ldstr "execution"
+			IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0717: ldstr "strictMode"
+			IL_071c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0726: stloc.1
+			IL_0727: ldstr "execution.strictMode: "
+			IL_072c: ldloc.1
+			IL_072d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0732: stloc.2
+			IL_0733: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0738: ldloc.2
+			IL_0739: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_073e: pop
+			IL_073f: ldarg.0
+			IL_0740: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0745: stloc.1
+			IL_0746: ldc.i4.1
+			IL_0747: newarr [System.Runtime]System.Object
+			IL_074c: dup
+			IL_074d: ldc.i4.0
+			IL_074e: ldarg.0
+			IL_074f: stelem.ref
+			IL_0750: stloc.0
+			IL_0751: ldloc.1
+			IL_0752: ldloc.0
+			IL_0753: ldarg.3
+			IL_0754: ldstr "execution"
+			IL_0759: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_075e: ldstr "defaultHarnessIncludes"
+			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0768: ldstr "length"
+			IL_076d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0772: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0777: stloc.1
+			IL_0778: ldstr "execution.defaultHarnessIncludes.length: "
+			IL_077d: ldloc.1
+			IL_077e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0783: stloc.2
+			IL_0784: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0789: ldloc.2
+			IL_078a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_078f: pop
+			IL_0790: ldarg.0
+			IL_0791: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0796: stloc.1
+			IL_0797: ldc.i4.1
+			IL_0798: newarr [System.Runtime]System.Object
+			IL_079d: dup
+			IL_079e: ldc.i4.0
+			IL_079f: ldarg.0
+			IL_07a0: stelem.ref
+			IL_07a1: stloc.0
+			IL_07a2: ldloc.1
+			IL_07a3: ldloc.0
+			IL_07a4: ldarg.3
+			IL_07a5: ldstr "execution"
+			IL_07aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07af: ldstr "defaultHarnessIncludes"
+			IL_07b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07b9: ldc.r8 0.0
+			IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07cc: stloc.1
+			IL_07cd: ldstr "execution.defaultHarnessIncludes[0]: "
+			IL_07d2: ldloc.1
+			IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_07d8: stloc.2
+			IL_07d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07de: ldloc.2
+			IL_07df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07e4: pop
+			IL_07e5: ldarg.0
+			IL_07e6: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_07eb: stloc.1
+			IL_07ec: ldc.i4.1
+			IL_07ed: newarr [System.Runtime]System.Object
+			IL_07f2: dup
+			IL_07f3: ldc.i4.0
+			IL_07f4: ldarg.0
+			IL_07f5: stelem.ref
+			IL_07f6: stloc.0
+			IL_07f7: ldloc.1
+			IL_07f8: ldloc.0
+			IL_07f9: ldarg.3
+			IL_07fa: ldstr "execution"
+			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0804: ldstr "defaultHarnessIncludes"
+			IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080e: ldc.r8 1
+			IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_081c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0821: stloc.1
+			IL_0822: ldstr "execution.defaultHarnessIncludes[1]: "
+			IL_0827: ldloc.1
+			IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_082d: stloc.2
+			IL_082e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0833: ldloc.2
+			IL_0834: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0839: pop
+			IL_083a: ldarg.0
+			IL_083b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0840: stloc.1
+			IL_0841: ldc.i4.1
+			IL_0842: newarr [System.Runtime]System.Object
+			IL_0847: dup
+			IL_0848: ldc.i4.0
+			IL_0849: ldarg.0
+			IL_084a: stelem.ref
+			IL_084b: stloc.0
+			IL_084c: ldloc.1
+			IL_084d: ldloc.0
+			IL_084e: ldarg.3
+			IL_084f: ldstr "execution"
+			IL_0854: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0859: ldstr "harnessIncludes"
+			IL_085e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0863: ldstr "length"
+			IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_086d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0872: stloc.1
+			IL_0873: ldstr "execution.harnessIncludes.length: "
+			IL_0878: ldloc.1
+			IL_0879: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_087e: stloc.2
+			IL_087f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0884: ldloc.2
+			IL_0885: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_088a: pop
+			IL_088b: ldarg.0
+			IL_088c: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0891: stloc.1
+			IL_0892: ldc.i4.1
+			IL_0893: newarr [System.Runtime]System.Object
+			IL_0898: dup
+			IL_0899: ldc.i4.0
+			IL_089a: ldarg.0
+			IL_089b: stelem.ref
+			IL_089c: stloc.0
+			IL_089d: ldloc.1
+			IL_089e: ldloc.0
+			IL_089f: ldarg.3
+			IL_08a0: ldstr "execution"
+			IL_08a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08aa: ldstr "harnessIncludes"
+			IL_08af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08b4: ldc.r8 0.0
+			IL_08bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_08c7: stloc.1
+			IL_08c8: ldstr "execution.harnessIncludes[0]: "
+			IL_08cd: ldloc.1
+			IL_08ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_08d3: stloc.2
+			IL_08d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08d9: ldloc.2
+			IL_08da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_08df: pop
+			IL_08e0: ldarg.0
+			IL_08e1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_08e6: stloc.1
+			IL_08e7: ldc.i4.1
+			IL_08e8: newarr [System.Runtime]System.Object
+			IL_08ed: dup
+			IL_08ee: ldc.i4.0
+			IL_08ef: ldarg.0
+			IL_08f0: stelem.ref
+			IL_08f1: stloc.0
+			IL_08f2: ldloc.1
 			IL_08f3: ldloc.0
-			IL_08f4: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_08f9: stloc.0
-			IL_08fa: ldstr "execution.requiresAgent: "
-			IL_08ff: ldloc.0
-			IL_0900: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0905: stloc.1
-			IL_0906: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_090b: ldloc.1
-			IL_090c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0911: pop
-			IL_0912: ldarg.3
-			IL_0913: ldstr "execution"
-			IL_0918: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_091d: ldstr "canBlock"
-			IL_0922: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0927: stloc.0
-			IL_0928: ldarg.0
-			IL_0929: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_092e: ldnull
-			IL_092f: ldloc.0
-			IL_0930: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0935: stloc.0
-			IL_0936: ldstr "execution.canBlock: "
-			IL_093b: ldloc.0
-			IL_093c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0941: stloc.1
-			IL_0942: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_08f4: ldarg.3
+			IL_08f5: ldstr "execution"
+			IL_08fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08ff: ldstr "harnessIncludes"
+			IL_0904: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0909: ldc.r8 1
+			IL_0912: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0917: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_091c: stloc.1
+			IL_091d: ldstr "execution.harnessIncludes[1]: "
+			IL_0922: ldloc.1
+			IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0928: stloc.2
+			IL_0929: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_092e: ldloc.2
+			IL_092f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0934: pop
+			IL_0935: ldarg.0
+			IL_0936: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_093b: stloc.1
+			IL_093c: ldc.i4.1
+			IL_093d: newarr [System.Runtime]System.Object
+			IL_0942: dup
+			IL_0943: ldc.i4.0
+			IL_0944: ldarg.0
+			IL_0945: stelem.ref
+			IL_0946: stloc.0
 			IL_0947: ldloc.1
-			IL_0948: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_094d: pop
-			IL_094e: ldarg.3
-			IL_094f: ldstr "execution"
-			IL_0954: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0959: ldstr "isModule"
-			IL_095e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0963: stloc.0
-			IL_0964: ldarg.0
-			IL_0965: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_096a: ldnull
-			IL_096b: ldloc.0
-			IL_096c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0971: stloc.0
-			IL_0972: ldstr "execution.isModule: "
-			IL_0977: ldloc.0
+			IL_0948: ldloc.0
+			IL_0949: ldarg.3
+			IL_094a: ldstr "execution"
+			IL_094f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0954: ldstr "harnessIncludes"
+			IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_095e: ldc.r8 2
+			IL_0967: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0971: stloc.1
+			IL_0972: ldstr "execution.harnessIncludes[2]: "
+			IL_0977: ldloc.1
 			IL_0978: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_097d: stloc.1
+			IL_097d: stloc.2
 			IL_097e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0983: ldloc.1
+			IL_0983: ldloc.2
 			IL_0984: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0989: pop
-			IL_098a: ldarg.3
-			IL_098b: ldstr "execution"
-			IL_0990: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0995: ldstr "isRaw"
-			IL_099a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_099f: stloc.0
-			IL_09a0: ldarg.0
-			IL_09a1: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_09a6: ldnull
-			IL_09a7: ldloc.0
-			IL_09a8: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_09ad: stloc.0
-			IL_09ae: ldstr "execution.isRaw: "
-			IL_09b3: ldloc.0
-			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_09b9: stloc.1
-			IL_09ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09bf: ldloc.1
-			IL_09c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_09c5: pop
-			IL_09c6: ldarg.3
-			IL_09c7: ldstr "execution"
-			IL_09cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09d1: ldstr "isAsync"
-			IL_09d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09db: stloc.0
-			IL_09dc: ldarg.0
-			IL_09dd: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_09e2: ldnull
-			IL_09e3: ldloc.0
-			IL_09e4: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_09e9: stloc.0
-			IL_09ea: ldstr "execution.isAsync: "
-			IL_09ef: ldloc.0
-			IL_09f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_09f5: stloc.1
-			IL_09f6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_09fb: ldloc.1
-			IL_09fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a01: pop
-			IL_0a02: ldarg.3
-			IL_0a03: ldstr "execution"
-			IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a0d: ldstr "isGenerated"
-			IL_0a12: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a17: stloc.0
-			IL_0a18: ldarg.0
-			IL_0a19: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0a1e: ldnull
-			IL_0a1f: ldloc.0
-			IL_0a20: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0a25: stloc.0
-			IL_0a26: ldstr "execution.isGenerated: "
-			IL_0a2b: ldloc.0
-			IL_0a2c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a31: stloc.1
-			IL_0a32: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a37: ldloc.1
-			IL_0a38: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a3d: pop
-			IL_0a3e: ldarg.3
-			IL_0a3f: ldstr "execution"
-			IL_0a44: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a49: ldstr "isNonDeterministic"
-			IL_0a4e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a53: stloc.0
-			IL_0a54: ldarg.0
-			IL_0a55: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0a5a: ldnull
-			IL_0a5b: ldloc.0
-			IL_0a5c: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0a61: stloc.0
-			IL_0a62: ldstr "execution.isNonDeterministic: "
-			IL_0a67: ldloc.0
-			IL_0a68: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0a6d: stloc.1
-			IL_0a6e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a73: ldloc.1
-			IL_0a74: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a79: pop
-			IL_0a7a: ldarg.3
-			IL_0a7b: ldstr "execution"
-			IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a85: ldstr "isFixture"
-			IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a8f: stloc.0
-			IL_0a90: ldarg.0
-			IL_0a91: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0a96: ldnull
-			IL_0a97: ldloc.0
-			IL_0a98: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0a9d: stloc.0
-			IL_0a9e: ldstr "execution.isFixture: "
-			IL_0aa3: ldloc.0
-			IL_0aa4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0aa9: stloc.1
-			IL_0aaa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0aaf: ldloc.1
-			IL_0ab0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0ab5: pop
-			IL_0ab6: ldarg.3
-			IL_0ab7: ldstr "mvpBlockers"
-			IL_0abc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac1: ldstr "length"
-			IL_0ac6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0acb: stloc.0
-			IL_0acc: ldarg.0
-			IL_0acd: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0ad2: ldnull
-			IL_0ad3: ldloc.0
-			IL_0ad4: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0ad9: stloc.0
-			IL_0ada: ldstr "mvpBlockers.length: "
-			IL_0adf: ldloc.0
-			IL_0ae0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0ae5: stloc.1
-			IL_0ae6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0aeb: ldloc.1
-			IL_0aec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0af1: pop
-			IL_0af2: ldarg.3
-			IL_0af3: ldstr "mvpBlockers"
-			IL_0af8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0afd: ldc.r8 0.0
-			IL_0b06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b0b: stloc.0
-			IL_0b0c: ldarg.0
-			IL_0b0d: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0b12: ldnull
-			IL_0b13: ldloc.0
-			IL_0b14: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0b19: stloc.0
-			IL_0b1a: ldstr "mvpBlockers[0]: "
-			IL_0b1f: ldloc.0
-			IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b25: stloc.1
-			IL_0b26: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b2b: ldloc.1
-			IL_0b2c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b31: pop
-			IL_0b32: ldarg.3
-			IL_0b33: ldstr "mvpBlockers"
-			IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b3d: ldc.r8 1
-			IL_0b46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b4b: stloc.0
-			IL_0b4c: ldarg.0
-			IL_0b4d: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0b52: ldnull
-			IL_0b53: ldloc.0
-			IL_0b54: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0b59: stloc.0
-			IL_0b5a: ldstr "mvpBlockers[1]: "
-			IL_0b5f: ldloc.0
-			IL_0b60: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0b65: stloc.1
-			IL_0b66: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b6b: ldloc.1
-			IL_0b6c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b71: pop
-			IL_0b72: ldarg.3
-			IL_0b73: ldstr "mvpBlockers"
-			IL_0b78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b7d: ldc.r8 2
-			IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b8b: stloc.0
-			IL_0b8c: ldarg.0
-			IL_0b8d: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0b92: ldnull
-			IL_0b93: ldloc.0
-			IL_0b94: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0b99: stloc.0
-			IL_0b9a: ldstr "mvpBlockers[2]: "
-			IL_0b9f: ldloc.0
-			IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0ba5: stloc.1
-			IL_0ba6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0bab: ldloc.1
-			IL_0bac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0bb1: pop
-			IL_0bb2: ldarg.3
-			IL_0bb3: ldstr "mvpBlockers"
-			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bbd: ldc.r8 3
-			IL_0bc6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0bcb: stloc.0
-			IL_0bcc: ldarg.0
-			IL_0bcd: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0bd2: ldnull
-			IL_0bd3: ldloc.0
-			IL_0bd4: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0bd9: stloc.0
-			IL_0bda: ldstr "mvpBlockers[3]: "
-			IL_0bdf: ldloc.0
-			IL_0be0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0be5: stloc.1
-			IL_0be6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0beb: ldloc.1
-			IL_0bec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0bf1: pop
-			IL_0bf2: ldarg.3
-			IL_0bf3: ldstr "unsupported"
-			IL_0bf8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0bfd: ldstr "length"
-			IL_0c02: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c07: stloc.0
-			IL_0c08: ldarg.0
-			IL_0c09: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0c0e: ldnull
-			IL_0c0f: ldloc.0
-			IL_0c10: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0c15: stloc.0
-			IL_0c16: ldstr "unsupported.length: "
-			IL_0c1b: ldloc.0
-			IL_0c1c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0c21: stloc.1
-			IL_0c22: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0c27: ldloc.1
-			IL_0c28: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c2d: pop
-			IL_0c2e: ldarg.3
-			IL_0c2f: ldstr "unsupported"
-			IL_0c34: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c39: ldc.r8 0.0
-			IL_0c42: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c47: stloc.0
-			IL_0c48: ldarg.0
-			IL_0c49: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0c4e: ldnull
-			IL_0c4f: ldloc.0
-			IL_0c50: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0c55: stloc.0
-			IL_0c56: ldstr "unsupported[0]: "
-			IL_0c5b: ldloc.0
-			IL_0c5c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0c61: stloc.1
-			IL_0c62: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0c67: ldloc.1
-			IL_0c68: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c6d: pop
-			IL_0c6e: ldarg.3
-			IL_0c6f: ldstr "unsupported"
-			IL_0c74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c79: ldc.r8 1
-			IL_0c82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c87: stloc.0
-			IL_0c88: ldarg.0
-			IL_0c89: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-			IL_0c8e: ldnull
-			IL_0c8f: ldloc.0
-			IL_0c90: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-			IL_0c95: stloc.0
-			IL_0c96: ldstr "unsupported[1]: "
-			IL_0c9b: ldloc.0
-			IL_0c9c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0ca1: stloc.1
-			IL_0ca2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0ca7: ldloc.1
-			IL_0ca8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0cad: pop
-			IL_0cae: ldnull
-			IL_0caf: ret
+			IL_098a: ldarg.0
+			IL_098b: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0990: stloc.1
+			IL_0991: ldc.i4.1
+			IL_0992: newarr [System.Runtime]System.Object
+			IL_0997: dup
+			IL_0998: ldc.i4.0
+			IL_0999: ldarg.0
+			IL_099a: stelem.ref
+			IL_099b: stloc.0
+			IL_099c: ldloc.1
+			IL_099d: ldloc.0
+			IL_099e: ldarg.3
+			IL_099f: ldstr "execution"
+			IL_09a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09a9: ldstr "harnessIncludes"
+			IL_09ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b3: ldc.r8 3
+			IL_09bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_09c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_09c6: stloc.1
+			IL_09c7: ldstr "execution.harnessIncludes[3]: "
+			IL_09cc: ldloc.1
+			IL_09cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_09d2: stloc.2
+			IL_09d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_09d8: ldloc.2
+			IL_09d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_09de: pop
+			IL_09df: ldarg.0
+			IL_09e0: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_09e5: stloc.1
+			IL_09e6: ldc.i4.1
+			IL_09e7: newarr [System.Runtime]System.Object
+			IL_09ec: dup
+			IL_09ed: ldc.i4.0
+			IL_09ee: ldarg.0
+			IL_09ef: stelem.ref
+			IL_09f0: stloc.0
+			IL_09f1: ldloc.1
+			IL_09f2: ldloc.0
+			IL_09f3: ldarg.3
+			IL_09f4: ldstr "execution"
+			IL_09f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09fe: ldstr "requiresDefaultHarness"
+			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0a0d: stloc.1
+			IL_0a0e: ldstr "execution.requiresDefaultHarness: "
+			IL_0a13: ldloc.1
+			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a19: stloc.2
+			IL_0a1a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a1f: ldloc.2
+			IL_0a20: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a25: pop
+			IL_0a26: ldarg.0
+			IL_0a27: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0a2c: stloc.1
+			IL_0a2d: ldc.i4.1
+			IL_0a2e: newarr [System.Runtime]System.Object
+			IL_0a33: dup
+			IL_0a34: ldc.i4.0
+			IL_0a35: ldarg.0
+			IL_0a36: stelem.ref
+			IL_0a37: stloc.0
+			IL_0a38: ldloc.1
+			IL_0a39: ldloc.0
+			IL_0a3a: ldarg.3
+			IL_0a3b: ldstr "execution"
+			IL_0a40: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a45: ldstr "requiresAsyncHarness"
+			IL_0a4a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a4f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0a54: stloc.1
+			IL_0a55: ldstr "execution.requiresAsyncHarness: "
+			IL_0a5a: ldloc.1
+			IL_0a5b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0a60: stloc.2
+			IL_0a61: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0a66: ldloc.2
+			IL_0a67: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0a6c: pop
+			IL_0a6d: ldarg.0
+			IL_0a6e: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0a73: stloc.1
+			IL_0a74: ldc.i4.1
+			IL_0a75: newarr [System.Runtime]System.Object
+			IL_0a7a: dup
+			IL_0a7b: ldc.i4.0
+			IL_0a7c: ldarg.0
+			IL_0a7d: stelem.ref
+			IL_0a7e: stloc.0
+			IL_0a7f: ldloc.1
+			IL_0a80: ldloc.0
+			IL_0a81: ldarg.3
+			IL_0a82: ldstr "execution"
+			IL_0a87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a8c: ldstr "requiresAgent"
+			IL_0a91: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a96: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0a9b: stloc.1
+			IL_0a9c: ldstr "execution.requiresAgent: "
+			IL_0aa1: ldloc.1
+			IL_0aa2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0aa7: stloc.2
+			IL_0aa8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0aad: ldloc.2
+			IL_0aae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ab3: pop
+			IL_0ab4: ldarg.0
+			IL_0ab5: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0aba: stloc.1
+			IL_0abb: ldc.i4.1
+			IL_0abc: newarr [System.Runtime]System.Object
+			IL_0ac1: dup
+			IL_0ac2: ldc.i4.0
+			IL_0ac3: ldarg.0
+			IL_0ac4: stelem.ref
+			IL_0ac5: stloc.0
+			IL_0ac6: ldloc.1
+			IL_0ac7: ldloc.0
+			IL_0ac8: ldarg.3
+			IL_0ac9: ldstr "execution"
+			IL_0ace: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ad3: ldstr "canBlock"
+			IL_0ad8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0ae2: stloc.1
+			IL_0ae3: ldstr "execution.canBlock: "
+			IL_0ae8: ldloc.1
+			IL_0ae9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0aee: stloc.2
+			IL_0aef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0af4: ldloc.2
+			IL_0af5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0afa: pop
+			IL_0afb: ldarg.0
+			IL_0afc: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0b01: stloc.1
+			IL_0b02: ldc.i4.1
+			IL_0b03: newarr [System.Runtime]System.Object
+			IL_0b08: dup
+			IL_0b09: ldc.i4.0
+			IL_0b0a: ldarg.0
+			IL_0b0b: stelem.ref
+			IL_0b0c: stloc.0
+			IL_0b0d: ldloc.1
+			IL_0b0e: ldloc.0
+			IL_0b0f: ldarg.3
+			IL_0b10: ldstr "execution"
+			IL_0b15: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b1a: ldstr "isModule"
+			IL_0b1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b24: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0b29: stloc.1
+			IL_0b2a: ldstr "execution.isModule: "
+			IL_0b2f: ldloc.1
+			IL_0b30: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b35: stloc.2
+			IL_0b36: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b3b: ldloc.2
+			IL_0b3c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b41: pop
+			IL_0b42: ldarg.0
+			IL_0b43: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0b48: stloc.1
+			IL_0b49: ldc.i4.1
+			IL_0b4a: newarr [System.Runtime]System.Object
+			IL_0b4f: dup
+			IL_0b50: ldc.i4.0
+			IL_0b51: ldarg.0
+			IL_0b52: stelem.ref
+			IL_0b53: stloc.0
+			IL_0b54: ldloc.1
+			IL_0b55: ldloc.0
+			IL_0b56: ldarg.3
+			IL_0b57: ldstr "execution"
+			IL_0b5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b61: ldstr "isRaw"
+			IL_0b66: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b6b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0b70: stloc.1
+			IL_0b71: ldstr "execution.isRaw: "
+			IL_0b76: ldloc.1
+			IL_0b77: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0b7c: stloc.2
+			IL_0b7d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b82: ldloc.2
+			IL_0b83: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b88: pop
+			IL_0b89: ldarg.0
+			IL_0b8a: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0b8f: stloc.1
+			IL_0b90: ldc.i4.1
+			IL_0b91: newarr [System.Runtime]System.Object
+			IL_0b96: dup
+			IL_0b97: ldc.i4.0
+			IL_0b98: ldarg.0
+			IL_0b99: stelem.ref
+			IL_0b9a: stloc.0
+			IL_0b9b: ldloc.1
+			IL_0b9c: ldloc.0
+			IL_0b9d: ldarg.3
+			IL_0b9e: ldstr "execution"
+			IL_0ba3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ba8: ldstr "isAsync"
+			IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bb2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0bb7: stloc.1
+			IL_0bb8: ldstr "execution.isAsync: "
+			IL_0bbd: ldloc.1
+			IL_0bbe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0bc3: stloc.2
+			IL_0bc4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0bc9: ldloc.2
+			IL_0bca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0bcf: pop
+			IL_0bd0: ldarg.0
+			IL_0bd1: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0bd6: stloc.1
+			IL_0bd7: ldc.i4.1
+			IL_0bd8: newarr [System.Runtime]System.Object
+			IL_0bdd: dup
+			IL_0bde: ldc.i4.0
+			IL_0bdf: ldarg.0
+			IL_0be0: stelem.ref
+			IL_0be1: stloc.0
+			IL_0be2: ldloc.1
+			IL_0be3: ldloc.0
+			IL_0be4: ldarg.3
+			IL_0be5: ldstr "execution"
+			IL_0bea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bef: ldstr "isGenerated"
+			IL_0bf4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0bf9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0bfe: stloc.1
+			IL_0bff: ldstr "execution.isGenerated: "
+			IL_0c04: ldloc.1
+			IL_0c05: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c0a: stloc.2
+			IL_0c0b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c10: ldloc.2
+			IL_0c11: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c16: pop
+			IL_0c17: ldarg.0
+			IL_0c18: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0c1d: stloc.1
+			IL_0c1e: ldc.i4.1
+			IL_0c1f: newarr [System.Runtime]System.Object
+			IL_0c24: dup
+			IL_0c25: ldc.i4.0
+			IL_0c26: ldarg.0
+			IL_0c27: stelem.ref
+			IL_0c28: stloc.0
+			IL_0c29: ldloc.1
+			IL_0c2a: ldloc.0
+			IL_0c2b: ldarg.3
+			IL_0c2c: ldstr "execution"
+			IL_0c31: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c36: ldstr "isNonDeterministic"
+			IL_0c3b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c40: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0c45: stloc.1
+			IL_0c46: ldstr "execution.isNonDeterministic: "
+			IL_0c4b: ldloc.1
+			IL_0c4c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c51: stloc.2
+			IL_0c52: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c57: ldloc.2
+			IL_0c58: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c5d: pop
+			IL_0c5e: ldarg.0
+			IL_0c5f: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0c64: stloc.1
+			IL_0c65: ldc.i4.1
+			IL_0c66: newarr [System.Runtime]System.Object
+			IL_0c6b: dup
+			IL_0c6c: ldc.i4.0
+			IL_0c6d: ldarg.0
+			IL_0c6e: stelem.ref
+			IL_0c6f: stloc.0
+			IL_0c70: ldloc.1
+			IL_0c71: ldloc.0
+			IL_0c72: ldarg.3
+			IL_0c73: ldstr "execution"
+			IL_0c78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c7d: ldstr "isFixture"
+			IL_0c82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c87: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0c8c: stloc.1
+			IL_0c8d: ldstr "execution.isFixture: "
+			IL_0c92: ldloc.1
+			IL_0c93: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0c98: stloc.2
+			IL_0c99: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c9e: ldloc.2
+			IL_0c9f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ca4: pop
+			IL_0ca5: ldarg.0
+			IL_0ca6: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0cab: stloc.1
+			IL_0cac: ldc.i4.1
+			IL_0cad: newarr [System.Runtime]System.Object
+			IL_0cb2: dup
+			IL_0cb3: ldc.i4.0
+			IL_0cb4: ldarg.0
+			IL_0cb5: stelem.ref
+			IL_0cb6: stloc.0
+			IL_0cb7: ldloc.1
+			IL_0cb8: ldloc.0
+			IL_0cb9: ldarg.3
+			IL_0cba: ldstr "mvpBlockers"
+			IL_0cbf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cc4: ldstr "length"
+			IL_0cc9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0cce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0cd3: stloc.1
+			IL_0cd4: ldstr "mvpBlockers.length: "
+			IL_0cd9: ldloc.1
+			IL_0cda: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0cdf: stloc.2
+			IL_0ce0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0ce5: ldloc.2
+			IL_0ce6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ceb: pop
+			IL_0cec: ldarg.0
+			IL_0ced: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_0cf2: stloc.1
+			IL_0cf3: ldc.i4.1
+			IL_0cf4: newarr [System.Runtime]System.Object
+			IL_0cf9: dup
+			IL_0cfa: ldc.i4.0
+			IL_0cfb: ldarg.0
+			IL_0cfc: stelem.ref
+			IL_0cfd: stloc.0
+			IL_0cfe: ldloc.1
+			IL_0cff: ldloc.0
+			IL_0d00: ldarg.3
+			IL_0d01: ldstr "mvpBlockers"
+			IL_0d06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d0b: ldc.r8 0.0
+			IL_0d14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d19: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0d1e: stloc.1
+			IL_0d1f: ldstr "mvpBlockers[0]: "
+			IL_0d24: ldloc.1
+			IL_0d25: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0d2a: stloc.2
+			IL_0d2b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0d30: ldloc.2
+			IL_0d31: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0d36: pop
+			IL_0d37: ldarg.0
+			IL_0d38: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_0d3d: stloc.1
+			IL_0d3e: ldc.i4.1
+			IL_0d3f: newarr [System.Runtime]System.Object
+			IL_0d44: dup
+			IL_0d45: ldc.i4.0
+			IL_0d46: ldarg.0
+			IL_0d47: stelem.ref
+			IL_0d48: stloc.0
+			IL_0d49: ldloc.1
+			IL_0d4a: ldloc.0
+			IL_0d4b: ldarg.3
+			IL_0d4c: ldstr "mvpBlockers"
+			IL_0d51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d56: ldc.r8 1
+			IL_0d5f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d64: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0d69: stloc.1
+			IL_0d6a: ldstr "mvpBlockers[1]: "
+			IL_0d6f: ldloc.1
+			IL_0d70: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0d75: stloc.2
+			IL_0d76: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0d7b: ldloc.2
+			IL_0d7c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0d81: pop
+			IL_0d82: ldarg.0
+			IL_0d83: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_0d88: stloc.1
+			IL_0d89: ldc.i4.1
+			IL_0d8a: newarr [System.Runtime]System.Object
+			IL_0d8f: dup
+			IL_0d90: ldc.i4.0
+			IL_0d91: ldarg.0
+			IL_0d92: stelem.ref
+			IL_0d93: stloc.0
+			IL_0d94: ldloc.1
+			IL_0d95: ldloc.0
+			IL_0d96: ldarg.3
+			IL_0d97: ldstr "mvpBlockers"
+			IL_0d9c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0da1: ldc.r8 2
+			IL_0daa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0daf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0db4: stloc.1
+			IL_0db5: ldstr "mvpBlockers[2]: "
+			IL_0dba: ldloc.1
+			IL_0dbb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0dc0: stloc.2
+			IL_0dc1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0dc6: ldloc.2
+			IL_0dc7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0dcc: pop
+			IL_0dcd: ldarg.0
+			IL_0dce: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_0dd3: stloc.1
+			IL_0dd4: ldc.i4.1
+			IL_0dd5: newarr [System.Runtime]System.Object
+			IL_0dda: dup
+			IL_0ddb: ldc.i4.0
+			IL_0ddc: ldarg.0
+			IL_0ddd: stelem.ref
+			IL_0dde: stloc.0
+			IL_0ddf: ldloc.1
+			IL_0de0: ldloc.0
+			IL_0de1: ldarg.3
+			IL_0de2: ldstr "mvpBlockers"
+			IL_0de7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dec: ldc.r8 3
+			IL_0df5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0dfa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0dff: stloc.1
+			IL_0e00: ldstr "mvpBlockers[3]: "
+			IL_0e05: ldloc.1
+			IL_0e06: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0e0b: stloc.2
+			IL_0e0c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0e11: ldloc.2
+			IL_0e12: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0e17: pop
+			IL_0e18: ldarg.0
+			IL_0e19: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatScalar
+			IL_0e1e: stloc.1
+			IL_0e1f: ldc.i4.1
+			IL_0e20: newarr [System.Runtime]System.Object
+			IL_0e25: dup
+			IL_0e26: ldc.i4.0
+			IL_0e27: ldarg.0
+			IL_0e28: stelem.ref
+			IL_0e29: stloc.0
+			IL_0e2a: ldloc.1
+			IL_0e2b: ldloc.0
+			IL_0e2c: ldarg.3
+			IL_0e2d: ldstr "unsupported"
+			IL_0e32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e37: ldstr "length"
+			IL_0e3c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e41: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0e46: stloc.1
+			IL_0e47: ldstr "unsupported.length: "
+			IL_0e4c: ldloc.1
+			IL_0e4d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0e52: stloc.2
+			IL_0e53: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0e58: ldloc.2
+			IL_0e59: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0e5e: pop
+			IL_0e5f: ldarg.0
+			IL_0e60: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_0e65: stloc.1
+			IL_0e66: ldc.i4.1
+			IL_0e67: newarr [System.Runtime]System.Object
+			IL_0e6c: dup
+			IL_0e6d: ldc.i4.0
+			IL_0e6e: ldarg.0
+			IL_0e6f: stelem.ref
+			IL_0e70: stloc.0
+			IL_0e71: ldloc.1
+			IL_0e72: ldloc.0
+			IL_0e73: ldarg.3
+			IL_0e74: ldstr "unsupported"
+			IL_0e79: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e7e: ldc.r8 0.0
+			IL_0e87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e8c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0e91: stloc.1
+			IL_0e92: ldstr "unsupported[0]: "
+			IL_0e97: ldloc.1
+			IL_0e98: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0e9d: stloc.2
+			IL_0e9e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0ea3: ldloc.2
+			IL_0ea4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ea9: pop
+			IL_0eaa: ldarg.0
+			IL_0eab: ldfld object Modules.Compile_Scripts_Test262MetadataParser/Scope::formatIssue
+			IL_0eb0: stloc.1
+			IL_0eb1: ldc.i4.1
+			IL_0eb2: newarr [System.Runtime]System.Object
+			IL_0eb7: dup
+			IL_0eb8: ldc.i4.0
+			IL_0eb9: ldarg.0
+			IL_0eba: stelem.ref
+			IL_0ebb: stloc.0
+			IL_0ebc: ldloc.1
+			IL_0ebd: ldloc.0
+			IL_0ebe: ldarg.3
+			IL_0ebf: ldstr "unsupported"
+			IL_0ec4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ec9: ldc.r8 1
+			IL_0ed2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0ed7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0edc: stloc.1
+			IL_0edd: ldstr "unsupported[1]: "
+			IL_0ee2: ldloc.1
+			IL_0ee3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0ee8: stloc.2
+			IL_0ee9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0eee: ldloc.2
+			IL_0eef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0ef4: pop
+			IL_0ef5: ldnull
+			IL_0ef6: ret
 		} // end of method writeParsedResult::__js_call__
 
 	} // end of class writeParsedResult
@@ -1693,7 +2102,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5c9d
+			// Method begins at RVA 0x64a5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1719,7 +2128,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 705 (0x2c1)
+		// Code size: 720 (0x2d0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262MetadataParser/Scope,
@@ -1922,58 +2331,63 @@
 		IL_0217: stloc.s 8
 		IL_0219: ldloc.s 8
 		IL_021b: stloc.s 7
-		IL_021d: ldloc.0
-		IL_021e: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0223: ldnull
-		IL_0224: ldstr "basic-strict"
-		IL_0229: ldloc.3
-		IL_022a: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_022f: pop
-		IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0235: ldstr "---"
-		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023f: pop
-		IL_0240: ldloc.0
-		IL_0241: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0246: ldnull
-		IL_0247: ldstr "negative-parse"
-		IL_024c: ldloc.s 4
-		IL_024e: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_0253: pop
-		IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0259: ldstr "---"
-		IL_025e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0263: pop
-		IL_0264: ldloc.0
-		IL_0265: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_026a: ldnull
-		IL_026b: ldstr "async-generated"
-		IL_0270: ldloc.s 5
-		IL_0272: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_0277: pop
-		IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027d: ldstr "---"
-		IL_0282: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0287: pop
-		IL_0288: ldloc.0
-		IL_0289: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_028e: ldnull
-		IL_028f: ldstr "module-resolution"
-		IL_0294: ldloc.s 6
-		IL_0296: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_029b: pop
-		IL_029c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02a1: ldstr "---"
-		IL_02a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02ab: pop
-		IL_02ac: ldloc.0
-		IL_02ad: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_02b2: ldnull
-		IL_02b3: ldstr "fixture-unsupported"
-		IL_02b8: ldloc.s 7
-		IL_02ba: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object, object)
-		IL_02bf: pop
-		IL_02c0: ret
+		IL_021d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0222: stloc.s 9
+		IL_0224: ldloc.1
+		IL_0225: ldloc.s 9
+		IL_0227: ldstr "basic-strict"
+		IL_022c: ldloc.3
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0232: pop
+		IL_0233: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0238: ldstr "---"
+		IL_023d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0242: pop
+		IL_0243: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0248: stloc.s 9
+		IL_024a: ldloc.1
+		IL_024b: ldloc.s 9
+		IL_024d: ldstr "negative-parse"
+		IL_0252: ldloc.s 4
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0259: pop
+		IL_025a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025f: ldstr "---"
+		IL_0264: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0269: pop
+		IL_026a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_026f: stloc.s 9
+		IL_0271: ldloc.1
+		IL_0272: ldloc.s 9
+		IL_0274: ldstr "async-generated"
+		IL_0279: ldloc.s 5
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0280: pop
+		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0286: ldstr "---"
+		IL_028b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0290: pop
+		IL_0291: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0296: stloc.s 9
+		IL_0298: ldloc.1
+		IL_0299: ldloc.s 9
+		IL_029b: ldstr "module-resolution"
+		IL_02a0: ldloc.s 6
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02a7: pop
+		IL_02a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ad: ldstr "---"
+		IL_02b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b7: pop
+		IL_02b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02bd: stloc.s 9
+		IL_02bf: ldloc.1
+		IL_02c0: ldloc.s 9
+		IL_02c2: ldstr "fixture-unsupported"
+		IL_02c7: ldloc.s 7
+		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02ce: pop
+		IL_02cf: ret
 	} // end of method Compile_Scripts_Test262MetadataParser::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262MetadataParser
@@ -1993,7 +2407,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d09
+				// Method begins at RVA 0x6511
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2017,7 +2431,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3810
+			// Method begins at RVA 0x3ab0
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -2081,7 +2495,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5d24
+						// Method begins at RVA 0x652c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2099,7 +2513,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d1b
+					// Method begins at RVA 0x6523
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2117,7 +2531,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d12
+				// Method begins at RVA 0x651a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2144,7 +2558,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3878
+			// Method begins at RVA 0x3b18
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -2249,7 +2663,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5d3f
+						// Method begins at RVA 0x6547
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2267,7 +2681,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d36
+					// Method begins at RVA 0x653e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2285,7 +2699,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d2d
+				// Method begins at RVA 0x6535
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2312,7 +2726,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3930
+			// Method begins at RVA 0x3bd0
 			// Header size: 12
 			// Code size: 355 (0x163)
 			.maxstack 8
@@ -2468,7 +2882,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d51
+					// Method begins at RVA 0x6559
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2486,7 +2900,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d48
+				// Method begins at RVA 0x6550
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2514,7 +2928,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5d6c
+						// Method begins at RVA 0x6574
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2532,7 +2946,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d63
+					// Method begins at RVA 0x656b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2550,7 +2964,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d5a
+				// Method begins at RVA 0x6562
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2577,9 +2991,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3aa0
+			// Method begins at RVA 0x3d40
 			// Header size: 12
-			// Code size: 308 (0x134)
+			// Code size: 317 (0x13d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2653,7 +3067,7 @@
 				IL_00b1: ldstr "length"
 				IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_00bb: clt
-				IL_00bd: brfalse IL_0132
+				IL_00bd: brfalse IL_013b
 
 				IL_00c2: newobj instance void Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41::.ctor()
 				IL_00c7: stloc.s 5
@@ -2673,30 +3087,35 @@
 				IL_00f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 				IL_00f6: stloc.s 9
 				IL_00f8: ldloc.s 9
-				IL_00fa: brfalse IL_011f
+				IL_00fa: brfalse IL_0128
 
 				IL_00ff: newobj instance void Modules.test262_metadataParser/parseInlineList/Scope_For_L69C7/Block_L69C41/Block_L71C21::.ctor()
 				IL_0104: stloc.s 7
 				IL_0106: ldarg.0
-				IL_0107: castclass Modules.test262_metadataParser/Scope
-				IL_010c: ldnull
-				IL_010d: ldloc.s 6
-				IL_010f: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_0114: stloc.s 8
-				IL_0116: ldloc.3
-				IL_0117: ldloc.s 8
-				IL_0119: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_011e: pop
+				IL_0107: ldfld object Modules.test262_metadataParser/Scope::unquote
+				IL_010c: ldc.i4.1
+				IL_010d: newarr [System.Runtime]System.Object
+				IL_0112: dup
+				IL_0113: ldc.i4.0
+				IL_0114: ldarg.0
+				IL_0115: stelem.ref
+				IL_0116: ldloc.s 6
+				IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_011d: stloc.s 8
+				IL_011f: ldloc.3
+				IL_0120: ldloc.s 8
+				IL_0122: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0127: pop
 
-				IL_011f: ldloc.s 4
-				IL_0121: ldc.r8 1
-				IL_012a: add
-				IL_012b: stloc.s 4
-				IL_012d: br IL_00ae
+				IL_0128: ldloc.s 4
+				IL_012a: ldc.r8 1
+				IL_0133: add
+				IL_0134: stloc.s 4
+				IL_0136: br IL_00ae
 			// end loop
 
-			IL_0132: ldloc.3
-			IL_0133: ret
+			IL_013b: ldloc.3
+			IL_013c: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -2716,7 +3135,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d7e
+					// Method begins at RVA 0x6586
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2734,7 +3153,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d75
+				// Method begins at RVA 0x657d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2761,7 +3180,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3be0
+			// Method begins at RVA 0x3e8c
 			// Header size: 12
 			// Code size: 151 (0x97)
 			.maxstack 8
@@ -2854,7 +3273,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d87
+				// Method begins at RVA 0x658f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2882,7 +3301,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5da2
+						// Method begins at RVA 0x65aa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2902,7 +3321,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5dab
+						// Method begins at RVA 0x65b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2922,7 +3341,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5db4
+						// Method begins at RVA 0x65bc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2942,7 +3361,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5dbd
+						// Method begins at RVA 0x65c5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2960,7 +3379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5d99
+					// Method begins at RVA 0x65a1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2978,7 +3397,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d90
+				// Method begins at RVA 0x6598
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3005,7 +3424,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3c84
+			// Method begins at RVA 0x3f30
 			// Header size: 12
 			// Code size: 323 (0x143)
 			.maxstack 8
@@ -3162,7 +3581,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5dd8
+						// Method begins at RVA 0x65e0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3182,7 +3601,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5de1
+						// Method begins at RVA 0x65e9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3202,7 +3621,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5dea
+						// Method begins at RVA 0x65f2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3220,7 +3639,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5dcf
+					// Method begins at RVA 0x65d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3238,7 +3657,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5dc6
+				// Method begins at RVA 0x65ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3268,9 +3687,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3dd4
+			// Method begins at RVA 0x4080
 			// Header size: 12
-			// Code size: 441 (0x1b9)
+			// Code size: 450 (0x1c2)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -3312,7 +3731,7 @@
 				IL_003c: ldloc.s 9
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_0176
+				IL_0045: brfalse IL_017f
 
 				IL_004a: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37::.ctor()
 				IL_004f: stloc.2
@@ -3355,96 +3774,101 @@
 				IL_00c2: br IL_0017
 
 				IL_00c7: ldarg.0
-				IL_00c8: castclass Modules.test262_metadataParser/Scope
-				IL_00cd: ldnull
-				IL_00ce: ldloc.3
-				IL_00cf: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_00d4: stloc.s 9
-				IL_00d6: ldloc.s 9
-				IL_00d8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00dd: stloc.s 10
-				IL_00df: ldloc.s 10
-				IL_00e1: stloc.s 5
-				IL_00e3: ldloc.s 5
-				IL_00e5: ldarg.s parentIndent
-				IL_00e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ec: cgt
-				IL_00ee: ldc.i4.0
-				IL_00ef: ceq
-				IL_00f1: brfalse IL_0102
+				IL_00c8: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_00cd: ldc.i4.1
+				IL_00ce: newarr [System.Runtime]System.Object
+				IL_00d3: dup
+				IL_00d4: ldc.i4.0
+				IL_00d5: ldarg.0
+				IL_00d6: stelem.ref
+				IL_00d7: ldloc.3
+				IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00dd: stloc.s 9
+				IL_00df: ldloc.s 9
+				IL_00e1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00e6: stloc.s 10
+				IL_00e8: ldloc.s 10
+				IL_00ea: stloc.s 5
+				IL_00ec: ldloc.s 5
+				IL_00ee: ldarg.s parentIndent
+				IL_00f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00f5: cgt
+				IL_00f7: ldc.i4.0
+				IL_00f8: ceq
+				IL_00fa: brfalse IL_010b
 
-				IL_00f6: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
-				IL_00fb: stloc.s 6
-				IL_00fd: br IL_0176
+				IL_00ff: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L126C32::.ctor()
+				IL_0104: stloc.s 6
+				IL_0106: br IL_017f
 
-				IL_0102: ldloc.1
-				IL_0103: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0108: stloc.s 10
-				IL_010a: ldloc.s 10
-				IL_010c: ldc.r8 0.0
-				IL_0115: clt
-				IL_0117: brfalse IL_012f
+				IL_010b: ldloc.1
+				IL_010c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0111: stloc.s 10
+				IL_0113: ldloc.s 10
+				IL_0115: ldc.r8 0.0
+				IL_011e: clt
+				IL_0120: brfalse IL_0138
 
-				IL_011c: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
-				IL_0121: stloc.s 7
-				IL_0123: ldloc.s 5
-				IL_0125: box [System.Runtime]System.Double
-				IL_012a: stloc.s 12
-				IL_012c: ldloc.s 12
-				IL_012e: stloc.1
+				IL_0125: newobj instance void Modules.test262_metadataParser/parseBlockScalar/Scope/Block_L117C37/Block_L130C25::.ctor()
+				IL_012a: stloc.s 7
+				IL_012c: ldloc.s 5
+				IL_012e: box [System.Runtime]System.Double
+				IL_0133: stloc.s 12
+				IL_0135: ldloc.s 12
+				IL_0137: stloc.1
 
-				IL_012f: ldloc.3
-				IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0135: stloc.s 9
-				IL_0137: ldloc.s 9
-				IL_0139: ldstr "substring"
-				IL_013e: ldloc.1
-				IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0144: stloc.s 9
-				IL_0146: ldloc.0
-				IL_0147: ldloc.s 9
-				IL_0149: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_014e: pop
-				IL_014f: ldarg.3
-				IL_0150: ldstr "index"
-				IL_0155: ldarg.3
-				IL_0156: ldstr "index"
-				IL_015b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0160: ldc.r8 1
-				IL_0169: add
-				IL_016a: ldc.i4.1
-				IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0170: pop
-				IL_0171: br IL_0017
+				IL_0138: ldloc.3
+				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_013e: stloc.s 9
+				IL_0140: ldloc.s 9
+				IL_0142: ldstr "substring"
+				IL_0147: ldloc.1
+				IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_014d: stloc.s 9
+				IL_014f: ldloc.0
+				IL_0150: ldloc.s 9
+				IL_0152: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0157: pop
+				IL_0158: ldarg.3
+				IL_0159: ldstr "index"
+				IL_015e: ldarg.3
+				IL_015f: ldstr "index"
+				IL_0164: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0169: ldc.r8 1
+				IL_0172: add
+				IL_0173: ldc.i4.1
+				IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_0179: pop
+				IL_017a: br IL_0017
 			// end loop
 
-			IL_0176: ldarg.s style
-			IL_0178: ldstr ">"
-			IL_017d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0182: stloc.s 11
-			IL_0184: ldloc.s 11
-			IL_0186: brfalse IL_01a0
+			IL_017f: ldarg.s style
+			IL_0181: ldstr ">"
+			IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_018b: stloc.s 11
+			IL_018d: ldloc.s 11
+			IL_018f: brfalse IL_01a9
 
-			IL_018b: ldarg.0
-			IL_018c: castclass Modules.test262_metadataParser/Scope
-			IL_0191: ldnull
-			IL_0192: ldloc.0
-			IL_0193: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0198: tail.
-			IL_019a: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_019f: ret
+			IL_0194: ldarg.0
+			IL_0195: castclass Modules.test262_metadataParser/Scope
+			IL_019a: ldnull
+			IL_019b: ldloc.0
+			IL_019c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01a1: tail.
+			IL_01a3: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01a8: ret
 
-			IL_01a0: ldloc.0
-			IL_01a1: ldc.i4.1
-			IL_01a2: newarr [System.Runtime]System.Object
-			IL_01a7: dup
-			IL_01a8: ldc.i4.0
-			IL_01a9: ldstr "\n"
-			IL_01ae: stelem.ref
-			IL_01af: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01b4: stloc.s 13
-			IL_01b6: ldloc.s 13
-			IL_01b8: ret
+			IL_01a9: ldloc.0
+			IL_01aa: ldc.i4.1
+			IL_01ab: newarr [System.Runtime]System.Object
+			IL_01b0: dup
+			IL_01b1: ldc.i4.0
+			IL_01b2: ldstr "\n"
+			IL_01b7: stelem.ref
+			IL_01b8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_01bd: stloc.s 13
+			IL_01bf: ldloc.s 13
+			IL_01c1: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -3464,7 +3888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5dfc
+					// Method begins at RVA 0x6604
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3484,7 +3908,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e05
+					// Method begins at RVA 0x660d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3504,7 +3928,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e0e
+					// Method begins at RVA 0x6616
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3522,7 +3946,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5df3
+				// Method begins at RVA 0x65fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3551,9 +3975,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x3f9c
+			// Method begins at RVA 0x4250
 			// Header size: 12
-			// Code size: 387 (0x183)
+			// Code size: 400 (0x190)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3568,7 +3992,8 @@
 				[9] object,
 				[10] object,
 				[11] object,
-				[12] object
+				[12] object,
+				[13] object[]
 			)
 
 			IL_0000: ldarg.3
@@ -3669,61 +4094,68 @@
 			IL_0100: ldstr ""
 			IL_0105: ret
 
-			IL_0106: ldarg.2
-			IL_0107: ldloc.0
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_010d: stloc.s 5
-			IL_010f: ldarg.0
-			IL_0110: castclass Modules.test262_metadataParser/Scope
-			IL_0115: ldnull
-			IL_0116: ldloc.s 5
-			IL_0118: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_011d: stloc.s 5
-			IL_011f: ldloc.s 5
-			IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0126: stloc.s 6
-			IL_0128: ldloc.s 6
-			IL_012a: stloc.3
-			IL_012b: ldloc.3
-			IL_012c: ldarg.s parentIndent
+			IL_0106: ldarg.0
+			IL_0107: ldfld object Modules.test262_metadataParser/Scope::countIndent
+			IL_010c: stloc.s 5
+			IL_010e: ldc.i4.1
+			IL_010f: newarr [System.Runtime]System.Object
+			IL_0114: dup
+			IL_0115: ldc.i4.0
+			IL_0116: ldarg.0
+			IL_0117: stelem.ref
+			IL_0118: stloc.s 13
+			IL_011a: ldloc.s 5
+			IL_011c: ldloc.s 13
+			IL_011e: ldarg.2
+			IL_011f: ldloc.0
+			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_012a: stloc.s 5
+			IL_012c: ldloc.s 5
 			IL_012e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0133: cgt
-			IL_0135: ldc.i4.0
-			IL_0136: ceq
-			IL_0138: brfalse IL_0158
+			IL_0133: stloc.s 6
+			IL_0135: ldloc.s 6
+			IL_0137: stloc.3
+			IL_0138: ldloc.3
+			IL_0139: ldarg.s parentIndent
+			IL_013b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0140: cgt
+			IL_0142: ldc.i4.0
+			IL_0143: ceq
+			IL_0145: brfalse IL_0165
 
-			IL_013d: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
-			IL_0142: stloc.s 4
-			IL_0144: ldarg.3
-			IL_0145: ldstr "index"
-			IL_014a: ldloc.0
-			IL_014b: ldc.i4.1
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0151: pop
-			IL_0152: ldstr ""
-			IL_0157: ret
+			IL_014a: newobj instance void Modules.test262_metadataParser/parseIndentedValue/Scope/Block_L153C34::.ctor()
+			IL_014f: stloc.s 4
+			IL_0151: ldarg.3
+			IL_0152: ldstr "index"
+			IL_0157: ldloc.0
+			IL_0158: ldc.i4.1
+			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_015e: pop
+			IL_015f: ldstr ""
+			IL_0164: ret
 
-			IL_0158: ldarg.3
-			IL_0159: ldstr "index"
-			IL_015e: ldloc.0
-			IL_015f: ldc.i4.1
-			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0165: pop
-			IL_0166: ldloc.3
-			IL_0167: box [System.Runtime]System.Double
-			IL_016c: stloc.s 12
-			IL_016e: ldarg.0
-			IL_016f: castclass Modules.test262_metadataParser/Scope
-			IL_0174: ldnull
-			IL_0175: ldarg.2
-			IL_0176: ldarg.3
-			IL_0177: ldloc.s 12
-			IL_0179: tail.
-			IL_017b: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0180: ret
-
+			IL_0165: ldarg.3
+			IL_0166: ldstr "index"
+			IL_016b: ldloc.0
+			IL_016c: ldc.i4.1
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0172: pop
+			IL_0173: ldloc.3
+			IL_0174: box [System.Runtime]System.Double
+			IL_0179: stloc.s 12
+			IL_017b: ldarg.0
+			IL_017c: castclass Modules.test262_metadataParser/Scope
 			IL_0181: ldnull
-			IL_0182: ret
+			IL_0182: ldarg.2
+			IL_0183: ldarg.3
+			IL_0184: ldloc.s 12
+			IL_0186: tail.
+			IL_0188: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_018d: ret
+
+			IL_018e: ldnull
+			IL_018f: ret
 		} // end of method parseIndentedValue::__js_call__
 
 	} // end of class parseIndentedValue
@@ -3747,7 +4179,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e29
+						// Method begins at RVA 0x6631
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3767,7 +4199,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e32
+						// Method begins at RVA 0x663a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3787,7 +4219,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e3b
+						// Method begins at RVA 0x6643
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3807,7 +4239,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e44
+						// Method begins at RVA 0x664c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3827,7 +4259,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e4d
+						// Method begins at RVA 0x6655
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3847,7 +4279,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e56
+						// Method begins at RVA 0x665e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3867,7 +4299,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e5f
+						// Method begins at RVA 0x6667
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3885,7 +4317,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e20
+					// Method begins at RVA 0x6628
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3903,7 +4335,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e17
+				// Method begins at RVA 0x661f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3932,9 +4364,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x412c
+			// Method begins at RVA 0x43ec
 			// Header size: 12
-			// Code size: 911 (0x38f)
+			// Code size: 981 (0x3d5)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -3966,7 +4398,9 @@
 				[26] string,
 				[27] object,
 				[28] object,
-				[29] object
+				[29] object,
+				[30] object[],
+				[31] object[]
 			)
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -3987,7 +4421,7 @@
 				IL_002b: ldloc.s 19
 				IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0032: clt
-				IL_0034: brfalse IL_038d
+				IL_0034: brfalse IL_03d3
 
 				IL_0039: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37::.ctor()
 				IL_003e: stloc.1
@@ -4026,266 +4460,308 @@
 				IL_00a4: br IL_0006
 
 				IL_00a9: ldarg.0
-				IL_00aa: castclass Modules.test262_metadataParser/Scope
-				IL_00af: ldnull
-				IL_00b0: ldloc.2
-				IL_00b1: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_00b6: stloc.s 19
-				IL_00b8: ldloc.s 19
-				IL_00ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00bf: stloc.s 20
-				IL_00c1: ldloc.s 20
-				IL_00c3: stloc.s 4
-				IL_00c5: ldloc.s 4
-				IL_00c7: ldarg.s baseIndent
-				IL_00c9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ce: clt
-				IL_00d0: brfalse IL_00e1
+				IL_00aa: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_00af: ldc.i4.1
+				IL_00b0: newarr [System.Runtime]System.Object
+				IL_00b5: dup
+				IL_00b6: ldc.i4.0
+				IL_00b7: ldarg.0
+				IL_00b8: stelem.ref
+				IL_00b9: ldloc.2
+				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00bf: stloc.s 19
+				IL_00c1: ldloc.s 19
+				IL_00c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00c8: stloc.s 20
+				IL_00ca: ldloc.s 20
+				IL_00cc: stloc.s 4
+				IL_00ce: ldloc.s 4
+				IL_00d0: ldarg.s baseIndent
+				IL_00d2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00d7: clt
+				IL_00d9: brfalse IL_00ea
 
-				IL_00d5: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
-				IL_00da: stloc.s 5
-				IL_00dc: br IL_038d
+				IL_00de: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L173C29::.ctor()
+				IL_00e3: stloc.s 5
+				IL_00e5: br IL_03d3
 
-				IL_00e1: ldloc.s 4
-				IL_00e3: ldarg.s baseIndent
-				IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ea: cgt
-				IL_00ec: brfalse IL_0161
+				IL_00ea: ldloc.s 4
+				IL_00ec: ldarg.s baseIndent
+				IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00f3: cgt
+				IL_00f5: brfalse IL_016a
 
-				IL_00f1: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
-				IL_00f6: stloc.s 6
-				IL_00f8: ldarg.3
-				IL_00f9: ldstr "index"
-				IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0103: ldc.r8 1
-				IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0111: stloc.s 22
-				IL_0113: ldloc.s 22
-				IL_0115: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_011a: stloc.s 23
-				IL_011c: ldstr "Unexpected indentation at frontmatter line "
-				IL_0121: ldloc.s 23
-				IL_0123: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0128: stloc.s 23
+				IL_00fa: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L177C29::.ctor()
+				IL_00ff: stloc.s 6
+				IL_0101: ldarg.3
+				IL_0102: ldstr "index"
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_010c: ldc.r8 1
+				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_011a: stloc.s 22
+				IL_011c: ldloc.s 22
+				IL_011e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0123: stloc.s 23
+				IL_0125: ldstr "Unexpected indentation at frontmatter line "
 				IL_012a: ldloc.s 23
-				IL_012c: ldstr "."
-				IL_0131: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0136: stloc.s 23
-				IL_0138: ldloc.s 23
-				IL_013a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0144: stloc.s 19
-				IL_0146: ldloc.s 19
-				IL_0148: stloc.s 7
-				IL_014a: ldloc.s 7
-				IL_014c: isinst [System.Runtime]System.Exception
-				IL_0151: dup
-				IL_0152: brtrue IL_0160
+				IL_012c: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0131: stloc.s 23
+				IL_0133: ldloc.s 23
+				IL_0135: ldstr "."
+				IL_013a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_013f: stloc.s 23
+				IL_0141: ldloc.s 23
+				IL_0143: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0148: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_014d: stloc.s 19
+				IL_014f: ldloc.s 19
+				IL_0151: stloc.s 7
+				IL_0153: ldloc.s 7
+				IL_0155: isinst [System.Runtime]System.Exception
+				IL_015a: dup
+				IL_015b: brtrue IL_0169
 
-				IL_0157: pop
-				IL_0158: ldloc.s 7
-				IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_015f: throw
+				IL_0160: pop
+				IL_0161: ldloc.s 7
+				IL_0163: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0168: throw
 
-				IL_0160: throw
+				IL_0169: throw
 
-				IL_0161: ldloc.2
-				IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0167: stloc.s 19
-				IL_0169: ldloc.s 4
-				IL_016b: box [System.Runtime]System.Double
-				IL_0170: stloc.s 24
-				IL_0172: ldloc.s 19
-				IL_0174: ldstr "substring"
-				IL_0179: ldloc.s 24
-				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0180: stloc.s 19
-				IL_0182: ldloc.s 19
-				IL_0184: stloc.s 8
-				IL_0186: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_018b: ldstr ""
-				IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0195: stloc.s 25
-				IL_0197: ldloc.s 25
-				IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_019e: stloc.s 19
-				IL_01a0: ldloc.s 19
-				IL_01a2: ldstr "exec"
-				IL_01a7: ldloc.s 8
-				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_01ae: stloc.s 19
-				IL_01b0: ldloc.s 19
-				IL_01b2: stloc.s 9
-				IL_01b4: ldloc.s 9
-				IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_01bb: ldc.i4.0
-				IL_01bc: ceq
-				IL_01be: stloc.s 21
-				IL_01c0: ldloc.s 21
-				IL_01c2: brfalse IL_024b
+				IL_016a: ldloc.2
+				IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0170: stloc.s 19
+				IL_0172: ldloc.s 4
+				IL_0174: box [System.Runtime]System.Double
+				IL_0179: stloc.s 24
+				IL_017b: ldloc.s 19
+				IL_017d: ldstr "substring"
+				IL_0182: ldloc.s 24
+				IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0189: stloc.s 19
+				IL_018b: ldloc.s 19
+				IL_018d: stloc.s 8
+				IL_018f: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_0194: ldstr ""
+				IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_019e: stloc.s 25
+				IL_01a0: ldloc.s 25
+				IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01a7: stloc.s 19
+				IL_01a9: ldloc.s 19
+				IL_01ab: ldstr "exec"
+				IL_01b0: ldloc.s 8
+				IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_01b7: stloc.s 19
+				IL_01b9: ldloc.s 19
+				IL_01bb: stloc.s 9
+				IL_01bd: ldloc.s 9
+				IL_01bf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01c4: ldc.i4.0
+				IL_01c5: ceq
+				IL_01c7: stloc.s 21
+				IL_01c9: ldloc.s 21
+				IL_01cb: brfalse IL_0254
 
-				IL_01c7: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
-				IL_01cc: stloc.s 10
-				IL_01ce: ldarg.3
-				IL_01cf: ldstr "index"
-				IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01d9: ldc.r8 1
-				IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01e7: stloc.s 22
-				IL_01e9: ldloc.s 22
-				IL_01eb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01f0: stloc.s 23
-				IL_01f2: ldstr "Invalid frontmatter line "
-				IL_01f7: ldloc.s 23
-				IL_01f9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01fe: stloc.s 23
+				IL_01d0: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L183C16::.ctor()
+				IL_01d5: stloc.s 10
+				IL_01d7: ldarg.3
+				IL_01d8: ldstr "index"
+				IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01e2: ldc.r8 1
+				IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01f0: stloc.s 22
+				IL_01f2: ldloc.s 22
+				IL_01f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01f9: stloc.s 23
+				IL_01fb: ldstr "Invalid frontmatter line "
 				IL_0200: ldloc.s 23
-				IL_0202: ldstr ": "
-				IL_0207: call string [System.Runtime]System.String::Concat(string, string)
-				IL_020c: stloc.s 23
-				IL_020e: ldloc.s 8
-				IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0215: stloc.s 26
-				IL_0217: ldloc.s 23
-				IL_0219: ldloc.s 26
-				IL_021b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0220: stloc.s 26
+				IL_0202: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0207: stloc.s 23
+				IL_0209: ldloc.s 23
+				IL_020b: ldstr ": "
+				IL_0210: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0215: stloc.s 23
+				IL_0217: ldloc.s 8
+				IL_0219: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_021e: stloc.s 26
+				IL_0220: ldloc.s 23
 				IL_0222: ldloc.s 26
-				IL_0224: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0229: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_022e: stloc.s 19
-				IL_0230: ldloc.s 19
-				IL_0232: stloc.s 11
-				IL_0234: ldloc.s 11
-				IL_0236: isinst [System.Runtime]System.Exception
-				IL_023b: dup
-				IL_023c: brtrue IL_024a
+				IL_0224: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0229: stloc.s 26
+				IL_022b: ldloc.s 26
+				IL_022d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0232: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0237: stloc.s 19
+				IL_0239: ldloc.s 19
+				IL_023b: stloc.s 11
+				IL_023d: ldloc.s 11
+				IL_023f: isinst [System.Runtime]System.Exception
+				IL_0244: dup
+				IL_0245: brtrue IL_0253
 
-				IL_0241: pop
-				IL_0242: ldloc.s 11
-				IL_0244: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0249: throw
+				IL_024a: pop
+				IL_024b: ldloc.s 11
+				IL_024d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0252: throw
 
-				IL_024a: throw
+				IL_0253: throw
 
-				IL_024b: ldloc.s 9
-				IL_024d: ldc.r8 1
-				IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_025b: stloc.s 12
-				IL_025d: ldloc.s 9
-				IL_025f: ldc.r8 2
-				IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0272: stloc.s 19
-				IL_0274: ldloc.s 19
-				IL_0276: ldstr "trim"
-				IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-				IL_0280: stloc.s 19
-				IL_0282: ldloc.s 19
-				IL_0284: stloc.s 13
-				IL_0286: ldarg.3
-				IL_0287: ldstr "index"
-				IL_028c: ldarg.3
-				IL_028d: ldstr "index"
-				IL_0292: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0297: ldc.r8 1
-				IL_02a0: add
-				IL_02a1: ldc.i4.1
-				IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_02a7: pop
-				IL_02a8: ldnull
-				IL_02a9: stloc.s 14
-				IL_02ab: ldloc.s 13
-				IL_02ad: ldstr "|"
-				IL_02b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02b7: stloc.s 21
-				IL_02b9: ldloc.s 21
-				IL_02bb: box [System.Runtime]System.Boolean
-				IL_02c0: stloc.s 27
-				IL_02c2: ldloc.s 27
-				IL_02c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02c9: stloc.s 21
-				IL_02cb: ldloc.s 21
-				IL_02cd: brtrue IL_02f2
+				IL_0254: ldloc.s 9
+				IL_0256: ldc.r8 1
+				IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0264: stloc.s 12
+				IL_0266: ldloc.s 9
+				IL_0268: ldc.r8 2
+				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_027b: stloc.s 19
+				IL_027d: ldloc.s 19
+				IL_027f: ldstr "trim"
+				IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+				IL_0289: stloc.s 19
+				IL_028b: ldloc.s 19
+				IL_028d: stloc.s 13
+				IL_028f: ldarg.3
+				IL_0290: ldstr "index"
+				IL_0295: ldarg.3
+				IL_0296: ldstr "index"
+				IL_029b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_02a0: ldc.r8 1
+				IL_02a9: add
+				IL_02aa: ldc.i4.1
+				IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_02b0: pop
+				IL_02b1: ldnull
+				IL_02b2: stloc.s 14
+				IL_02b4: ldloc.s 13
+				IL_02b6: ldstr "|"
+				IL_02bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02c0: stloc.s 21
+				IL_02c2: ldloc.s 21
+				IL_02c4: box [System.Runtime]System.Boolean
+				IL_02c9: stloc.s 27
+				IL_02cb: ldloc.s 27
+				IL_02cd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02d2: stloc.s 21
+				IL_02d4: ldloc.s 21
+				IL_02d6: brtrue IL_02fb
 
-				IL_02d2: ldloc.s 13
-				IL_02d4: ldstr ">"
-				IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02de: stloc.s 21
-				IL_02e0: ldloc.s 21
-				IL_02e2: box [System.Runtime]System.Boolean
-				IL_02e7: stloc.s 28
-				IL_02e9: ldloc.s 28
-				IL_02eb: stloc.s 29
-				IL_02ed: br IL_02f6
-
-				IL_02f2: ldloc.s 27
+				IL_02db: ldloc.s 13
+				IL_02dd: ldstr ">"
+				IL_02e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02e7: stloc.s 21
+				IL_02e9: ldloc.s 21
+				IL_02eb: box [System.Runtime]System.Boolean
+				IL_02f0: stloc.s 28
+				IL_02f2: ldloc.s 28
 				IL_02f4: stloc.s 29
+				IL_02f6: br IL_02ff
 
-				IL_02f6: ldloc.s 29
-				IL_02f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02fd: stloc.s 21
-				IL_02ff: ldloc.s 21
-				IL_0301: brfalse IL_032a
+				IL_02fb: ldloc.s 27
+				IL_02fd: stloc.s 29
 
-				IL_0306: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
-				IL_030b: stloc.s 15
-				IL_030d: ldarg.0
-				IL_030e: castclass Modules.test262_metadataParser/Scope
-				IL_0313: ldnull
-				IL_0314: ldarg.2
-				IL_0315: ldarg.3
-				IL_0316: ldarg.s baseIndent
-				IL_0318: ldloc.s 13
-				IL_031a: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object, object)
-				IL_031f: stloc.s 19
-				IL_0321: ldloc.s 19
-				IL_0323: stloc.s 14
-				IL_0325: br IL_037c
+				IL_02ff: ldloc.s 29
+				IL_0301: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0306: stloc.s 21
+				IL_0308: ldloc.s 21
+				IL_030a: brfalse IL_035a
 
-				IL_032a: ldloc.s 13
-				IL_032c: ldstr ""
-				IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0336: stloc.s 21
-				IL_0338: ldloc.s 21
-				IL_033a: brfalse IL_0361
+				IL_030f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L192C48::.ctor()
+				IL_0314: stloc.s 15
+				IL_0316: ldarg.0
+				IL_0317: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_031c: stloc.s 19
+				IL_031e: ldc.i4.1
+				IL_031f: newarr [System.Runtime]System.Object
+				IL_0324: dup
+				IL_0325: ldc.i4.0
+				IL_0326: ldarg.0
+				IL_0327: stelem.ref
+				IL_0328: stloc.s 30
+				IL_032a: ldc.i4.4
+				IL_032b: newarr [System.Runtime]System.Object
+				IL_0330: dup
+				IL_0331: ldc.i4.0
+				IL_0332: ldarg.2
+				IL_0333: stelem.ref
+				IL_0334: dup
+				IL_0335: ldc.i4.1
+				IL_0336: ldarg.3
+				IL_0337: stelem.ref
+				IL_0338: dup
+				IL_0339: ldc.i4.2
+				IL_033a: ldarg.s baseIndent
+				IL_033c: stelem.ref
+				IL_033d: dup
+				IL_033e: ldc.i4.3
+				IL_033f: ldloc.s 13
+				IL_0341: stelem.ref
+				IL_0342: stloc.s 31
+				IL_0344: ldloc.s 19
+				IL_0346: ldloc.s 30
+				IL_0348: ldloc.s 31
+				IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_034f: stloc.s 19
+				IL_0351: ldloc.s 19
+				IL_0353: stloc.s 14
+				IL_0355: br IL_03c2
 
-				IL_033f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
-				IL_0344: stloc.s 16
-				IL_0346: ldarg.0
-				IL_0347: castclass Modules.test262_metadataParser/Scope
-				IL_034c: ldnull
-				IL_034d: ldarg.2
-				IL_034e: ldarg.3
-				IL_034f: ldarg.s baseIndent
-				IL_0351: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-				IL_0356: stloc.s 19
-				IL_0358: ldloc.s 19
-				IL_035a: stloc.s 14
-				IL_035c: br IL_037c
+				IL_035a: ldloc.s 13
+				IL_035c: ldstr ""
+				IL_0361: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0366: stloc.s 21
+				IL_0368: ldloc.s 21
+				IL_036a: brfalse IL_039e
 
-				IL_0361: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
-				IL_0366: stloc.s 17
-				IL_0368: ldarg.0
-				IL_0369: castclass Modules.test262_metadataParser/Scope
-				IL_036e: ldnull
-				IL_036f: ldloc.s 13
-				IL_0371: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-				IL_0376: stloc.s 19
-				IL_0378: ldloc.s 19
-				IL_037a: stloc.s 14
+				IL_036f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L194C33::.ctor()
+				IL_0374: stloc.s 16
+				IL_0376: ldc.i4.1
+				IL_0377: newarr [System.Runtime]System.Object
+				IL_037c: dup
+				IL_037d: ldc.i4.0
+				IL_037e: ldarg.0
+				IL_037f: stelem.ref
+				IL_0380: stloc.s 31
+				IL_0382: ldarg.0
+				IL_0383: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_0388: ldloc.s 31
+				IL_038a: ldarg.2
+				IL_038b: ldarg.3
+				IL_038c: ldarg.s baseIndent
+				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0393: stloc.s 19
+				IL_0395: ldloc.s 19
+				IL_0397: stloc.s 14
+				IL_0399: br IL_03c2
 
-				IL_037c: ldloc.0
-				IL_037d: ldloc.s 12
-				IL_037f: ldloc.s 14
-				IL_0381: ldc.i4.1
-				IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0387: pop
-				IL_0388: br IL_0006
+				IL_039e: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/Scope/Block_L165C37/Block_L196C11::.ctor()
+				IL_03a3: stloc.s 17
+				IL_03a5: ldarg.0
+				IL_03a6: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_03ab: ldc.i4.1
+				IL_03ac: newarr [System.Runtime]System.Object
+				IL_03b1: dup
+				IL_03b2: ldc.i4.0
+				IL_03b3: ldarg.0
+				IL_03b4: stelem.ref
+				IL_03b5: ldloc.s 13
+				IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_03bc: stloc.s 19
+				IL_03be: ldloc.s 19
+				IL_03c0: stloc.s 14
+
+				IL_03c2: ldloc.0
+				IL_03c3: ldloc.s 12
+				IL_03c5: ldloc.s 14
+				IL_03c7: ldc.i4.1
+				IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_03cd: pop
+				IL_03ce: br IL_0006
 			// end loop
 
-			IL_038d: ldloc.0
-			IL_038e: ret
+			IL_03d3: ldloc.0
+			IL_03d4: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -4301,7 +4777,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e68
+				// Method begins at RVA 0x6670
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4328,49 +4804,59 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x44c8
+			// Method begins at RVA 0x47d0
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 110 (0x6e)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[1] object[],
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.2
-			IL_0002: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
-			IL_0007: stloc.1
-			IL_0008: ldloc.1
-			IL_0009: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_000e: stloc.1
-			IL_000f: ldloc.1
-			IL_0010: ldstr "split"
-			IL_0015: ldstr "\n"
-			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_001f: stloc.1
-			IL_0020: ldloc.1
-			IL_0021: stloc.0
-			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0027: dup
-			IL_0028: ldstr "index"
-			IL_002d: ldc.r8 0.0
-			IL_0036: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-			IL_003b: stloc.2
-			IL_003c: ldarg.0
-			IL_003d: castclass Modules.test262_metadataParser/Scope
-			IL_0042: ldnull
-			IL_0043: ldloc.0
-			IL_0044: ldloc.2
-			IL_0045: ldc.r8 0.0
-			IL_004e: box [System.Runtime]System.Double
-			IL_0053: tail.
-			IL_0055: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_005a: ret
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.1
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
+			IL_0011: ldloc.1
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: stloc.2
+			IL_0019: ldloc.2
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_001f: stloc.2
+			IL_0020: ldloc.2
+			IL_0021: ldstr "split"
+			IL_0026: ldstr "\n"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0030: stloc.2
+			IL_0031: ldloc.2
+			IL_0032: stloc.0
+			IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0038: dup
+			IL_0039: ldstr "index"
+			IL_003e: ldc.r8 0.0
+			IL_0047: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+			IL_004c: stloc.3
+			IL_004d: ldarg.0
+			IL_004e: castclass Modules.test262_metadataParser/Scope
+			IL_0053: ldnull
+			IL_0054: ldloc.0
+			IL_0055: ldloc.3
+			IL_0056: ldc.r8 0.0
+			IL_005f: box [System.Runtime]System.Double
+			IL_0064: tail.
+			IL_0066: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+			IL_006b: ret
 
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_006c: ldnull
+			IL_006d: ret
 		} // end of method parseTest262Frontmatter::__js_call__
 
 	} // end of class parseTest262Frontmatter
@@ -4390,7 +4876,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e7a
+					// Method begins at RVA 0x6682
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4410,7 +4896,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e83
+					// Method begins at RVA 0x668b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4430,7 +4916,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e8c
+					// Method begins at RVA 0x6694
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4448,7 +4934,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e71
+				// Method begins at RVA 0x6679
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4475,9 +4961,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4534
+			// Method begins at RVA 0x484c
 			// Header size: 12
-			// Code size: 348 (0x15c)
+			// Code size: 367 (0x16f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4488,130 +4974,140 @@
 				[5] object,
 				[6] object,
 				[7] class Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L224C36,
-				[8] object,
-				[9] float64,
-				[10] object,
-				[11] bool
+				[8] object[],
+				[9] object,
+				[10] float64,
+				[11] object,
+				[12] bool
 			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.2
-			IL_0002: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
-			IL_0007: stloc.s 8
-			IL_0009: ldloc.s 8
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0012: stloc.s 8
-			IL_0014: ldloc.s 8
-			IL_0016: ldstr "indexOf"
-			IL_001b: ldstr "/*---"
-			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0025: stloc.s 8
-			IL_0027: ldloc.s 8
-			IL_0029: stloc.1
-			IL_002a: ldloc.1
-			IL_002b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0030: stloc.s 9
-			IL_0032: ldloc.s 9
-			IL_0034: ldc.r8 0.0
-			IL_003d: clt
-			IL_003f: brfalse IL_0051
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.test262_metadataParser/Scope::normalizeLineEndings
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.2
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0025: stloc.s 9
+			IL_0027: ldloc.s 9
+			IL_0029: ldstr "indexOf"
+			IL_002e: ldstr "/*---"
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0038: stloc.s 9
+			IL_003a: ldloc.s 9
+			IL_003c: stloc.1
+			IL_003d: ldloc.1
+			IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0043: stloc.s 10
+			IL_0045: ldloc.s 10
+			IL_0047: ldc.r8 0.0
+			IL_0050: clt
+			IL_0052: brfalse IL_0064
 
-			IL_0044: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L214C17::.ctor()
-			IL_0049: stloc.2
-			IL_004a: ldc.i4.0
-			IL_004b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0050: ret
+			IL_0057: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L214C17::.ctor()
+			IL_005c: stloc.2
+			IL_005d: ldc.i4.0
+			IL_005e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0063: ret
 
-			IL_0051: ldloc.0
-			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0057: stloc.s 8
-			IL_0059: ldloc.1
-			IL_005a: ldc.r8 5
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0068: stloc.s 10
-			IL_006a: ldloc.s 8
-			IL_006c: ldstr "indexOf"
-			IL_0071: ldstr "---*/"
-			IL_0076: ldloc.s 10
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_007d: stloc.s 8
-			IL_007f: ldloc.s 8
-			IL_0081: stloc.3
-			IL_0082: ldloc.3
-			IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0088: stloc.s 9
-			IL_008a: ldloc.s 9
-			IL_008c: ldc.r8 0.0
-			IL_0095: clt
-			IL_0097: brfalse IL_00cf
+			IL_0064: ldloc.0
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: stloc.s 9
+			IL_006c: ldloc.1
+			IL_006d: ldc.r8 5
+			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_007b: stloc.s 11
+			IL_007d: ldloc.s 9
+			IL_007f: ldstr "indexOf"
+			IL_0084: ldstr "---*/"
+			IL_0089: ldloc.s 11
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0090: stloc.s 9
+			IL_0092: ldloc.s 9
+			IL_0094: stloc.3
+			IL_0095: ldloc.3
+			IL_0096: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009b: stloc.s 10
+			IL_009d: ldloc.s 10
+			IL_009f: ldc.r8 0.0
+			IL_00a8: clt
+			IL_00aa: brfalse IL_00e2
 
-			IL_009c: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L219C15::.ctor()
-			IL_00a1: stloc.s 4
-			IL_00a3: ldstr "Unterminated test262 frontmatter block."
-			IL_00a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00b2: stloc.s 8
-			IL_00b4: ldloc.s 8
-			IL_00b6: stloc.s 5
-			IL_00b8: ldloc.s 5
-			IL_00ba: isinst [System.Runtime]System.Exception
-			IL_00bf: dup
-			IL_00c0: brtrue IL_00ce
+			IL_00af: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L219C15::.ctor()
+			IL_00b4: stloc.s 4
+			IL_00b6: ldstr "Unterminated test262 frontmatter block."
+			IL_00bb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00c5: stloc.s 9
+			IL_00c7: ldloc.s 9
+			IL_00c9: stloc.s 5
+			IL_00cb: ldloc.s 5
+			IL_00cd: isinst [System.Runtime]System.Exception
+			IL_00d2: dup
+			IL_00d3: brtrue IL_00e1
 
-			IL_00c5: pop
-			IL_00c6: ldloc.s 5
-			IL_00c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00cd: throw
+			IL_00d8: pop
+			IL_00d9: ldloc.s 5
+			IL_00db: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00e0: throw
 
-			IL_00ce: throw
+			IL_00e1: throw
 
-			IL_00cf: ldloc.0
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d5: stloc.s 8
-			IL_00d7: ldloc.1
-			IL_00d8: ldc.r8 5
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00e6: stloc.s 10
-			IL_00e8: ldloc.s 8
-			IL_00ea: ldstr "substring"
-			IL_00ef: ldloc.s 10
-			IL_00f1: ldloc.3
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00f7: stloc.s 8
-			IL_00f9: ldloc.s 8
-			IL_00fb: stloc.s 6
-			IL_00fd: ldloc.s 6
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0104: stloc.s 8
-			IL_0106: ldloc.s 8
-			IL_0108: ldstr "startsWith"
-			IL_010d: ldstr "\n"
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0117: stloc.s 8
-			IL_0119: ldloc.s 8
-			IL_011b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0120: stloc.s 11
-			IL_0122: ldloc.s 11
-			IL_0124: brfalse IL_0159
+			IL_00e2: ldloc.0
+			IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e8: stloc.s 9
+			IL_00ea: ldloc.1
+			IL_00eb: ldc.r8 5
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00f9: stloc.s 11
+			IL_00fb: ldloc.s 9
+			IL_00fd: ldstr "substring"
+			IL_0102: ldloc.s 11
+			IL_0104: ldloc.3
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_010a: stloc.s 9
+			IL_010c: ldloc.s 9
+			IL_010e: stloc.s 6
+			IL_0110: ldloc.s 6
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0117: stloc.s 9
+			IL_0119: ldloc.s 9
+			IL_011b: ldstr "startsWith"
+			IL_0120: ldstr "\n"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_012a: stloc.s 9
+			IL_012c: ldloc.s 9
+			IL_012e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0133: stloc.s 12
+			IL_0135: ldloc.s 12
+			IL_0137: brfalse IL_016c
 
-			IL_0129: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L224C36::.ctor()
-			IL_012e: stloc.s 7
-			IL_0130: ldloc.s 6
-			IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0137: stloc.s 8
-			IL_0139: ldloc.s 8
-			IL_013b: ldstr "substring"
-			IL_0140: ldc.r8 1
-			IL_0149: box [System.Runtime]System.Double
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0153: stloc.s 8
-			IL_0155: ldloc.s 8
-			IL_0157: stloc.s 6
+			IL_013c: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/Scope/Block_L224C36::.ctor()
+			IL_0141: stloc.s 7
+			IL_0143: ldloc.s 6
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014a: stloc.s 9
+			IL_014c: ldloc.s 9
+			IL_014e: ldstr "substring"
+			IL_0153: ldc.r8 1
+			IL_015c: box [System.Runtime]System.Double
+			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0166: stloc.s 9
+			IL_0168: ldloc.s 9
+			IL_016a: stloc.s 6
 
-			IL_0159: ldloc.s 6
-			IL_015b: ret
+			IL_016c: ldloc.s 6
+			IL_016e: ret
 		} // end of method extractTest262Frontmatter::__js_call__
 
 	} // end of class extractTest262Frontmatter
@@ -4627,7 +5123,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e95
+				// Method begins at RVA 0x669d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4651,7 +5147,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x469c
+			// Method begins at RVA 0x49c8
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -4710,7 +5206,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ea7
+					// Method begins at RVA 0x66af
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4728,7 +5224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e9e
+				// Method begins at RVA 0x66a6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4752,7 +5248,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x46f0
+			// Method begins at RVA 0x4a1c
 			// Header size: 12
 			// Code size: 125 (0x7d)
 			.maxstack 8
@@ -4830,7 +5326,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5eb0
+				// Method begins at RVA 0x66b8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4855,7 +5351,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x477c
+			// Method begins at RVA 0x4aa8
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -4903,7 +5399,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5eb9
+				// Method begins at RVA 0x66c1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4930,7 +5426,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x47bc
+			// Method begins at RVA 0x4ae8
 			// Header size: 12
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -4979,7 +5475,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ecb
+					// Method begins at RVA 0x66d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4999,7 +5495,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ed4
+					// Method begins at RVA 0x66dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5017,7 +5513,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ec2
+				// Method begins at RVA 0x66ca
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5045,7 +5541,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5eef
+						// Method begins at RVA 0x66f7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5063,7 +5559,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ee6
+					// Method begins at RVA 0x66ee
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5081,7 +5577,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5edd
+				// Method begins at RVA 0x66e5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5110,9 +5606,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4808
+			// Method begins at RVA 0x4b34
 			// Header size: 12
-			// Code size: 405 (0x195)
+			// Code size: 495 (0x1ef)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.test262_metadataParser/toStringArray/Scope/Block_L257C61,
@@ -5128,7 +5624,10 @@
 				[10] object,
 				[11] object,
 				[12] object,
-				[13] string
+				[13] object,
+				[14] object[],
+				[15] string,
+				[16] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -5196,95 +5695,149 @@
 			IL_009d: ceq
 			IL_009f: stloc.s 7
 			IL_00a1: ldloc.s 7
-			IL_00a3: brfalse IL_00ea
+			IL_00a3: brfalse IL_0117
 
 			IL_00a8: newobj instance void Modules.test262_metadataParser/toStringArray/Scope/Block_L261C29::.ctor()
 			IL_00ad: stloc.1
-			IL_00ae: ldarg.3
-			IL_00af: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00ae: ldarg.0
+			IL_00af: ldfld object Modules.test262_metadataParser/Scope::pushIssue
 			IL_00b4: stloc.s 13
-			IL_00b6: ldstr "Expected an array for '"
-			IL_00bb: ldloc.s 13
-			IL_00bd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c2: stloc.s 13
-			IL_00c4: ldloc.s 13
-			IL_00c6: ldstr "'."
-			IL_00cb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d0: stloc.s 13
-			IL_00d2: ldnull
-			IL_00d3: ldarg.s issues
-			IL_00d5: ldstr "invalid-array"
-			IL_00da: ldarg.3
-			IL_00db: ldloc.s 13
-			IL_00dd: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_00e2: pop
-			IL_00e3: ldc.i4.0
-			IL_00e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00e9: ret
+			IL_00b6: ldc.i4.1
+			IL_00b7: newarr [System.Runtime]System.Object
+			IL_00bc: dup
+			IL_00bd: ldc.i4.0
+			IL_00be: ldarg.0
+			IL_00bf: stelem.ref
+			IL_00c0: stloc.s 14
+			IL_00c2: ldarg.3
+			IL_00c3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c8: stloc.s 15
+			IL_00ca: ldstr "Expected an array for '"
+			IL_00cf: ldloc.s 15
+			IL_00d1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d6: stloc.s 15
+			IL_00d8: ldloc.s 15
+			IL_00da: ldstr "'."
+			IL_00df: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00e4: stloc.s 15
+			IL_00e6: ldc.i4.4
+			IL_00e7: newarr [System.Runtime]System.Object
+			IL_00ec: dup
+			IL_00ed: ldc.i4.0
+			IL_00ee: ldarg.s issues
+			IL_00f0: stelem.ref
+			IL_00f1: dup
+			IL_00f2: ldc.i4.1
+			IL_00f3: ldstr "invalid-array"
+			IL_00f8: stelem.ref
+			IL_00f9: dup
+			IL_00fa: ldc.i4.2
+			IL_00fb: ldarg.3
+			IL_00fc: stelem.ref
+			IL_00fd: dup
+			IL_00fe: ldc.i4.3
+			IL_00ff: ldloc.s 15
+			IL_0101: stelem.ref
+			IL_0102: stloc.s 16
+			IL_0104: ldloc.s 13
+			IL_0106: ldloc.s 14
+			IL_0108: ldloc.s 16
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_010f: pop
+			IL_0110: ldc.i4.0
+			IL_0111: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0116: ret
 
-			IL_00ea: ldc.i4.0
-			IL_00eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00f0: stloc.2
-			IL_00f1: ldc.r8 0.0
-			IL_00fa: stloc.3
-			// loop start (head: IL_00fb)
-				IL_00fb: ldloc.3
-				IL_00fc: ldarg.2
-				IL_00fd: ldstr "length"
-				IL_0102: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0107: clt
-				IL_0109: brfalse IL_0193
+			IL_0117: ldc.i4.0
+			IL_0118: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_011d: stloc.2
+			IL_011e: ldc.r8 0.0
+			IL_0127: stloc.3
+			// loop start (head: IL_0128)
+				IL_0128: ldloc.3
+				IL_0129: ldarg.2
+				IL_012a: ldstr "length"
+				IL_012f: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0134: clt
+				IL_0136: brfalse IL_01ed
 
-				IL_010e: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41::.ctor()
-				IL_0113: stloc.s 4
-				IL_0115: ldarg.2
-				IL_0116: ldloc.3
-				IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_011c: stloc.s 5
-				IL_011e: ldloc.s 5
-				IL_0120: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-				IL_0125: ldstr "string"
-				IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_012f: stloc.s 7
-				IL_0131: ldloc.s 7
-				IL_0133: brfalse IL_0179
+				IL_013b: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41::.ctor()
+				IL_0140: stloc.s 4
+				IL_0142: ldarg.2
+				IL_0143: ldloc.3
+				IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0149: stloc.s 5
+				IL_014b: ldloc.s 5
+				IL_014d: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+				IL_0152: ldstr "string"
+				IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_015c: stloc.s 7
+				IL_015e: ldloc.s 7
+				IL_0160: brfalse IL_01d3
 
-				IL_0138: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41/Block_L269C35::.ctor()
-				IL_013d: stloc.s 6
-				IL_013f: ldarg.3
-				IL_0140: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0145: stloc.s 13
-				IL_0147: ldstr "Expected string entries for '"
-				IL_014c: ldloc.s 13
-				IL_014e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0153: stloc.s 13
-				IL_0155: ldloc.s 13
-				IL_0157: ldstr "'."
-				IL_015c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0161: stloc.s 13
-				IL_0163: ldnull
-				IL_0164: ldarg.s issues
-				IL_0166: ldstr "invalid-array-entry"
-				IL_016b: ldarg.3
-				IL_016c: ldloc.s 13
-				IL_016e: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_0173: pop
-				IL_0174: br IL_0182
+				IL_0165: newobj instance void Modules.test262_metadataParser/toStringArray/Scope_For_L267C7/Block_L267C41/Block_L269C35::.ctor()
+				IL_016a: stloc.s 6
+				IL_016c: ldarg.0
+				IL_016d: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0172: stloc.s 13
+				IL_0174: ldc.i4.1
+				IL_0175: newarr [System.Runtime]System.Object
+				IL_017a: dup
+				IL_017b: ldc.i4.0
+				IL_017c: ldarg.0
+				IL_017d: stelem.ref
+				IL_017e: stloc.s 16
+				IL_0180: ldarg.3
+				IL_0181: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0186: stloc.s 15
+				IL_0188: ldstr "Expected string entries for '"
+				IL_018d: ldloc.s 15
+				IL_018f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0194: stloc.s 15
+				IL_0196: ldloc.s 15
+				IL_0198: ldstr "'."
+				IL_019d: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01a2: stloc.s 15
+				IL_01a4: ldc.i4.4
+				IL_01a5: newarr [System.Runtime]System.Object
+				IL_01aa: dup
+				IL_01ab: ldc.i4.0
+				IL_01ac: ldarg.s issues
+				IL_01ae: stelem.ref
+				IL_01af: dup
+				IL_01b0: ldc.i4.1
+				IL_01b1: ldstr "invalid-array-entry"
+				IL_01b6: stelem.ref
+				IL_01b7: dup
+				IL_01b8: ldc.i4.2
+				IL_01b9: ldarg.3
+				IL_01ba: stelem.ref
+				IL_01bb: dup
+				IL_01bc: ldc.i4.3
+				IL_01bd: ldloc.s 15
+				IL_01bf: stelem.ref
+				IL_01c0: stloc.s 14
+				IL_01c2: ldloc.s 13
+				IL_01c4: ldloc.s 16
+				IL_01c6: ldloc.s 14
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_01cd: pop
+				IL_01ce: br IL_01dc
 
-				IL_0179: ldloc.2
-				IL_017a: ldloc.s 5
-				IL_017c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0181: pop
+				IL_01d3: ldloc.2
+				IL_01d4: ldloc.s 5
+				IL_01d6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01db: pop
 
-				IL_0182: ldloc.3
-				IL_0183: ldc.r8 1
-				IL_018c: add
-				IL_018d: stloc.3
-				IL_018e: br IL_00fb
+				IL_01dc: ldloc.3
+				IL_01dd: ldc.r8 1
+				IL_01e6: add
+				IL_01e7: stloc.3
+				IL_01e8: br IL_0128
 			// end loop
 
-			IL_0193: ldloc.2
-			IL_0194: ret
+			IL_01ed: ldloc.2
+			IL_01ee: ret
 		} // end of method toStringArray::__js_call__
 
 	} // end of class toStringArray
@@ -5304,7 +5857,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f01
+					// Method begins at RVA 0x6709
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5324,7 +5877,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f0a
+					// Method begins at RVA 0x6712
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5342,7 +5895,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5ef8
+				// Method begins at RVA 0x6700
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5371,9 +5924,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x49ac
+			// Method begins at RVA 0x4d30
 			// Header size: 12
-			// Code size: 220 (0xdc)
+			// Code size: 265 (0x109)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.test262_metadataParser/toNullableString/Scope/Block_L281C61,
@@ -5384,7 +5937,10 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] string
+				[8] object,
+				[9] object[],
+				[10] string,
+				[11] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -5450,34 +6006,61 @@
 			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 			IL_0091: stloc.2
 			IL_0092: ldloc.2
-			IL_0093: brfalse IL_00da
+			IL_0093: brfalse IL_0107
 
 			IL_0098: newobj instance void Modules.test262_metadataParser/toNullableString/Scope/Block_L285C33::.ctor()
 			IL_009d: stloc.1
-			IL_009e: ldarg.3
-			IL_009f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009e: ldarg.0
+			IL_009f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
 			IL_00a4: stloc.s 8
-			IL_00a6: ldstr "Expected a string for '"
-			IL_00ab: ldloc.s 8
-			IL_00ad: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b2: stloc.s 8
-			IL_00b4: ldloc.s 8
-			IL_00b6: ldstr "'."
-			IL_00bb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c0: stloc.s 8
-			IL_00c2: ldnull
-			IL_00c3: ldarg.s issues
-			IL_00c5: ldstr "invalid-string"
-			IL_00ca: ldarg.3
-			IL_00cb: ldloc.s 8
-			IL_00cd: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_00d2: pop
-			IL_00d3: ldc.i4.0
-			IL_00d4: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00d9: ret
+			IL_00a6: ldc.i4.1
+			IL_00a7: newarr [System.Runtime]System.Object
+			IL_00ac: dup
+			IL_00ad: ldc.i4.0
+			IL_00ae: ldarg.0
+			IL_00af: stelem.ref
+			IL_00b0: stloc.s 9
+			IL_00b2: ldarg.3
+			IL_00b3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b8: stloc.s 10
+			IL_00ba: ldstr "Expected a string for '"
+			IL_00bf: ldloc.s 10
+			IL_00c1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c6: stloc.s 10
+			IL_00c8: ldloc.s 10
+			IL_00ca: ldstr "'."
+			IL_00cf: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d4: stloc.s 10
+			IL_00d6: ldc.i4.4
+			IL_00d7: newarr [System.Runtime]System.Object
+			IL_00dc: dup
+			IL_00dd: ldc.i4.0
+			IL_00de: ldarg.s issues
+			IL_00e0: stelem.ref
+			IL_00e1: dup
+			IL_00e2: ldc.i4.1
+			IL_00e3: ldstr "invalid-string"
+			IL_00e8: stelem.ref
+			IL_00e9: dup
+			IL_00ea: ldc.i4.2
+			IL_00eb: ldarg.3
+			IL_00ec: stelem.ref
+			IL_00ed: dup
+			IL_00ee: ldc.i4.3
+			IL_00ef: ldloc.s 10
+			IL_00f1: stelem.ref
+			IL_00f2: stloc.s 11
+			IL_00f4: ldloc.s 8
+			IL_00f6: ldloc.s 9
+			IL_00f8: ldloc.s 11
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_00ff: pop
+			IL_0100: ldc.i4.0
+			IL_0101: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0106: ret
 
-			IL_00da: ldarg.2
-			IL_00db: ret
+			IL_0107: ldarg.2
+			IL_0108: ret
 		} // end of method toNullableString::__js_call__
 
 	} // end of class toNullableString
@@ -5497,7 +6080,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f1c
+					// Method begins at RVA 0x6724
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5517,7 +6100,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f25
+					// Method begins at RVA 0x672d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5537,7 +6120,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f2e
+					// Method begins at RVA 0x6736
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5557,7 +6140,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f52
+					// Method begins at RVA 0x675a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5575,7 +6158,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f13
+				// Method begins at RVA 0x671b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5603,7 +6186,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f49
+						// Method begins at RVA 0x6751
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5621,7 +6204,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f40
+					// Method begins at RVA 0x6748
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5639,7 +6222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f37
+				// Method begins at RVA 0x673f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5667,9 +6250,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4a94
+			// Method begins at RVA 0x4e48
 			// Header size: 12
-			// Code size: 971 (0x3cb)
+			// Code size: 1136 (0x470)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.test262_metadataParser/normalizeNegative/Scope/Block_L294C79,
@@ -5693,13 +6276,16 @@
 				[18] object,
 				[19] object,
 				[20] object,
-				[21] float64,
+				[21] object[],
 				[22] object,
-				[23] string,
+				[23] float64,
 				[24] object,
 				[25] string,
-				[26] object,
-				[27] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[26] object[],
+				[27] object,
+				[28] string,
+				[29] object,
+				[30] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.2
@@ -5808,259 +6394,356 @@
 			IL_010a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_010f: stloc.s 12
 			IL_0111: ldloc.s 12
-			IL_0113: brfalse IL_013c
+			IL_0113: brfalse IL_0165
 
 			IL_0118: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L298C85::.ctor()
 			IL_011d: stloc.1
-			IL_011e: ldnull
-			IL_011f: ldarg.3
-			IL_0120: ldstr "invalid-negative"
-			IL_0125: ldstr "negative"
-			IL_012a: ldstr "Expected an object for the negative frontmatter value."
-			IL_012f: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0134: pop
-			IL_0135: ldc.i4.0
-			IL_0136: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_013b: ret
+			IL_011e: ldarg.0
+			IL_011f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0124: stloc.s 20
+			IL_0126: ldc.i4.1
+			IL_0127: newarr [System.Runtime]System.Object
+			IL_012c: dup
+			IL_012d: ldc.i4.0
+			IL_012e: ldarg.0
+			IL_012f: stelem.ref
+			IL_0130: stloc.s 21
+			IL_0132: ldloc.s 20
+			IL_0134: ldloc.s 21
+			IL_0136: ldc.i4.4
+			IL_0137: newarr [System.Runtime]System.Object
+			IL_013c: dup
+			IL_013d: ldc.i4.0
+			IL_013e: ldarg.3
+			IL_013f: stelem.ref
+			IL_0140: dup
+			IL_0141: ldc.i4.1
+			IL_0142: ldstr "invalid-negative"
+			IL_0147: stelem.ref
+			IL_0148: dup
+			IL_0149: ldc.i4.2
+			IL_014a: ldstr "negative"
+			IL_014f: stelem.ref
+			IL_0150: dup
+			IL_0151: ldc.i4.3
+			IL_0152: ldstr "Expected an object for the negative frontmatter value."
+			IL_0157: stelem.ref
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_015d: pop
+			IL_015e: ldc.i4.0
+			IL_015f: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0164: ret
 
-			IL_013c: ldarg.2
-			IL_013d: ldstr "phase"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0147: stloc.s 20
-			IL_0149: ldarg.0
-			IL_014a: castclass Modules.test262_metadataParser/Scope
-			IL_014f: ldnull
-			IL_0150: ldloc.s 20
-			IL_0152: ldstr "negative.phase"
-			IL_0157: ldarg.3
-			IL_0158: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_015d: stloc.s 20
-			IL_015f: ldloc.s 20
-			IL_0161: stloc.2
-			IL_0162: ldarg.2
-			IL_0163: ldstr "type"
-			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_016d: stloc.s 20
-			IL_016f: ldarg.0
-			IL_0170: castclass Modules.test262_metadataParser/Scope
-			IL_0175: ldnull
-			IL_0176: ldloc.s 20
-			IL_0178: ldstr "negative.type"
-			IL_017d: ldarg.3
-			IL_017e: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0183: stloc.s 20
-			IL_0185: ldloc.s 20
-			IL_0187: stloc.3
-			IL_0188: ldc.i4.3
-			IL_0189: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_018e: dup
-			IL_018f: ldstr "parse"
-			IL_0194: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0199: dup
-			IL_019a: ldstr "resolution"
-			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01a4: dup
-			IL_01a5: ldstr "runtime"
-			IL_01aa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01af: stloc.s 4
-			IL_01b1: ldloc.2
-			IL_01b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b7: stloc.s 12
-			IL_01b9: ldloc.s 12
-			IL_01bb: brfalse IL_01f4
+			IL_0165: ldarg.0
+			IL_0166: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_016b: stloc.s 20
+			IL_016d: ldc.i4.1
+			IL_016e: newarr [System.Runtime]System.Object
+			IL_0173: dup
+			IL_0174: ldc.i4.0
+			IL_0175: ldarg.0
+			IL_0176: stelem.ref
+			IL_0177: stloc.s 21
+			IL_0179: ldarg.2
+			IL_017a: ldstr "phase"
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0184: stloc.s 22
+			IL_0186: ldloc.s 20
+			IL_0188: ldloc.s 21
+			IL_018a: ldloc.s 22
+			IL_018c: ldstr "negative.phase"
+			IL_0191: ldarg.3
+			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0197: stloc.s 22
+			IL_0199: ldloc.s 22
+			IL_019b: stloc.2
+			IL_019c: ldarg.0
+			IL_019d: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_01a2: stloc.s 22
+			IL_01a4: ldc.i4.1
+			IL_01a5: newarr [System.Runtime]System.Object
+			IL_01aa: dup
+			IL_01ab: ldc.i4.0
+			IL_01ac: ldarg.0
+			IL_01ad: stelem.ref
+			IL_01ae: stloc.s 21
+			IL_01b0: ldarg.2
+			IL_01b1: ldstr "type"
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bb: stloc.s 20
+			IL_01bd: ldloc.s 22
+			IL_01bf: ldloc.s 21
+			IL_01c1: ldloc.s 20
+			IL_01c3: ldstr "negative.type"
+			IL_01c8: ldarg.3
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01ce: stloc.s 20
+			IL_01d0: ldloc.s 20
+			IL_01d2: stloc.3
+			IL_01d3: ldc.i4.3
+			IL_01d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01d9: dup
+			IL_01da: ldstr "parse"
+			IL_01df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01e4: dup
+			IL_01e5: ldstr "resolution"
+			IL_01ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01ef: dup
+			IL_01f0: ldstr "runtime"
+			IL_01f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01fa: stloc.s 4
+			IL_01fc: ldloc.2
+			IL_01fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0202: stloc.s 12
+			IL_0204: ldloc.s 12
+			IL_0206: brfalse IL_023f
 
-			IL_01c0: ldloc.s 4
-			IL_01c2: ldc.i4.1
-			IL_01c3: newarr [System.Runtime]System.Object
-			IL_01c8: dup
-			IL_01c9: ldc.i4.0
-			IL_01ca: ldloc.2
-			IL_01cb: stelem.ref
-			IL_01cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-			IL_01d1: stloc.s 21
-			IL_01d3: ldloc.s 21
-			IL_01d5: ldc.r8 0.0
-			IL_01de: clt
-			IL_01e0: stloc.s 12
-			IL_01e2: ldloc.s 12
-			IL_01e4: box [System.Runtime]System.Boolean
-			IL_01e9: stloc.s 13
-			IL_01eb: ldloc.s 13
-			IL_01ed: stloc.s 22
-			IL_01ef: br IL_01f7
+			IL_020b: ldloc.s 4
+			IL_020d: ldc.i4.1
+			IL_020e: newarr [System.Runtime]System.Object
+			IL_0213: dup
+			IL_0214: ldc.i4.0
+			IL_0215: ldloc.2
+			IL_0216: stelem.ref
+			IL_0217: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+			IL_021c: stloc.s 23
+			IL_021e: ldloc.s 23
+			IL_0220: ldc.r8 0.0
+			IL_0229: clt
+			IL_022b: stloc.s 12
+			IL_022d: ldloc.s 12
+			IL_022f: box [System.Runtime]System.Boolean
+			IL_0234: stloc.s 13
+			IL_0236: ldloc.s 13
+			IL_0238: stloc.s 24
+			IL_023a: br IL_0242
 
-			IL_01f4: ldloc.2
-			IL_01f5: stloc.s 22
+			IL_023f: ldloc.2
+			IL_0240: stloc.s 24
 
-			IL_01f7: ldloc.s 22
-			IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01fe: stloc.s 12
-			IL_0200: ldloc.s 12
-			IL_0202: brfalse IL_0246
+			IL_0242: ldloc.s 24
+			IL_0244: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0249: stloc.s 12
+			IL_024b: ldloc.s 12
+			IL_024d: brfalse IL_02be
 
-			IL_0207: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L307C49::.ctor()
-			IL_020c: stloc.s 5
-			IL_020e: ldloc.2
-			IL_020f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0214: stloc.s 23
-			IL_0216: ldstr "Unsupported negative phase '"
-			IL_021b: ldloc.s 23
-			IL_021d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0222: stloc.s 23
-			IL_0224: ldloc.s 23
-			IL_0226: ldstr "'."
-			IL_022b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0230: stloc.s 23
-			IL_0232: ldnull
-			IL_0233: ldarg.3
-			IL_0234: ldstr "unknown-negative-phase"
-			IL_0239: ldstr "negative.phase"
-			IL_023e: ldloc.s 23
-			IL_0240: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0245: pop
+			IL_0252: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L307C49::.ctor()
+			IL_0257: stloc.s 5
+			IL_0259: ldarg.0
+			IL_025a: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_025f: stloc.s 20
+			IL_0261: ldc.i4.1
+			IL_0262: newarr [System.Runtime]System.Object
+			IL_0267: dup
+			IL_0268: ldc.i4.0
+			IL_0269: ldarg.0
+			IL_026a: stelem.ref
+			IL_026b: stloc.s 21
+			IL_026d: ldloc.2
+			IL_026e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0273: stloc.s 25
+			IL_0275: ldstr "Unsupported negative phase '"
+			IL_027a: ldloc.s 25
+			IL_027c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0281: stloc.s 25
+			IL_0283: ldloc.s 25
+			IL_0285: ldstr "'."
+			IL_028a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_028f: stloc.s 25
+			IL_0291: ldc.i4.4
+			IL_0292: newarr [System.Runtime]System.Object
+			IL_0297: dup
+			IL_0298: ldc.i4.0
+			IL_0299: ldarg.3
+			IL_029a: stelem.ref
+			IL_029b: dup
+			IL_029c: ldc.i4.1
+			IL_029d: ldstr "unknown-negative-phase"
+			IL_02a2: stelem.ref
+			IL_02a3: dup
+			IL_02a4: ldc.i4.2
+			IL_02a5: ldstr "negative.phase"
+			IL_02aa: stelem.ref
+			IL_02ab: dup
+			IL_02ac: ldc.i4.3
+			IL_02ad: ldloc.s 25
+			IL_02af: stelem.ref
+			IL_02b0: stloc.s 26
+			IL_02b2: ldloc.s 20
+			IL_02b4: ldloc.s 21
+			IL_02b6: ldloc.s 26
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_02bd: pop
 
-			IL_0246: ldarg.2
-			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_024c: stloc.s 20
-			IL_024e: ldloc.s 20
-			IL_0250: stloc.s 6
-			IL_0252: ldc.r8 0.0
-			IL_025b: stloc.s 7
-			// loop start (head: IL_025d)
-				IL_025d: ldloc.s 7
-				IL_025f: ldloc.s 6
-				IL_0261: ldstr "length"
-				IL_0266: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_026b: clt
-				IL_026d: brfalse IL_0346
+			IL_02be: ldarg.2
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_02c4: stloc.s 20
+			IL_02c6: ldloc.s 20
+			IL_02c8: stloc.s 6
+			IL_02ca: ldc.r8 0.0
+			IL_02d3: stloc.s 7
+			// loop start (head: IL_02d5)
+				IL_02d5: ldloc.s 7
+				IL_02d7: ldloc.s 6
+				IL_02d9: ldstr "length"
+				IL_02de: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_02e3: clt
+				IL_02e5: brfalse IL_03eb
 
-				IL_0272: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40::.ctor()
-				IL_0277: stloc.s 8
-				IL_0279: ldloc.s 6
-				IL_027b: ldloc.s 7
-				IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0282: stloc.s 9
-				IL_0284: ldloc.s 9
-				IL_0286: ldstr "phase"
-				IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0290: stloc.s 12
-				IL_0292: ldloc.s 12
-				IL_0294: box [System.Runtime]System.Boolean
-				IL_0299: stloc.s 13
-				IL_029b: ldloc.s 13
-				IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02a2: stloc.s 12
-				IL_02a4: ldloc.s 12
-				IL_02a6: brfalse IL_02cb
+				IL_02ea: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40::.ctor()
+				IL_02ef: stloc.s 8
+				IL_02f1: ldloc.s 6
+				IL_02f3: ldloc.s 7
+				IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02fa: stloc.s 9
+				IL_02fc: ldloc.s 9
+				IL_02fe: ldstr "phase"
+				IL_0303: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0308: stloc.s 12
+				IL_030a: ldloc.s 12
+				IL_030c: box [System.Runtime]System.Boolean
+				IL_0311: stloc.s 13
+				IL_0313: ldloc.s 13
+				IL_0315: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_031a: stloc.s 12
+				IL_031c: ldloc.s 12
+				IL_031e: brfalse IL_0343
 
-				IL_02ab: ldloc.s 9
-				IL_02ad: ldstr "type"
-				IL_02b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_02b7: stloc.s 12
-				IL_02b9: ldloc.s 12
-				IL_02bb: box [System.Runtime]System.Boolean
-				IL_02c0: stloc.s 14
-				IL_02c2: ldloc.s 14
-				IL_02c4: stloc.s 24
-				IL_02c6: br IL_02cf
+				IL_0323: ldloc.s 9
+				IL_0325: ldstr "type"
+				IL_032a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_032f: stloc.s 12
+				IL_0331: ldloc.s 12
+				IL_0333: box [System.Runtime]System.Boolean
+				IL_0338: stloc.s 14
+				IL_033a: ldloc.s 14
+				IL_033c: stloc.s 27
+				IL_033e: br IL_0347
 
-				IL_02cb: ldloc.s 13
-				IL_02cd: stloc.s 24
+				IL_0343: ldloc.s 13
+				IL_0345: stloc.s 27
 
-				IL_02cf: ldloc.s 24
-				IL_02d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02d6: stloc.s 12
-				IL_02d8: ldloc.s 12
-				IL_02da: brfalse IL_0333
+				IL_0347: ldloc.s 27
+				IL_0349: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_034e: stloc.s 12
+				IL_0350: ldloc.s 12
+				IL_0352: brfalse IL_03d8
 
-				IL_02df: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40/Block_L314C43::.ctor()
-				IL_02e4: stloc.s 10
-				IL_02e6: ldloc.s 9
-				IL_02e8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_02ed: stloc.s 23
-				IL_02ef: ldstr "negative."
-				IL_02f4: ldloc.s 23
-				IL_02f6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_02fb: stloc.s 23
-				IL_02fd: ldloc.s 9
-				IL_02ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0304: stloc.s 25
-				IL_0306: ldstr "Unsupported negative metadata key '"
-				IL_030b: ldloc.s 25
-				IL_030d: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0312: stloc.s 25
-				IL_0314: ldloc.s 25
-				IL_0316: ldstr "'."
-				IL_031b: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0320: stloc.s 25
-				IL_0322: ldnull
-				IL_0323: ldarg.3
-				IL_0324: ldstr "unknown-negative-key"
-				IL_0329: ldloc.s 23
-				IL_032b: ldloc.s 25
-				IL_032d: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_0332: pop
+				IL_0357: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope_For_L312C7/Block_L312C40/Block_L314C43::.ctor()
+				IL_035c: stloc.s 10
+				IL_035e: ldarg.0
+				IL_035f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0364: stloc.s 20
+				IL_0366: ldc.i4.1
+				IL_0367: newarr [System.Runtime]System.Object
+				IL_036c: dup
+				IL_036d: ldc.i4.0
+				IL_036e: ldarg.0
+				IL_036f: stelem.ref
+				IL_0370: stloc.s 26
+				IL_0372: ldloc.s 9
+				IL_0374: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0379: stloc.s 25
+				IL_037b: ldstr "negative."
+				IL_0380: ldloc.s 25
+				IL_0382: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0387: stloc.s 25
+				IL_0389: ldloc.s 9
+				IL_038b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0390: stloc.s 28
+				IL_0392: ldstr "Unsupported negative metadata key '"
+				IL_0397: ldloc.s 28
+				IL_0399: call string [System.Runtime]System.String::Concat(string, string)
+				IL_039e: stloc.s 28
+				IL_03a0: ldloc.s 28
+				IL_03a2: ldstr "'."
+				IL_03a7: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03ac: stloc.s 28
+				IL_03ae: ldc.i4.4
+				IL_03af: newarr [System.Runtime]System.Object
+				IL_03b4: dup
+				IL_03b5: ldc.i4.0
+				IL_03b6: ldarg.3
+				IL_03b7: stelem.ref
+				IL_03b8: dup
+				IL_03b9: ldc.i4.1
+				IL_03ba: ldstr "unknown-negative-key"
+				IL_03bf: stelem.ref
+				IL_03c0: dup
+				IL_03c1: ldc.i4.2
+				IL_03c2: ldloc.s 25
+				IL_03c4: stelem.ref
+				IL_03c5: dup
+				IL_03c6: ldc.i4.3
+				IL_03c7: ldloc.s 28
+				IL_03c9: stelem.ref
+				IL_03ca: stloc.s 21
+				IL_03cc: ldloc.s 20
+				IL_03ce: ldloc.s 26
+				IL_03d0: ldloc.s 21
+				IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_03d7: pop
 
-				IL_0333: ldloc.s 7
-				IL_0335: ldc.r8 1
-				IL_033e: add
-				IL_033f: stloc.s 7
-				IL_0341: br IL_025d
+				IL_03d8: ldloc.s 7
+				IL_03da: ldc.r8 1
+				IL_03e3: add
+				IL_03e4: stloc.s 7
+				IL_03e6: br IL_02d5
 			// end loop
 
-			IL_0346: ldloc.2
-			IL_0347: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_034c: ldc.i4.0
-			IL_034d: ceq
-			IL_034f: stloc.s 12
-			IL_0351: ldloc.s 12
-			IL_0353: box [System.Runtime]System.Boolean
-			IL_0358: stloc.s 13
-			IL_035a: ldloc.s 13
-			IL_035c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0361: stloc.s 12
-			IL_0363: ldloc.s 12
-			IL_0365: brtrue IL_0387
+			IL_03eb: ldloc.2
+			IL_03ec: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03f1: ldc.i4.0
+			IL_03f2: ceq
+			IL_03f4: stloc.s 12
+			IL_03f6: ldloc.s 12
+			IL_03f8: box [System.Runtime]System.Boolean
+			IL_03fd: stloc.s 13
+			IL_03ff: ldloc.s 13
+			IL_0401: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0406: stloc.s 12
+			IL_0408: ldloc.s 12
+			IL_040a: brtrue IL_042c
 
-			IL_036a: ldloc.3
-			IL_036b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0370: ldc.i4.0
-			IL_0371: ceq
-			IL_0373: stloc.s 12
-			IL_0375: ldloc.s 12
-			IL_0377: box [System.Runtime]System.Boolean
-			IL_037c: stloc.s 14
-			IL_037e: ldloc.s 14
-			IL_0380: stloc.s 26
-			IL_0382: br IL_038b
+			IL_040f: ldloc.3
+			IL_0410: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0415: ldc.i4.0
+			IL_0416: ceq
+			IL_0418: stloc.s 12
+			IL_041a: ldloc.s 12
+			IL_041c: box [System.Runtime]System.Boolean
+			IL_0421: stloc.s 14
+			IL_0423: ldloc.s 14
+			IL_0425: stloc.s 29
+			IL_0427: br IL_0430
 
-			IL_0387: ldloc.s 13
-			IL_0389: stloc.s 26
+			IL_042c: ldloc.s 13
+			IL_042e: stloc.s 29
 
-			IL_038b: ldloc.s 26
-			IL_038d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0392: stloc.s 12
-			IL_0394: ldloc.s 12
-			IL_0396: brfalse IL_03a9
+			IL_0430: ldloc.s 29
+			IL_0432: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0437: stloc.s 12
+			IL_0439: ldloc.s 12
+			IL_043b: brfalse IL_044e
 
-			IL_039b: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L319C23::.ctor()
-			IL_03a0: stloc.s 11
-			IL_03a2: ldc.i4.0
-			IL_03a3: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03a8: ret
+			IL_0440: newobj instance void Modules.test262_metadataParser/normalizeNegative/Scope/Block_L319C23::.ctor()
+			IL_0445: stloc.s 11
+			IL_0447: ldc.i4.0
+			IL_0448: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_044d: ret
 
-			IL_03a9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03ae: dup
-			IL_03af: ldstr "phase"
-			IL_03b4: ldloc.2
-			IL_03b5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03ba: dup
-			IL_03bb: ldstr "type"
-			IL_03c0: ldloc.3
-			IL_03c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03c6: stloc.s 27
-			IL_03c8: ldloc.s 27
-			IL_03ca: ret
+			IL_044e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0453: dup
+			IL_0454: ldstr "phase"
+			IL_0459: ldloc.2
+			IL_045a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_045f: dup
+			IL_0460: ldstr "type"
+			IL_0465: ldloc.3
+			IL_0466: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_046b: stloc.s 30
+			IL_046d: ldloc.s 30
+			IL_046f: ret
 		} // end of method normalizeNegative::__js_call__
 
 	} // end of class normalizeNegative
@@ -6084,7 +6767,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f88
+						// Method begins at RVA 0x6790
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6104,7 +6787,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f91
+						// Method begins at RVA 0x6799
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6124,7 +6807,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f9a
+						// Method begins at RVA 0x67a2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6142,7 +6825,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f7f
+					// Method begins at RVA 0x6787
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6162,7 +6845,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fa3
+					// Method begins at RVA 0x67ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6182,7 +6865,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fac
+					// Method begins at RVA 0x67b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6200,7 +6883,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f5b
+				// Method begins at RVA 0x6763
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6228,7 +6911,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f76
+						// Method begins at RVA 0x677e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6246,7 +6929,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f6d
+					// Method begins at RVA 0x6775
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6264,7 +6947,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5f64
+				// Method begins at RVA 0x676c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6292,7 +6975,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5fc7
+						// Method begins at RVA 0x67cf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6310,7 +6993,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fbe
+					// Method begins at RVA 0x67c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6328,7 +7011,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5fb5
+				// Method begins at RVA 0x67bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6357,9 +7040,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x4e6c
+			// Method begins at RVA 0x52c4
 			// Header size: 12
-			// Code size: 1461 (0x5b5)
+			// Code size: 1681 (0x691)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6393,548 +7076,653 @@
 				[28] object,
 				[29] object,
 				[30] object,
-				[31] object,
-				[32] float64,
-				[33] bool,
-				[34] string,
-				[35] object,
+				[31] object[],
+				[32] object,
+				[33] float64,
+				[34] bool,
+				[35] string,
 				[36] object,
 				[37] object,
 				[38] object,
-				[39] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[40] object,
+				[39] object,
+				[40] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[41] object,
-				[42] bool,
-				[43] object,
+				[42] object,
+				[43] bool,
 				[44] object,
 				[45] object,
-				[46] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[46] object,
+				[47] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.2
-			IL_0002: ldstr "module"
-			IL_0007: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_000c: stloc.s 31
-			IL_000e: ldloc.s 31
-			IL_0010: stloc.0
-			IL_0011: ldnull
-			IL_0012: ldarg.2
-			IL_0013: ldstr "raw"
-			IL_0018: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_001d: stloc.s 31
-			IL_001f: ldloc.s 31
-			IL_0021: stloc.1
-			IL_0022: ldnull
-			IL_0023: ldarg.2
-			IL_0024: ldstr "async"
-			IL_0029: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 31
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0012: ldloc.s 31
+			IL_0014: ldarg.2
+			IL_0015: ldstr "module"
+			IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_001f: stloc.s 32
+			IL_0021: ldloc.s 32
+			IL_0023: stloc.0
+			IL_0024: ldc.i4.1
+			IL_0025: newarr [System.Runtime]System.Object
+			IL_002a: dup
+			IL_002b: ldc.i4.0
+			IL_002c: ldarg.0
+			IL_002d: stelem.ref
 			IL_002e: stloc.s 31
-			IL_0030: ldloc.s 31
-			IL_0032: stloc.2
-			IL_0033: ldnull
-			IL_0034: ldarg.2
-			IL_0035: ldstr "generated"
-			IL_003a: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_003f: stloc.s 31
-			IL_0041: ldloc.s 31
-			IL_0043: stloc.3
-			IL_0044: ldnull
-			IL_0045: ldarg.2
-			IL_0046: ldstr "non-deterministic"
-			IL_004b: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_0050: stloc.s 31
-			IL_0052: ldloc.s 31
-			IL_0054: stloc.s 4
-			IL_0056: ldarg.s fileName
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005d: stloc.s 31
-			IL_005f: ldloc.s 31
-			IL_0061: ldstr "indexOf"
-			IL_0066: ldstr "_FIXTURE"
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0070: stloc.s 31
-			IL_0072: ldloc.s 31
-			IL_0074: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0079: stloc.s 32
-			IL_007b: ldloc.s 32
-			IL_007d: ldc.r8 0.0
-			IL_0086: clt
-			IL_0088: ldc.i4.0
-			IL_0089: ceq
-			IL_008b: stloc.s 33
-			IL_008d: ldloc.s 33
-			IL_008f: stloc.s 5
-			IL_0091: ldc.i4.0
-			IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0097: stloc.s 6
-			IL_0099: ldc.i4.4
-			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_009f: dup
-			IL_00a0: ldstr "onlyStrict"
-			IL_00a5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00aa: dup
-			IL_00ab: ldstr "noStrict"
-			IL_00b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00b5: dup
-			IL_00b6: ldstr "module"
-			IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00c0: dup
-			IL_00c1: ldstr "raw"
-			IL_00c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00cb: stloc.s 7
-			IL_00cd: ldc.r8 0.0
-			IL_00d6: stloc.s 8
-			// loop start (head: IL_00d8)
-				IL_00d8: ldloc.s 8
-				IL_00da: ldloc.s 7
-				IL_00dc: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-				IL_00e1: conv.r8
-				IL_00e2: clt
-				IL_00e4: brfalse IL_013f
+			IL_0030: ldarg.0
+			IL_0031: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0036: ldloc.s 31
+			IL_0038: ldarg.2
+			IL_0039: ldstr "raw"
+			IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0043: stloc.s 32
+			IL_0045: ldloc.s 32
+			IL_0047: stloc.1
+			IL_0048: ldc.i4.1
+			IL_0049: newarr [System.Runtime]System.Object
+			IL_004e: dup
+			IL_004f: ldc.i4.0
+			IL_0050: ldarg.0
+			IL_0051: stelem.ref
+			IL_0052: stloc.s 31
+			IL_0054: ldarg.0
+			IL_0055: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_005a: ldloc.s 31
+			IL_005c: ldarg.2
+			IL_005d: ldstr "async"
+			IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0067: stloc.s 32
+			IL_0069: ldloc.s 32
+			IL_006b: stloc.2
+			IL_006c: ldc.i4.1
+			IL_006d: newarr [System.Runtime]System.Object
+			IL_0072: dup
+			IL_0073: ldc.i4.0
+			IL_0074: ldarg.0
+			IL_0075: stelem.ref
+			IL_0076: stloc.s 31
+			IL_0078: ldarg.0
+			IL_0079: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_007e: ldloc.s 31
+			IL_0080: ldarg.2
+			IL_0081: ldstr "generated"
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_008b: stloc.s 32
+			IL_008d: ldloc.s 32
+			IL_008f: stloc.3
+			IL_0090: ldc.i4.1
+			IL_0091: newarr [System.Runtime]System.Object
+			IL_0096: dup
+			IL_0097: ldc.i4.0
+			IL_0098: ldarg.0
+			IL_0099: stelem.ref
+			IL_009a: stloc.s 31
+			IL_009c: ldarg.0
+			IL_009d: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_00a2: ldloc.s 31
+			IL_00a4: ldarg.2
+			IL_00a5: ldstr "non-deterministic"
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00af: stloc.s 32
+			IL_00b1: ldloc.s 32
+			IL_00b3: stloc.s 4
+			IL_00b5: ldarg.s fileName
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bc: stloc.s 32
+			IL_00be: ldloc.s 32
+			IL_00c0: ldstr "indexOf"
+			IL_00c5: ldstr "_FIXTURE"
+			IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00cf: stloc.s 32
+			IL_00d1: ldloc.s 32
+			IL_00d3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d8: stloc.s 33
+			IL_00da: ldloc.s 33
+			IL_00dc: ldc.r8 0.0
+			IL_00e5: clt
+			IL_00e7: ldc.i4.0
+			IL_00e8: ceq
+			IL_00ea: stloc.s 34
+			IL_00ec: ldloc.s 34
+			IL_00ee: stloc.s 5
+			IL_00f0: ldc.i4.0
+			IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00f6: stloc.s 6
+			IL_00f8: ldc.i4.4
+			IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00fe: dup
+			IL_00ff: ldstr "onlyStrict"
+			IL_0104: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0109: dup
+			IL_010a: ldstr "noStrict"
+			IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0114: dup
+			IL_0115: ldstr "module"
+			IL_011a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011f: dup
+			IL_0120: ldstr "raw"
+			IL_0125: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012a: stloc.s 7
+			IL_012c: ldc.r8 0.0
+			IL_0135: stloc.s 8
+			// loop start (head: IL_0137)
+				IL_0137: ldloc.s 8
+				IL_0139: ldloc.s 7
+				IL_013b: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+				IL_0140: conv.r8
+				IL_0141: clt
+				IL_0143: brfalse IL_01b1
 
-				IL_00e9: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51::.ctor()
-				IL_00ee: stloc.s 9
-				IL_00f0: ldloc.s 7
-				IL_00f2: ldloc.s 8
-				IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_00f9: castclass [System.Runtime]System.String
-				IL_00fe: stloc.s 10
-				IL_0100: ldnull
-				IL_0101: ldarg.2
-				IL_0102: ldloc.s 10
-				IL_0104: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-				IL_0109: stloc.s 31
-				IL_010b: ldloc.s 31
-				IL_010d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0112: stloc.s 33
-				IL_0114: ldloc.s 33
-				IL_0116: brfalse IL_012c
+				IL_0148: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51::.ctor()
+				IL_014d: stloc.s 9
+				IL_014f: ldloc.s 7
+				IL_0151: ldloc.s 8
+				IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0158: castclass [System.Runtime]System.String
+				IL_015d: stloc.s 10
+				IL_015f: ldc.i4.1
+				IL_0160: newarr [System.Runtime]System.Object
+				IL_0165: dup
+				IL_0166: ldc.i4.0
+				IL_0167: ldarg.0
+				IL_0168: stelem.ref
+				IL_0169: stloc.s 31
+				IL_016b: ldarg.0
+				IL_016c: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_0171: ldloc.s 31
+				IL_0173: ldarg.2
+				IL_0174: ldloc.s 10
+				IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_017b: stloc.s 32
+				IL_017d: ldloc.s 32
+				IL_017f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0184: stloc.s 34
+				IL_0186: ldloc.s 34
+				IL_0188: brfalse IL_019e
 
-				IL_011b: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51/Block_L338C31::.ctor()
-				IL_0120: stloc.s 11
-				IL_0122: ldloc.s 6
-				IL_0124: ldloc.s 10
-				IL_0126: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_012b: pop
+				IL_018d: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L336C7/Block_L336C51/Block_L338C31::.ctor()
+				IL_0192: stloc.s 11
+				IL_0194: ldloc.s 6
+				IL_0196: ldloc.s 10
+				IL_0198: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_019d: pop
 
-				IL_012c: ldloc.s 8
-				IL_012e: ldc.r8 1
-				IL_0137: add
-				IL_0138: stloc.s 8
-				IL_013a: br IL_00d8
+				IL_019e: ldloc.s 8
+				IL_01a0: ldc.r8 1
+				IL_01a9: add
+				IL_01aa: stloc.s 8
+				IL_01ac: br IL_0137
 			// end loop
 
-			IL_013f: ldstr "strict-and-non-strict"
-			IL_0144: stloc.s 12
-			IL_0146: ldloc.s 6
-			IL_0148: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_014d: conv.r8
-			IL_014e: ldc.r8 1
-			IL_0157: ceq
-			IL_0159: brfalse IL_0241
+			IL_01b1: ldstr "strict-and-non-strict"
+			IL_01b6: stloc.s 12
+			IL_01b8: ldloc.s 6
+			IL_01ba: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_01bf: conv.r8
+			IL_01c0: ldc.r8 1
+			IL_01c9: ceq
+			IL_01cb: brfalse IL_02b3
 
-			IL_015e: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36::.ctor()
-			IL_0163: stloc.s 13
-			IL_0165: ldloc.s 6
-			IL_0167: ldc.r8 0.0
-			IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0175: stloc.s 14
-			IL_0177: ldloc.s 14
-			IL_0179: ldstr "onlyStrict"
-			IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0183: stloc.s 33
-			IL_0185: ldloc.s 33
-			IL_0187: brfalse IL_01a3
-
-			IL_018c: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L346C31::.ctor()
-			IL_0191: stloc.s 15
-			IL_0193: ldstr "strict-only"
-			IL_0198: stloc.s 34
-			IL_019a: ldloc.s 34
-			IL_019c: stloc.s 12
-			IL_019e: br IL_023c
-
-			IL_01a3: ldloc.s 14
-			IL_01a5: ldstr "noStrict"
-			IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01af: stloc.s 33
-			IL_01b1: ldloc.s 33
-			IL_01b3: box [System.Runtime]System.Boolean
-			IL_01b8: stloc.s 35
-			IL_01ba: ldloc.s 35
-			IL_01bc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01c1: stloc.s 33
-			IL_01c3: ldloc.s 33
-			IL_01c5: brtrue IL_01ea
-
-			IL_01ca: ldloc.s 14
-			IL_01cc: ldstr "raw"
-			IL_01d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01d6: stloc.s 33
-			IL_01d8: ldloc.s 33
-			IL_01da: box [System.Runtime]System.Boolean
-			IL_01df: stloc.s 36
-			IL_01e1: ldloc.s 36
-			IL_01e3: stloc.s 38
-			IL_01e5: br IL_01ee
-
-			IL_01ea: ldloc.s 35
-			IL_01ec: stloc.s 38
-
-			IL_01ee: ldloc.s 38
-			IL_01f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01f5: stloc.s 33
-			IL_01f7: ldloc.s 33
+			IL_01d0: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36::.ctor()
+			IL_01d5: stloc.s 13
+			IL_01d7: ldloc.s 6
+			IL_01d9: ldc.r8 0.0
+			IL_01e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01e7: stloc.s 14
+			IL_01e9: ldloc.s 14
+			IL_01eb: ldstr "onlyStrict"
+			IL_01f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01f5: stloc.s 34
+			IL_01f7: ldloc.s 34
 			IL_01f9: brfalse IL_0215
 
-			IL_01fe: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L348C54::.ctor()
-			IL_0203: stloc.s 16
-			IL_0205: ldstr "non-strict-only"
-			IL_020a: stloc.s 34
-			IL_020c: ldloc.s 34
+			IL_01fe: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L346C31::.ctor()
+			IL_0203: stloc.s 15
+			IL_0205: ldstr "strict-only"
+			IL_020a: stloc.s 35
+			IL_020c: ldloc.s 35
 			IL_020e: stloc.s 12
-			IL_0210: br IL_023c
+			IL_0210: br IL_02ae
 
 			IL_0215: ldloc.s 14
-			IL_0217: ldstr "module"
+			IL_0217: ldstr "noStrict"
 			IL_021c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0221: stloc.s 33
-			IL_0223: ldloc.s 33
-			IL_0225: brfalse IL_023c
+			IL_0221: stloc.s 34
+			IL_0223: ldloc.s 34
+			IL_0225: box [System.Runtime]System.Boolean
+			IL_022a: stloc.s 36
+			IL_022c: ldloc.s 36
+			IL_022e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0233: stloc.s 34
+			IL_0235: ldloc.s 34
+			IL_0237: brtrue IL_025c
 
-			IL_022a: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L350C34::.ctor()
-			IL_022f: stloc.s 17
-			IL_0231: ldstr "module"
-			IL_0236: stloc.s 34
-			IL_0238: ldloc.s 34
-			IL_023a: stloc.s 12
+			IL_023c: ldloc.s 14
+			IL_023e: ldstr "raw"
+			IL_0243: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0248: stloc.s 34
+			IL_024a: ldloc.s 34
+			IL_024c: box [System.Runtime]System.Boolean
+			IL_0251: stloc.s 37
+			IL_0253: ldloc.s 37
+			IL_0255: stloc.s 39
+			IL_0257: br IL_0260
 
-			IL_023c: br IL_026b
+			IL_025c: ldloc.s 36
+			IL_025e: stloc.s 39
 
-			IL_0241: ldloc.s 6
-			IL_0243: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-			IL_0248: conv.r8
-			IL_0249: ldc.r8 1
-			IL_0252: cgt
-			IL_0254: brfalse IL_026b
+			IL_0260: ldloc.s 39
+			IL_0262: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0267: stloc.s 34
+			IL_0269: ldloc.s 34
+			IL_026b: brfalse IL_0287
 
-			IL_0259: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L353C41::.ctor()
-			IL_025e: stloc.s 18
-			IL_0260: ldstr "conflicting-flags"
-			IL_0265: stloc.s 34
-			IL_0267: ldloc.s 34
-			IL_0269: stloc.s 12
+			IL_0270: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L348C54::.ctor()
+			IL_0275: stloc.s 16
+			IL_0277: ldstr "non-strict-only"
+			IL_027c: stloc.s 35
+			IL_027e: ldloc.s 35
+			IL_0280: stloc.s 12
+			IL_0282: br IL_02ae
 
-			IL_026b: ldloc.1
-			IL_026c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0271: stloc.s 33
-			IL_0273: ldloc.s 33
-			IL_0275: brfalse IL_0287
+			IL_0287: ldloc.s 14
+			IL_0289: ldstr "module"
+			IL_028e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0293: stloc.s 34
+			IL_0295: ldloc.s 34
+			IL_0297: brfalse IL_02ae
 
-			IL_027a: ldc.i4.0
-			IL_027b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0280: stloc.s 19
-			IL_0282: br IL_0298
+			IL_029c: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L344C36/Block_L350C34::.ctor()
+			IL_02a1: stloc.s 17
+			IL_02a3: ldstr "module"
+			IL_02a8: stloc.s 35
+			IL_02aa: ldloc.s 35
+			IL_02ac: stloc.s 12
 
-			IL_0287: ldarg.0
-			IL_0288: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_028d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_0292: stloc.s 39
-			IL_0294: ldloc.s 39
-			IL_0296: stloc.s 19
+			IL_02ae: br IL_02dd
 
-			IL_0298: ldloc.s 19
-			IL_029a: stloc.s 20
-			IL_029c: ldloc.s 20
-			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02a3: stloc.s 31
-			IL_02a5: ldloc.s 31
-			IL_02a7: ldstr "slice"
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02b1: stloc.s 31
-			IL_02b3: ldloc.s 31
-			IL_02b5: stloc.s 21
-			IL_02b7: ldloc.2
-			IL_02b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02bd: stloc.s 33
-			IL_02bf: ldloc.s 33
-			IL_02c1: brfalse IL_02e3
+			IL_02b3: ldloc.s 6
+			IL_02b5: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
+			IL_02ba: conv.r8
+			IL_02bb: ldc.r8 1
+			IL_02c4: cgt
+			IL_02c6: brfalse IL_02dd
 
-			IL_02c6: ldloc.1
-			IL_02c7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02cc: ldc.i4.0
-			IL_02cd: ceq
-			IL_02cf: stloc.s 33
-			IL_02d1: ldloc.s 33
-			IL_02d3: box [System.Runtime]System.Boolean
-			IL_02d8: stloc.s 35
-			IL_02da: ldloc.s 35
-			IL_02dc: stloc.s 40
-			IL_02de: br IL_02e6
+			IL_02cb: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L353C41::.ctor()
+			IL_02d0: stloc.s 18
+			IL_02d2: ldstr "conflicting-flags"
+			IL_02d7: stloc.s 35
+			IL_02d9: ldloc.s 35
+			IL_02db: stloc.s 12
 
-			IL_02e3: ldloc.2
-			IL_02e4: stloc.s 40
+			IL_02dd: ldloc.1
+			IL_02de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02e3: stloc.s 34
+			IL_02e5: ldloc.s 34
+			IL_02e7: brfalse IL_02f9
 
-			IL_02e6: ldloc.s 40
-			IL_02e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02ed: stloc.s 33
-			IL_02ef: ldloc.s 33
-			IL_02f1: brfalse IL_0328
+			IL_02ec: ldc.i4.0
+			IL_02ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02f2: stloc.s 19
+			IL_02f4: br IL_030a
 
-			IL_02f6: ldarg.0
-			IL_02f7: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_02fc: stloc.s 31
-			IL_02fe: ldnull
-			IL_02ff: ldloc.s 21
-			IL_0301: ldloc.s 31
-			IL_0303: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_0308: stloc.s 31
-			IL_030a: ldloc.s 31
-			IL_030c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0311: ldc.i4.0
-			IL_0312: ceq
-			IL_0314: stloc.s 33
-			IL_0316: ldloc.s 33
-			IL_0318: box [System.Runtime]System.Boolean
-			IL_031d: stloc.s 35
-			IL_031f: ldloc.s 35
-			IL_0321: stloc.s 40
-			IL_0323: br IL_0328
+			IL_02f9: ldarg.0
+			IL_02fa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+			IL_02ff: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_0304: stloc.s 40
+			IL_0306: ldloc.s 40
+			IL_0308: stloc.s 19
 
-			IL_0328: ldloc.s 40
+			IL_030a: ldloc.s 19
+			IL_030c: stloc.s 20
+			IL_030e: ldloc.s 20
+			IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0315: stloc.s 32
+			IL_0317: ldloc.s 32
+			IL_0319: ldstr "slice"
+			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0323: stloc.s 32
+			IL_0325: ldloc.s 32
+			IL_0327: stloc.s 21
+			IL_0329: ldloc.2
 			IL_032a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_032f: stloc.s 33
-			IL_0331: ldloc.s 33
-			IL_0333: brfalse IL_035b
+			IL_032f: stloc.s 34
+			IL_0331: ldloc.s 34
+			IL_0333: brfalse IL_0355
 
-			IL_0338: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L360C78::.ctor()
-			IL_033d: stloc.s 22
-			IL_033f: ldloc.s 21
-			IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0346: stloc.s 31
-			IL_0348: ldloc.s 31
-			IL_034a: ldstr "push"
-			IL_034f: ldarg.0
-			IL_0350: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0355: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_035a: pop
+			IL_0338: ldloc.1
+			IL_0339: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_033e: ldc.i4.0
+			IL_033f: ceq
+			IL_0341: stloc.s 34
+			IL_0343: ldloc.s 34
+			IL_0345: box [System.Runtime]System.Boolean
+			IL_034a: stloc.s 36
+			IL_034c: ldloc.s 36
+			IL_034e: stloc.s 41
+			IL_0350: br IL_0358
 
-			IL_035b: ldc.r8 0.0
-			IL_0364: stloc.s 23
-			// loop start (head: IL_0366)
-				IL_0366: ldloc.s 23
-				IL_0368: ldarg.3
-				IL_0369: ldstr "length"
-				IL_036e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0373: clt
-				IL_0375: brfalse IL_03e2
+			IL_0355: ldloc.2
+			IL_0356: stloc.s 41
 
-				IL_037a: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
-				IL_037f: stloc.s 24
-				IL_0381: ldarg.3
-				IL_0382: ldloc.s 23
-				IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0389: stloc.s 31
-				IL_038b: ldnull
-				IL_038c: ldloc.s 21
-				IL_038e: ldloc.s 31
-				IL_0390: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-				IL_0395: stloc.s 31
-				IL_0397: ldloc.s 31
-				IL_0399: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_039e: ldc.i4.0
-				IL_039f: ceq
-				IL_03a1: stloc.s 33
-				IL_03a3: ldloc.s 33
-				IL_03a5: brfalse IL_03cf
+			IL_0358: ldloc.s 41
+			IL_035a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_035f: stloc.s 34
+			IL_0361: ldloc.s 34
+			IL_0363: brfalse IL_03a9
 
-				IL_03aa: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
-				IL_03af: stloc.s 25
-				IL_03b1: ldloc.s 21
-				IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03b8: stloc.s 31
-				IL_03ba: ldloc.s 31
-				IL_03bc: ldstr "push"
-				IL_03c1: ldarg.3
-				IL_03c2: ldloc.s 23
-				IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_03ce: pop
+			IL_0368: ldc.i4.1
+			IL_0369: newarr [System.Runtime]System.Object
+			IL_036e: dup
+			IL_036f: ldc.i4.0
+			IL_0370: ldarg.0
+			IL_0371: stelem.ref
+			IL_0372: stloc.s 31
+			IL_0374: ldarg.0
+			IL_0375: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_037a: ldloc.s 31
+			IL_037c: ldloc.s 21
+			IL_037e: ldarg.0
+			IL_037f: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0389: stloc.s 32
+			IL_038b: ldloc.s 32
+			IL_038d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0392: ldc.i4.0
+			IL_0393: ceq
+			IL_0395: stloc.s 34
+			IL_0397: ldloc.s 34
+			IL_0399: box [System.Runtime]System.Boolean
+			IL_039e: stloc.s 36
+			IL_03a0: ldloc.s 36
+			IL_03a2: stloc.s 41
+			IL_03a4: br IL_03a9
 
-				IL_03cf: ldloc.s 23
-				IL_03d1: ldc.r8 1
-				IL_03da: add
-				IL_03db: stloc.s 23
-				IL_03dd: br IL_0366
+			IL_03a9: ldloc.s 41
+			IL_03ab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03b0: stloc.s 34
+			IL_03b2: ldloc.s 34
+			IL_03b4: brfalse IL_03dc
+
+			IL_03b9: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope/Block_L360C78::.ctor()
+			IL_03be: stloc.s 22
+			IL_03c0: ldloc.s 21
+			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03c7: stloc.s 32
+			IL_03c9: ldloc.s 32
+			IL_03cb: ldstr "push"
+			IL_03d0: ldarg.0
+			IL_03d1: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_03db: pop
+
+			IL_03dc: ldc.r8 0.0
+			IL_03e5: stloc.s 23
+			// loop start (head: IL_03e7)
+				IL_03e7: ldloc.s 23
+				IL_03e9: ldarg.3
+				IL_03ea: ldstr "length"
+				IL_03ef: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_03f4: clt
+				IL_03f6: brfalse IL_0476
+
+				IL_03fb: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44::.ctor()
+				IL_0400: stloc.s 24
+				IL_0402: ldarg.0
+				IL_0403: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_0408: stloc.s 32
+				IL_040a: ldc.i4.1
+				IL_040b: newarr [System.Runtime]System.Object
+				IL_0410: dup
+				IL_0411: ldc.i4.0
+				IL_0412: ldarg.0
+				IL_0413: stelem.ref
+				IL_0414: stloc.s 31
+				IL_0416: ldloc.s 32
+				IL_0418: ldloc.s 31
+				IL_041a: ldloc.s 21
+				IL_041c: ldarg.3
+				IL_041d: ldloc.s 23
+				IL_041f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0429: stloc.s 32
+				IL_042b: ldloc.s 32
+				IL_042d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0432: ldc.i4.0
+				IL_0433: ceq
+				IL_0435: stloc.s 34
+				IL_0437: ldloc.s 34
+				IL_0439: brfalse IL_0463
+
+				IL_043e: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/Scope_For_L364C7/Block_L364C44/Block_L365C49::.ctor()
+				IL_0443: stloc.s 25
+				IL_0445: ldloc.s 21
+				IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_044c: stloc.s 32
+				IL_044e: ldloc.s 32
+				IL_0450: ldstr "push"
+				IL_0455: ldarg.3
+				IL_0456: ldloc.s 23
+				IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0462: pop
+
+				IL_0463: ldloc.s 23
+				IL_0465: ldc.r8 1
+				IL_046e: add
+				IL_046f: stloc.s 23
+				IL_0471: br IL_03e7
 			// end loop
 
-			IL_03e2: ldnull
-			IL_03e3: ldarg.3
-			IL_03e4: ldstr "agent.js"
-			IL_03e9: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_03ee: stloc.s 31
-			IL_03f0: ldloc.s 31
-			IL_03f2: stloc.s 26
-			IL_03f4: ldnull
-			IL_03f5: ldarg.2
-			IL_03f6: ldstr "CanBlockIsFalse"
-			IL_03fb: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_0400: stloc.s 31
-			IL_0402: ldloc.s 31
-			IL_0404: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0409: stloc.s 33
-			IL_040b: ldloc.s 33
-			IL_040d: brfalse IL_041e
+			IL_0476: ldc.i4.1
+			IL_0477: newarr [System.Runtime]System.Object
+			IL_047c: dup
+			IL_047d: ldc.i4.0
+			IL_047e: ldarg.0
+			IL_047f: stelem.ref
+			IL_0480: stloc.s 31
+			IL_0482: ldarg.0
+			IL_0483: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0488: ldloc.s 31
+			IL_048a: ldarg.3
+			IL_048b: ldstr "agent.js"
+			IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0495: stloc.s 32
+			IL_0497: ldloc.s 32
+			IL_0499: stloc.s 26
+			IL_049b: ldc.i4.1
+			IL_049c: newarr [System.Runtime]System.Object
+			IL_04a1: dup
+			IL_04a2: ldc.i4.0
+			IL_04a3: ldarg.0
+			IL_04a4: stelem.ref
+			IL_04a5: stloc.s 31
+			IL_04a7: ldarg.0
+			IL_04a8: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04ad: ldloc.s 31
+			IL_04af: ldarg.2
+			IL_04b0: ldstr "CanBlockIsFalse"
+			IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04ba: stloc.s 32
+			IL_04bc: ldloc.s 32
+			IL_04be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04c3: stloc.s 34
+			IL_04c5: ldloc.s 34
+			IL_04c7: brfalse IL_04d8
 
-			IL_0412: ldstr "false"
-			IL_0417: stloc.s 27
-			IL_0419: br IL_0453
+			IL_04cc: ldstr "false"
+			IL_04d1: stloc.s 27
+			IL_04d3: br IL_0520
 
-			IL_041e: ldnull
-			IL_041f: ldarg.2
-			IL_0420: ldstr "CanBlockIsTrue"
-			IL_0425: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_042a: stloc.s 31
-			IL_042c: ldloc.s 31
-			IL_042e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0433: stloc.s 33
-			IL_0435: ldloc.s 33
-			IL_0437: brfalse IL_0448
+			IL_04d8: ldc.i4.1
+			IL_04d9: newarr [System.Runtime]System.Object
+			IL_04de: dup
+			IL_04df: ldc.i4.0
+			IL_04e0: ldarg.0
+			IL_04e1: stelem.ref
+			IL_04e2: stloc.s 31
+			IL_04e4: ldarg.0
+			IL_04e5: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04ea: ldloc.s 31
+			IL_04ec: ldarg.2
+			IL_04ed: ldstr "CanBlockIsTrue"
+			IL_04f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04f7: stloc.s 32
+			IL_04f9: ldloc.s 32
+			IL_04fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0500: stloc.s 34
+			IL_0502: ldloc.s 34
+			IL_0504: brfalse IL_0515
 
-			IL_043c: ldstr "true"
-			IL_0441: stloc.s 28
-			IL_0443: br IL_044f
+			IL_0509: ldstr "true"
+			IL_050e: stloc.s 28
+			IL_0510: br IL_051c
 
-			IL_0448: ldstr "unspecified"
-			IL_044d: stloc.s 28
+			IL_0515: ldstr "unspecified"
+			IL_051a: stloc.s 28
 
-			IL_044f: ldloc.s 28
-			IL_0451: stloc.s 27
+			IL_051c: ldloc.s 28
+			IL_051e: stloc.s 27
 
-			IL_0453: ldloc.s 27
-			IL_0455: stloc.s 29
-			IL_0457: ldloc.0
-			IL_0458: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_045d: stloc.s 33
-			IL_045f: ldloc.s 33
-			IL_0461: brfalse IL_0472
+			IL_0520: ldloc.s 27
+			IL_0522: stloc.s 29
+			IL_0524: ldloc.0
+			IL_0525: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_052a: stloc.s 34
+			IL_052c: ldloc.s 34
+			IL_052e: brfalse IL_053f
 
-			IL_0466: ldstr "module"
-			IL_046b: stloc.s 30
-			IL_046d: br IL_0479
+			IL_0533: ldstr "module"
+			IL_0538: stloc.s 30
+			IL_053a: br IL_0546
 
-			IL_0472: ldstr "script"
-			IL_0477: stloc.s 30
+			IL_053f: ldstr "script"
+			IL_0544: stloc.s 30
 
-			IL_0479: ldloc.s 20
-			IL_047b: ldstr "length"
-			IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0485: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_048a: ldc.r8 0.0
-			IL_0493: cgt
-			IL_0495: stloc.s 33
-			IL_0497: ldloc.2
-			IL_0498: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_049d: stloc.s 42
-			IL_049f: ldloc.s 42
-			IL_04a1: brtrue IL_04c2
+			IL_0546: ldloc.s 20
+			IL_0548: ldstr "length"
+			IL_054d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0552: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0557: ldc.r8 0.0
+			IL_0560: cgt
+			IL_0562: stloc.s 34
+			IL_0564: ldloc.2
+			IL_0565: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_056a: stloc.s 43
+			IL_056c: ldloc.s 43
+			IL_056e: brtrue IL_059e
 
-			IL_04a6: ldarg.0
-			IL_04a7: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_04ac: stloc.s 31
-			IL_04ae: ldnull
-			IL_04af: ldarg.3
-			IL_04b0: ldloc.s 31
-			IL_04b2: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-			IL_04b7: stloc.s 31
-			IL_04b9: ldloc.s 31
-			IL_04bb: stloc.s 43
-			IL_04bd: br IL_04c5
+			IL_0573: ldc.i4.1
+			IL_0574: newarr [System.Runtime]System.Object
+			IL_0579: dup
+			IL_057a: ldc.i4.0
+			IL_057b: ldarg.0
+			IL_057c: stelem.ref
+			IL_057d: stloc.s 31
+			IL_057f: ldarg.0
+			IL_0580: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0585: ldloc.s 31
+			IL_0587: ldarg.3
+			IL_0588: ldarg.0
+			IL_0589: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_058e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0593: stloc.s 32
+			IL_0595: ldloc.s 32
+			IL_0597: stloc.s 44
+			IL_0599: br IL_05a1
 
-			IL_04c2: ldloc.2
-			IL_04c3: stloc.s 43
+			IL_059e: ldloc.2
+			IL_059f: stloc.s 44
 
-			IL_04c5: ldloc.s 26
-			IL_04c7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04cc: stloc.s 42
-			IL_04ce: ldloc.s 42
-			IL_04d0: brtrue IL_04f5
+			IL_05a1: ldloc.s 26
+			IL_05a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05a8: stloc.s 43
+			IL_05aa: ldloc.s 43
+			IL_05ac: brtrue IL_05d1
 
-			IL_04d5: ldloc.s 29
-			IL_04d7: ldstr "unspecified"
-			IL_04dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_04e1: stloc.s 42
-			IL_04e3: ldloc.s 42
-			IL_04e5: box [System.Runtime]System.Boolean
-			IL_04ea: stloc.s 35
-			IL_04ec: ldloc.s 35
-			IL_04ee: stloc.s 45
-			IL_04f0: br IL_04f9
+			IL_05b1: ldloc.s 29
+			IL_05b3: ldstr "unspecified"
+			IL_05b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_05bd: stloc.s 43
+			IL_05bf: ldloc.s 43
+			IL_05c1: box [System.Runtime]System.Boolean
+			IL_05c6: stloc.s 36
+			IL_05c8: ldloc.s 36
+			IL_05ca: stloc.s 46
+			IL_05cc: br IL_05d5
 
-			IL_04f5: ldloc.s 26
-			IL_04f7: stloc.s 45
+			IL_05d1: ldloc.s 26
+			IL_05d3: stloc.s 46
 
-			IL_04f9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04fe: dup
-			IL_04ff: ldstr "sourceType"
-			IL_0504: ldloc.s 30
-			IL_0506: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_050b: dup
-			IL_050c: ldstr "strictMode"
-			IL_0511: ldloc.s 12
-			IL_0513: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0518: dup
-			IL_0519: ldstr "defaultHarnessIncludes"
-			IL_051e: ldloc.s 20
-			IL_0520: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0525: dup
-			IL_0526: ldstr "harnessIncludes"
-			IL_052b: ldloc.s 21
-			IL_052d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0532: dup
-			IL_0533: ldstr "requiresDefaultHarness"
-			IL_0538: ldloc.s 33
-			IL_053a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_053f: dup
-			IL_0540: ldstr "requiresAsyncHarness"
-			IL_0545: ldloc.s 43
-			IL_0547: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_054c: dup
-			IL_054d: ldstr "requiresAgent"
-			IL_0552: ldloc.s 45
-			IL_0554: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0559: dup
-			IL_055a: ldstr "canBlock"
-			IL_055f: ldloc.s 29
-			IL_0561: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0566: dup
-			IL_0567: ldstr "isModule"
-			IL_056c: ldloc.0
-			IL_056d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0572: dup
-			IL_0573: ldstr "isRaw"
-			IL_0578: ldloc.1
-			IL_0579: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_057e: dup
-			IL_057f: ldstr "isAsync"
-			IL_0584: ldloc.2
-			IL_0585: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_058a: dup
-			IL_058b: ldstr "isGenerated"
-			IL_0590: ldloc.3
-			IL_0591: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0596: dup
-			IL_0597: ldstr "isNonDeterministic"
-			IL_059c: ldloc.s 4
-			IL_059e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05a3: dup
-			IL_05a4: ldstr "isFixture"
-			IL_05a9: ldloc.s 5
-			IL_05ab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05b0: stloc.s 46
-			IL_05b2: ldloc.s 46
-			IL_05b4: ret
+			IL_05d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05da: dup
+			IL_05db: ldstr "sourceType"
+			IL_05e0: ldloc.s 30
+			IL_05e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05e7: dup
+			IL_05e8: ldstr "strictMode"
+			IL_05ed: ldloc.s 12
+			IL_05ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05f4: dup
+			IL_05f5: ldstr "defaultHarnessIncludes"
+			IL_05fa: ldloc.s 20
+			IL_05fc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0601: dup
+			IL_0602: ldstr "harnessIncludes"
+			IL_0607: ldloc.s 21
+			IL_0609: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_060e: dup
+			IL_060f: ldstr "requiresDefaultHarness"
+			IL_0614: ldloc.s 34
+			IL_0616: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_061b: dup
+			IL_061c: ldstr "requiresAsyncHarness"
+			IL_0621: ldloc.s 44
+			IL_0623: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0628: dup
+			IL_0629: ldstr "requiresAgent"
+			IL_062e: ldloc.s 46
+			IL_0630: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0635: dup
+			IL_0636: ldstr "canBlock"
+			IL_063b: ldloc.s 29
+			IL_063d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0642: dup
+			IL_0643: ldstr "isModule"
+			IL_0648: ldloc.0
+			IL_0649: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_064e: dup
+			IL_064f: ldstr "isRaw"
+			IL_0654: ldloc.1
+			IL_0655: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_065a: dup
+			IL_065b: ldstr "isAsync"
+			IL_0660: ldloc.2
+			IL_0661: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0666: dup
+			IL_0667: ldstr "isGenerated"
+			IL_066c: ldloc.3
+			IL_066d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0672: dup
+			IL_0673: ldstr "isNonDeterministic"
+			IL_0678: ldloc.s 4
+			IL_067a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_067f: dup
+			IL_0680: ldstr "isFixture"
+			IL_0685: ldloc.s 5
+			IL_0687: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_068c: stloc.s 47
+			IL_068e: ldloc.s 47
+			IL_0690: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata
@@ -6954,7 +7742,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fd9
+					// Method begins at RVA 0x67e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6974,7 +7762,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fe2
+					// Method begins at RVA 0x67ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6994,7 +7782,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5feb
+					// Method begins at RVA 0x67f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7014,7 +7802,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ff4
+					// Method begins at RVA 0x67fc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7034,7 +7822,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ffd
+					// Method begins at RVA 0x6805
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7054,7 +7842,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6006
+					// Method begins at RVA 0x680e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7074,7 +7862,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x600f
+					// Method begins at RVA 0x6817
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7092,7 +7880,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5fd0
+				// Method begins at RVA 0x67d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7121,9 +7909,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5430
+			// Method begins at RVA 0x5964
 			// Header size: 12
-			// Code size: 549 (0x225)
+			// Code size: 864 (0x360)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -7137,10 +7925,13 @@
 				[8] class Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L422C51,
 				[9] bool,
 				[10] object,
-				[11] object,
-				[12] string,
+				[11] object[],
+				[12] object,
 				[13] object,
-				[14] object
+				[14] object[],
+				[15] string,
+				[16] object,
+				[17] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -7152,185 +7943,374 @@
 			IL_0013: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0018: stloc.s 9
 			IL_001a: ldloc.s 9
-			IL_001c: brfalse IL_0059
+			IL_001c: brfalse IL_0086
 
 			IL_0021: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L398C27::.ctor()
 			IL_0026: stloc.1
-			IL_0027: ldarg.2
-			IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002d: stloc.s 9
-			IL_002f: ldloc.s 9
-			IL_0031: brtrue IL_0042
+			IL_0027: ldarg.0
+			IL_0028: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_002d: stloc.s 10
+			IL_002f: ldc.i4.1
+			IL_0030: newarr [System.Runtime]System.Object
+			IL_0035: dup
+			IL_0036: ldc.i4.0
+			IL_0037: ldarg.0
+			IL_0038: stelem.ref
+			IL_0039: stloc.s 11
+			IL_003b: ldarg.2
+			IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0041: stloc.s 9
+			IL_0043: ldloc.s 9
+			IL_0045: brtrue IL_0056
 
-			IL_0036: ldstr "<anonymous>"
-			IL_003b: stloc.s 11
-			IL_003d: br IL_0045
+			IL_004a: ldstr "<anonymous>"
+			IL_004f: stloc.s 13
+			IL_0051: br IL_0059
 
-			IL_0042: ldarg.2
-			IL_0043: stloc.s 11
+			IL_0056: ldarg.2
+			IL_0057: stloc.s 13
 
-			IL_0045: ldnull
-			IL_0046: ldloc.0
-			IL_0047: ldstr "fixture-file"
-			IL_004c: ldloc.s 11
-			IL_004e: ldstr "Files whose names include `_FIXTURE` are support files, not standalone MVP tests."
-			IL_0053: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0058: pop
+			IL_0059: ldc.i4.4
+			IL_005a: newarr [System.Runtime]System.Object
+			IL_005f: dup
+			IL_0060: ldc.i4.0
+			IL_0061: ldloc.0
+			IL_0062: stelem.ref
+			IL_0063: dup
+			IL_0064: ldc.i4.1
+			IL_0065: ldstr "fixture-file"
+			IL_006a: stelem.ref
+			IL_006b: dup
+			IL_006c: ldc.i4.2
+			IL_006d: ldloc.s 13
+			IL_006f: stelem.ref
+			IL_0070: dup
+			IL_0071: ldc.i4.3
+			IL_0072: ldstr "Files whose names include `_FIXTURE` are support files, not standalone MVP tests."
+			IL_0077: stelem.ref
+			IL_0078: stloc.s 14
+			IL_007a: ldloc.s 10
+			IL_007c: ldloc.s 11
+			IL_007e: ldloc.s 14
+			IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0085: pop
 
-			IL_0059: ldarg.s execution
-			IL_005b: ldstr "isModule"
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0065: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_006a: stloc.s 9
-			IL_006c: ldloc.s 9
-			IL_006e: brfalse IL_0090
+			IL_0086: ldarg.s execution
+			IL_0088: ldstr "isModule"
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0092: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0097: stloc.s 9
+			IL_0099: ldloc.s 9
+			IL_009b: brfalse IL_00ea
 
-			IL_0073: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L402C26::.ctor()
-			IL_0078: stloc.2
-			IL_0079: ldnull
-			IL_007a: ldloc.0
-			IL_007b: ldstr "module-flag"
-			IL_0080: ldstr "flags:module"
-			IL_0085: ldstr "Module tests are outside the plain synchronous script MVP."
-			IL_008a: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_008f: pop
+			IL_00a0: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L402C26::.ctor()
+			IL_00a5: stloc.2
+			IL_00a6: ldarg.0
+			IL_00a7: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_00ac: stloc.s 10
+			IL_00ae: ldc.i4.1
+			IL_00af: newarr [System.Runtime]System.Object
+			IL_00b4: dup
+			IL_00b5: ldc.i4.0
+			IL_00b6: ldarg.0
+			IL_00b7: stelem.ref
+			IL_00b8: stloc.s 14
+			IL_00ba: ldc.i4.4
+			IL_00bb: newarr [System.Runtime]System.Object
+			IL_00c0: dup
+			IL_00c1: ldc.i4.0
+			IL_00c2: ldloc.0
+			IL_00c3: stelem.ref
+			IL_00c4: dup
+			IL_00c5: ldc.i4.1
+			IL_00c6: ldstr "module-flag"
+			IL_00cb: stelem.ref
+			IL_00cc: dup
+			IL_00cd: ldc.i4.2
+			IL_00ce: ldstr "flags:module"
+			IL_00d3: stelem.ref
+			IL_00d4: dup
+			IL_00d5: ldc.i4.3
+			IL_00d6: ldstr "Module tests are outside the plain synchronous script MVP."
+			IL_00db: stelem.ref
+			IL_00dc: stloc.s 11
+			IL_00de: ldloc.s 10
+			IL_00e0: ldloc.s 14
+			IL_00e2: ldloc.s 11
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_00e9: pop
 
-			IL_0090: ldarg.s execution
-			IL_0092: ldstr "isRaw"
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a1: stloc.s 9
-			IL_00a3: ldloc.s 9
-			IL_00a5: brfalse IL_00c7
+			IL_00ea: ldarg.s execution
+			IL_00ec: ldstr "isRaw"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00fb: stloc.s 9
+			IL_00fd: ldloc.s 9
+			IL_00ff: brfalse IL_014e
 
-			IL_00aa: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L406C23::.ctor()
-			IL_00af: stloc.3
-			IL_00b0: ldnull
-			IL_00b1: ldloc.0
-			IL_00b2: ldstr "raw-flag"
-			IL_00b7: ldstr "flags:raw"
-			IL_00bc: ldstr "Raw tests bypass default harness injection and are outside the initial MVP."
-			IL_00c1: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_00c6: pop
+			IL_0104: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L406C23::.ctor()
+			IL_0109: stloc.3
+			IL_010a: ldarg.0
+			IL_010b: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0110: stloc.s 10
+			IL_0112: ldc.i4.1
+			IL_0113: newarr [System.Runtime]System.Object
+			IL_0118: dup
+			IL_0119: ldc.i4.0
+			IL_011a: ldarg.0
+			IL_011b: stelem.ref
+			IL_011c: stloc.s 11
+			IL_011e: ldc.i4.4
+			IL_011f: newarr [System.Runtime]System.Object
+			IL_0124: dup
+			IL_0125: ldc.i4.0
+			IL_0126: ldloc.0
+			IL_0127: stelem.ref
+			IL_0128: dup
+			IL_0129: ldc.i4.1
+			IL_012a: ldstr "raw-flag"
+			IL_012f: stelem.ref
+			IL_0130: dup
+			IL_0131: ldc.i4.2
+			IL_0132: ldstr "flags:raw"
+			IL_0137: stelem.ref
+			IL_0138: dup
+			IL_0139: ldc.i4.3
+			IL_013a: ldstr "Raw tests bypass default harness injection and are outside the initial MVP."
+			IL_013f: stelem.ref
+			IL_0140: stloc.s 14
+			IL_0142: ldloc.s 10
+			IL_0144: ldloc.s 11
+			IL_0146: ldloc.s 14
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_014d: pop
 
-			IL_00c7: ldarg.s execution
-			IL_00c9: ldstr "requiresAsyncHarness"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00d8: stloc.s 9
-			IL_00da: ldloc.s 9
-			IL_00dc: brfalse IL_00ff
+			IL_014e: ldarg.s execution
+			IL_0150: ldstr "requiresAsyncHarness"
+			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_015f: stloc.s 9
+			IL_0161: ldloc.s 9
+			IL_0163: brfalse IL_01b3
 
-			IL_00e1: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L410C38::.ctor()
-			IL_00e6: stloc.s 4
-			IL_00e8: ldnull
-			IL_00e9: ldloc.0
-			IL_00ea: ldstr "async-requirement"
-			IL_00ef: ldstr "flags/includes"
-			IL_00f4: ldstr "Async tests and async harness requirements are outside the initial MVP."
-			IL_00f9: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_00fe: pop
+			IL_0168: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L410C38::.ctor()
+			IL_016d: stloc.s 4
+			IL_016f: ldarg.0
+			IL_0170: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0175: stloc.s 10
+			IL_0177: ldc.i4.1
+			IL_0178: newarr [System.Runtime]System.Object
+			IL_017d: dup
+			IL_017e: ldc.i4.0
+			IL_017f: ldarg.0
+			IL_0180: stelem.ref
+			IL_0181: stloc.s 14
+			IL_0183: ldc.i4.4
+			IL_0184: newarr [System.Runtime]System.Object
+			IL_0189: dup
+			IL_018a: ldc.i4.0
+			IL_018b: ldloc.0
+			IL_018c: stelem.ref
+			IL_018d: dup
+			IL_018e: ldc.i4.1
+			IL_018f: ldstr "async-requirement"
+			IL_0194: stelem.ref
+			IL_0195: dup
+			IL_0196: ldc.i4.2
+			IL_0197: ldstr "flags/includes"
+			IL_019c: stelem.ref
+			IL_019d: dup
+			IL_019e: ldc.i4.3
+			IL_019f: ldstr "Async tests and async harness requirements are outside the initial MVP."
+			IL_01a4: stelem.ref
+			IL_01a5: stloc.s 11
+			IL_01a7: ldloc.s 10
+			IL_01a9: ldloc.s 14
+			IL_01ab: ldloc.s 11
+			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_01b2: pop
 
-			IL_00ff: ldarg.s execution
-			IL_0101: ldstr "requiresAgent"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0110: stloc.s 9
-			IL_0112: ldloc.s 9
-			IL_0114: brfalse IL_0137
+			IL_01b3: ldarg.s execution
+			IL_01b5: ldstr "requiresAgent"
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01c4: stloc.s 9
+			IL_01c6: ldloc.s 9
+			IL_01c8: brfalse IL_0218
 
-			IL_0119: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L414C31::.ctor()
-			IL_011e: stloc.s 5
-			IL_0120: ldnull
-			IL_0121: ldloc.0
-			IL_0122: ldstr "agent-requirement"
-			IL_0127: ldstr "flags/includes"
-			IL_012c: ldstr "Agent-sensitive tests are outside the initial MVP."
-			IL_0131: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0136: pop
+			IL_01cd: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L414C31::.ctor()
+			IL_01d2: stloc.s 5
+			IL_01d4: ldarg.0
+			IL_01d5: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_01da: stloc.s 10
+			IL_01dc: ldc.i4.1
+			IL_01dd: newarr [System.Runtime]System.Object
+			IL_01e2: dup
+			IL_01e3: ldc.i4.0
+			IL_01e4: ldarg.0
+			IL_01e5: stelem.ref
+			IL_01e6: stloc.s 11
+			IL_01e8: ldc.i4.4
+			IL_01e9: newarr [System.Runtime]System.Object
+			IL_01ee: dup
+			IL_01ef: ldc.i4.0
+			IL_01f0: ldloc.0
+			IL_01f1: stelem.ref
+			IL_01f2: dup
+			IL_01f3: ldc.i4.1
+			IL_01f4: ldstr "agent-requirement"
+			IL_01f9: stelem.ref
+			IL_01fa: dup
+			IL_01fb: ldc.i4.2
+			IL_01fc: ldstr "flags/includes"
+			IL_0201: stelem.ref
+			IL_0202: dup
+			IL_0203: ldc.i4.3
+			IL_0204: ldstr "Agent-sensitive tests are outside the initial MVP."
+			IL_0209: stelem.ref
+			IL_020a: stloc.s 14
+			IL_020c: ldloc.s 10
+			IL_020e: ldloc.s 11
+			IL_0210: ldloc.s 14
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0217: pop
 
-			IL_0137: ldarg.s execution
-			IL_0139: ldstr "canBlock"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0143: ldstr "unspecified"
-			IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_014d: stloc.s 9
-			IL_014f: ldloc.s 9
-			IL_0151: brfalse IL_01ba
+			IL_0218: ldarg.s execution
+			IL_021a: ldstr "canBlock"
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0224: ldstr "unspecified"
+			IL_0229: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_022e: stloc.s 9
+			IL_0230: ldloc.s 9
+			IL_0232: brfalse IL_02c8
 
-			IL_0156: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L418C44::.ctor()
-			IL_015b: stloc.s 6
-			IL_015d: ldarg.s execution
-			IL_015f: ldstr "canBlock"
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0169: ldstr "true"
-			IL_016e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0173: stloc.s 9
-			IL_0175: ldloc.s 9
-			IL_0177: brfalse IL_0188
+			IL_0237: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L418C44::.ctor()
+			IL_023c: stloc.s 6
+			IL_023e: ldarg.0
+			IL_023f: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0244: stloc.s 10
+			IL_0246: ldc.i4.1
+			IL_0247: newarr [System.Runtime]System.Object
+			IL_024c: dup
+			IL_024d: ldc.i4.0
+			IL_024e: ldarg.0
+			IL_024f: stelem.ref
+			IL_0250: stloc.s 14
+			IL_0252: ldarg.s execution
+			IL_0254: ldstr "canBlock"
+			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025e: ldstr "true"
+			IL_0263: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0268: stloc.s 9
+			IL_026a: ldloc.s 9
+			IL_026c: brfalse IL_027d
 
-			IL_017c: ldstr "True"
-			IL_0181: stloc.s 7
-			IL_0183: br IL_018f
+			IL_0271: ldstr "True"
+			IL_0276: stloc.s 7
+			IL_0278: br IL_0284
 
-			IL_0188: ldstr "False"
-			IL_018d: stloc.s 7
+			IL_027d: ldstr "False"
+			IL_0282: stloc.s 7
 
-			IL_018f: ldloc.s 7
-			IL_0191: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0196: stloc.s 12
-			IL_0198: ldstr "flags:CanBlockIs"
-			IL_019d: ldloc.s 12
-			IL_019f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a4: stloc.s 12
-			IL_01a6: ldnull
-			IL_01a7: ldloc.0
-			IL_01a8: ldstr "can-block-requirement"
-			IL_01ad: ldloc.s 12
-			IL_01af: ldstr "Tests requiring a specific [[CanBlock]] mode are outside the initial MVP."
-			IL_01b4: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_01b9: pop
+			IL_0284: ldloc.s 7
+			IL_0286: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_028b: stloc.s 15
+			IL_028d: ldstr "flags:CanBlockIs"
+			IL_0292: ldloc.s 15
+			IL_0294: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0299: stloc.s 15
+			IL_029b: ldc.i4.4
+			IL_029c: newarr [System.Runtime]System.Object
+			IL_02a1: dup
+			IL_02a2: ldc.i4.0
+			IL_02a3: ldloc.0
+			IL_02a4: stelem.ref
+			IL_02a5: dup
+			IL_02a6: ldc.i4.1
+			IL_02a7: ldstr "can-block-requirement"
+			IL_02ac: stelem.ref
+			IL_02ad: dup
+			IL_02ae: ldc.i4.2
+			IL_02af: ldloc.s 15
+			IL_02b1: stelem.ref
+			IL_02b2: dup
+			IL_02b3: ldc.i4.3
+			IL_02b4: ldstr "Tests requiring a specific [[CanBlock]] mode are outside the initial MVP."
+			IL_02b9: stelem.ref
+			IL_02ba: stloc.s 11
+			IL_02bc: ldloc.s 10
+			IL_02be: ldloc.s 14
+			IL_02c0: ldloc.s 11
+			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_02c7: pop
 
-			IL_01ba: ldarg.3
-			IL_01bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01c0: stloc.s 9
-			IL_01c2: ldloc.s 9
-			IL_01c4: brfalse IL_01f2
+			IL_02c8: ldarg.3
+			IL_02c9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02ce: stloc.s 9
+			IL_02d0: ldloc.s 9
+			IL_02d2: brfalse IL_0300
 
-			IL_01c9: ldarg.3
-			IL_01ca: ldstr "phase"
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d4: ldstr "resolution"
-			IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01de: stloc.s 9
-			IL_01e0: ldloc.s 9
-			IL_01e2: box [System.Runtime]System.Boolean
-			IL_01e7: stloc.s 13
-			IL_01e9: ldloc.s 13
-			IL_01eb: stloc.s 14
-			IL_01ed: br IL_01f5
+			IL_02d7: ldarg.3
+			IL_02d8: ldstr "phase"
+			IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e2: ldstr "resolution"
+			IL_02e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_02ec: stloc.s 9
+			IL_02ee: ldloc.s 9
+			IL_02f0: box [System.Runtime]System.Boolean
+			IL_02f5: stloc.s 16
+			IL_02f7: ldloc.s 16
+			IL_02f9: stloc.s 17
+			IL_02fb: br IL_0303
 
-			IL_01f2: ldarg.3
-			IL_01f3: stloc.s 14
+			IL_0300: ldarg.3
+			IL_0301: stloc.s 17
 
-			IL_01f5: ldloc.s 14
-			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01fc: stloc.s 9
-			IL_01fe: ldloc.s 9
-			IL_0200: brfalse IL_0223
+			IL_0303: ldloc.s 17
+			IL_0305: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_030a: stloc.s 9
+			IL_030c: ldloc.s 9
+			IL_030e: brfalse IL_035e
 
-			IL_0205: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L422C51::.ctor()
-			IL_020a: stloc.s 8
-			IL_020c: ldnull
-			IL_020d: ldloc.0
-			IL_020e: ldstr "resolution-negative"
-			IL_0213: ldstr "negative.phase"
-			IL_0218: ldstr "Module resolution failures are outside the plain script MVP."
-			IL_021d: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_0222: pop
+			IL_0313: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/Scope/Block_L422C51::.ctor()
+			IL_0318: stloc.s 8
+			IL_031a: ldarg.0
+			IL_031b: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_0320: stloc.s 10
+			IL_0322: ldc.i4.1
+			IL_0323: newarr [System.Runtime]System.Object
+			IL_0328: dup
+			IL_0329: ldc.i4.0
+			IL_032a: ldarg.0
+			IL_032b: stelem.ref
+			IL_032c: stloc.s 11
+			IL_032e: ldc.i4.4
+			IL_032f: newarr [System.Runtime]System.Object
+			IL_0334: dup
+			IL_0335: ldc.i4.0
+			IL_0336: ldloc.0
+			IL_0337: stelem.ref
+			IL_0338: dup
+			IL_0339: ldc.i4.1
+			IL_033a: ldstr "resolution-negative"
+			IL_033f: stelem.ref
+			IL_0340: dup
+			IL_0341: ldc.i4.2
+			IL_0342: ldstr "negative.phase"
+			IL_0347: stelem.ref
+			IL_0348: dup
+			IL_0349: ldc.i4.3
+			IL_034a: ldstr "Module resolution failures are outside the plain script MVP."
+			IL_034f: stelem.ref
+			IL_0350: stloc.s 14
+			IL_0352: ldloc.s 10
+			IL_0354: ldloc.s 11
+			IL_0356: ldloc.s 14
+			IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_035d: pop
 
-			IL_0223: ldloc.0
-			IL_0224: ret
+			IL_035e: ldloc.0
+			IL_035f: ret
 		} // end of method buildMvpBlockers::__js_call__
 
 	} // end of class buildMvpBlockers
@@ -7350,7 +8330,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6057
+					// Method begins at RVA 0x685f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7368,7 +8348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6018
+				// Method begins at RVA 0x6820
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7396,7 +8376,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x6033
+						// Method begins at RVA 0x683b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7414,7 +8394,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x602a
+					// Method begins at RVA 0x6832
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7432,7 +8412,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6021
+				// Method begins at RVA 0x6829
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7460,7 +8440,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x604e
+						// Method begins at RVA 0x6856
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -7478,7 +8458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x6045
+					// Method begins at RVA 0x684d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -7496,7 +8476,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x603c
+				// Method begins at RVA 0x6844
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -7524,9 +8504,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5664
+			// Method begins at RVA 0x5cd0
 			// Header size: 12
-			// Code size: 1498 (0x5da)
+			// Code size: 1910 (0x776)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7543,11 +8523,11 @@
 				[11] class Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48,
 				[12] object,
 				[13] class Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49,
-				[14] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[16] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[17] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[14] object,
+				[15] object,
+				[16] object,
+				[17] object,
+				[18] object,
 				[19] object,
 				[20] float64,
 				[21] class Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41,
@@ -7558,20 +8538,23 @@
 				[26] object,
 				[27] object,
 				[28] object,
-				[29] object,
-				[30] float64,
-				[31] string,
-				[32] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[29] object[],
+				[30] object,
+				[31] object,
+				[32] float64,
 				[33] string,
-				[34] object,
-				[35] object,
-				[36] object,
+				[34] object[],
+				[35] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[36] string,
 				[37] object,
 				[38] object,
 				[39] object,
 				[40] object,
 				[41] object,
-				[42] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[42] object,
+				[43] object,
+				[44] object,
+				[45] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.3
@@ -7589,516 +8572,742 @@
 
 			IL_001e: ldloc.s 27
 			IL_0020: stloc.0
-			IL_0021: ldloc.0
-			IL_0022: ldstr "filePath"
-			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002c: stloc.s 28
-			IL_002e: ldloc.s 28
-			IL_0030: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0035: stloc.s 25
-			IL_0037: ldloc.s 25
-			IL_0039: brtrue IL_004a
+			IL_0021: ldarg.0
+			IL_0022: ldfld object Modules.test262_metadataParser/Scope::normalizePath
+			IL_0027: stloc.s 28
+			IL_0029: ldc.i4.1
+			IL_002a: newarr [System.Runtime]System.Object
+			IL_002f: dup
+			IL_0030: ldc.i4.0
+			IL_0031: ldarg.0
+			IL_0032: stelem.ref
+			IL_0033: stloc.s 29
+			IL_0035: ldloc.0
+			IL_0036: ldstr "filePath"
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0040: stloc.s 30
+			IL_0042: ldloc.s 30
+			IL_0044: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0049: stloc.s 25
+			IL_004b: ldloc.s 25
+			IL_004d: brtrue IL_005e
 
-			IL_003e: ldstr ""
-			IL_0043: stloc.s 29
-			IL_0045: br IL_004e
+			IL_0052: ldstr ""
+			IL_0057: stloc.s 31
+			IL_0059: br IL_0062
 
-			IL_004a: ldloc.s 28
-			IL_004c: stloc.s 29
+			IL_005e: ldloc.s 30
+			IL_0060: stloc.s 31
 
-			IL_004e: ldnull
-			IL_004f: ldloc.s 29
-			IL_0051: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
-			IL_0056: stloc.s 28
-			IL_0058: ldloc.s 28
-			IL_005a: stloc.1
-			IL_005b: ldnull
-			IL_005c: ldloc.1
-			IL_005d: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
-			IL_0062: stloc.s 28
-			IL_0064: ldloc.s 28
-			IL_0066: stloc.2
-			IL_0067: ldarg.0
-			IL_0068: castclass Modules.test262_metadataParser/Scope
-			IL_006d: ldnull
-			IL_006e: ldarg.2
-			IL_006f: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_0074: stloc.s 28
-			IL_0076: ldloc.s 28
-			IL_0078: stloc.3
-			IL_0079: ldc.i4.0
-			IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_007f: stloc.s 4
-			IL_0081: ldloc.3
-			IL_0082: ldc.i4.0
-			IL_0083: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0088: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_008d: stloc.s 25
-			IL_008f: ldloc.s 25
-			IL_0091: stloc.s 5
-			IL_0093: ldloc.s 5
-			IL_0095: brfalse IL_00b2
-
-			IL_009a: ldarg.0
-			IL_009b: castclass Modules.test262_metadataParser/Scope
-			IL_00a0: ldnull
-			IL_00a1: ldloc.3
-			IL_00a2: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0062: ldloc.s 28
+			IL_0064: ldloc.s 29
+			IL_0066: ldloc.s 31
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_006d: stloc.s 28
+			IL_006f: ldloc.s 28
+			IL_0071: stloc.1
+			IL_0072: ldarg.0
+			IL_0073: ldfld object Modules.test262_metadataParser/Scope::getFileName
+			IL_0078: ldc.i4.1
+			IL_0079: newarr [System.Runtime]System.Object
+			IL_007e: dup
+			IL_007f: ldc.i4.0
+			IL_0080: ldarg.0
+			IL_0081: stelem.ref
+			IL_0082: ldloc.1
+			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0088: stloc.s 28
+			IL_008a: ldloc.s 28
+			IL_008c: stloc.2
+			IL_008d: ldc.i4.1
+			IL_008e: newarr [System.Runtime]System.Object
+			IL_0093: dup
+			IL_0094: ldc.i4.0
+			IL_0095: ldarg.0
+			IL_0096: stelem.ref
+			IL_0097: stloc.s 29
+			IL_0099: ldarg.0
+			IL_009a: ldfld object Modules.test262_metadataParser/Scope::extractTest262Frontmatter
+			IL_009f: ldloc.s 29
+			IL_00a1: ldarg.2
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_00a7: stloc.s 28
 			IL_00a9: ldloc.s 28
-			IL_00ab: stloc.s 6
-			IL_00ad: br IL_00b9
+			IL_00ab: stloc.3
+			IL_00ac: ldc.i4.0
+			IL_00ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00b2: stloc.s 4
+			IL_00b4: ldloc.3
+			IL_00b5: ldc.i4.0
+			IL_00b6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_00c0: stloc.s 25
+			IL_00c2: ldloc.s 25
+			IL_00c4: stloc.s 5
+			IL_00c6: ldloc.s 5
+			IL_00c8: brfalse IL_00ee
 
-			IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00b7: stloc.s 6
+			IL_00cd: ldarg.0
+			IL_00ce: ldfld object Modules.test262_metadataParser/Scope::parseTest262Frontmatter
+			IL_00d3: ldc.i4.1
+			IL_00d4: newarr [System.Runtime]System.Object
+			IL_00d9: dup
+			IL_00da: ldc.i4.0
+			IL_00db: ldarg.0
+			IL_00dc: stelem.ref
+			IL_00dd: ldloc.3
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00e3: stloc.s 28
+			IL_00e5: ldloc.s 28
+			IL_00e7: stloc.s 6
+			IL_00e9: br IL_00f5
 
-			IL_00b9: ldloc.s 6
-			IL_00bb: stloc.s 7
-			IL_00bd: ldloc.s 7
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-			IL_00c4: stloc.s 28
-			IL_00c6: ldloc.s 28
-			IL_00c8: stloc.s 8
-			IL_00ca: ldc.i4.0
-			IL_00cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00d0: stloc.s 9
-			IL_00d2: ldc.r8 0.0
-			IL_00db: stloc.s 10
-			// loop start (head: IL_00dd)
-				IL_00dd: ldloc.s 10
-				IL_00df: ldloc.s 8
-				IL_00e1: ldstr "length"
-				IL_00e6: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00eb: clt
-				IL_00ed: brfalse IL_0189
+			IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00f3: stloc.s 6
 
-				IL_00f2: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
-				IL_00f7: stloc.s 11
-				IL_00f9: ldloc.s 8
-				IL_00fb: ldloc.s 10
-				IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0102: stloc.s 12
-				IL_0104: ldarg.0
-				IL_0105: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
-				IL_010a: ldc.i4.1
-				IL_010b: newarr [System.Runtime]System.Object
-				IL_0110: dup
-				IL_0111: ldc.i4.0
-				IL_0112: ldloc.s 12
-				IL_0114: stelem.ref
-				IL_0115: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_011a: stloc.s 30
-				IL_011c: ldloc.s 30
-				IL_011e: ldc.r8 0.0
+			IL_00f5: ldloc.s 6
+			IL_00f7: stloc.s 7
+			IL_00f9: ldloc.s 7
+			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+			IL_0100: stloc.s 28
+			IL_0102: ldloc.s 28
+			IL_0104: stloc.s 8
+			IL_0106: ldc.i4.0
+			IL_0107: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_010c: stloc.s 9
+			IL_010e: ldc.r8 0.0
+			IL_0117: stloc.s 10
+			// loop start (head: IL_0119)
+				IL_0119: ldloc.s 10
+				IL_011b: ldloc.s 8
+				IL_011d: ldstr "length"
+				IL_0122: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_0127: clt
-				IL_0129: brfalse IL_0176
+				IL_0129: brfalse IL_01f2
 
-				IL_012e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
-				IL_0133: stloc.s 13
-				IL_0135: ldloc.s 9
-				IL_0137: ldloc.s 12
-				IL_0139: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_013e: pop
-				IL_013f: ldloc.s 12
-				IL_0141: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0146: stloc.s 31
-				IL_0148: ldstr "Unsupported frontmatter key '"
-				IL_014d: ldloc.s 31
-				IL_014f: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0154: stloc.s 31
-				IL_0156: ldloc.s 31
-				IL_0158: ldstr "'."
-				IL_015d: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0162: stloc.s 31
-				IL_0164: ldnull
-				IL_0165: ldloc.s 4
-				IL_0167: ldstr "unknown-frontmatter-key"
-				IL_016c: ldloc.s 12
-				IL_016e: ldloc.s 31
-				IL_0170: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_0175: pop
+				IL_012e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48::.ctor()
+				IL_0133: stloc.s 11
+				IL_0135: ldloc.s 8
+				IL_0137: ldloc.s 10
+				IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_013e: stloc.s 12
+				IL_0140: ldarg.0
+				IL_0141: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FRONTMATTER_KEYS
+				IL_0146: ldc.i4.1
+				IL_0147: newarr [System.Runtime]System.Object
+				IL_014c: dup
+				IL_014d: ldc.i4.0
+				IL_014e: ldloc.s 12
+				IL_0150: stelem.ref
+				IL_0151: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_0156: stloc.s 32
+				IL_0158: ldloc.s 32
+				IL_015a: ldc.r8 0.0
+				IL_0163: clt
+				IL_0165: brfalse IL_01df
 
-				IL_0176: ldloc.s 10
-				IL_0178: ldc.r8 1
-				IL_0181: add
-				IL_0182: stloc.s 10
-				IL_0184: br IL_00dd
+				IL_016a: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L440C7/Block_L440C48/Block_L442C49::.ctor()
+				IL_016f: stloc.s 13
+				IL_0171: ldloc.s 9
+				IL_0173: ldloc.s 12
+				IL_0175: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_017a: pop
+				IL_017b: ldarg.0
+				IL_017c: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_0181: stloc.s 28
+				IL_0183: ldc.i4.1
+				IL_0184: newarr [System.Runtime]System.Object
+				IL_0189: dup
+				IL_018a: ldc.i4.0
+				IL_018b: ldarg.0
+				IL_018c: stelem.ref
+				IL_018d: stloc.s 29
+				IL_018f: ldloc.s 12
+				IL_0191: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0196: stloc.s 33
+				IL_0198: ldstr "Unsupported frontmatter key '"
+				IL_019d: ldloc.s 33
+				IL_019f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01a4: stloc.s 33
+				IL_01a6: ldloc.s 33
+				IL_01a8: ldstr "'."
+				IL_01ad: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01b2: stloc.s 33
+				IL_01b4: ldc.i4.4
+				IL_01b5: newarr [System.Runtime]System.Object
+				IL_01ba: dup
+				IL_01bb: ldc.i4.0
+				IL_01bc: ldloc.s 4
+				IL_01be: stelem.ref
+				IL_01bf: dup
+				IL_01c0: ldc.i4.1
+				IL_01c1: ldstr "unknown-frontmatter-key"
+				IL_01c6: stelem.ref
+				IL_01c7: dup
+				IL_01c8: ldc.i4.2
+				IL_01c9: ldloc.s 12
+				IL_01cb: stelem.ref
+				IL_01cc: dup
+				IL_01cd: ldc.i4.3
+				IL_01ce: ldloc.s 33
+				IL_01d0: stelem.ref
+				IL_01d1: stloc.s 34
+				IL_01d3: ldloc.s 28
+				IL_01d5: ldloc.s 29
+				IL_01d7: ldloc.s 34
+				IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_01de: pop
+
+				IL_01df: ldloc.s 10
+				IL_01e1: ldc.r8 1
+				IL_01ea: add
+				IL_01eb: stloc.s 10
+				IL_01ed: br IL_0119
 			// end loop
 
-			IL_0189: ldloc.s 7
-			IL_018b: ldstr "includes"
-			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0195: stloc.s 28
-			IL_0197: ldarg.0
-			IL_0198: castclass Modules.test262_metadataParser/Scope
-			IL_019d: ldnull
-			IL_019e: ldloc.s 28
-			IL_01a0: ldstr "includes"
-			IL_01a5: ldloc.s 4
-			IL_01a7: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01ac: stloc.s 32
-			IL_01ae: ldloc.s 32
-			IL_01b0: stloc.s 14
-			IL_01b2: ldloc.s 7
-			IL_01b4: ldstr "flags"
-			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01be: stloc.s 28
-			IL_01c0: ldarg.0
-			IL_01c1: castclass Modules.test262_metadataParser/Scope
-			IL_01c6: ldnull
-			IL_01c7: ldloc.s 28
-			IL_01c9: ldstr "flags"
-			IL_01ce: ldloc.s 4
-			IL_01d0: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01d5: stloc.s 32
-			IL_01d7: ldloc.s 32
-			IL_01d9: stloc.s 15
-			IL_01db: ldloc.s 7
-			IL_01dd: ldstr "features"
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e7: stloc.s 28
-			IL_01e9: ldarg.0
-			IL_01ea: castclass Modules.test262_metadataParser/Scope
-			IL_01ef: ldnull
-			IL_01f0: ldloc.s 28
-			IL_01f2: ldstr "features"
-			IL_01f7: ldloc.s 4
-			IL_01f9: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_01fe: stloc.s 32
-			IL_0200: ldloc.s 32
-			IL_0202: stloc.s 16
-			IL_0204: ldloc.s 7
-			IL_0206: ldstr "locale"
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0210: stloc.s 28
-			IL_0212: ldarg.0
-			IL_0213: castclass Modules.test262_metadataParser/Scope
-			IL_0218: ldnull
-			IL_0219: ldloc.s 28
-			IL_021b: ldstr "locale"
-			IL_0220: ldloc.s 4
-			IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0227: stloc.s 32
-			IL_0229: ldloc.s 32
-			IL_022b: stloc.s 17
-			IL_022d: ldloc.s 7
-			IL_022f: ldstr "defines"
-			IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0239: stloc.s 28
-			IL_023b: ldarg.0
-			IL_023c: castclass Modules.test262_metadataParser/Scope
-			IL_0241: ldnull
-			IL_0242: ldloc.s 28
-			IL_0244: ldstr "defines"
-			IL_0249: ldloc.s 4
-			IL_024b: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0250: stloc.s 32
-			IL_0252: ldloc.s 32
-			IL_0254: stloc.s 18
-			IL_0256: ldloc.s 7
-			IL_0258: ldstr "negative"
-			IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0262: stloc.s 28
-			IL_0264: ldarg.0
-			IL_0265: castclass Modules.test262_metadataParser/Scope
-			IL_026a: ldnull
-			IL_026b: ldloc.s 28
-			IL_026d: ldloc.s 4
-			IL_026f: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-			IL_0274: stloc.s 28
-			IL_0276: ldloc.s 28
-			IL_0278: stloc.s 19
-			IL_027a: ldc.r8 0.0
-			IL_0283: stloc.s 20
-			// loop start (head: IL_0285)
-				IL_0285: ldloc.s 20
-				IL_0287: ldloc.s 15
-				IL_0289: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-				IL_028e: conv.r8
-				IL_028f: clt
-				IL_0291: brfalse IL_0348
+			IL_01f2: ldarg.0
+			IL_01f3: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_01f8: stloc.s 28
+			IL_01fa: ldc.i4.1
+			IL_01fb: newarr [System.Runtime]System.Object
+			IL_0200: dup
+			IL_0201: ldc.i4.0
+			IL_0202: ldarg.0
+			IL_0203: stelem.ref
+			IL_0204: stloc.s 34
+			IL_0206: ldloc.s 7
+			IL_0208: ldstr "includes"
+			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0212: stloc.s 30
+			IL_0214: ldloc.s 28
+			IL_0216: ldloc.s 34
+			IL_0218: ldloc.s 30
+			IL_021a: ldstr "includes"
+			IL_021f: ldloc.s 4
+			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0226: stloc.s 30
+			IL_0228: ldloc.s 30
+			IL_022a: stloc.s 14
+			IL_022c: ldarg.0
+			IL_022d: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_0232: stloc.s 30
+			IL_0234: ldc.i4.1
+			IL_0235: newarr [System.Runtime]System.Object
+			IL_023a: dup
+			IL_023b: ldc.i4.0
+			IL_023c: ldarg.0
+			IL_023d: stelem.ref
+			IL_023e: stloc.s 34
+			IL_0240: ldloc.s 7
+			IL_0242: ldstr "flags"
+			IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_024c: stloc.s 28
+			IL_024e: ldloc.s 30
+			IL_0250: ldloc.s 34
+			IL_0252: ldloc.s 28
+			IL_0254: ldstr "flags"
+			IL_0259: ldloc.s 4
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0260: stloc.s 28
+			IL_0262: ldloc.s 28
+			IL_0264: stloc.s 15
+			IL_0266: ldarg.0
+			IL_0267: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_026c: stloc.s 28
+			IL_026e: ldc.i4.1
+			IL_026f: newarr [System.Runtime]System.Object
+			IL_0274: dup
+			IL_0275: ldc.i4.0
+			IL_0276: ldarg.0
+			IL_0277: stelem.ref
+			IL_0278: stloc.s 34
+			IL_027a: ldloc.s 7
+			IL_027c: ldstr "features"
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0286: stloc.s 30
+			IL_0288: ldloc.s 28
+			IL_028a: ldloc.s 34
+			IL_028c: ldloc.s 30
+			IL_028e: ldstr "features"
+			IL_0293: ldloc.s 4
+			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_029a: stloc.s 30
+			IL_029c: ldloc.s 30
+			IL_029e: stloc.s 16
+			IL_02a0: ldarg.0
+			IL_02a1: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_02a6: stloc.s 30
+			IL_02a8: ldc.i4.1
+			IL_02a9: newarr [System.Runtime]System.Object
+			IL_02ae: dup
+			IL_02af: ldc.i4.0
+			IL_02b0: ldarg.0
+			IL_02b1: stelem.ref
+			IL_02b2: stloc.s 34
+			IL_02b4: ldloc.s 7
+			IL_02b6: ldstr "locale"
+			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c0: stloc.s 28
+			IL_02c2: ldloc.s 30
+			IL_02c4: ldloc.s 34
+			IL_02c6: ldloc.s 28
+			IL_02c8: ldstr "locale"
+			IL_02cd: ldloc.s 4
+			IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_02d4: stloc.s 28
+			IL_02d6: ldloc.s 28
+			IL_02d8: stloc.s 17
+			IL_02da: ldarg.0
+			IL_02db: ldfld object Modules.test262_metadataParser/Scope::toStringArray
+			IL_02e0: stloc.s 28
+			IL_02e2: ldc.i4.1
+			IL_02e3: newarr [System.Runtime]System.Object
+			IL_02e8: dup
+			IL_02e9: ldc.i4.0
+			IL_02ea: ldarg.0
+			IL_02eb: stelem.ref
+			IL_02ec: stloc.s 34
+			IL_02ee: ldloc.s 7
+			IL_02f0: ldstr "defines"
+			IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02fa: stloc.s 30
+			IL_02fc: ldloc.s 28
+			IL_02fe: ldloc.s 34
+			IL_0300: ldloc.s 30
+			IL_0302: ldstr "defines"
+			IL_0307: ldloc.s 4
+			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_030e: stloc.s 30
+			IL_0310: ldloc.s 30
+			IL_0312: stloc.s 18
+			IL_0314: ldarg.0
+			IL_0315: ldfld object Modules.test262_metadataParser/Scope::normalizeNegative
+			IL_031a: stloc.s 30
+			IL_031c: ldc.i4.1
+			IL_031d: newarr [System.Runtime]System.Object
+			IL_0322: dup
+			IL_0323: ldc.i4.0
+			IL_0324: ldarg.0
+			IL_0325: stelem.ref
+			IL_0326: stloc.s 34
+			IL_0328: ldloc.s 30
+			IL_032a: ldloc.s 34
+			IL_032c: ldloc.s 7
+			IL_032e: ldstr "negative"
+			IL_0333: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0338: ldloc.s 4
+			IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_033f: stloc.s 30
+			IL_0341: ldloc.s 30
+			IL_0343: stloc.s 19
+			IL_0345: ldc.r8 0.0
+			IL_034e: stloc.s 20
+			// loop start (head: IL_0350)
+				IL_0350: ldloc.s 20
+				IL_0352: ldloc.s 15
+				IL_0354: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_0359: clt
+				IL_035b: brfalse IL_043f
 
-				IL_0296: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
-				IL_029b: stloc.s 21
-				IL_029d: ldarg.0
-				IL_029e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
-				IL_02a3: stloc.s 32
-				IL_02a5: ldloc.s 32
-				IL_02a7: ldc.i4.1
-				IL_02a8: newarr [System.Runtime]System.Object
-				IL_02ad: dup
-				IL_02ae: ldc.i4.0
-				IL_02af: ldloc.s 15
-				IL_02b1: ldloc.s 20
-				IL_02b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_02b8: stelem.ref
-				IL_02b9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
-				IL_02be: stloc.s 30
-				IL_02c0: ldloc.s 30
-				IL_02c2: ldc.r8 0.0
-				IL_02cb: clt
-				IL_02cd: brfalse IL_0335
+				IL_0360: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41::.ctor()
+				IL_0365: stloc.s 21
+				IL_0367: ldarg.0
+				IL_0368: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::KNOWN_FLAG_VALUES
+				IL_036d: stloc.s 35
+				IL_036f: ldloc.s 35
+				IL_0371: ldc.i4.1
+				IL_0372: newarr [System.Runtime]System.Object
+				IL_0377: dup
+				IL_0378: ldc.i4.0
+				IL_0379: ldloc.s 15
+				IL_037b: ldloc.s 20
+				IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0382: stelem.ref
+				IL_0383: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::indexOf(object[])
+				IL_0388: stloc.s 32
+				IL_038a: ldloc.s 32
+				IL_038c: ldc.r8 0.0
+				IL_0395: clt
+				IL_0397: brfalse IL_042c
 
-				IL_02d2: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
-				IL_02d7: stloc.s 22
-				IL_02d9: ldloc.s 15
-				IL_02db: ldloc.s 20
-				IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_02e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_02e7: stloc.s 31
-				IL_02e9: ldstr "flags:"
-				IL_02ee: ldloc.s 31
-				IL_02f0: call string [System.Runtime]System.String::Concat(string, string)
-				IL_02f5: stloc.s 31
-				IL_02f7: ldloc.s 15
-				IL_02f9: ldloc.s 20
-				IL_02fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0300: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0305: stloc.s 33
-				IL_0307: ldstr "Unsupported flag '"
-				IL_030c: ldloc.s 33
-				IL_030e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0313: stloc.s 33
-				IL_0315: ldloc.s 33
-				IL_0317: ldstr "'."
-				IL_031c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0321: stloc.s 33
-				IL_0323: ldnull
-				IL_0324: ldloc.s 4
-				IL_0326: ldstr "unknown-flag"
-				IL_032b: ldloc.s 31
-				IL_032d: ldloc.s 33
-				IL_032f: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-				IL_0334: pop
+				IL_039c: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope_For_L455C7/Block_L455C41/Block_L456C49::.ctor()
+				IL_03a1: stloc.s 22
+				IL_03a3: ldarg.0
+				IL_03a4: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+				IL_03a9: stloc.s 30
+				IL_03ab: ldc.i4.1
+				IL_03ac: newarr [System.Runtime]System.Object
+				IL_03b1: dup
+				IL_03b2: ldc.i4.0
+				IL_03b3: ldarg.0
+				IL_03b4: stelem.ref
+				IL_03b5: stloc.s 34
+				IL_03b7: ldloc.s 15
+				IL_03b9: ldloc.s 20
+				IL_03bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_03c5: stloc.s 33
+				IL_03c7: ldstr "flags:"
+				IL_03cc: ldloc.s 33
+				IL_03ce: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03d3: stloc.s 33
+				IL_03d5: ldloc.s 15
+				IL_03d7: ldloc.s 20
+				IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_03de: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_03e3: stloc.s 36
+				IL_03e5: ldstr "Unsupported flag '"
+				IL_03ea: ldloc.s 36
+				IL_03ec: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03f1: stloc.s 36
+				IL_03f3: ldloc.s 36
+				IL_03f5: ldstr "'."
+				IL_03fa: call string [System.Runtime]System.String::Concat(string, string)
+				IL_03ff: stloc.s 36
+				IL_0401: ldc.i4.4
+				IL_0402: newarr [System.Runtime]System.Object
+				IL_0407: dup
+				IL_0408: ldc.i4.0
+				IL_0409: ldloc.s 4
+				IL_040b: stelem.ref
+				IL_040c: dup
+				IL_040d: ldc.i4.1
+				IL_040e: ldstr "unknown-flag"
+				IL_0413: stelem.ref
+				IL_0414: dup
+				IL_0415: ldc.i4.2
+				IL_0416: ldloc.s 33
+				IL_0418: stelem.ref
+				IL_0419: dup
+				IL_041a: ldc.i4.3
+				IL_041b: ldloc.s 36
+				IL_041d: stelem.ref
+				IL_041e: stloc.s 29
+				IL_0420: ldloc.s 30
+				IL_0422: ldloc.s 34
+				IL_0424: ldloc.s 29
+				IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+				IL_042b: pop
 
-				IL_0335: ldloc.s 20
-				IL_0337: ldc.r8 1
-				IL_0340: add
-				IL_0341: stloc.s 20
-				IL_0343: br IL_0285
+				IL_042c: ldloc.s 20
+				IL_042e: ldc.r8 1
+				IL_0437: add
+				IL_0438: stloc.s 20
+				IL_043a: br IL_0350
 			// end loop
 
-			IL_0348: ldarg.0
-			IL_0349: castclass Modules.test262_metadataParser/Scope
-			IL_034e: ldnull
-			IL_034f: ldloc.s 15
-			IL_0351: ldloc.s 14
-			IL_0353: ldloc.2
-			IL_0354: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0359: stloc.s 28
-			IL_035b: ldloc.s 28
-			IL_035d: stloc.s 23
-			IL_035f: ldloc.s 23
-			IL_0361: ldstr "strictMode"
-			IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_036b: ldstr "conflicting-flags"
-			IL_0370: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0375: stloc.s 25
-			IL_0377: ldloc.s 25
-			IL_0379: brfalse IL_039d
+			IL_043f: ldarg.0
+			IL_0440: ldfld object Modules.test262_metadataParser/Scope::buildExecutionMetadata
+			IL_0445: ldc.i4.1
+			IL_0446: newarr [System.Runtime]System.Object
+			IL_044b: dup
+			IL_044c: ldc.i4.0
+			IL_044d: ldarg.0
+			IL_044e: stelem.ref
+			IL_044f: ldloc.s 15
+			IL_0451: ldloc.s 14
+			IL_0453: ldloc.2
+			IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0459: stloc.s 30
+			IL_045b: ldloc.s 30
+			IL_045d: stloc.s 23
+			IL_045f: ldloc.s 23
+			IL_0461: ldstr "strictMode"
+			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_046b: ldstr "conflicting-flags"
+			IL_0470: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0475: stloc.s 25
+			IL_0477: ldloc.s 25
+			IL_0479: brfalse IL_04ca
 
-			IL_037e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
-			IL_0383: stloc.s 24
-			IL_0385: ldnull
-			IL_0386: ldloc.s 4
-			IL_0388: ldstr "conflicting-strictness-flags"
-			IL_038d: ldstr "flags"
-			IL_0392: ldstr "Multiple strictness/source-type flags were declared together."
-			IL_0397: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, object, object, object, object)
-			IL_039c: pop
+			IL_047e: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/Scope/Block_L462C52::.ctor()
+			IL_0483: stloc.s 24
+			IL_0485: ldarg.0
+			IL_0486: ldfld object Modules.test262_metadataParser/Scope::pushIssue
+			IL_048b: stloc.s 30
+			IL_048d: ldc.i4.1
+			IL_048e: newarr [System.Runtime]System.Object
+			IL_0493: dup
+			IL_0494: ldc.i4.0
+			IL_0495: ldarg.0
+			IL_0496: stelem.ref
+			IL_0497: stloc.s 29
+			IL_0499: ldc.i4.4
+			IL_049a: newarr [System.Runtime]System.Object
+			IL_049f: dup
+			IL_04a0: ldc.i4.0
+			IL_04a1: ldloc.s 4
+			IL_04a3: stelem.ref
+			IL_04a4: dup
+			IL_04a5: ldc.i4.1
+			IL_04a6: ldstr "conflicting-strictness-flags"
+			IL_04ab: stelem.ref
+			IL_04ac: dup
+			IL_04ad: ldc.i4.2
+			IL_04ae: ldstr "flags"
+			IL_04b3: stelem.ref
+			IL_04b4: dup
+			IL_04b5: ldc.i4.3
+			IL_04b6: ldstr "Multiple strictness/source-type flags were declared together."
+			IL_04bb: stelem.ref
+			IL_04bc: stloc.s 34
+			IL_04be: ldloc.s 30
+			IL_04c0: ldloc.s 29
+			IL_04c2: ldloc.s 34
+			IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_04c9: pop
 
-			IL_039d: ldloc.1
-			IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03a3: stloc.s 25
-			IL_03a5: ldloc.s 25
-			IL_03a7: brtrue IL_03b9
+			IL_04ca: ldloc.1
+			IL_04cb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04d0: stloc.s 25
+			IL_04d2: ldloc.s 25
+			IL_04d4: brtrue IL_04e6
 
-			IL_03ac: ldc.i4.0
-			IL_03ad: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03b2: stloc.s 34
-			IL_03b4: br IL_03bc
+			IL_04d9: ldc.i4.0
+			IL_04da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04df: stloc.s 37
+			IL_04e1: br IL_04e9
 
-			IL_03b9: ldloc.1
-			IL_03ba: stloc.s 34
+			IL_04e6: ldloc.1
+			IL_04e7: stloc.s 37
 
-			IL_03bc: ldloc.2
-			IL_03bd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03c2: stloc.s 25
-			IL_03c4: ldloc.s 25
-			IL_03c6: brtrue IL_03d8
+			IL_04e9: ldloc.2
+			IL_04ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04ef: stloc.s 25
+			IL_04f1: ldloc.s 25
+			IL_04f3: brtrue IL_0505
 
-			IL_03cb: ldc.i4.0
-			IL_03cc: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03d1: stloc.s 36
-			IL_03d3: br IL_03db
+			IL_04f8: ldc.i4.0
+			IL_04f9: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04fe: stloc.s 39
+			IL_0500: br IL_0508
 
-			IL_03d8: ldloc.2
-			IL_03d9: stloc.s 36
+			IL_0505: ldloc.2
+			IL_0506: stloc.s 39
 
-			IL_03db: ldloc.s 7
-			IL_03dd: ldstr "description"
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e7: stloc.s 28
-			IL_03e9: ldarg.0
-			IL_03ea: castclass Modules.test262_metadataParser/Scope
-			IL_03ef: ldnull
-			IL_03f0: ldloc.s 28
-			IL_03f2: ldstr "description"
-			IL_03f7: ldloc.s 4
-			IL_03f9: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_03fe: stloc.s 28
-			IL_0400: ldloc.s 7
-			IL_0402: ldstr "info"
-			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_040c: stloc.s 37
-			IL_040e: ldarg.0
-			IL_040f: castclass Modules.test262_metadataParser/Scope
-			IL_0414: ldnull
-			IL_0415: ldloc.s 37
-			IL_0417: ldstr "info"
-			IL_041c: ldloc.s 4
-			IL_041e: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0423: stloc.s 37
-			IL_0425: ldloc.s 7
-			IL_0427: ldstr "esid"
-			IL_042c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0431: stloc.s 38
-			IL_0433: ldarg.0
-			IL_0434: castclass Modules.test262_metadataParser/Scope
-			IL_0439: ldnull
-			IL_043a: ldloc.s 38
-			IL_043c: ldstr "esid"
-			IL_0441: ldloc.s 4
-			IL_0443: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0448: stloc.s 38
-			IL_044a: ldloc.s 7
-			IL_044c: ldstr "es5id"
-			IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0456: stloc.s 39
-			IL_0458: ldarg.0
-			IL_0459: castclass Modules.test262_metadataParser/Scope
-			IL_045e: ldnull
-			IL_045f: ldloc.s 39
-			IL_0461: ldstr "es5id"
-			IL_0466: ldloc.s 4
-			IL_0468: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_046d: stloc.s 39
-			IL_046f: ldloc.s 7
-			IL_0471: ldstr "es6id"
-			IL_0476: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_047b: stloc.s 40
-			IL_047d: ldarg.0
-			IL_047e: castclass Modules.test262_metadataParser/Scope
-			IL_0483: ldnull
-			IL_0484: ldloc.s 40
-			IL_0486: ldstr "es6id"
-			IL_048b: ldloc.s 4
-			IL_048d: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_0492: stloc.s 40
-			IL_0494: ldloc.s 7
-			IL_0496: ldstr "author"
-			IL_049b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04a0: stloc.s 41
-			IL_04a2: ldarg.0
-			IL_04a3: castclass Modules.test262_metadataParser/Scope
-			IL_04a8: ldnull
-			IL_04a9: ldloc.s 41
-			IL_04ab: ldstr "author"
-			IL_04b0: ldloc.s 4
-			IL_04b2: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_04b7: stloc.s 41
-			IL_04b9: ldarg.0
-			IL_04ba: castclass Modules.test262_metadataParser/Scope
-			IL_04bf: ldnull
-			IL_04c0: ldloc.1
-			IL_04c1: ldloc.s 19
-			IL_04c3: ldloc.s 23
-			IL_04c5: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-			IL_04ca: stloc.s 32
-			IL_04cc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04d1: dup
-			IL_04d2: ldstr "filePath"
-			IL_04d7: ldloc.s 34
-			IL_04d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04de: dup
-			IL_04df: ldstr "fileName"
-			IL_04e4: ldloc.s 36
-			IL_04e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04eb: dup
-			IL_04ec: ldstr "hasFrontmatter"
-			IL_04f1: ldloc.s 5
-			IL_04f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04f8: dup
-			IL_04f9: ldstr "frontmatter"
-			IL_04fe: ldloc.s 7
-			IL_0500: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0505: dup
-			IL_0506: ldstr "unknownKeys"
-			IL_050b: ldloc.s 9
-			IL_050d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0512: dup
-			IL_0513: ldstr "description"
-			IL_0518: ldloc.s 28
-			IL_051a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_051f: dup
-			IL_0520: ldstr "info"
-			IL_0525: ldloc.s 37
-			IL_0527: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_052c: dup
-			IL_052d: ldstr "esid"
-			IL_0532: ldloc.s 38
-			IL_0534: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0539: dup
-			IL_053a: ldstr "es5id"
-			IL_053f: ldloc.s 39
-			IL_0541: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0546: dup
-			IL_0547: ldstr "es6id"
-			IL_054c: ldloc.s 40
-			IL_054e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0553: dup
-			IL_0554: ldstr "author"
-			IL_0559: ldloc.s 41
-			IL_055b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0560: dup
-			IL_0561: ldstr "includes"
-			IL_0566: ldloc.s 14
-			IL_0568: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_056d: dup
-			IL_056e: ldstr "flags"
-			IL_0573: ldloc.s 15
-			IL_0575: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_057a: dup
-			IL_057b: ldstr "features"
-			IL_0580: ldloc.s 16
-			IL_0582: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0587: dup
-			IL_0588: ldstr "locale"
-			IL_058d: ldloc.s 17
-			IL_058f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0594: dup
-			IL_0595: ldstr "defines"
-			IL_059a: ldloc.s 18
-			IL_059c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05a1: dup
-			IL_05a2: ldstr "negative"
-			IL_05a7: ldloc.s 19
-			IL_05a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05ae: dup
-			IL_05af: ldstr "execution"
-			IL_05b4: ldloc.s 23
-			IL_05b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05bb: dup
-			IL_05bc: ldstr "mvpBlockers"
-			IL_05c1: ldloc.s 32
-			IL_05c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05c8: dup
-			IL_05c9: ldstr "unsupported"
-			IL_05ce: ldloc.s 4
-			IL_05d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05d5: stloc.s 42
-			IL_05d7: ldloc.s 42
-			IL_05d9: ret
+			IL_0508: ldarg.0
+			IL_0509: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_050e: stloc.s 30
+			IL_0510: ldc.i4.1
+			IL_0511: newarr [System.Runtime]System.Object
+			IL_0516: dup
+			IL_0517: ldc.i4.0
+			IL_0518: ldarg.0
+			IL_0519: stelem.ref
+			IL_051a: stloc.s 34
+			IL_051c: ldloc.s 7
+			IL_051e: ldstr "description"
+			IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0528: stloc.s 28
+			IL_052a: ldloc.s 30
+			IL_052c: ldloc.s 34
+			IL_052e: ldloc.s 28
+			IL_0530: ldstr "description"
+			IL_0535: ldloc.s 4
+			IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_053c: stloc.s 28
+			IL_053e: ldarg.0
+			IL_053f: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_0544: stloc.s 30
+			IL_0546: ldc.i4.1
+			IL_0547: newarr [System.Runtime]System.Object
+			IL_054c: dup
+			IL_054d: ldc.i4.0
+			IL_054e: ldarg.0
+			IL_054f: stelem.ref
+			IL_0550: stloc.s 34
+			IL_0552: ldloc.s 7
+			IL_0554: ldstr "info"
+			IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_055e: stloc.s 40
+			IL_0560: ldloc.s 30
+			IL_0562: ldloc.s 34
+			IL_0564: ldloc.s 40
+			IL_0566: ldstr "info"
+			IL_056b: ldloc.s 4
+			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0572: stloc.s 40
+			IL_0574: ldarg.0
+			IL_0575: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_057a: stloc.s 30
+			IL_057c: ldc.i4.1
+			IL_057d: newarr [System.Runtime]System.Object
+			IL_0582: dup
+			IL_0583: ldc.i4.0
+			IL_0584: ldarg.0
+			IL_0585: stelem.ref
+			IL_0586: stloc.s 34
+			IL_0588: ldloc.s 7
+			IL_058a: ldstr "esid"
+			IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0594: stloc.s 41
+			IL_0596: ldloc.s 30
+			IL_0598: ldloc.s 34
+			IL_059a: ldloc.s 41
+			IL_059c: ldstr "esid"
+			IL_05a1: ldloc.s 4
+			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_05a8: stloc.s 41
+			IL_05aa: ldarg.0
+			IL_05ab: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_05b0: stloc.s 30
+			IL_05b2: ldc.i4.1
+			IL_05b3: newarr [System.Runtime]System.Object
+			IL_05b8: dup
+			IL_05b9: ldc.i4.0
+			IL_05ba: ldarg.0
+			IL_05bb: stelem.ref
+			IL_05bc: stloc.s 34
+			IL_05be: ldloc.s 7
+			IL_05c0: ldstr "es5id"
+			IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05ca: stloc.s 42
+			IL_05cc: ldloc.s 30
+			IL_05ce: ldloc.s 34
+			IL_05d0: ldloc.s 42
+			IL_05d2: ldstr "es5id"
+			IL_05d7: ldloc.s 4
+			IL_05d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_05de: stloc.s 42
+			IL_05e0: ldarg.0
+			IL_05e1: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_05e6: stloc.s 30
+			IL_05e8: ldc.i4.1
+			IL_05e9: newarr [System.Runtime]System.Object
+			IL_05ee: dup
+			IL_05ef: ldc.i4.0
+			IL_05f0: ldarg.0
+			IL_05f1: stelem.ref
+			IL_05f2: stloc.s 34
+			IL_05f4: ldloc.s 7
+			IL_05f6: ldstr "es6id"
+			IL_05fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0600: stloc.s 43
+			IL_0602: ldloc.s 30
+			IL_0604: ldloc.s 34
+			IL_0606: ldloc.s 43
+			IL_0608: ldstr "es6id"
+			IL_060d: ldloc.s 4
+			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0614: stloc.s 43
+			IL_0616: ldarg.0
+			IL_0617: ldfld object Modules.test262_metadataParser/Scope::toNullableString
+			IL_061c: stloc.s 30
+			IL_061e: ldc.i4.1
+			IL_061f: newarr [System.Runtime]System.Object
+			IL_0624: dup
+			IL_0625: ldc.i4.0
+			IL_0626: ldarg.0
+			IL_0627: stelem.ref
+			IL_0628: stloc.s 34
+			IL_062a: ldloc.s 7
+			IL_062c: ldstr "author"
+			IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0636: stloc.s 44
+			IL_0638: ldloc.s 30
+			IL_063a: ldloc.s 34
+			IL_063c: ldloc.s 44
+			IL_063e: ldstr "author"
+			IL_0643: ldloc.s 4
+			IL_0645: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_064a: stloc.s 44
+			IL_064c: ldarg.0
+			IL_064d: ldfld object Modules.test262_metadataParser/Scope::buildMvpBlockers
+			IL_0652: ldc.i4.1
+			IL_0653: newarr [System.Runtime]System.Object
+			IL_0658: dup
+			IL_0659: ldc.i4.0
+			IL_065a: ldarg.0
+			IL_065b: stelem.ref
+			IL_065c: ldloc.1
+			IL_065d: ldloc.s 19
+			IL_065f: ldloc.s 23
+			IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0666: stloc.s 30
+			IL_0668: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_066d: dup
+			IL_066e: ldstr "filePath"
+			IL_0673: ldloc.s 37
+			IL_0675: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_067a: dup
+			IL_067b: ldstr "fileName"
+			IL_0680: ldloc.s 39
+			IL_0682: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0687: dup
+			IL_0688: ldstr "hasFrontmatter"
+			IL_068d: ldloc.s 5
+			IL_068f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0694: dup
+			IL_0695: ldstr "frontmatter"
+			IL_069a: ldloc.s 7
+			IL_069c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06a1: dup
+			IL_06a2: ldstr "unknownKeys"
+			IL_06a7: ldloc.s 9
+			IL_06a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06ae: dup
+			IL_06af: ldstr "description"
+			IL_06b4: ldloc.s 28
+			IL_06b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06bb: dup
+			IL_06bc: ldstr "info"
+			IL_06c1: ldloc.s 40
+			IL_06c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06c8: dup
+			IL_06c9: ldstr "esid"
+			IL_06ce: ldloc.s 41
+			IL_06d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06d5: dup
+			IL_06d6: ldstr "es5id"
+			IL_06db: ldloc.s 42
+			IL_06dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06e2: dup
+			IL_06e3: ldstr "es6id"
+			IL_06e8: ldloc.s 43
+			IL_06ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06ef: dup
+			IL_06f0: ldstr "author"
+			IL_06f5: ldloc.s 44
+			IL_06f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_06fc: dup
+			IL_06fd: ldstr "includes"
+			IL_0702: ldloc.s 14
+			IL_0704: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0709: dup
+			IL_070a: ldstr "flags"
+			IL_070f: ldloc.s 15
+			IL_0711: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0716: dup
+			IL_0717: ldstr "features"
+			IL_071c: ldloc.s 16
+			IL_071e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0723: dup
+			IL_0724: ldstr "locale"
+			IL_0729: ldloc.s 17
+			IL_072b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0730: dup
+			IL_0731: ldstr "defines"
+			IL_0736: ldloc.s 18
+			IL_0738: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_073d: dup
+			IL_073e: ldstr "negative"
+			IL_0743: ldloc.s 19
+			IL_0745: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_074a: dup
+			IL_074b: ldstr "execution"
+			IL_0750: ldloc.s 23
+			IL_0752: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0757: dup
+			IL_0758: ldstr "mvpBlockers"
+			IL_075d: ldloc.s 30
+			IL_075f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0764: dup
+			IL_0765: ldstr "unsupported"
+			IL_076a: ldloc.s 4
+			IL_076c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0771: stloc.s 45
+			IL_0773: ldloc.s 45
+			IL_0775: ret
 		} // end of method parseTest262Metadata::__js_call__
 
 	} // end of class parseTest262Metadata
@@ -8114,7 +9323,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x6060
+				// Method begins at RVA 0x6868
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -8141,7 +9350,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x5c4c
+			// Method begins at RVA 0x6454
 			// Header size: 12
 			// Code size: 69 (0x45)
 			.maxstack 8
@@ -8241,7 +9450,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5d00
+			// Method begins at RVA 0x6508
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -8265,7 +9474,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2320
+		// Method begins at RVA 0x232c
 		// Header size: 12
 		// Code size: 1428 (0x594)
 		.maxstack 8
@@ -8831,7 +10040,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x6069
+		// Method begins at RVA 0x6871
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Test262.Tests/language/function-code/Snapshots/ExecutionTests._10_4_3_1_27_s.verified.txt
+++ b/tests/Jroc.Test262.Tests/language/function-code/Snapshots/ExecutionTests._10_4_3_1_27_s.verified.txt
@@ -1,1 +1,1 @@
-﻿false
+﻿true

--- a/tests/Jroc.Test262.Tests/language/function-code/Snapshots/ExecutionTests._10_4_3_1_28_s.verified.txt
+++ b/tests/Jroc.Test262.Tests/language/function-code/Snapshots/ExecutionTests._10_4_3_1_28_s.verified.txt
@@ -1,1 +1,1 @@
-﻿false
+﻿true

--- a/tests/Jroc.Test262.Tests/language/function-code/Snapshots/ExecutionTests._10_4_3_1_29_s.verified.txt
+++ b/tests/Jroc.Test262.Tests/language/function-code/Snapshots/ExecutionTests._10_4_3_1_29_s.verified.txt
@@ -1,1 +1,1 @@
-﻿false
+﻿true

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Array_AsArray_Ternary
+﻿// IL code: Array_AsArray_Ternary
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213c
+				// Method begins at RVA 0x214c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f0
+			// Method begins at RVA 0x2100
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -95,7 +95,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2133
+			// Method begins at RVA 0x2143
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -121,7 +121,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 148 (0x94)
+		// Code size: 162 (0xa2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_AsArray_Ternary/Scope,
@@ -129,7 +129,7 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Array_AsArray_Ternary/Scope::.ctor()
@@ -146,39 +146,43 @@
 		IL_0020: stloc.s 4
 		IL_0022: ldloc.s 4
 		IL_0024: stloc.1
-		IL_0025: ldc.i4.1
-		IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_002b: dup
-		IL_002c: ldc.r8 1
-		IL_0035: box [System.Runtime]System.Double
-		IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_003f: stloc.s 5
-		IL_0041: ldnull
-		IL_0042: ldloc.s 5
-		IL_0044: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
-		IL_0049: stloc.s 4
-		IL_004b: ldloc.s 4
-		IL_004d: stloc.2
-		IL_004e: ldnull
-		IL_004f: ldc.r8 0.0
-		IL_0058: box [System.Runtime]System.Double
-		IL_005d: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
-		IL_0062: stloc.s 4
-		IL_0064: ldloc.s 4
-		IL_0066: stloc.3
-		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006c: ldloc.2
-		IL_006d: ldstr "length"
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007c: pop
-		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0082: ldloc.3
-		IL_0083: ldstr "length"
-		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0092: pop
-		IL_0093: ret
+		IL_0025: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002a: stloc.s 5
+		IL_002c: ldloc.1
+		IL_002d: ldloc.s 5
+		IL_002f: ldc.i4.1
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0035: dup
+		IL_0036: ldc.r8 1
+		IL_003f: box [System.Runtime]System.Double
+		IL_0044: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_004e: stloc.s 4
+		IL_0050: ldloc.s 4
+		IL_0052: stloc.2
+		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0058: stloc.s 5
+		IL_005a: ldloc.1
+		IL_005b: ldloc.s 5
+		IL_005d: ldc.r8 0.0
+		IL_0066: box [System.Runtime]System.Double
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.s 4
+		IL_0074: stloc.3
+		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007a: ldloc.2
+		IL_007b: ldstr "length"
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008a: pop
+		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0090: ldloc.3
+		IL_0091: ldstr "length"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a0: pop
+		IL_00a1: ret
 	} // end of method Array_AsArray_Ternary::__js_module_init__
 
 } // end of class Modules.Array_AsArray_Ternary
@@ -190,7 +194,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2145
+		// Method begins at RVA 0x2155
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -329,7 +329,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 230 (0xe6)
+		// Code size: 229 (0xe5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Map_NestedParam/Scope,
@@ -338,7 +338,7 @@
 			[3] object,
 			[4] class Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40,
 			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[6] object[],
 			[7] float64,
 			[8] object
 		)
@@ -365,67 +365,66 @@
 		IL_0030: stloc.s 5
 		IL_0032: ldloc.s 5
 		IL_0034: stloc.1
-		IL_0035: ldc.i4.3
-		IL_0036: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_003b: dup
-		IL_003c: ldstr "a"
-		IL_0041: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0046: dup
-		IL_0047: ldstr "bb"
-		IL_004c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0051: dup
-		IL_0052: ldstr "ccc"
-		IL_0057: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_005c: stloc.s 6
-		IL_005e: ldloc.0
-		IL_005f: castclass Modules.Array_Map_NestedParam/Scope
-		IL_0064: ldnull
-		IL_0065: ldloc.s 6
-		IL_0067: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
-		IL_006c: stloc.s 5
-		IL_006e: ldloc.s 5
-		IL_0070: stloc.2
-		IL_0071: ldc.r8 0.0
-		IL_007a: box [System.Runtime]System.Double
-		IL_007f: stloc.3
-		// loop start (head: IL_0080)
-			IL_0080: ldloc.2
-			IL_0081: ldstr "length"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_008b: stloc.s 5
-			IL_008d: ldloc.3
-			IL_008e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0093: stloc.s 7
-			IL_0095: ldloc.s 7
-			IL_0097: ldloc.s 5
-			IL_0099: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_009e: clt
-			IL_00a0: brfalse IL_00e5
+		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003a: stloc.s 6
+		IL_003c: ldloc.1
+		IL_003d: ldloc.s 6
+		IL_003f: ldc.i4.3
+		IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0045: dup
+		IL_0046: ldstr "a"
+		IL_004b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0050: dup
+		IL_0051: ldstr "bb"
+		IL_0056: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_005b: dup
+		IL_005c: ldstr "ccc"
+		IL_0061: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_006b: stloc.s 5
+		IL_006d: ldloc.s 5
+		IL_006f: stloc.2
+		IL_0070: ldc.r8 0.0
+		IL_0079: box [System.Runtime]System.Double
+		IL_007e: stloc.3
+		// loop start (head: IL_007f)
+			IL_007f: ldloc.2
+			IL_0080: ldstr "length"
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008a: stloc.s 5
+			IL_008c: ldloc.3
+			IL_008d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0092: stloc.s 7
+			IL_0094: ldloc.s 7
+			IL_0096: ldloc.s 5
+			IL_0098: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009d: clt
+			IL_009f: brfalse IL_00e4
 
-			IL_00a5: newobj instance void Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40::.ctor()
-			IL_00aa: stloc.s 4
-			IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00b1: ldloc.2
-			IL_00b2: ldloc.3
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bd: pop
-			IL_00be: ldloc.3
-			IL_00bf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c4: stloc.s 7
-			IL_00c6: ldloc.s 7
-			IL_00c8: ldc.r8 1
-			IL_00d1: add
-			IL_00d2: stloc.s 7
-			IL_00d4: ldloc.s 7
-			IL_00d6: box [System.Runtime]System.Double
-			IL_00db: stloc.s 8
-			IL_00dd: ldloc.s 8
-			IL_00df: stloc.3
-			IL_00e0: br IL_0080
+			IL_00a4: newobj instance void Modules.Array_Map_NestedParam/Scope_For_L13C5/Block_L13C40::.ctor()
+			IL_00a9: stloc.s 4
+			IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00b0: ldloc.2
+			IL_00b1: ldloc.3
+			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00bc: pop
+			IL_00bd: ldloc.3
+			IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00c3: stloc.s 7
+			IL_00c5: ldloc.s 7
+			IL_00c7: ldc.r8 1
+			IL_00d0: add
+			IL_00d1: stloc.s 7
+			IL_00d3: ldloc.s 7
+			IL_00d5: box [System.Runtime]System.Double
+			IL_00da: stloc.s 8
+			IL_00dc: ldloc.s 8
+			IL_00de: stloc.3
+			IL_00df: br IL_007f
 		// end loop
 
-		IL_00e5: ret
+		IL_00e4: ret
 	} // end of method Array_Map_NestedParam::__js_module_init__
 
 } // end of class Modules.Array_Map_NestedParam

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21be
+					// Method begins at RVA 0x21c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2168
+				// Method begins at RVA 0x2170
 				// Header size: 12
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b5
+				// Method begins at RVA 0x21bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -119,7 +119,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2100
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -185,7 +185,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ac
+			// Method begins at RVA 0x21b4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -211,13 +211,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 163 (0xa3)
+		// Code size: 171 (0xab)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope,
 			[1] object,
 			[2] object,
-			[3] object
+			[3] object,
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope::.ctor()
@@ -242,42 +243,44 @@
 		IL_0030: stloc.3
 		IL_0031: ldloc.3
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope
-		IL_0039: ldnull
-		IL_003a: ldc.r8 10
-		IL_0043: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
-		IL_0048: stloc.3
-		IL_0049: ldloc.3
-		IL_004a: stloc.2
-		IL_004b: ldloc.2
-		IL_004c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0056: stloc.3
-		IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005c: ldstr "First increment:"
-		IL_0061: ldloc.3
-		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0067: pop
-		IL_0068: ldloc.2
-		IL_0069: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0073: stloc.3
-		IL_0074: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0079: ldstr "Second increment:"
-		IL_007e: ldloc.3
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0084: pop
-		IL_0085: ldloc.2
-		IL_0086: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0090: stloc.3
-		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0096: ldstr "Third increment:"
-		IL_009b: ldloc.3
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00a1: pop
-		IL_00a2: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.s 4
+		IL_003a: ldloc.1
+		IL_003b: ldloc.s 4
+		IL_003d: ldc.r8 10
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0050: stloc.3
+		IL_0051: ldloc.3
+		IL_0052: stloc.2
+		IL_0053: ldloc.2
+		IL_0054: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005e: stloc.3
+		IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0064: ldstr "First increment:"
+		IL_0069: ldloc.3
+		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_006f: pop
+		IL_0070: ldloc.2
+		IL_0071: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_007b: stloc.3
+		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0081: ldstr "Second increment:"
+		IL_0086: ldloc.3
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008c: pop
+		IL_008d: ldloc.2
+		IL_008e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0098: stloc.3
+		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009e: ldstr "Third increment:"
+		IL_00a3: ldloc.3
+		IL_00a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a9: pop
+		IL_00aa: ret
 	} // end of method ArrowFunction_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_ClosureMutatesOuterVariable
@@ -289,7 +292,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c7
+		// Method begins at RVA 0x21cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b2
+				// Method begins at RVA 0x22c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x2100
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -81,7 +81,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22bb
+				// Method begins at RVA 0x22cf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -105,14 +105,15 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x211c
 			// Header size: 12
-			// Code size: 258 (0x102)
+			// Code size: 284 (0x11c)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Async_Calls_Module_Function_Before_Await/main/Scope,
 				[1] object,
-				[2] object
+				[2] object[],
+				[3] object
 			)
 
 			IL_0000: ldarg.0
@@ -164,62 +165,76 @@
 
 			IL_006a: ldloc.0
 			IL_006b: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0070: switch (IL_007d, IL_00c4)
+			IL_0070: switch (IL_007d, IL_00de)
 
-			IL_007d: ldnull
-			IL_007e: ldstr "27.3"
-			IL_0083: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
-			IL_0088: stloc.2
-			IL_0089: ldloc.2
-			IL_008a: stloc.1
-			IL_008b: ldc.i4.0
-			IL_008c: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_0096: stloc.2
-			IL_0097: ldloc.0
-			IL_0098: ldc.i4.1
-			IL_0099: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_009e: ldloc.0
-			IL_009f: ldloc.2
-			IL_00a0: ldarg.0
-			IL_00a1: ldc.i4.1
-			IL_00a2: ldloc.0
-			IL_00a3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00ad: ldloc.0
-			IL_00ae: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00b3: dup
-			IL_00b4: ldc.i4.0
-			IL_00b5: ldloc.1
-			IL_00b6: stelem.ref
-			IL_00b7: pop
+			IL_007d: ldc.i4.1
+			IL_007e: newarr [System.Runtime]System.Object
+			IL_0083: dup
+			IL_0084: ldc.i4.0
+			IL_0085: ldarg.0
+			IL_0086: ldc.i4.1
+			IL_0087: ldelem.ref
+			IL_0088: stelem.ref
+			IL_0089: stloc.2
+			IL_008a: ldarg.0
+			IL_008b: ldc.i4.1
+			IL_008c: ldelem.ref
+			IL_008d: castclass Modules.Async_Calls_Module_Function_Before_Await/Scope
+			IL_0092: ldfld object Modules.Async_Calls_Module_Function_Before_Await/Scope::formatSection
+			IL_0097: ldloc.2
+			IL_0098: ldstr "27.3"
+			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a2: stloc.3
+			IL_00a3: ldloc.3
+			IL_00a4: stloc.1
+			IL_00a5: ldc.i4.0
+			IL_00a6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_00b0: stloc.3
+			IL_00b1: ldloc.0
+			IL_00b2: ldc.i4.1
+			IL_00b3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_00b8: ldloc.0
-			IL_00b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00be: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_00c3: ret
+			IL_00b9: ldloc.3
+			IL_00ba: ldarg.0
+			IL_00bb: ldc.i4.1
+			IL_00bc: ldloc.0
+			IL_00bd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00c7: ldloc.0
+			IL_00c8: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_00cd: dup
+			IL_00ce: ldc.i4.0
+			IL_00cf: ldloc.1
+			IL_00d0: stelem.ref
+			IL_00d1: pop
+			IL_00d2: ldloc.0
+			IL_00d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00d8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_00dd: ret
 
-			IL_00c4: ldloc.0
-			IL_00c5: ldfld object Modules.Async_Calls_Module_Function_Before_Await/main/Scope::_awaited1
-			IL_00ca: pop
-			IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00d0: ldloc.1
-			IL_00d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00d6: pop
-			IL_00d7: ldloc.0
-			IL_00d8: ldc.i4.m1
-			IL_00d9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_00de: ldloc.0
-			IL_00df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_00e9: ldarg.0
-			IL_00ea: ldc.i4.1
-			IL_00eb: newarr [System.Runtime]System.Object
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_00f5: pop
-			IL_00f6: ldloc.0
-			IL_00f7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00fc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0101: ret
+			IL_00df: ldfld object Modules.Async_Calls_Module_Function_Before_Await/main/Scope::_awaited1
+			IL_00e4: pop
+			IL_00e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ea: ldloc.1
+			IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00f0: pop
+			IL_00f1: ldloc.0
+			IL_00f2: ldc.i4.m1
+			IL_00f3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00f8: ldloc.0
+			IL_00f9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_00fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0103: ldarg.0
+			IL_0104: ldc.i4.1
+			IL_0105: newarr [System.Runtime]System.Object
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_010f: pop
+			IL_0110: ldloc.0
+			IL_0111: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0116: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_011b: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -242,7 +257,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c4
+				// Method begins at RVA 0x22d8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -266,7 +281,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2230
+			// Method begins at RVA 0x2244
 			// Header size: 12
 			// Code size: 109 (0x6d)
 			.maxstack 8
@@ -343,7 +358,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22a9
+			// Method begins at RVA 0x22bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -369,7 +384,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 168 (0xa8)
+		// Code size: 163 (0xa3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_Calls_Module_Function_Before_Await/Scope,
@@ -410,43 +425,38 @@
 		IL_004b: stloc.2
 		IL_004c: ldloc.2
 		IL_004d: stloc.1
-		IL_004e: ldc.i4.1
-		IL_004f: newarr [System.Runtime]System.Object
-		IL_0054: dup
-		IL_0055: ldc.i4.0
-		IL_0056: ldloc.0
-		IL_0057: stelem.ref
-		IL_0058: ldnull
-		IL_0059: call object Modules.Async_Calls_Module_Function_Before_Await/main::__js_call__(object[], object)
-		IL_005e: stloc.2
-		IL_005f: ldloc.2
-		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0065: stloc.2
-		IL_0066: ldnull
-		IL_0067: ldftn object Modules.Async_Calls_Module_Function_Before_Await/ArrowFunction_L13C14::__js_call__(object, object)
-		IL_006d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0072: ldc.i4.1
-		IL_0073: newarr [System.Runtime]System.Object
-		IL_0078: dup
-		IL_0079: ldc.i4.0
-		IL_007a: ldloc.0
-		IL_007b: stelem.ref
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0086: ldc.i4.1
-		IL_0087: conv.r8
-		IL_0088: ldstr ""
-		IL_008d: ldc.i4.0
-		IL_008e: ldc.i4.1
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0099: stloc.3
-		IL_009a: ldloc.2
-		IL_009b: ldstr "catch"
-		IL_00a0: ldloc.3
-		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00a6: pop
-		IL_00a7: ret
+		IL_004e: ldloc.1
+		IL_004f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0059: stloc.2
+		IL_005a: ldloc.2
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0060: stloc.2
+		IL_0061: ldnull
+		IL_0062: ldftn object Modules.Async_Calls_Module_Function_Before_Await/ArrowFunction_L13C14::__js_call__(object, object)
+		IL_0068: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_006d: ldc.i4.1
+		IL_006e: newarr [System.Runtime]System.Object
+		IL_0073: dup
+		IL_0074: ldc.i4.0
+		IL_0075: ldloc.0
+		IL_0076: stelem.ref
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0081: ldc.i4.1
+		IL_0082: conv.r8
+		IL_0083: ldstr ""
+		IL_0088: ldc.i4.0
+		IL_0089: ldc.i4.1
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0094: stloc.3
+		IL_0095: ldloc.2
+		IL_0096: ldstr "catch"
+		IL_009b: ldloc.3
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a1: pop
+		IL_00a2: ret
 	} // end of method Async_Calls_Module_Function_Before_Await::__js_module_init__
 
 } // end of class Modules.Async_Calls_Module_Function_Before_Await
@@ -458,7 +468,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22cd
+		// Method begins at RVA 0x22e1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_ForAwaitOf_Array
+﻿// IL code: Async_ForAwaitOf_Array
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a0
+				// Method begins at RVA 0x249c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24b2
+					// Method begins at RVA 0x24ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24a9
+				// Method begins at RVA 0x24a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -94,7 +94,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 916 (0x394)
 			.maxstack 8
@@ -512,7 +512,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24bb
+				// Method begins at RVA 0x24b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -535,7 +535,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2484
+			// Method begins at RVA 0x2480
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -564,7 +564,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2497
+			// Method begins at RVA 0x2493
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -590,7 +590,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_Array/Scope,
@@ -618,43 +618,38 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_ForAwaitOf_Array/test::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_ForAwaitOf_Array/ArrowFunction_L15C13::__js_call__(object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.0
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_ForAwaitOf_Array/ArrowFunction_L15C13::__js_call__(object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Async_ForAwaitOf_Array::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_Array
@@ -666,7 +661,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24c4
+		// Method begins at RVA 0x24c0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_ForAwaitOf_AsyncIterator_BreakCloses
+﻿// IL code: Async_ForAwaitOf_AsyncIterator_BreakCloses
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x265b
+					// Method begins at RVA 0x2653
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x257c
+				// Method begins at RVA 0x2574
 				// Header size: 12
 				// Code size: 122 (0x7a)
 				.maxstack 8
@@ -112,7 +112,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2664
+					// Method begins at RVA 0x265c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -136,7 +136,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2604
+				// Method begins at RVA 0x25fc
 				// Header size: 12
 				// Code size: 57 (0x39)
 				.maxstack 8
@@ -178,7 +178,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2652
+				// Method begins at RVA 0x264a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -204,7 +204,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x212c
 			// Header size: 12
 			// Code size: 170 (0xaa)
 			.maxstack 8
@@ -304,7 +304,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x266d
+				// Method begins at RVA 0x2665
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -332,7 +332,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2688
+						// Method begins at RVA 0x2680
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -350,7 +350,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x267f
+					// Method begins at RVA 0x2677
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -368,7 +368,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2676
+				// Method begins at RVA 0x266e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -392,7 +392,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ec
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 878 (0x36e)
 			.maxstack 8
@@ -803,7 +803,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2691
+				// Method begins at RVA 0x2689
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -826,7 +826,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2566
+			// Method begins at RVA 0x255e
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -857,7 +857,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2649
+			// Method begins at RVA 0x2641
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -883,7 +883,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 208 (0xd0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope,
@@ -943,43 +943,38 @@
 		IL_0073: ldloc.0
 		IL_0074: ldloc.s 4
 		IL_0076: stfld object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope::iterable
-		IL_007b: ldc.i4.1
-		IL_007c: newarr [System.Runtime]System.Object
-		IL_0081: dup
-		IL_0082: ldc.i4.0
-		IL_0083: ldloc.0
-		IL_0084: stelem.ref
-		IL_0085: ldnull
-		IL_0086: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test::__js_call__(object[], object)
-		IL_008b: stloc.3
-		IL_008c: ldloc.3
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0092: stloc.3
-		IL_0093: ldnull
-		IL_0094: ldftn object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13::__js_call__(object)
-		IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_009f: ldc.i4.1
-		IL_00a0: newarr [System.Runtime]System.Object
-		IL_00a5: dup
-		IL_00a6: ldc.i4.0
-		IL_00a7: ldloc.0
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00b3: ldc.i4.0
-		IL_00b4: conv.r8
-		IL_00b5: ldstr ""
-		IL_00ba: ldc.i4.0
-		IL_00bb: ldc.i4.1
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00c6: stloc.2
-		IL_00c7: ldloc.3
-		IL_00c8: ldstr "then"
-		IL_00cd: ldloc.2
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_007b: ldloc.1
+		IL_007c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0086: stloc.3
+		IL_0087: ldloc.3
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008d: stloc.3
+		IL_008e: ldnull
+		IL_008f: ldftn object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/ArrowFunction_L28C13::__js_call__(object)
+		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldloc.0
+		IL_00a3: stelem.ref
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00ae: ldc.i4.0
+		IL_00af: conv.r8
+		IL_00b0: ldstr ""
+		IL_00b5: ldc.i4.0
+		IL_00b6: ldc.i4.1
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_00c1: stloc.2
+		IL_00c2: ldloc.3
+		IL_00c3: ldstr "then"
+		IL_00c8: ldloc.2
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ce: pop
+		IL_00cf: ret
 	} // end of method Async_ForAwaitOf_AsyncIterator_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses
@@ -991,7 +986,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x269a
+		// Method begins at RVA 0x2692
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+﻿// IL code: Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2630
+					// Method begins at RVA 0x2628
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x257c
+				// Method begins at RVA 0x2574
 				// Header size: 12
 				// Code size: 115 (0x73)
 				.maxstack 8
@@ -109,7 +109,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2639
+					// Method begins at RVA 0x2631
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -133,7 +133,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25fb
+				// Method begins at RVA 0x25f3
 				// Header size: 1
 				// Code size: 34 (0x22)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2627
+				// Method begins at RVA 0x261f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -191,7 +191,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x212c
 			// Header size: 12
 			// Code size: 170 (0xaa)
 			.maxstack 8
@@ -291,7 +291,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2642
+				// Method begins at RVA 0x263a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -319,7 +319,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x265d
+						// Method begins at RVA 0x2655
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -337,7 +337,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2654
+					// Method begins at RVA 0x264c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -355,7 +355,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x264b
+				// Method begins at RVA 0x2643
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -379,7 +379,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21ec
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 878 (0x36e)
 			.maxstack 8
@@ -790,7 +790,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2666
+				// Method begins at RVA 0x265e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -813,7 +813,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2566
+			// Method begins at RVA 0x255e
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -844,7 +844,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x261e
+			// Method begins at RVA 0x2616
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -870,7 +870,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 213 (0xd5)
+		// Code size: 208 (0xd0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope,
@@ -930,43 +930,38 @@
 		IL_0073: ldloc.0
 		IL_0074: ldloc.s 4
 		IL_0076: stfld object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope::iterable
-		IL_007b: ldc.i4.1
-		IL_007c: newarr [System.Runtime]System.Object
-		IL_0081: dup
-		IL_0082: ldc.i4.0
-		IL_0083: ldloc.0
-		IL_0084: stelem.ref
-		IL_0085: ldnull
-		IL_0086: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test::__js_call__(object[], object)
-		IL_008b: stloc.3
-		IL_008c: ldloc.3
-		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0092: stloc.3
-		IL_0093: ldnull
-		IL_0094: ldftn object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13::__js_call__(object)
-		IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_009f: ldc.i4.1
-		IL_00a0: newarr [System.Runtime]System.Object
-		IL_00a5: dup
-		IL_00a6: ldc.i4.0
-		IL_00a7: ldloc.0
-		IL_00a8: stelem.ref
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00b3: ldc.i4.0
-		IL_00b4: conv.r8
-		IL_00b5: ldstr ""
-		IL_00ba: ldc.i4.0
-		IL_00bb: ldc.i4.1
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00c6: stloc.2
-		IL_00c7: ldloc.3
-		IL_00c8: ldstr "then"
-		IL_00cd: ldloc.2
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00d3: pop
-		IL_00d4: ret
+		IL_007b: ldloc.1
+		IL_007c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0086: stloc.3
+		IL_0087: ldloc.3
+		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008d: stloc.3
+		IL_008e: ldnull
+		IL_008f: ldftn object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/ArrowFunction_L29C13::__js_call__(object)
+		IL_0095: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_009a: ldc.i4.1
+		IL_009b: newarr [System.Runtime]System.Object
+		IL_00a0: dup
+		IL_00a1: ldc.i4.0
+		IL_00a2: ldloc.0
+		IL_00a3: stelem.ref
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00ae: ldc.i4.0
+		IL_00af: conv.r8
+		IL_00b0: ldstr ""
+		IL_00b5: ldc.i4.0
+		IL_00b6: ldc.i4.1
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_00c1: stloc.2
+		IL_00c2: ldloc.3
+		IL_00c3: ldstr "then"
+		IL_00c8: ldloc.2
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ce: pop
+		IL_00cf: ret
 	} // end of method Async_ForAwaitOf_SyncIteratorFallback_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
@@ -978,7 +973,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x266f
+		// Method begins at RVA 0x2667
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_HelloWorld.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_HelloWorld
+﻿// IL code: Async_HelloWorld
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20db
+				// Method begins at RVA 0x20d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ba
+			// Method begins at RVA 0x20b5
 			// Header size: 1
 			// Code size: 23 (0x17)
 			.maxstack 8
@@ -73,7 +73,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d2
+			// Method begins at RVA 0x20cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -99,7 +99,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 94 (0x5e)
+		// Code size: 89 (0x59)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_HelloWorld/Scope,
@@ -130,20 +130,15 @@
 		IL_0031: ldstr "Before calling async function"
 		IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_003b: pop
-		IL_003c: ldc.i4.1
-		IL_003d: newarr [System.Runtime]System.Object
-		IL_0042: dup
-		IL_0043: ldc.i4.0
-		IL_0044: ldloc.0
-		IL_0045: stelem.ref
-		IL_0046: ldnull
-		IL_0047: call object Modules.Async_HelloWorld/helloWorld::__js_call__(object[], object)
-		IL_004c: pop
-		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0052: ldstr "After calling async function"
-		IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005c: pop
-		IL_005d: ret
+		IL_003c: ldloc.1
+		IL_003d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0047: pop
+		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004d: ldstr "After calling async function"
+		IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0057: pop
+		IL_0058: ret
 	} // end of method Async_HelloWorld::__js_module_init__
 
 } // end of class Modules.Async_HelloWorld
@@ -155,7 +150,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e4
+		// Method begins at RVA 0x20df
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_PendingPromiseAwait
+﻿// IL code: Async_PendingPromiseAwait
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2356
+						// Method begins at RVA 0x2352
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -50,7 +50,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x22e0
+					// Method begins at RVA 0x22dc
 					// Header size: 12
 					// Code size: 79 (0x4f)
 					.maxstack 8
@@ -116,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x234d
+					// Method begins at RVA 0x2349
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -141,7 +141,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2268
+				// Method begins at RVA 0x2264
 				// Header size: 12
 				// Code size: 106 (0x6a)
 				.maxstack 8
@@ -216,7 +216,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2344
+				// Method begins at RVA 0x2340
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -240,7 +240,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2104
+			// Method begins at RVA 0x2100
 			// Header size: 12
 			// Code size: 324 (0x144)
 			.maxstack 8
@@ -407,7 +407,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x235f
+				// Method begins at RVA 0x235b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -431,7 +431,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2254
+			// Method begins at RVA 0x2250
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -461,7 +461,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x233b
+			// Method begins at RVA 0x2337
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -487,7 +487,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 166 (0xa6)
+		// Code size: 161 (0xa1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_PendingPromiseAwait/Scope,
@@ -519,47 +519,42 @@
 		IL_0031: ldstr "Before async function"
 		IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_003b: pop
-		IL_003c: ldc.i4.1
-		IL_003d: newarr [System.Runtime]System.Object
-		IL_0042: dup
-		IL_0043: ldc.i4.0
-		IL_0044: ldloc.0
-		IL_0045: stelem.ref
-		IL_0046: ldnull
-		IL_0047: call object Modules.Async_PendingPromiseAwait/test::__js_call__(object[], object)
-		IL_004c: stloc.2
-		IL_004d: ldloc.2
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0053: stloc.2
-		IL_0054: ldnull
-		IL_0055: ldftn object Modules.Async_PendingPromiseAwait/ArrowFunction_L20C13::__js_call__(object, object)
-		IL_005b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0060: ldc.i4.1
-		IL_0061: newarr [System.Runtime]System.Object
-		IL_0066: dup
-		IL_0067: ldc.i4.0
-		IL_0068: ldloc.0
-		IL_0069: stelem.ref
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0074: ldc.i4.1
-		IL_0075: conv.r8
-		IL_0076: ldstr ""
-		IL_007b: ldc.i4.0
-		IL_007c: ldc.i4.1
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0087: stloc.3
-		IL_0088: ldloc.2
-		IL_0089: ldstr "then"
-		IL_008e: ldloc.3
-		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0094: pop
-		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009a: ldstr "After calling async function"
-		IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a4: pop
-		IL_00a5: ret
+		IL_003c: ldloc.1
+		IL_003d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0047: stloc.2
+		IL_0048: ldloc.2
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_004e: stloc.2
+		IL_004f: ldnull
+		IL_0050: ldftn object Modules.Async_PendingPromiseAwait/ArrowFunction_L20C13::__js_call__(object, object)
+		IL_0056: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_005b: ldc.i4.1
+		IL_005c: newarr [System.Runtime]System.Object
+		IL_0061: dup
+		IL_0062: ldc.i4.0
+		IL_0063: ldloc.0
+		IL_0064: stelem.ref
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_006f: ldc.i4.1
+		IL_0070: conv.r8
+		IL_0071: ldstr ""
+		IL_0076: ldc.i4.0
+		IL_0077: ldc.i4.1
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0082: stloc.3
+		IL_0083: ldloc.2
+		IL_0084: ldstr "then"
+		IL_0089: ldloc.3
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008f: pop
+		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0095: ldstr "After calling async function"
+		IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009f: pop
+		IL_00a0: ret
 	} // end of method Async_PendingPromiseAwait::__js_module_init__
 
 } // end of class Modules.Async_PendingPromiseAwait
@@ -571,7 +566,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2368
+		// Method begins at RVA 0x2364
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x229a
+						// Method begins at RVA 0x2296
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -50,7 +50,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2241
+					// Method begins at RVA 0x223d
 					// Header size: 1
 					// Code size: 61 (0x3d)
 					.maxstack 8
@@ -106,7 +106,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2291
+					// Method begins at RVA 0x228d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -131,7 +131,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21b8
+				// Method begins at RVA 0x21b4
 				// Header size: 12
 				// Code size: 106 (0x6a)
 				.maxstack 8
@@ -200,7 +200,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22a3
+					// Method begins at RVA 0x229f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -223,7 +223,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x222e
+				// Method begins at RVA 0x222a
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -245,7 +245,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2288
+				// Method begins at RVA 0x2284
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -271,7 +271,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20f4
 			// Header size: 12
 			// Code size: 159 (0x9f)
 			.maxstack 8
@@ -358,7 +358,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ac
+				// Method begins at RVA 0x22a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -381,7 +381,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a3
+			// Method begins at RVA 0x219f
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -410,7 +410,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227f
+			// Method begins at RVA 0x227b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -436,7 +436,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 153 (0x99)
+		// Code size: 152 (0x98)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_RealSuspension_SetTimeout/Scope,
@@ -471,39 +471,38 @@
 		IL_0038: ldstr "Before calling async function"
 		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0042: pop
-		IL_0043: ldloc.0
-		IL_0044: castclass Modules.Async_RealSuspension_SetTimeout/Scope
-		IL_0049: ldnull
-		IL_004a: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
-		IL_004f: stloc.2
-		IL_0050: ldloc.2
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0056: stloc.2
-		IL_0057: ldnull
-		IL_0058: ldftn object Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12::__js_call__(object)
-		IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0063: ldc.i4.1
-		IL_0064: newarr [System.Runtime]System.Object
-		IL_0069: dup
-		IL_006a: ldc.i4.0
-		IL_006b: ldloc.0
-		IL_006c: stelem.ref
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0077: ldc.i4.0
-		IL_0078: conv.r8
-		IL_0079: ldstr ""
-		IL_007e: ldc.i4.0
-		IL_007f: ldc.i4.1
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_008a: stloc.3
-		IL_008b: ldloc.2
-		IL_008c: ldstr "then"
-		IL_0091: ldloc.3
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0097: pop
-		IL_0098: ret
+		IL_0043: ldloc.1
+		IL_0044: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004e: stloc.2
+		IL_004f: ldloc.2
+		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0055: stloc.2
+		IL_0056: ldnull
+		IL_0057: ldftn object Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12::__js_call__(object)
+		IL_005d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0062: ldc.i4.1
+		IL_0063: newarr [System.Runtime]System.Object
+		IL_0068: dup
+		IL_0069: ldc.i4.0
+		IL_006a: ldloc.0
+		IL_006b: stelem.ref
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0076: ldc.i4.0
+		IL_0077: conv.r8
+		IL_0078: ldstr ""
+		IL_007d: ldc.i4.0
+		IL_007e: ldc.i4.1
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0089: stloc.3
+		IL_008a: ldloc.2
+		IL_008b: ldstr "then"
+		IL_0090: ldloc.3
+		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0096: pop
+		IL_0097: ret
 	} // end of method Async_RealSuspension_SetTimeout::__js_module_init__
 
 } // end of class Modules.Async_RealSuspension_SetTimeout
@@ -515,7 +514,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22b5
+		// Method begins at RVA 0x22b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_ReturnValue
+﻿// IL code: Async_ReturnValue
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2114
+				// Method begins at RVA 0x210f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e2
+			// Method begins at RVA 0x20dd
 			// Header size: 1
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x211d
+				// Method begins at RVA 0x2118
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -97,7 +97,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f7
+			// Method begins at RVA 0x20f2
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -127,7 +127,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210b
+			// Method begins at RVA 0x2106
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -153,7 +153,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ReturnValue/Scope,
@@ -181,43 +181,38 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_ReturnValue/getValue::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_ReturnValue/ArrowFunction_L7C17::__js_call__(object, object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.1
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_ReturnValue/ArrowFunction_L7C17::__js_call__(object, object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.1
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Async_ReturnValue::__js_module_init__
 
 } // end of class Modules.Async_ReturnValue
@@ -229,7 +224,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2126
+		// Method begins at RVA 0x2121
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_SimpleAwait
+﻿// IL code: Async_SimpleAwait
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2214
+				// Method begins at RVA 0x2210
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 263 (0x107)
 			.maxstack 8
@@ -190,7 +190,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x221d
+				// Method begins at RVA 0x2219
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -214,7 +214,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f7
+			// Method begins at RVA 0x21f3
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -244,7 +244,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x220b
+			// Method begins at RVA 0x2207
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -270,7 +270,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_SimpleAwait/Scope,
@@ -298,43 +298,38 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_SimpleAwait/test::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_SimpleAwait/ArrowFunction_L10C13::__js_call__(object, object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.1
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_SimpleAwait/ArrowFunction_L10C13::__js_call__(object, object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.1
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Async_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_SimpleAwait
@@ -346,7 +341,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2226
+		// Method begins at RVA 0x2222
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_TryCatchFinally_AwaitInFinally_OnReject
+﻿// IL code: Async_TryCatchFinally_AwaitInFinally_OnReject
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x246c
+					// Method begins at RVA 0x2468
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2475
+					// Method begins at RVA 0x2471
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x247e
+					// Method begins at RVA 0x247a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2463
+				// Method begins at RVA 0x245f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -129,7 +129,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 842 (0x34a)
 			.maxstack 8
@@ -498,7 +498,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2487
+				// Method begins at RVA 0x2483
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -521,7 +521,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x243c
+			// Method begins at RVA 0x2438
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -553,7 +553,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x245a
+			// Method begins at RVA 0x2456
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -579,7 +579,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/Scope,
@@ -607,43 +607,38 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/ArrowFunction_L20C13::__js_call__(object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.0
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/ArrowFunction_L20C13::__js_call__(object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Async_TryCatchFinally_AwaitInFinally_OnReject::__js_module_init__
 
 } // end of class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject
@@ -655,7 +650,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2490
+		// Method begins at RVA 0x248c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_TryCatch_AwaitReject
+﻿// IL code: Async_TryCatch_AwaitReject
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -31,7 +31,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22cb
+					// Method begins at RVA 0x22c7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22d4
+					// Method begins at RVA 0x22d0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c2
+				// Method begins at RVA 0x22be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 422 (0x1a6)
 			.maxstack 8
@@ -293,7 +293,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22dd
+				// Method begins at RVA 0x22d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -316,7 +316,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a6
+			// Method begins at RVA 0x22a2
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -346,7 +346,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22b9
+			// Method begins at RVA 0x22b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -372,7 +372,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 150 (0x96)
+		// Code size: 145 (0x91)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryCatch_AwaitReject/Scope,
@@ -400,47 +400,42 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_TryCatch_AwaitReject/testTryCatch::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_TryCatch_AwaitReject/ArrowFunction_L16C21::__js_call__(object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.0
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008a: ldstr "After calling async function"
-		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0094: pop
-		IL_0095: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_TryCatch_AwaitReject/ArrowFunction_L16C21::__js_call__(object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0085: ldstr "After calling async function"
+		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008f: pop
+		IL_0090: ret
 	} // end of method Async_TryCatch_AwaitReject::__js_module_init__
 
 } // end of class Modules.Async_TryCatch_AwaitReject
@@ -452,7 +447,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e6
+		// Method begins at RVA 0x22e2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_TryFinally_AwaitInFinally_Normal
+﻿// IL code: Async_TryFinally_AwaitInFinally_Normal
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x241a
+					// Method begins at RVA 0x2416
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2423
+					// Method begins at RVA 0x241f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -85,7 +85,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2411
+				// Method begins at RVA 0x240d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -109,7 +109,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f4
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 757 (0x2f5)
 			.maxstack 8
@@ -443,7 +443,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x242c
+				// Method begins at RVA 0x2428
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -466,7 +466,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f5
+			// Method begins at RVA 0x23f1
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -495,7 +495,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2408
+			// Method begins at RVA 0x2404
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -521,7 +521,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 150 (0x96)
+		// Code size: 145 (0x91)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_AwaitInFinally_Normal/Scope,
@@ -549,47 +549,42 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_TryFinally_AwaitInFinally_Normal/test::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_TryFinally_AwaitInFinally_Normal/ArrowFunction_L18C13::__js_call__(object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.0
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008a: ldstr "after call"
-		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0094: pop
-		IL_0095: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_TryFinally_AwaitInFinally_Normal/ArrowFunction_L18C13::__js_call__(object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0085: ldstr "after call"
+		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008f: pop
+		IL_0090: ret
 	} // end of method Async_TryFinally_AwaitInFinally_Normal::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_AwaitInFinally_Normal
@@ -601,7 +596,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2435
+		// Method begins at RVA 0x2431
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_TryFinally_FinallyThrowOverridesOriginal
+﻿// IL code: Async_TryFinally_FinallyThrowOverridesOriginal
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x23fd
+						// Method begins at RVA 0x23f9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2406
+						// Method begins at RVA 0x2402
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23f4
+					// Method begins at RVA 0x23f0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x240f
+					// Method begins at RVA 0x240b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23eb
+				// Method begins at RVA 0x23e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -151,7 +151,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 723 (0x2d3)
 			.maxstack 8
@@ -473,7 +473,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2418
+				// Method begins at RVA 0x2414
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -496,7 +496,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c4
+			// Method begins at RVA 0x23c0
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -528,7 +528,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23e2
+			// Method begins at RVA 0x23de
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -554,7 +554,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/Scope,
@@ -582,43 +582,38 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/ArrowFunction_L20C13::__js_call__(object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.0
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/ArrowFunction_L20C13::__js_call__(object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Async_TryFinally_FinallyThrowOverridesOriginal::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_FinallyThrowOverridesOriginal
@@ -630,7 +625,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2421
+		// Method begins at RVA 0x241d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_TryFinally_PreservesExceptionThroughAwait
+﻿// IL code: Async_TryFinally_PreservesExceptionThroughAwait
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -41,7 +41,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2471
+						// Method begins at RVA 0x246d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -61,7 +61,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x247a
+						// Method begins at RVA 0x2476
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -79,7 +79,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2468
+					// Method begins at RVA 0x2464
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -99,7 +99,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2483
+					// Method begins at RVA 0x247f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -135,7 +135,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x245f
+				// Method begins at RVA 0x245b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -159,7 +159,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 838 (0x346)
 			.maxstack 8
@@ -529,7 +529,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248c
+				// Method begins at RVA 0x2488
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -552,7 +552,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2438
+			// Method begins at RVA 0x2434
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -584,7 +584,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2456
+			// Method begins at RVA 0x2452
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -610,7 +610,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/Scope,
@@ -638,43 +638,38 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_TryFinally_PreservesExceptionThroughAwait/ArrowFunction_L22C13::__js_call__(object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.0
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_TryFinally_PreservesExceptionThroughAwait/ArrowFunction_L22C13::__js_call__(object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.0
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Async_TryFinally_PreservesExceptionThroughAwait::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_PreservesExceptionThroughAwait
@@ -686,7 +681,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2495
+		// Method begins at RVA 0x2491
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Async_TryFinally_ReturnPreservedThroughAwait
+﻿// IL code: Async_TryFinally_ReturnPreservedThroughAwait
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -31,7 +31,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x239d
+					// Method begins at RVA 0x2399
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -51,7 +51,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23a6
+					// Method begins at RVA 0x23a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2394
+				// Method begins at RVA 0x2390
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -99,7 +99,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e0
 			// Header size: 12
 			// Code size: 647 (0x287)
 			.maxstack 8
@@ -386,7 +386,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23af
+				// Method begins at RVA 0x23ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -410,7 +410,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2377
+			// Method begins at RVA 0x2373
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -440,7 +440,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x238b
+			// Method begins at RVA 0x2387
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -466,7 +466,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 129 (0x81)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_ReturnPreservedThroughAwait/Scope,
@@ -494,43 +494,38 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldc.i4.1
-		IL_002d: newarr [System.Runtime]System.Object
-		IL_0032: dup
-		IL_0033: ldc.i4.0
-		IL_0034: ldloc.0
-		IL_0035: stelem.ref
-		IL_0036: ldnull
-		IL_0037: call object Modules.Async_TryFinally_ReturnPreservedThroughAwait/test::__js_call__(object[], object)
-		IL_003c: stloc.2
-		IL_003d: ldloc.2
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0043: stloc.2
-		IL_0044: ldnull
-		IL_0045: ldftn object Modules.Async_TryFinally_ReturnPreservedThroughAwait/ArrowFunction_L16C13::__js_call__(object, object)
-		IL_004b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0050: ldc.i4.1
-		IL_0051: newarr [System.Runtime]System.Object
-		IL_0056: dup
-		IL_0057: ldc.i4.0
-		IL_0058: ldloc.0
-		IL_0059: stelem.ref
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0064: ldc.i4.1
-		IL_0065: conv.r8
-		IL_0066: ldstr ""
-		IL_006b: ldc.i4.0
-		IL_006c: ldc.i4.1
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0077: stloc.3
-		IL_0078: ldloc.2
-		IL_0079: ldstr "then"
-		IL_007e: ldloc.3
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_002c: ldloc.1
+		IL_002d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0037: stloc.2
+		IL_0038: ldloc.2
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_003e: stloc.2
+		IL_003f: ldnull
+		IL_0040: ldftn object Modules.Async_TryFinally_ReturnPreservedThroughAwait/ArrowFunction_L16C13::__js_call__(object, object)
+		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_004b: ldc.i4.1
+		IL_004c: newarr [System.Runtime]System.Object
+		IL_0051: dup
+		IL_0052: ldc.i4.0
+		IL_0053: ldloc.0
+		IL_0054: stelem.ref
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_005f: ldc.i4.1
+		IL_0060: conv.r8
+		IL_0061: ldstr ""
+		IL_0066: ldc.i4.0
+		IL_0067: ldc.i4.1
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0072: stloc.3
+		IL_0073: ldloc.2
+		IL_0074: ldstr "then"
+		IL_0079: ldloc.3
+		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007f: pop
+		IL_0080: ret
 	} // end of method Async_TryFinally_ReturnPreservedThroughAwait::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_ReturnPreservedThroughAwait
@@ -542,7 +537,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23b8
+		// Method begins at RVA 0x23b4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
@@ -33,7 +33,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2660
+				// Method begins at RVA 0x266c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -339,7 +339,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2669
+				// Method begins at RVA 0x2675
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -365,7 +365,7 @@
 			)
 			// Method begins at RVA 0x2358
 			// Header size: 12
-			// Code size: 755 (0x2f3)
+			// Code size: 767 (0x2ff)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope,
@@ -439,252 +439,256 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_0092, IL_00fa, IL_01ae, IL_0262)
+			IL_007d: switch (IL_0092, IL_0106, IL_01ba, IL_026e)
 
-			IL_0092: ldc.i4.1
-			IL_0093: newarr [System.Runtime]System.Object
-			IL_0098: dup
-			IL_0099: ldc.i4.0
-			IL_009a: ldarg.0
-			IL_009b: ldc.i4.1
-			IL_009c: ldelem.ref
-			IL_009d: stelem.ref
-			IL_009e: ldnull
-			IL_009f: call object Modules.AsyncGenerator_BasicNext/g::__js_call__(object[], object)
-			IL_00a4: stloc.s 5
-			IL_00a6: ldloc.s 5
-			IL_00a8: stloc.1
-			IL_00a9: ldloc.1
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00af: stloc.s 5
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldstr "next"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.0
-			IL_00c0: ldc.i4.1
-			IL_00c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c6: ldloc.0
-			IL_00c7: ldloc.s 5
-			IL_00c9: ldarg.0
-			IL_00ca: ldc.i4.1
+			IL_0092: ldarg.0
+			IL_0093: ldc.i4.1
+			IL_0094: ldelem.ref
+			IL_0095: castclass Modules.AsyncGenerator_BasicNext/Scope
+			IL_009a: ldfld object Modules.AsyncGenerator_BasicNext/Scope::g
+			IL_009f: ldc.i4.1
+			IL_00a0: newarr [System.Runtime]System.Object
+			IL_00a5: dup
+			IL_00a6: ldc.i4.0
+			IL_00a7: ldarg.0
+			IL_00a8: ldc.i4.1
+			IL_00a9: ldelem.ref
+			IL_00aa: stelem.ref
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00b0: stloc.s 5
+			IL_00b2: ldloc.s 5
+			IL_00b4: stloc.1
+			IL_00b5: ldloc.1
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bb: stloc.s 5
+			IL_00bd: ldloc.s 5
+			IL_00bf: ldstr "next"
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00c9: stloc.s 5
 			IL_00cb: ldloc.0
-			IL_00cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00d6: ldloc.0
-			IL_00d7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00dc: dup
-			IL_00dd: ldc.i4.0
-			IL_00de: ldloc.1
-			IL_00df: stelem.ref
-			IL_00e0: dup
-			IL_00e1: ldc.i4.1
-			IL_00e2: ldloc.2
-			IL_00e3: stelem.ref
-			IL_00e4: dup
-			IL_00e5: ldc.i4.2
-			IL_00e6: ldloc.3
-			IL_00e7: stelem.ref
+			IL_00cc: ldc.i4.1
+			IL_00cd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00d2: ldloc.0
+			IL_00d3: ldloc.s 5
+			IL_00d5: ldarg.0
+			IL_00d6: ldc.i4.1
+			IL_00d7: ldloc.0
+			IL_00d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00e2: ldloc.0
+			IL_00e3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_00e8: dup
-			IL_00e9: ldc.i4.3
-			IL_00ea: ldloc.s 4
-			IL_00ec: stelem.ref
-			IL_00ed: pop
-			IL_00ee: ldloc.0
-			IL_00ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00f4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_00f9: ret
-
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldloc.1
+			IL_00eb: stelem.ref
+			IL_00ec: dup
+			IL_00ed: ldc.i4.1
+			IL_00ee: ldloc.2
+			IL_00ef: stelem.ref
+			IL_00f0: dup
+			IL_00f1: ldc.i4.2
+			IL_00f2: ldloc.3
+			IL_00f3: stelem.ref
+			IL_00f4: dup
+			IL_00f5: ldc.i4.3
+			IL_00f6: ldloc.s 4
+			IL_00f8: stelem.ref
+			IL_00f9: pop
 			IL_00fa: ldloc.0
-			IL_00fb: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited1
-			IL_0100: stloc.s 5
-			IL_0102: ldloc.s 5
-			IL_0104: stloc.2
-			IL_0105: ldloc.2
-			IL_0106: ldstr "value"
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0110: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0115: stloc.s 6
-			IL_0117: ldstr "v1: "
-			IL_011c: ldloc.s 6
-			IL_011e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0123: stloc.s 6
-			IL_0125: ldloc.s 6
-			IL_0127: ldstr " done: "
-			IL_012c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0131: stloc.s 6
-			IL_0133: ldloc.2
-			IL_0134: ldstr "done"
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_013e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0143: stloc.s 7
-			IL_0145: ldloc.s 6
-			IL_0147: ldloc.s 7
-			IL_0149: call string [System.Runtime]System.String::Concat(string, string)
-			IL_014e: stloc.s 7
-			IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0155: ldloc.s 7
-			IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_015c: pop
-			IL_015d: ldloc.1
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0163: stloc.s 5
-			IL_0165: ldloc.s 5
-			IL_0167: ldstr "next"
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0171: stloc.s 5
-			IL_0173: ldloc.0
-			IL_0174: ldc.i4.2
-			IL_0175: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_017a: ldloc.0
-			IL_017b: ldloc.s 5
-			IL_017d: ldarg.0
-			IL_017e: ldc.i4.2
+			IL_00fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0100: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0105: ret
+
+			IL_0106: ldloc.0
+			IL_0107: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited1
+			IL_010c: stloc.s 5
+			IL_010e: ldloc.s 5
+			IL_0110: stloc.2
+			IL_0111: ldloc.2
+			IL_0112: ldstr "value"
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_011c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0121: stloc.s 6
+			IL_0123: ldstr "v1: "
+			IL_0128: ldloc.s 6
+			IL_012a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_012f: stloc.s 6
+			IL_0131: ldloc.s 6
+			IL_0133: ldstr " done: "
+			IL_0138: call string [System.Runtime]System.String::Concat(string, string)
+			IL_013d: stloc.s 6
+			IL_013f: ldloc.2
+			IL_0140: ldstr "done"
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_014a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_014f: stloc.s 7
+			IL_0151: ldloc.s 6
+			IL_0153: ldloc.s 7
+			IL_0155: call string [System.Runtime]System.String::Concat(string, string)
+			IL_015a: stloc.s 7
+			IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0161: ldloc.s 7
+			IL_0163: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0168: pop
+			IL_0169: ldloc.1
+			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016f: stloc.s 5
+			IL_0171: ldloc.s 5
+			IL_0173: ldstr "next"
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_017d: stloc.s 5
 			IL_017f: ldloc.0
-			IL_0180: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0185: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_018a: ldloc.0
-			IL_018b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0190: dup
-			IL_0191: ldc.i4.0
-			IL_0192: ldloc.1
-			IL_0193: stelem.ref
-			IL_0194: dup
-			IL_0195: ldc.i4.1
-			IL_0196: ldloc.2
-			IL_0197: stelem.ref
-			IL_0198: dup
-			IL_0199: ldc.i4.2
-			IL_019a: ldloc.3
-			IL_019b: stelem.ref
+			IL_0180: ldc.i4.2
+			IL_0181: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0186: ldloc.0
+			IL_0187: ldloc.s 5
+			IL_0189: ldarg.0
+			IL_018a: ldc.i4.2
+			IL_018b: ldloc.0
+			IL_018c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0191: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0196: ldloc.0
+			IL_0197: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_019c: dup
-			IL_019d: ldc.i4.3
-			IL_019e: ldloc.s 4
-			IL_01a0: stelem.ref
-			IL_01a1: pop
-			IL_01a2: ldloc.0
-			IL_01a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a8: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01ad: ret
-
+			IL_019d: ldc.i4.0
+			IL_019e: ldloc.1
+			IL_019f: stelem.ref
+			IL_01a0: dup
+			IL_01a1: ldc.i4.1
+			IL_01a2: ldloc.2
+			IL_01a3: stelem.ref
+			IL_01a4: dup
+			IL_01a5: ldc.i4.2
+			IL_01a6: ldloc.3
+			IL_01a7: stelem.ref
+			IL_01a8: dup
+			IL_01a9: ldc.i4.3
+			IL_01aa: ldloc.s 4
+			IL_01ac: stelem.ref
+			IL_01ad: pop
 			IL_01ae: ldloc.0
-			IL_01af: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited2
-			IL_01b4: stloc.s 5
-			IL_01b6: ldloc.s 5
-			IL_01b8: stloc.3
-			IL_01b9: ldloc.3
-			IL_01ba: ldstr "value"
-			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c9: stloc.s 7
-			IL_01cb: ldstr "v2: "
-			IL_01d0: ldloc.s 7
-			IL_01d2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d7: stloc.s 7
-			IL_01d9: ldloc.s 7
-			IL_01db: ldstr " done: "
-			IL_01e0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e5: stloc.s 7
-			IL_01e7: ldloc.3
-			IL_01e8: ldstr "done"
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f7: stloc.s 6
-			IL_01f9: ldloc.s 7
-			IL_01fb: ldloc.s 6
-			IL_01fd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0202: stloc.s 6
-			IL_0204: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0209: ldloc.s 6
-			IL_020b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0210: pop
-			IL_0211: ldloc.1
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0217: stloc.s 5
-			IL_0219: ldloc.s 5
-			IL_021b: ldstr "next"
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0225: stloc.s 5
-			IL_0227: ldloc.0
-			IL_0228: ldc.i4.3
-			IL_0229: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_022e: ldloc.0
-			IL_022f: ldloc.s 5
-			IL_0231: ldarg.0
-			IL_0232: ldc.i4.3
-			IL_0233: ldloc.0
-			IL_0234: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0239: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_023e: ldloc.0
-			IL_023f: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0244: dup
-			IL_0245: ldc.i4.0
-			IL_0246: ldloc.1
-			IL_0247: stelem.ref
-			IL_0248: dup
-			IL_0249: ldc.i4.1
-			IL_024a: ldloc.2
-			IL_024b: stelem.ref
-			IL_024c: dup
-			IL_024d: ldc.i4.2
-			IL_024e: ldloc.3
-			IL_024f: stelem.ref
-			IL_0250: dup
-			IL_0251: ldc.i4.3
-			IL_0252: ldloc.s 4
-			IL_0254: stelem.ref
-			IL_0255: pop
-			IL_0256: ldloc.0
-			IL_0257: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_025c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0261: ret
+			IL_01af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01b9: ret
 
+			IL_01ba: ldloc.0
+			IL_01bb: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited2
+			IL_01c0: stloc.s 5
+			IL_01c2: ldloc.s 5
+			IL_01c4: stloc.3
+			IL_01c5: ldloc.3
+			IL_01c6: ldstr "value"
+			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d5: stloc.s 7
+			IL_01d7: ldstr "v2: "
+			IL_01dc: ldloc.s 7
+			IL_01de: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e3: stloc.s 7
+			IL_01e5: ldloc.s 7
+			IL_01e7: ldstr " done: "
+			IL_01ec: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f1: stloc.s 7
+			IL_01f3: ldloc.3
+			IL_01f4: ldstr "done"
+			IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0203: stloc.s 6
+			IL_0205: ldloc.s 7
+			IL_0207: ldloc.s 6
+			IL_0209: call string [System.Runtime]System.String::Concat(string, string)
+			IL_020e: stloc.s 6
+			IL_0210: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0215: ldloc.s 6
+			IL_0217: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_021c: pop
+			IL_021d: ldloc.1
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0223: stloc.s 5
+			IL_0225: ldloc.s 5
+			IL_0227: ldstr "next"
+			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0231: stloc.s 5
+			IL_0233: ldloc.0
+			IL_0234: ldc.i4.3
+			IL_0235: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_023a: ldloc.0
+			IL_023b: ldloc.s 5
+			IL_023d: ldarg.0
+			IL_023e: ldc.i4.3
+			IL_023f: ldloc.0
+			IL_0240: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0245: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_024a: ldloc.0
+			IL_024b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0250: dup
+			IL_0251: ldc.i4.0
+			IL_0252: ldloc.1
+			IL_0253: stelem.ref
+			IL_0254: dup
+			IL_0255: ldc.i4.1
+			IL_0256: ldloc.2
+			IL_0257: stelem.ref
+			IL_0258: dup
+			IL_0259: ldc.i4.2
+			IL_025a: ldloc.3
+			IL_025b: stelem.ref
+			IL_025c: dup
+			IL_025d: ldc.i4.3
+			IL_025e: ldloc.s 4
+			IL_0260: stelem.ref
+			IL_0261: pop
 			IL_0262: ldloc.0
-			IL_0263: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited3
-			IL_0268: stloc.s 5
-			IL_026a: ldloc.s 5
-			IL_026c: stloc.s 4
-			IL_026e: ldloc.s 4
-			IL_0270: ldstr "value"
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_027f: stloc.s 6
-			IL_0281: ldstr "v3: "
-			IL_0286: ldloc.s 6
-			IL_0288: call string [System.Runtime]System.String::Concat(string, string)
-			IL_028d: stloc.s 6
-			IL_028f: ldloc.s 6
-			IL_0291: ldstr " done: "
-			IL_0296: call string [System.Runtime]System.String::Concat(string, string)
-			IL_029b: stloc.s 6
-			IL_029d: ldloc.s 4
-			IL_029f: ldstr "done"
-			IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02a9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02ae: stloc.s 7
-			IL_02b0: ldloc.s 6
-			IL_02b2: ldloc.s 7
-			IL_02b4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02b9: stloc.s 7
-			IL_02bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02c0: ldloc.s 7
-			IL_02c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02c7: pop
-			IL_02c8: ldloc.0
-			IL_02c9: ldc.i4.m1
-			IL_02ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02cf: ldloc.0
-			IL_02d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02da: ldarg.0
-			IL_02db: ldc.i4.1
-			IL_02dc: newarr [System.Runtime]System.Object
-			IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02e6: pop
-			IL_02e7: ldloc.0
-			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02f2: ret
+			IL_0263: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0268: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_026d: ret
+
+			IL_026e: ldloc.0
+			IL_026f: ldfld object Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/Scope::_awaited3
+			IL_0274: stloc.s 5
+			IL_0276: ldloc.s 5
+			IL_0278: stloc.s 4
+			IL_027a: ldloc.s 4
+			IL_027c: ldstr "value"
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0286: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_028b: stloc.s 6
+			IL_028d: ldstr "v3: "
+			IL_0292: ldloc.s 6
+			IL_0294: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0299: stloc.s 6
+			IL_029b: ldloc.s 6
+			IL_029d: ldstr " done: "
+			IL_02a2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a7: stloc.s 6
+			IL_02a9: ldloc.s 4
+			IL_02ab: ldstr "done"
+			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02b5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02ba: stloc.s 7
+			IL_02bc: ldloc.s 6
+			IL_02be: ldloc.s 7
+			IL_02c0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02c5: stloc.s 7
+			IL_02c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02cc: ldloc.s 7
+			IL_02ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02d3: pop
+			IL_02d4: ldloc.0
+			IL_02d5: ldc.i4.m1
+			IL_02d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02db: ldloc.0
+			IL_02dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02e6: ldarg.0
+			IL_02e7: ldc.i4.1
+			IL_02e8: newarr [System.Runtime]System.Object
+			IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02f2: pop
+			IL_02f3: ldloc.0
+			IL_02f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02f9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02fe: ret
 		} // end of method ArrowFunction_L9C2::__js_call__
 
 	} // end of class ArrowFunction_L9C2
@@ -702,7 +706,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2657
+			// Method begins at RVA 0x2663
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -797,7 +801,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2672
+		// Method begins at RVA 0x267e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26ed
+				// Method begins at RVA 0x26f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -306,7 +306,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26f6
+				// Method begins at RVA 0x2702
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -330,7 +330,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2708
+					// Method begins at RVA 0x2714
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -348,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26ff
+				// Method begins at RVA 0x270b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -374,7 +374,7 @@
 			)
 			// Method begins at RVA 0x233c
 			// Header size: 12
-			// Code size: 924 (0x39c)
+			// Code size: 936 (0x3a8)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope,
@@ -477,319 +477,323 @@
 
 			IL_00ae: ldloc.0
 			IL_00af: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00b4: switch (IL_00cd, IL_022b, IL_02d0, IL_0194, IL_02c4)
+			IL_00b4: switch (IL_00cd, IL_0237, IL_02dc, IL_01a0, IL_02d0)
 
 			IL_00cd: ldc.r8 0.0
 			IL_00d6: stloc.1
-			IL_00d7: ldc.i4.1
-			IL_00d8: newarr [System.Runtime]System.Object
-			IL_00dd: dup
-			IL_00de: ldc.i4.0
-			IL_00df: ldarg.0
-			IL_00e0: ldc.i4.1
-			IL_00e1: ldelem.ref
-			IL_00e2: stelem.ref
-			IL_00e3: ldnull
-			IL_00e4: call object Modules.AsyncGenerator_ForAwaitOf/g::__js_call__(object[], object)
-			IL_00e9: stloc.s 9
-			IL_00eb: ldloc.s 9
-			IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
-			IL_00f2: stloc.2
-			IL_00f3: ldc.i4.0
-			IL_00f4: stloc.3
-			IL_00f5: ldc.i4.0
-			IL_00f6: stloc.s 4
-			IL_00f8: ldloc.0
-			IL_00f9: ldc.i4.0
-			IL_00fa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00ff: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_00d7: ldarg.0
+			IL_00d8: ldc.i4.1
+			IL_00d9: ldelem.ref
+			IL_00da: castclass Modules.AsyncGenerator_ForAwaitOf/Scope
+			IL_00df: ldfld object Modules.AsyncGenerator_ForAwaitOf/Scope::g
+			IL_00e4: ldc.i4.1
+			IL_00e5: newarr [System.Runtime]System.Object
+			IL_00ea: dup
+			IL_00eb: ldc.i4.0
+			IL_00ec: ldarg.0
+			IL_00ed: ldc.i4.1
+			IL_00ee: ldelem.ref
+			IL_00ef: stelem.ref
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00f5: stloc.s 9
+			IL_00f7: ldloc.s 9
+			IL_00f9: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptAsyncIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetAsyncIterator(object)
+			IL_00fe: stloc.2
+			IL_00ff: ldc.i4.0
+			IL_0100: stloc.3
+			IL_0101: ldc.i4.0
+			IL_0102: stloc.s 4
 			IL_0104: ldloc.0
 			IL_0105: ldc.i4.0
 			IL_0106: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_010b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_010b: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
 			IL_0110: ldloc.0
 			IL_0111: ldc.i4.0
-			IL_0112: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0117: ldloc.0
-			IL_0118: ldc.i4.0
-			IL_0119: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0112: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0117: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_011c: ldloc.0
+			IL_011d: ldc.i4.0
+			IL_011e: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_0123: ldloc.0
+			IL_0124: ldc.i4.0
+			IL_0125: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
 
-			IL_011e: ldloc.2
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
-			IL_0124: stloc.s 9
-			IL_0126: ldloc.0
-			IL_0127: ldc.i4.3
-			IL_0128: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_012d: ldloc.0
-			IL_012e: ldloc.s 9
-			IL_0130: ldarg.0
-			IL_0131: ldc.i4.1
+			IL_012a: ldloc.2
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorNext(object)
+			IL_0130: stloc.s 9
 			IL_0132: ldloc.0
-			IL_0133: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0138: ldc.i4.1
-			IL_0139: ldstr "_pendingException"
-			IL_013e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0143: ldloc.0
-			IL_0144: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0149: dup
-			IL_014a: ldc.i4.0
-			IL_014b: ldloc.1
-			IL_014c: box [System.Runtime]System.Double
-			IL_0151: stelem.ref
-			IL_0152: dup
-			IL_0153: ldc.i4.1
-			IL_0154: ldloc.2
-			IL_0155: stelem.ref
-			IL_0156: dup
-			IL_0157: ldc.i4.2
-			IL_0158: ldloc.3
-			IL_0159: box [System.Runtime]System.Boolean
-			IL_015e: stelem.ref
-			IL_015f: dup
-			IL_0160: ldc.i4.3
-			IL_0161: ldloc.s 4
-			IL_0163: box [System.Runtime]System.Boolean
-			IL_0168: stelem.ref
-			IL_0169: dup
-			IL_016a: ldc.i4.4
-			IL_016b: ldloc.s 5
-			IL_016d: stelem.ref
-			IL_016e: dup
-			IL_016f: ldc.i4.5
-			IL_0170: ldloc.s 6
-			IL_0172: stelem.ref
-			IL_0173: dup
-			IL_0174: ldc.i4.6
-			IL_0175: ldloc.s 7
-			IL_0177: box [System.Runtime]System.Boolean
-			IL_017c: stelem.ref
-			IL_017d: dup
-			IL_017e: ldc.i4.7
-			IL_017f: ldloc.s 8
-			IL_0181: box [System.Runtime]System.Boolean
-			IL_0186: stelem.ref
-			IL_0187: pop
-			IL_0188: ldloc.0
-			IL_0189: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_018e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0193: ret
-
+			IL_0133: ldc.i4.3
+			IL_0134: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0139: ldloc.0
+			IL_013a: ldloc.s 9
+			IL_013c: ldarg.0
+			IL_013d: ldc.i4.1
+			IL_013e: ldloc.0
+			IL_013f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0144: ldc.i4.1
+			IL_0145: ldstr "_pendingException"
+			IL_014a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_014f: ldloc.0
+			IL_0150: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0155: dup
+			IL_0156: ldc.i4.0
+			IL_0157: ldloc.1
+			IL_0158: box [System.Runtime]System.Double
+			IL_015d: stelem.ref
+			IL_015e: dup
+			IL_015f: ldc.i4.1
+			IL_0160: ldloc.2
+			IL_0161: stelem.ref
+			IL_0162: dup
+			IL_0163: ldc.i4.2
+			IL_0164: ldloc.3
+			IL_0165: box [System.Runtime]System.Boolean
+			IL_016a: stelem.ref
+			IL_016b: dup
+			IL_016c: ldc.i4.3
+			IL_016d: ldloc.s 4
+			IL_016f: box [System.Runtime]System.Boolean
+			IL_0174: stelem.ref
+			IL_0175: dup
+			IL_0176: ldc.i4.4
+			IL_0177: ldloc.s 5
+			IL_0179: stelem.ref
+			IL_017a: dup
+			IL_017b: ldc.i4.5
+			IL_017c: ldloc.s 6
+			IL_017e: stelem.ref
+			IL_017f: dup
+			IL_0180: ldc.i4.6
+			IL_0181: ldloc.s 7
+			IL_0183: box [System.Runtime]System.Boolean
+			IL_0188: stelem.ref
+			IL_0189: dup
+			IL_018a: ldc.i4.7
+			IL_018b: ldloc.s 8
+			IL_018d: box [System.Runtime]System.Boolean
+			IL_0192: stelem.ref
+			IL_0193: pop
 			IL_0194: ldloc.0
-			IL_0195: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited1
-			IL_019a: stloc.s 9
-			IL_019c: ldloc.s 9
-			IL_019e: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_01a3: stloc.s 10
-			IL_01a5: ldloc.s 10
-			IL_01a7: brtrue IL_0224
+			IL_0195: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_019a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_019f: ret
 
-			IL_01ac: ldloc.s 9
-			IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_01b3: stloc.s 9
-			IL_01b5: ldloc.s 9
-			IL_01b7: stloc.s 5
-			IL_01b9: newobj instance void Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope_ForOf_L10C13/Block_L10C29::.ctor()
-			IL_01be: stloc.s 6
-			IL_01c0: ldloc.1
-			IL_01c1: ldc.r8 1
-			IL_01ca: add
-			IL_01cb: stloc.1
+			IL_01a0: ldloc.0
+			IL_01a1: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited1
+			IL_01a6: stloc.s 9
+			IL_01a8: ldloc.s 9
+			IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_01af: stloc.s 10
+			IL_01b1: ldloc.s 10
+			IL_01b3: brtrue IL_0230
+
+			IL_01b8: ldloc.s 9
+			IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_01bf: stloc.s 9
+			IL_01c1: ldloc.s 9
+			IL_01c3: stloc.s 5
+			IL_01c5: newobj instance void Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope_ForOf_L10C13/Block_L10C29::.ctor()
+			IL_01ca: stloc.s 6
 			IL_01cc: ldloc.1
-			IL_01cd: box [System.Runtime]System.Double
-			IL_01d2: stloc.s 11
-			IL_01d4: ldloc.s 11
-			IL_01d6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01db: stloc.s 12
-			IL_01dd: ldstr "x"
-			IL_01e2: ldloc.s 12
-			IL_01e4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e9: stloc.s 12
-			IL_01eb: ldloc.s 12
-			IL_01ed: ldstr ": "
-			IL_01f2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f7: stloc.s 12
-			IL_01f9: ldloc.s 5
-			IL_01fb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0200: stloc.s 13
-			IL_0202: ldloc.s 12
-			IL_0204: ldloc.s 13
-			IL_0206: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020b: stloc.s 13
-			IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0212: ldloc.s 13
-			IL_0214: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0219: pop
-			IL_021a: br IL_011e
+			IL_01cd: ldc.r8 1
+			IL_01d6: add
+			IL_01d7: stloc.1
+			IL_01d8: ldloc.1
+			IL_01d9: box [System.Runtime]System.Double
+			IL_01de: stloc.s 11
+			IL_01e0: ldloc.s 11
+			IL_01e2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e7: stloc.s 12
+			IL_01e9: ldstr "x"
+			IL_01ee: ldloc.s 12
+			IL_01f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f5: stloc.s 12
+			IL_01f7: ldloc.s 12
+			IL_01f9: ldstr ": "
+			IL_01fe: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0203: stloc.s 12
+			IL_0205: ldloc.s 5
+			IL_0207: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_020c: stloc.s 13
+			IL_020e: ldloc.s 12
+			IL_0210: ldloc.s 13
+			IL_0212: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0217: stloc.s 13
+			IL_0219: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_021e: ldloc.s 13
+			IL_0220: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0225: pop
+			IL_0226: br IL_012a
 
-			IL_021f: br IL_023e
+			IL_022b: br IL_024a
 
-			IL_0224: ldc.i4.1
-			IL_0225: stloc.3
-			IL_0226: br IL_023e
+			IL_0230: ldc.i4.1
+			IL_0231: stloc.3
+			IL_0232: br IL_024a
 
-			IL_022b: ldloc.0
-			IL_022c: ldc.i4.1
-			IL_022d: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_0232: ldloc.0
-			IL_0233: ldc.i4.0
-			IL_0234: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0239: br IL_023e
+			IL_0237: ldloc.0
+			IL_0238: ldc.i4.1
+			IL_0239: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_023e: ldloc.0
+			IL_023f: ldc.i4.0
+			IL_0240: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_0245: br IL_024a
 
-			IL_023e: ldloc.3
-			IL_023f: brtrue IL_02cb
+			IL_024a: ldloc.3
+			IL_024b: brtrue IL_02d7
 
-			IL_0244: ldloc.s 4
-			IL_0246: brtrue IL_02cb
+			IL_0250: ldloc.s 4
+			IL_0252: brtrue IL_02d7
 
-			IL_024b: ldc.i4.1
-			IL_024c: stloc.s 4
-			IL_024e: ldloc.2
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
-			IL_0254: stloc.s 9
-			IL_0256: ldloc.0
-			IL_0257: ldc.i4.4
-			IL_0258: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_025d: ldloc.0
-			IL_025e: ldloc.s 9
-			IL_0260: ldarg.0
-			IL_0261: ldc.i4.2
+			IL_0257: ldc.i4.1
+			IL_0258: stloc.s 4
+			IL_025a: ldloc.2
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::AsyncIteratorClose(object)
+			IL_0260: stloc.s 9
 			IL_0262: ldloc.0
-			IL_0263: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0268: ldc.i4.2
-			IL_0269: ldstr "_pendingException"
-			IL_026e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0273: ldloc.0
-			IL_0274: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0279: dup
-			IL_027a: ldc.i4.0
-			IL_027b: ldloc.1
-			IL_027c: box [System.Runtime]System.Double
-			IL_0281: stelem.ref
-			IL_0282: dup
-			IL_0283: ldc.i4.1
-			IL_0284: ldloc.2
-			IL_0285: stelem.ref
-			IL_0286: dup
-			IL_0287: ldc.i4.2
-			IL_0288: ldloc.3
-			IL_0289: box [System.Runtime]System.Boolean
-			IL_028e: stelem.ref
-			IL_028f: dup
-			IL_0290: ldc.i4.3
-			IL_0291: ldloc.s 4
-			IL_0293: box [System.Runtime]System.Boolean
-			IL_0298: stelem.ref
-			IL_0299: dup
-			IL_029a: ldc.i4.4
-			IL_029b: ldloc.s 5
-			IL_029d: stelem.ref
-			IL_029e: dup
-			IL_029f: ldc.i4.5
-			IL_02a0: ldloc.s 6
-			IL_02a2: stelem.ref
-			IL_02a3: dup
-			IL_02a4: ldc.i4.6
-			IL_02a5: ldloc.s 7
-			IL_02a7: box [System.Runtime]System.Boolean
-			IL_02ac: stelem.ref
-			IL_02ad: dup
-			IL_02ae: ldc.i4.7
-			IL_02af: ldloc.s 8
-			IL_02b1: box [System.Runtime]System.Boolean
-			IL_02b6: stelem.ref
-			IL_02b7: pop
-			IL_02b8: ldloc.0
-			IL_02b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02be: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c3: ret
-
+			IL_0263: ldc.i4.4
+			IL_0264: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0269: ldloc.0
+			IL_026a: ldloc.s 9
+			IL_026c: ldarg.0
+			IL_026d: ldc.i4.2
+			IL_026e: ldloc.0
+			IL_026f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0274: ldc.i4.2
+			IL_0275: ldstr "_pendingException"
+			IL_027a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_027f: ldloc.0
+			IL_0280: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0285: dup
+			IL_0286: ldc.i4.0
+			IL_0287: ldloc.1
+			IL_0288: box [System.Runtime]System.Double
+			IL_028d: stelem.ref
+			IL_028e: dup
+			IL_028f: ldc.i4.1
+			IL_0290: ldloc.2
+			IL_0291: stelem.ref
+			IL_0292: dup
+			IL_0293: ldc.i4.2
+			IL_0294: ldloc.3
+			IL_0295: box [System.Runtime]System.Boolean
+			IL_029a: stelem.ref
+			IL_029b: dup
+			IL_029c: ldc.i4.3
+			IL_029d: ldloc.s 4
+			IL_029f: box [System.Runtime]System.Boolean
+			IL_02a4: stelem.ref
+			IL_02a5: dup
+			IL_02a6: ldc.i4.4
+			IL_02a7: ldloc.s 5
+			IL_02a9: stelem.ref
+			IL_02aa: dup
+			IL_02ab: ldc.i4.5
+			IL_02ac: ldloc.s 6
+			IL_02ae: stelem.ref
+			IL_02af: dup
+			IL_02b0: ldc.i4.6
+			IL_02b1: ldloc.s 7
+			IL_02b3: box [System.Runtime]System.Boolean
+			IL_02b8: stelem.ref
+			IL_02b9: dup
+			IL_02ba: ldc.i4.7
+			IL_02bb: ldloc.s 8
+			IL_02bd: box [System.Runtime]System.Boolean
+			IL_02c2: stelem.ref
+			IL_02c3: pop
 			IL_02c4: ldloc.0
-			IL_02c5: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited2
-			IL_02ca: pop
-
-			IL_02cb: br IL_02e3
+			IL_02c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02ca: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02cf: ret
 
 			IL_02d0: ldloc.0
-			IL_02d1: ldc.i4.1
-			IL_02d2: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02d7: ldloc.0
-			IL_02d8: ldc.i4.0
-			IL_02d9: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_02de: br IL_02e3
+			IL_02d1: ldfld object Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/Scope::_awaited2
+			IL_02d6: pop
 
+			IL_02d7: br IL_02ef
+
+			IL_02dc: ldloc.0
+			IL_02dd: ldc.i4.1
+			IL_02de: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
 			IL_02e3: ldloc.0
-			IL_02e4: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
-			IL_02e9: stloc.s 7
-			IL_02eb: ldloc.s 7
-			IL_02ed: brfalse IL_032a
+			IL_02e4: ldc.i4.0
+			IL_02e5: stfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_02ea: br IL_02ef
 
-			IL_02f2: ldloc.0
-			IL_02f3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_02f8: stloc.s 9
-			IL_02fa: ldloc.0
-			IL_02fb: ldc.i4.m1
-			IL_02fc: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0301: ldloc.0
-			IL_0302: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0307: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_030c: ldarg.0
-			IL_030d: ldc.i4.1
-			IL_030e: newarr [System.Runtime]System.Object
-			IL_0313: dup
-			IL_0314: ldc.i4.0
-			IL_0315: ldloc.s 9
-			IL_0317: stelem.ref
-			IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_031d: pop
-			IL_031e: ldloc.0
-			IL_031f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0324: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0329: ret
+			IL_02ef: ldloc.0
+			IL_02f0: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingException
+			IL_02f5: stloc.s 7
+			IL_02f7: ldloc.s 7
+			IL_02f9: brfalse IL_0336
 
+			IL_02fe: ldloc.0
+			IL_02ff: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_0304: stloc.s 9
+			IL_0306: ldloc.0
+			IL_0307: ldc.i4.m1
+			IL_0308: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_030d: ldloc.0
+			IL_030e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0313: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0318: ldarg.0
+			IL_0319: ldc.i4.1
+			IL_031a: newarr [System.Runtime]System.Object
+			IL_031f: dup
+			IL_0320: ldc.i4.0
+			IL_0321: ldloc.s 9
+			IL_0323: stelem.ref
+			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0329: pop
 			IL_032a: ldloc.0
-			IL_032b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
-			IL_0330: stloc.s 8
-			IL_0332: ldloc.s 8
-			IL_0334: brfalse IL_0371
+			IL_032b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0330: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0335: ret
 
-			IL_0339: ldloc.0
-			IL_033a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
-			IL_033f: stloc.s 9
-			IL_0341: ldloc.0
-			IL_0342: ldc.i4.m1
-			IL_0343: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0348: ldloc.0
-			IL_0349: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0353: ldarg.0
-			IL_0354: ldc.i4.1
-			IL_0355: newarr [System.Runtime]System.Object
-			IL_035a: dup
-			IL_035b: ldc.i4.0
-			IL_035c: ldloc.s 9
-			IL_035e: stelem.ref
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0364: pop
-			IL_0365: ldloc.0
-			IL_0366: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_036b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0370: ret
+			IL_0336: ldloc.0
+			IL_0337: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_hasPendingReturn
+			IL_033c: stloc.s 8
+			IL_033e: ldloc.s 8
+			IL_0340: brfalse IL_037d
 
+			IL_0345: ldloc.0
+			IL_0346: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingReturnValue
+			IL_034b: stloc.s 9
+			IL_034d: ldloc.0
+			IL_034e: ldc.i4.m1
+			IL_034f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0354: ldloc.0
+			IL_0355: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_035a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_035f: ldarg.0
+			IL_0360: ldc.i4.1
+			IL_0361: newarr [System.Runtime]System.Object
+			IL_0366: dup
+			IL_0367: ldc.i4.0
+			IL_0368: ldloc.s 9
+			IL_036a: stelem.ref
+			IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0370: pop
 			IL_0371: ldloc.0
-			IL_0372: ldc.i4.m1
-			IL_0373: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0378: ldloc.0
-			IL_0379: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_037e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0383: ldarg.0
-			IL_0384: ldc.i4.1
-			IL_0385: newarr [System.Runtime]System.Object
-			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_038f: pop
-			IL_0390: ldloc.0
-			IL_0391: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0396: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_039b: ret
+			IL_0372: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0377: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_037c: ret
+
+			IL_037d: ldloc.0
+			IL_037e: ldc.i4.m1
+			IL_037f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0384: ldloc.0
+			IL_0385: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_038a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_038f: ldarg.0
+			IL_0390: ldc.i4.1
+			IL_0391: newarr [System.Runtime]System.Object
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_039b: pop
+			IL_039c: ldloc.0
+			IL_039d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03a2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03a7: ret
 		} // end of method ArrowFunction_L8C2::__js_call__
 
 	} // end of class ArrowFunction_L8C2
@@ -807,7 +811,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x26e4
+			// Method begins at RVA 0x26f0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -902,7 +906,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2711
+		// Method begins at RVA 0x271d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x275b
+					// Method begins at RVA 0x2767
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2764
+					// Method begins at RVA 0x2770
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2752
+				// Method begins at RVA 0x275e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -473,7 +473,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x276d
+				// Method begins at RVA 0x2779
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -499,7 +499,7 @@
 			)
 			// Method begins at RVA 0x246c
 			// Header size: 12
-			// Code size: 721 (0x2d1)
+			// Code size: 733 (0x2dd)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope,
@@ -572,236 +572,240 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_0092, IL_00fa, IL_01ac, IL_0250)
+			IL_007d: switch (IL_0092, IL_0106, IL_01b8, IL_025c)
 
-			IL_0092: ldc.i4.1
-			IL_0093: newarr [System.Runtime]System.Object
-			IL_0098: dup
-			IL_0099: ldc.i4.0
-			IL_009a: ldarg.0
-			IL_009b: ldc.i4.1
-			IL_009c: ldelem.ref
-			IL_009d: stelem.ref
-			IL_009e: ldnull
-			IL_009f: call object Modules.AsyncGenerator_Return/g::__js_call__(object[], object)
-			IL_00a4: stloc.s 5
-			IL_00a6: ldloc.s 5
-			IL_00a8: stloc.1
-			IL_00a9: ldloc.1
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00af: stloc.s 5
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldstr "next"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.0
-			IL_00c0: ldc.i4.1
-			IL_00c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c6: ldloc.0
-			IL_00c7: ldloc.s 5
-			IL_00c9: ldarg.0
-			IL_00ca: ldc.i4.1
+			IL_0092: ldarg.0
+			IL_0093: ldc.i4.1
+			IL_0094: ldelem.ref
+			IL_0095: castclass Modules.AsyncGenerator_Return/Scope
+			IL_009a: ldfld object Modules.AsyncGenerator_Return/Scope::g
+			IL_009f: ldc.i4.1
+			IL_00a0: newarr [System.Runtime]System.Object
+			IL_00a5: dup
+			IL_00a6: ldc.i4.0
+			IL_00a7: ldarg.0
+			IL_00a8: ldc.i4.1
+			IL_00a9: ldelem.ref
+			IL_00aa: stelem.ref
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00b0: stloc.s 5
+			IL_00b2: ldloc.s 5
+			IL_00b4: stloc.1
+			IL_00b5: ldloc.1
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bb: stloc.s 5
+			IL_00bd: ldloc.s 5
+			IL_00bf: ldstr "next"
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00c9: stloc.s 5
 			IL_00cb: ldloc.0
-			IL_00cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00d6: ldloc.0
-			IL_00d7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00dc: dup
-			IL_00dd: ldc.i4.0
-			IL_00de: ldloc.1
-			IL_00df: stelem.ref
-			IL_00e0: dup
-			IL_00e1: ldc.i4.1
-			IL_00e2: ldloc.2
-			IL_00e3: stelem.ref
-			IL_00e4: dup
-			IL_00e5: ldc.i4.2
-			IL_00e6: ldloc.3
-			IL_00e7: stelem.ref
+			IL_00cc: ldc.i4.1
+			IL_00cd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00d2: ldloc.0
+			IL_00d3: ldloc.s 5
+			IL_00d5: ldarg.0
+			IL_00d6: ldc.i4.1
+			IL_00d7: ldloc.0
+			IL_00d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00e2: ldloc.0
+			IL_00e3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_00e8: dup
-			IL_00e9: ldc.i4.3
-			IL_00ea: ldloc.s 4
-			IL_00ec: stelem.ref
-			IL_00ed: pop
-			IL_00ee: ldloc.0
-			IL_00ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00f4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_00f9: ret
-
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldloc.1
+			IL_00eb: stelem.ref
+			IL_00ec: dup
+			IL_00ed: ldc.i4.1
+			IL_00ee: ldloc.2
+			IL_00ef: stelem.ref
+			IL_00f0: dup
+			IL_00f1: ldc.i4.2
+			IL_00f2: ldloc.3
+			IL_00f3: stelem.ref
+			IL_00f4: dup
+			IL_00f5: ldc.i4.3
+			IL_00f6: ldloc.s 4
+			IL_00f8: stelem.ref
+			IL_00f9: pop
 			IL_00fa: ldloc.0
-			IL_00fb: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited1
-			IL_0100: stloc.s 5
-			IL_0102: ldloc.s 5
-			IL_0104: stloc.2
-			IL_0105: ldstr "r1.value="
-			IL_010a: ldloc.2
-			IL_010b: ldstr "value"
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_011a: stloc.s 6
-			IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0121: ldloc.s 6
-			IL_0123: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0128: pop
-			IL_0129: ldstr "r1.done="
-			IL_012e: ldloc.2
-			IL_012f: ldstr "done"
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_013e: stloc.s 6
-			IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0145: ldloc.s 6
-			IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_014c: pop
-			IL_014d: ldloc.1
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0153: stloc.s 5
-			IL_0155: ldloc.s 5
-			IL_0157: ldstr "return"
-			IL_015c: ldc.r8 99
-			IL_0165: box [System.Runtime]System.Double
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_016f: stloc.s 5
-			IL_0171: ldloc.0
-			IL_0172: ldc.i4.2
-			IL_0173: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: ldloc.0
-			IL_0179: ldloc.s 5
-			IL_017b: ldarg.0
-			IL_017c: ldc.i4.2
+			IL_00fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0100: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0105: ret
+
+			IL_0106: ldloc.0
+			IL_0107: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited1
+			IL_010c: stloc.s 5
+			IL_010e: ldloc.s 5
+			IL_0110: stloc.2
+			IL_0111: ldstr "r1.value="
+			IL_0116: ldloc.2
+			IL_0117: ldstr "value"
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0126: stloc.s 6
+			IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012d: ldloc.s 6
+			IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0134: pop
+			IL_0135: ldstr "r1.done="
+			IL_013a: ldloc.2
+			IL_013b: ldstr "done"
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_014a: stloc.s 6
+			IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0151: ldloc.s 6
+			IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0158: pop
+			IL_0159: ldloc.1
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015f: stloc.s 5
+			IL_0161: ldloc.s 5
+			IL_0163: ldstr "return"
+			IL_0168: ldc.r8 99
+			IL_0171: box [System.Runtime]System.Double
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_017b: stloc.s 5
 			IL_017d: ldloc.0
-			IL_017e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0188: ldloc.0
-			IL_0189: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldloc.1
-			IL_0191: stelem.ref
-			IL_0192: dup
-			IL_0193: ldc.i4.1
-			IL_0194: ldloc.2
-			IL_0195: stelem.ref
-			IL_0196: dup
-			IL_0197: ldc.i4.2
-			IL_0198: ldloc.3
-			IL_0199: stelem.ref
+			IL_017e: ldc.i4.2
+			IL_017f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0184: ldloc.0
+			IL_0185: ldloc.s 5
+			IL_0187: ldarg.0
+			IL_0188: ldc.i4.2
+			IL_0189: ldloc.0
+			IL_018a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_018f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0194: ldloc.0
+			IL_0195: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_019a: dup
-			IL_019b: ldc.i4.3
-			IL_019c: ldloc.s 4
-			IL_019e: stelem.ref
-			IL_019f: pop
-			IL_01a0: ldloc.0
-			IL_01a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01a6: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01ab: ret
-
+			IL_019b: ldc.i4.0
+			IL_019c: ldloc.1
+			IL_019d: stelem.ref
+			IL_019e: dup
+			IL_019f: ldc.i4.1
+			IL_01a0: ldloc.2
+			IL_01a1: stelem.ref
+			IL_01a2: dup
+			IL_01a3: ldc.i4.2
+			IL_01a4: ldloc.3
+			IL_01a5: stelem.ref
+			IL_01a6: dup
+			IL_01a7: ldc.i4.3
+			IL_01a8: ldloc.s 4
+			IL_01aa: stelem.ref
+			IL_01ab: pop
 			IL_01ac: ldloc.0
-			IL_01ad: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited2
-			IL_01b2: stloc.s 5
-			IL_01b4: ldloc.s 5
-			IL_01b6: stloc.3
-			IL_01b7: ldstr "r2.value="
-			IL_01bc: ldloc.3
-			IL_01bd: ldstr "value"
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01cc: stloc.s 6
-			IL_01ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01d3: ldloc.s 6
-			IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01da: pop
-			IL_01db: ldstr "r2.done="
-			IL_01e0: ldloc.3
-			IL_01e1: ldstr "done"
-			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01f0: stloc.s 6
-			IL_01f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01f7: ldloc.s 6
-			IL_01f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01fe: pop
-			IL_01ff: ldloc.1
-			IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0205: stloc.s 5
-			IL_0207: ldloc.s 5
-			IL_0209: ldstr "next"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0213: stloc.s 5
-			IL_0215: ldloc.0
-			IL_0216: ldc.i4.3
-			IL_0217: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_021c: ldloc.0
-			IL_021d: ldloc.s 5
-			IL_021f: ldarg.0
-			IL_0220: ldc.i4.3
-			IL_0221: ldloc.0
-			IL_0222: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0227: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_022c: ldloc.0
-			IL_022d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0232: dup
-			IL_0233: ldc.i4.0
-			IL_0234: ldloc.1
-			IL_0235: stelem.ref
-			IL_0236: dup
-			IL_0237: ldc.i4.1
-			IL_0238: ldloc.2
-			IL_0239: stelem.ref
-			IL_023a: dup
-			IL_023b: ldc.i4.2
-			IL_023c: ldloc.3
-			IL_023d: stelem.ref
-			IL_023e: dup
-			IL_023f: ldc.i4.3
-			IL_0240: ldloc.s 4
-			IL_0242: stelem.ref
-			IL_0243: pop
-			IL_0244: ldloc.0
-			IL_0245: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_024a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_024f: ret
+			IL_01ad: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01b7: ret
 
+			IL_01b8: ldloc.0
+			IL_01b9: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited2
+			IL_01be: stloc.s 5
+			IL_01c0: ldloc.s 5
+			IL_01c2: stloc.3
+			IL_01c3: ldstr "r2.value="
+			IL_01c8: ldloc.3
+			IL_01c9: ldstr "value"
+			IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01d8: stloc.s 6
+			IL_01da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01df: ldloc.s 6
+			IL_01e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01e6: pop
+			IL_01e7: ldstr "r2.done="
+			IL_01ec: ldloc.3
+			IL_01ed: ldstr "done"
+			IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01fc: stloc.s 6
+			IL_01fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0203: ldloc.s 6
+			IL_0205: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_020a: pop
+			IL_020b: ldloc.1
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0211: stloc.s 5
+			IL_0213: ldloc.s 5
+			IL_0215: ldstr "next"
+			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_021f: stloc.s 5
+			IL_0221: ldloc.0
+			IL_0222: ldc.i4.3
+			IL_0223: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0228: ldloc.0
+			IL_0229: ldloc.s 5
+			IL_022b: ldarg.0
+			IL_022c: ldc.i4.3
+			IL_022d: ldloc.0
+			IL_022e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0233: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0238: ldloc.0
+			IL_0239: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_023e: dup
+			IL_023f: ldc.i4.0
+			IL_0240: ldloc.1
+			IL_0241: stelem.ref
+			IL_0242: dup
+			IL_0243: ldc.i4.1
+			IL_0244: ldloc.2
+			IL_0245: stelem.ref
+			IL_0246: dup
+			IL_0247: ldc.i4.2
+			IL_0248: ldloc.3
+			IL_0249: stelem.ref
+			IL_024a: dup
+			IL_024b: ldc.i4.3
+			IL_024c: ldloc.s 4
+			IL_024e: stelem.ref
+			IL_024f: pop
 			IL_0250: ldloc.0
-			IL_0251: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited3
-			IL_0256: stloc.s 5
-			IL_0258: ldloc.s 5
-			IL_025a: stloc.s 4
-			IL_025c: ldstr "r3.value="
-			IL_0261: ldloc.s 4
-			IL_0263: ldstr "value"
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0272: stloc.s 6
-			IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0279: ldloc.s 6
-			IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0280: pop
-			IL_0281: ldstr "r3.done="
-			IL_0286: ldloc.s 4
-			IL_0288: ldstr "done"
-			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0297: stloc.s 6
-			IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_029e: ldloc.s 6
-			IL_02a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02a5: pop
-			IL_02a6: ldloc.0
-			IL_02a7: ldc.i4.m1
-			IL_02a8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02ad: ldloc.0
-			IL_02ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02b8: ldarg.0
-			IL_02b9: ldc.i4.1
-			IL_02ba: newarr [System.Runtime]System.Object
-			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02c4: pop
-			IL_02c5: ldloc.0
-			IL_02c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02cb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02d0: ret
+			IL_0251: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0256: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_025b: ret
+
+			IL_025c: ldloc.0
+			IL_025d: ldfld object Modules.AsyncGenerator_Return/ArrowFunction_L14C2/Scope::_awaited3
+			IL_0262: stloc.s 5
+			IL_0264: ldloc.s 5
+			IL_0266: stloc.s 4
+			IL_0268: ldstr "r3.value="
+			IL_026d: ldloc.s 4
+			IL_026f: ldstr "value"
+			IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_027e: stloc.s 6
+			IL_0280: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0285: ldloc.s 6
+			IL_0287: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_028c: pop
+			IL_028d: ldstr "r3.done="
+			IL_0292: ldloc.s 4
+			IL_0294: ldstr "done"
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02a3: stloc.s 6
+			IL_02a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02aa: ldloc.s 6
+			IL_02ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02b1: pop
+			IL_02b2: ldloc.0
+			IL_02b3: ldc.i4.m1
+			IL_02b4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02b9: ldloc.0
+			IL_02ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02c4: ldarg.0
+			IL_02c5: ldc.i4.1
+			IL_02c6: newarr [System.Runtime]System.Object
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02d0: pop
+			IL_02d1: ldloc.0
+			IL_02d2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02d7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02dc: ret
 		} // end of method ArrowFunction_L14C2::__js_call__
 
 	} // end of class ArrowFunction_L14C2
@@ -819,7 +823,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2749
+			// Method begins at RVA 0x2755
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -914,7 +918,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2776
+		// Method begins at RVA 0x2782
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2786
+					// Method begins at RVA 0x2792
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x278f
+					// Method begins at RVA 0x279b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2798
+					// Method begins at RVA 0x27a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x277d
+				// Method begins at RVA 0x2789
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -516,7 +516,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a1
+				// Method begins at RVA 0x27ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -542,7 +542,7 @@
 			)
 			// Method begins at RVA 0x24a0
 			// Header size: 12
-			// Code size: 712 (0x2c8)
+			// Code size: 724 (0x2d4)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope,
@@ -615,235 +615,239 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_0092, IL_00fa, IL_01a3, IL_0247)
+			IL_007d: switch (IL_0092, IL_0106, IL_01af, IL_0253)
 
-			IL_0092: ldc.i4.1
-			IL_0093: newarr [System.Runtime]System.Object
-			IL_0098: dup
-			IL_0099: ldc.i4.0
-			IL_009a: ldarg.0
-			IL_009b: ldc.i4.1
-			IL_009c: ldelem.ref
-			IL_009d: stelem.ref
-			IL_009e: ldnull
-			IL_009f: call object Modules.AsyncGenerator_Throw/g::__js_call__(object[], object)
-			IL_00a4: stloc.s 5
-			IL_00a6: ldloc.s 5
-			IL_00a8: stloc.1
-			IL_00a9: ldloc.1
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00af: stloc.s 5
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldstr "next"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00bd: stloc.s 5
-			IL_00bf: ldloc.0
-			IL_00c0: ldc.i4.1
-			IL_00c1: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00c6: ldloc.0
-			IL_00c7: ldloc.s 5
-			IL_00c9: ldarg.0
-			IL_00ca: ldc.i4.1
+			IL_0092: ldarg.0
+			IL_0093: ldc.i4.1
+			IL_0094: ldelem.ref
+			IL_0095: castclass Modules.AsyncGenerator_Throw/Scope
+			IL_009a: ldfld object Modules.AsyncGenerator_Throw/Scope::g
+			IL_009f: ldc.i4.1
+			IL_00a0: newarr [System.Runtime]System.Object
+			IL_00a5: dup
+			IL_00a6: ldc.i4.0
+			IL_00a7: ldarg.0
+			IL_00a8: ldc.i4.1
+			IL_00a9: ldelem.ref
+			IL_00aa: stelem.ref
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00b0: stloc.s 5
+			IL_00b2: ldloc.s 5
+			IL_00b4: stloc.1
+			IL_00b5: ldloc.1
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bb: stloc.s 5
+			IL_00bd: ldloc.s 5
+			IL_00bf: ldstr "next"
+			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00c9: stloc.s 5
 			IL_00cb: ldloc.0
-			IL_00cc: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00d6: ldloc.0
-			IL_00d7: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00dc: dup
-			IL_00dd: ldc.i4.0
-			IL_00de: ldloc.1
-			IL_00df: stelem.ref
-			IL_00e0: dup
-			IL_00e1: ldc.i4.1
-			IL_00e2: ldloc.2
-			IL_00e3: stelem.ref
-			IL_00e4: dup
-			IL_00e5: ldc.i4.2
-			IL_00e6: ldloc.3
-			IL_00e7: stelem.ref
+			IL_00cc: ldc.i4.1
+			IL_00cd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00d2: ldloc.0
+			IL_00d3: ldloc.s 5
+			IL_00d5: ldarg.0
+			IL_00d6: ldc.i4.1
+			IL_00d7: ldloc.0
+			IL_00d8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00e2: ldloc.0
+			IL_00e3: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_00e8: dup
-			IL_00e9: ldc.i4.3
-			IL_00ea: ldloc.s 4
-			IL_00ec: stelem.ref
-			IL_00ed: pop
-			IL_00ee: ldloc.0
-			IL_00ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_00f4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_00f9: ret
-
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldloc.1
+			IL_00eb: stelem.ref
+			IL_00ec: dup
+			IL_00ed: ldc.i4.1
+			IL_00ee: ldloc.2
+			IL_00ef: stelem.ref
+			IL_00f0: dup
+			IL_00f1: ldc.i4.2
+			IL_00f2: ldloc.3
+			IL_00f3: stelem.ref
+			IL_00f4: dup
+			IL_00f5: ldc.i4.3
+			IL_00f6: ldloc.s 4
+			IL_00f8: stelem.ref
+			IL_00f9: pop
 			IL_00fa: ldloc.0
-			IL_00fb: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited1
-			IL_0100: stloc.s 5
-			IL_0102: ldloc.s 5
-			IL_0104: stloc.2
-			IL_0105: ldstr "r1.value="
-			IL_010a: ldloc.2
-			IL_010b: ldstr "value"
-			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_011a: stloc.s 6
-			IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0121: ldloc.s 6
-			IL_0123: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0128: pop
-			IL_0129: ldstr "r1.done="
-			IL_012e: ldloc.2
-			IL_012f: ldstr "done"
-			IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_013e: stloc.s 6
-			IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0145: ldloc.s 6
-			IL_0147: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_014c: pop
-			IL_014d: ldloc.1
-			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0153: stloc.s 5
-			IL_0155: ldloc.s 5
-			IL_0157: ldstr "throw"
-			IL_015c: ldstr "boom"
-			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0166: stloc.s 5
-			IL_0168: ldloc.0
-			IL_0169: ldc.i4.2
-			IL_016a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_016f: ldloc.0
-			IL_0170: ldloc.s 5
-			IL_0172: ldarg.0
-			IL_0173: ldc.i4.2
+			IL_00fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0100: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0105: ret
+
+			IL_0106: ldloc.0
+			IL_0107: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited1
+			IL_010c: stloc.s 5
+			IL_010e: ldloc.s 5
+			IL_0110: stloc.2
+			IL_0111: ldstr "r1.value="
+			IL_0116: ldloc.2
+			IL_0117: ldstr "value"
+			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0126: stloc.s 6
+			IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012d: ldloc.s 6
+			IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0134: pop
+			IL_0135: ldstr "r1.done="
+			IL_013a: ldloc.2
+			IL_013b: ldstr "done"
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_014a: stloc.s 6
+			IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0151: ldloc.s 6
+			IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0158: pop
+			IL_0159: ldloc.1
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015f: stloc.s 5
+			IL_0161: ldloc.s 5
+			IL_0163: ldstr "throw"
+			IL_0168: ldstr "boom"
+			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0172: stloc.s 5
 			IL_0174: ldloc.0
-			IL_0175: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_017a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_017f: ldloc.0
-			IL_0180: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0185: dup
-			IL_0186: ldc.i4.0
-			IL_0187: ldloc.1
-			IL_0188: stelem.ref
-			IL_0189: dup
-			IL_018a: ldc.i4.1
-			IL_018b: ldloc.2
-			IL_018c: stelem.ref
-			IL_018d: dup
-			IL_018e: ldc.i4.2
-			IL_018f: ldloc.3
-			IL_0190: stelem.ref
+			IL_0175: ldc.i4.2
+			IL_0176: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_017b: ldloc.0
+			IL_017c: ldloc.s 5
+			IL_017e: ldarg.0
+			IL_017f: ldc.i4.2
+			IL_0180: ldloc.0
+			IL_0181: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0186: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_018b: ldloc.0
+			IL_018c: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0191: dup
-			IL_0192: ldc.i4.3
-			IL_0193: ldloc.s 4
-			IL_0195: stelem.ref
-			IL_0196: pop
-			IL_0197: ldloc.0
-			IL_0198: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_019d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01a2: ret
-
+			IL_0192: ldc.i4.0
+			IL_0193: ldloc.1
+			IL_0194: stelem.ref
+			IL_0195: dup
+			IL_0196: ldc.i4.1
+			IL_0197: ldloc.2
+			IL_0198: stelem.ref
+			IL_0199: dup
+			IL_019a: ldc.i4.2
+			IL_019b: ldloc.3
+			IL_019c: stelem.ref
+			IL_019d: dup
+			IL_019e: ldc.i4.3
+			IL_019f: ldloc.s 4
+			IL_01a1: stelem.ref
+			IL_01a2: pop
 			IL_01a3: ldloc.0
-			IL_01a4: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited2
-			IL_01a9: stloc.s 5
-			IL_01ab: ldloc.s 5
-			IL_01ad: stloc.3
-			IL_01ae: ldstr "r2.value="
-			IL_01b3: ldloc.3
-			IL_01b4: ldstr "value"
-			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01c3: stloc.s 6
-			IL_01c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01ca: ldloc.s 6
-			IL_01cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01d1: pop
-			IL_01d2: ldstr "r2.done="
-			IL_01d7: ldloc.3
-			IL_01d8: ldstr "done"
-			IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01e7: stloc.s 6
-			IL_01e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01ee: ldloc.s 6
-			IL_01f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01f5: pop
-			IL_01f6: ldloc.1
-			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fc: stloc.s 5
-			IL_01fe: ldloc.s 5
-			IL_0200: ldstr "next"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_020a: stloc.s 5
-			IL_020c: ldloc.0
-			IL_020d: ldc.i4.3
-			IL_020e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0213: ldloc.0
-			IL_0214: ldloc.s 5
-			IL_0216: ldarg.0
-			IL_0217: ldc.i4.3
-			IL_0218: ldloc.0
-			IL_0219: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_021e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0223: ldloc.0
-			IL_0224: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0229: dup
-			IL_022a: ldc.i4.0
-			IL_022b: ldloc.1
-			IL_022c: stelem.ref
-			IL_022d: dup
-			IL_022e: ldc.i4.1
-			IL_022f: ldloc.2
-			IL_0230: stelem.ref
-			IL_0231: dup
-			IL_0232: ldc.i4.2
-			IL_0233: ldloc.3
-			IL_0234: stelem.ref
-			IL_0235: dup
-			IL_0236: ldc.i4.3
-			IL_0237: ldloc.s 4
-			IL_0239: stelem.ref
-			IL_023a: pop
-			IL_023b: ldloc.0
-			IL_023c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0241: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0246: ret
+			IL_01a4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01a9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01ae: ret
 
+			IL_01af: ldloc.0
+			IL_01b0: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited2
+			IL_01b5: stloc.s 5
+			IL_01b7: ldloc.s 5
+			IL_01b9: stloc.3
+			IL_01ba: ldstr "r2.value="
+			IL_01bf: ldloc.3
+			IL_01c0: ldstr "value"
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01cf: stloc.s 6
+			IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01d6: ldloc.s 6
+			IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01dd: pop
+			IL_01de: ldstr "r2.done="
+			IL_01e3: ldloc.3
+			IL_01e4: ldstr "done"
+			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01f3: stloc.s 6
+			IL_01f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01fa: ldloc.s 6
+			IL_01fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0201: pop
+			IL_0202: ldloc.1
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0208: stloc.s 5
+			IL_020a: ldloc.s 5
+			IL_020c: ldstr "next"
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0216: stloc.s 5
+			IL_0218: ldloc.0
+			IL_0219: ldc.i4.3
+			IL_021a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_021f: ldloc.0
+			IL_0220: ldloc.s 5
+			IL_0222: ldarg.0
+			IL_0223: ldc.i4.3
+			IL_0224: ldloc.0
+			IL_0225: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_022a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_022f: ldloc.0
+			IL_0230: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0235: dup
+			IL_0236: ldc.i4.0
+			IL_0237: ldloc.1
+			IL_0238: stelem.ref
+			IL_0239: dup
+			IL_023a: ldc.i4.1
+			IL_023b: ldloc.2
+			IL_023c: stelem.ref
+			IL_023d: dup
+			IL_023e: ldc.i4.2
+			IL_023f: ldloc.3
+			IL_0240: stelem.ref
+			IL_0241: dup
+			IL_0242: ldc.i4.3
+			IL_0243: ldloc.s 4
+			IL_0245: stelem.ref
+			IL_0246: pop
 			IL_0247: ldloc.0
-			IL_0248: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited3
-			IL_024d: stloc.s 5
-			IL_024f: ldloc.s 5
-			IL_0251: stloc.s 4
-			IL_0253: ldstr "r3.value="
-			IL_0258: ldloc.s 4
-			IL_025a: ldstr "value"
-			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0269: stloc.s 6
-			IL_026b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0270: ldloc.s 6
-			IL_0272: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0277: pop
-			IL_0278: ldstr "r3.done="
-			IL_027d: ldloc.s 4
-			IL_027f: ldstr "done"
-			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_028e: stloc.s 6
-			IL_0290: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0295: ldloc.s 6
-			IL_0297: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_029c: pop
-			IL_029d: ldloc.0
-			IL_029e: ldc.i4.m1
-			IL_029f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02a4: ldloc.0
-			IL_02a5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02af: ldarg.0
-			IL_02b0: ldc.i4.1
-			IL_02b1: newarr [System.Runtime]System.Object
-			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02bb: pop
-			IL_02bc: ldloc.0
-			IL_02bd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02c7: ret
+			IL_0248: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_024d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0252: ret
+
+			IL_0253: ldloc.0
+			IL_0254: ldfld object Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/Scope::_awaited3
+			IL_0259: stloc.s 5
+			IL_025b: ldloc.s 5
+			IL_025d: stloc.s 4
+			IL_025f: ldstr "r3.value="
+			IL_0264: ldloc.s 4
+			IL_0266: ldstr "value"
+			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0275: stloc.s 6
+			IL_0277: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_027c: ldloc.s 6
+			IL_027e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0283: pop
+			IL_0284: ldstr "r3.done="
+			IL_0289: ldloc.s 4
+			IL_028b: ldstr "done"
+			IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_029a: stloc.s 6
+			IL_029c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02a1: ldloc.s 6
+			IL_02a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02a8: pop
+			IL_02a9: ldloc.0
+			IL_02aa: ldc.i4.m1
+			IL_02ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02b0: ldloc.0
+			IL_02b1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02bb: ldarg.0
+			IL_02bc: ldc.i4.1
+			IL_02bd: newarr [System.Runtime]System.Object
+			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02c7: pop
+			IL_02c8: ldloc.0
+			IL_02c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02ce: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02d3: ret
 		} // end of method ArrowFunction_L15C2::__js_call__
 
 	} // end of class ArrowFunction_L15C2
@@ -861,7 +865,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2774
+			// Method begins at RVA 0x2780
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -956,7 +960,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27aa
+		// Method begins at RVA 0x27b6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
@@ -37,7 +37,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2996
+					// Method begins at RVA 0x29a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -57,7 +57,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x299f
+					// Method begins at RVA 0x29ab
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -77,7 +77,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29a8
+					// Method begins at RVA 0x29b4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -105,7 +105,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x298d
+				// Method begins at RVA 0x2999
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -708,7 +708,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b1
+				// Method begins at RVA 0x29bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -734,7 +734,7 @@
 			)
 			// Method begins at RVA 0x2660
 			// Header size: 12
-			// Code size: 792 (0x318)
+			// Code size: 804 (0x324)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope,
@@ -812,286 +812,290 @@
 
 			IL_007c: ldloc.0
 			IL_007d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0082: switch (IL_009b, IL_0108, IL_018d, IL_0212, IL_0299)
+			IL_0082: switch (IL_009b, IL_0114, IL_0199, IL_021e, IL_02a5)
 
-			IL_009b: ldc.i4.1
-			IL_009c: newarr [System.Runtime]System.Object
-			IL_00a1: dup
-			IL_00a2: ldc.i4.0
-			IL_00a3: ldarg.0
-			IL_00a4: ldc.i4.1
-			IL_00a5: ldelem.ref
-			IL_00a6: stelem.ref
-			IL_00a7: ldnull
-			IL_00a8: call object Modules.AsyncGenerator_TryCatchFinally/g::__js_call__(object[], object)
-			IL_00ad: stloc.s 6
-			IL_00af: ldloc.s 6
-			IL_00b1: stloc.1
-			IL_00b2: ldloc.1
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b8: stloc.s 6
-			IL_00ba: ldloc.s 6
-			IL_00bc: ldstr "next"
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00c6: stloc.s 6
-			IL_00c8: ldloc.0
-			IL_00c9: ldc.i4.1
-			IL_00ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00cf: ldloc.0
-			IL_00d0: ldloc.s 6
-			IL_00d2: ldarg.0
-			IL_00d3: ldc.i4.1
+			IL_009b: ldarg.0
+			IL_009c: ldc.i4.1
+			IL_009d: ldelem.ref
+			IL_009e: castclass Modules.AsyncGenerator_TryCatchFinally/Scope
+			IL_00a3: ldfld object Modules.AsyncGenerator_TryCatchFinally/Scope::g
+			IL_00a8: ldc.i4.1
+			IL_00a9: newarr [System.Runtime]System.Object
+			IL_00ae: dup
+			IL_00af: ldc.i4.0
+			IL_00b0: ldarg.0
+			IL_00b1: ldc.i4.1
+			IL_00b2: ldelem.ref
+			IL_00b3: stelem.ref
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00b9: stloc.s 6
+			IL_00bb: ldloc.s 6
+			IL_00bd: stloc.1
+			IL_00be: ldloc.1
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c4: stloc.s 6
+			IL_00c6: ldloc.s 6
+			IL_00c8: ldstr "next"
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00d2: stloc.s 6
 			IL_00d4: ldloc.0
-			IL_00d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00df: ldloc.0
-			IL_00e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00e5: dup
-			IL_00e6: ldc.i4.0
-			IL_00e7: ldloc.1
-			IL_00e8: stelem.ref
-			IL_00e9: dup
-			IL_00ea: ldc.i4.1
-			IL_00eb: ldloc.2
-			IL_00ec: stelem.ref
-			IL_00ed: dup
-			IL_00ee: ldc.i4.2
-			IL_00ef: ldloc.3
-			IL_00f0: stelem.ref
+			IL_00d5: ldc.i4.1
+			IL_00d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00db: ldloc.0
+			IL_00dc: ldloc.s 6
+			IL_00de: ldarg.0
+			IL_00df: ldc.i4.1
+			IL_00e0: ldloc.0
+			IL_00e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00eb: ldloc.0
+			IL_00ec: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_00f1: dup
-			IL_00f2: ldc.i4.3
-			IL_00f3: ldloc.s 4
-			IL_00f5: stelem.ref
-			IL_00f6: dup
-			IL_00f7: ldc.i4.4
-			IL_00f8: ldloc.s 5
-			IL_00fa: stelem.ref
-			IL_00fb: pop
-			IL_00fc: ldloc.0
-			IL_00fd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0102: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0107: ret
-
+			IL_00f2: ldc.i4.0
+			IL_00f3: ldloc.1
+			IL_00f4: stelem.ref
+			IL_00f5: dup
+			IL_00f6: ldc.i4.1
+			IL_00f7: ldloc.2
+			IL_00f8: stelem.ref
+			IL_00f9: dup
+			IL_00fa: ldc.i4.2
+			IL_00fb: ldloc.3
+			IL_00fc: stelem.ref
+			IL_00fd: dup
+			IL_00fe: ldc.i4.3
+			IL_00ff: ldloc.s 4
+			IL_0101: stelem.ref
+			IL_0102: dup
+			IL_0103: ldc.i4.4
+			IL_0104: ldloc.s 5
+			IL_0106: stelem.ref
+			IL_0107: pop
 			IL_0108: ldloc.0
-			IL_0109: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited1
-			IL_010e: stloc.s 6
-			IL_0110: ldloc.s 6
-			IL_0112: stloc.2
-			IL_0113: ldstr "r1="
-			IL_0118: ldloc.2
-			IL_0119: ldstr "value"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0128: stloc.s 7
-			IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012f: ldloc.s 7
-			IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0136: pop
-			IL_0137: ldloc.1
-			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013d: stloc.s 6
-			IL_013f: ldloc.s 6
-			IL_0141: ldstr "next"
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_014b: stloc.s 6
-			IL_014d: ldloc.0
-			IL_014e: ldc.i4.2
-			IL_014f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0154: ldloc.0
-			IL_0155: ldloc.s 6
-			IL_0157: ldarg.0
-			IL_0158: ldc.i4.2
+			IL_0109: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_010e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0113: ret
+
+			IL_0114: ldloc.0
+			IL_0115: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited1
+			IL_011a: stloc.s 6
+			IL_011c: ldloc.s 6
+			IL_011e: stloc.2
+			IL_011f: ldstr "r1="
+			IL_0124: ldloc.2
+			IL_0125: ldstr "value"
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0134: stloc.s 7
+			IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_013b: ldloc.s 7
+			IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0142: pop
+			IL_0143: ldloc.1
+			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0149: stloc.s 6
+			IL_014b: ldloc.s 6
+			IL_014d: ldstr "next"
+			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0157: stloc.s 6
 			IL_0159: ldloc.0
-			IL_015a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_015f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0164: ldloc.0
-			IL_0165: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_016a: dup
-			IL_016b: ldc.i4.0
-			IL_016c: ldloc.1
-			IL_016d: stelem.ref
-			IL_016e: dup
-			IL_016f: ldc.i4.1
-			IL_0170: ldloc.2
-			IL_0171: stelem.ref
-			IL_0172: dup
-			IL_0173: ldc.i4.2
-			IL_0174: ldloc.3
-			IL_0175: stelem.ref
+			IL_015a: ldc.i4.2
+			IL_015b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0160: ldloc.0
+			IL_0161: ldloc.s 6
+			IL_0163: ldarg.0
+			IL_0164: ldc.i4.2
+			IL_0165: ldloc.0
+			IL_0166: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_016b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0170: ldloc.0
+			IL_0171: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0176: dup
-			IL_0177: ldc.i4.3
-			IL_0178: ldloc.s 4
-			IL_017a: stelem.ref
-			IL_017b: dup
-			IL_017c: ldc.i4.4
-			IL_017d: ldloc.s 5
-			IL_017f: stelem.ref
-			IL_0180: pop
-			IL_0181: ldloc.0
-			IL_0182: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0187: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_018c: ret
-
+			IL_0177: ldc.i4.0
+			IL_0178: ldloc.1
+			IL_0179: stelem.ref
+			IL_017a: dup
+			IL_017b: ldc.i4.1
+			IL_017c: ldloc.2
+			IL_017d: stelem.ref
+			IL_017e: dup
+			IL_017f: ldc.i4.2
+			IL_0180: ldloc.3
+			IL_0181: stelem.ref
+			IL_0182: dup
+			IL_0183: ldc.i4.3
+			IL_0184: ldloc.s 4
+			IL_0186: stelem.ref
+			IL_0187: dup
+			IL_0188: ldc.i4.4
+			IL_0189: ldloc.s 5
+			IL_018b: stelem.ref
+			IL_018c: pop
 			IL_018d: ldloc.0
-			IL_018e: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited2
-			IL_0193: stloc.s 6
-			IL_0195: ldloc.s 6
-			IL_0197: stloc.3
-			IL_0198: ldstr "r2="
-			IL_019d: ldloc.3
-			IL_019e: ldstr "value"
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01ad: stloc.s 7
-			IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01b4: ldloc.s 7
-			IL_01b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01bb: pop
-			IL_01bc: ldloc.1
-			IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c2: stloc.s 6
-			IL_01c4: ldloc.s 6
-			IL_01c6: ldstr "next"
-			IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01d0: stloc.s 6
-			IL_01d2: ldloc.0
-			IL_01d3: ldc.i4.3
-			IL_01d4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01d9: ldloc.0
-			IL_01da: ldloc.s 6
-			IL_01dc: ldarg.0
-			IL_01dd: ldc.i4.3
+			IL_018e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0193: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0198: ret
+
+			IL_0199: ldloc.0
+			IL_019a: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited2
+			IL_019f: stloc.s 6
+			IL_01a1: ldloc.s 6
+			IL_01a3: stloc.3
+			IL_01a4: ldstr "r2="
+			IL_01a9: ldloc.3
+			IL_01aa: ldstr "value"
+			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01b9: stloc.s 7
+			IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01c0: ldloc.s 7
+			IL_01c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01c7: pop
+			IL_01c8: ldloc.1
+			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ce: stloc.s 6
+			IL_01d0: ldloc.s 6
+			IL_01d2: ldstr "next"
+			IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_01dc: stloc.s 6
 			IL_01de: ldloc.0
-			IL_01df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_01e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_01e9: ldloc.0
-			IL_01ea: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_01ef: dup
-			IL_01f0: ldc.i4.0
-			IL_01f1: ldloc.1
-			IL_01f2: stelem.ref
-			IL_01f3: dup
-			IL_01f4: ldc.i4.1
-			IL_01f5: ldloc.2
-			IL_01f6: stelem.ref
-			IL_01f7: dup
-			IL_01f8: ldc.i4.2
-			IL_01f9: ldloc.3
-			IL_01fa: stelem.ref
+			IL_01df: ldc.i4.3
+			IL_01e0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01e5: ldloc.0
+			IL_01e6: ldloc.s 6
+			IL_01e8: ldarg.0
+			IL_01e9: ldc.i4.3
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01f5: ldloc.0
+			IL_01f6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_01fb: dup
-			IL_01fc: ldc.i4.3
-			IL_01fd: ldloc.s 4
-			IL_01ff: stelem.ref
-			IL_0200: dup
-			IL_0201: ldc.i4.4
-			IL_0202: ldloc.s 5
-			IL_0204: stelem.ref
-			IL_0205: pop
-			IL_0206: ldloc.0
-			IL_0207: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_020c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0211: ret
-
+			IL_01fc: ldc.i4.0
+			IL_01fd: ldloc.1
+			IL_01fe: stelem.ref
+			IL_01ff: dup
+			IL_0200: ldc.i4.1
+			IL_0201: ldloc.2
+			IL_0202: stelem.ref
+			IL_0203: dup
+			IL_0204: ldc.i4.2
+			IL_0205: ldloc.3
+			IL_0206: stelem.ref
+			IL_0207: dup
+			IL_0208: ldc.i4.3
+			IL_0209: ldloc.s 4
+			IL_020b: stelem.ref
+			IL_020c: dup
+			IL_020d: ldc.i4.4
+			IL_020e: ldloc.s 5
+			IL_0210: stelem.ref
+			IL_0211: pop
 			IL_0212: ldloc.0
-			IL_0213: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited3
-			IL_0218: stloc.s 6
-			IL_021a: ldloc.s 6
-			IL_021c: stloc.s 4
-			IL_021e: ldstr "r3="
-			IL_0223: ldloc.s 4
-			IL_0225: ldstr "value"
-			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0234: stloc.s 7
-			IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_023b: ldloc.s 7
-			IL_023d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0242: pop
-			IL_0243: ldloc.1
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0249: stloc.s 6
-			IL_024b: ldloc.s 6
-			IL_024d: ldstr "next"
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0257: stloc.s 6
-			IL_0259: ldloc.0
-			IL_025a: ldc.i4.4
-			IL_025b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0260: ldloc.0
-			IL_0261: ldloc.s 6
-			IL_0263: ldarg.0
-			IL_0264: ldc.i4.4
-			IL_0265: ldloc.0
-			IL_0266: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_026b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0270: ldloc.0
-			IL_0271: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0276: dup
-			IL_0277: ldc.i4.0
-			IL_0278: ldloc.1
-			IL_0279: stelem.ref
-			IL_027a: dup
-			IL_027b: ldc.i4.1
-			IL_027c: ldloc.2
-			IL_027d: stelem.ref
-			IL_027e: dup
-			IL_027f: ldc.i4.2
-			IL_0280: ldloc.3
-			IL_0281: stelem.ref
-			IL_0282: dup
-			IL_0283: ldc.i4.3
-			IL_0284: ldloc.s 4
-			IL_0286: stelem.ref
-			IL_0287: dup
-			IL_0288: ldc.i4.4
-			IL_0289: ldloc.s 5
-			IL_028b: stelem.ref
-			IL_028c: pop
-			IL_028d: ldloc.0
-			IL_028e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0293: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0298: ret
+			IL_0213: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0218: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_021d: ret
 
+			IL_021e: ldloc.0
+			IL_021f: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited3
+			IL_0224: stloc.s 6
+			IL_0226: ldloc.s 6
+			IL_0228: stloc.s 4
+			IL_022a: ldstr "r3="
+			IL_022f: ldloc.s 4
+			IL_0231: ldstr "value"
+			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0240: stloc.s 7
+			IL_0242: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0247: ldloc.s 7
+			IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_024e: pop
+			IL_024f: ldloc.1
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0255: stloc.s 6
+			IL_0257: ldloc.s 6
+			IL_0259: ldstr "next"
+			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0263: stloc.s 6
+			IL_0265: ldloc.0
+			IL_0266: ldc.i4.4
+			IL_0267: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_026c: ldloc.0
+			IL_026d: ldloc.s 6
+			IL_026f: ldarg.0
+			IL_0270: ldc.i4.4
+			IL_0271: ldloc.0
+			IL_0272: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0277: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_027c: ldloc.0
+			IL_027d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0282: dup
+			IL_0283: ldc.i4.0
+			IL_0284: ldloc.1
+			IL_0285: stelem.ref
+			IL_0286: dup
+			IL_0287: ldc.i4.1
+			IL_0288: ldloc.2
+			IL_0289: stelem.ref
+			IL_028a: dup
+			IL_028b: ldc.i4.2
+			IL_028c: ldloc.3
+			IL_028d: stelem.ref
+			IL_028e: dup
+			IL_028f: ldc.i4.3
+			IL_0290: ldloc.s 4
+			IL_0292: stelem.ref
+			IL_0293: dup
+			IL_0294: ldc.i4.4
+			IL_0295: ldloc.s 5
+			IL_0297: stelem.ref
+			IL_0298: pop
 			IL_0299: ldloc.0
-			IL_029a: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited4
-			IL_029f: stloc.s 6
-			IL_02a1: ldloc.s 6
-			IL_02a3: stloc.s 5
-			IL_02a5: ldstr "r4="
-			IL_02aa: ldloc.s 5
-			IL_02ac: ldstr "value"
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02bb: stloc.s 7
-			IL_02bd: ldloc.s 7
-			IL_02bf: ldstr " done="
-			IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02c9: stloc.s 7
-			IL_02cb: ldloc.s 7
-			IL_02cd: ldloc.s 5
-			IL_02cf: ldstr "done"
-			IL_02d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02de: stloc.s 7
-			IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02e5: ldloc.s 7
-			IL_02e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02ec: pop
-			IL_02ed: ldloc.0
-			IL_02ee: ldc.i4.m1
-			IL_02ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02f4: ldloc.0
-			IL_02f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_02ff: ldarg.0
-			IL_0300: ldc.i4.1
-			IL_0301: newarr [System.Runtime]System.Object
-			IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_030b: pop
-			IL_030c: ldloc.0
-			IL_030d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0312: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0317: ret
+			IL_029a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_029f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02a4: ret
+
+			IL_02a5: ldloc.0
+			IL_02a6: ldfld object Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/Scope::_awaited4
+			IL_02ab: stloc.s 6
+			IL_02ad: ldloc.s 6
+			IL_02af: stloc.s 5
+			IL_02b1: ldstr "r4="
+			IL_02b6: ldloc.s 5
+			IL_02b8: ldstr "value"
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02c7: stloc.s 7
+			IL_02c9: ldloc.s 7
+			IL_02cb: ldstr " done="
+			IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d5: stloc.s 7
+			IL_02d7: ldloc.s 7
+			IL_02d9: ldloc.s 5
+			IL_02db: ldstr "done"
+			IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ea: stloc.s 7
+			IL_02ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f1: ldloc.s 7
+			IL_02f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02f8: pop
+			IL_02f9: ldloc.0
+			IL_02fa: ldc.i4.m1
+			IL_02fb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0300: ldloc.0
+			IL_0301: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0306: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_030b: ldarg.0
+			IL_030c: ldc.i4.1
+			IL_030d: newarr [System.Runtime]System.Object
+			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0317: pop
+			IL_0318: ldloc.0
+			IL_0319: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_031e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0323: ret
 		} // end of method ArrowFunction_L19C2::__js_call__
 
 	} // end of class ArrowFunction_L19C2
@@ -1109,7 +1113,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2984
+			// Method begins at RVA 0x2990
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1204,7 +1208,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29ba
+		// Method begins at RVA 0x29c6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
@@ -30,7 +30,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2878
+				// Method begins at RVA 0x2884
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -496,7 +496,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2881
+				// Method begins at RVA 0x288d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -522,7 +522,7 @@
 			)
 			// Method begins at RVA 0x24dc
 			// Header size: 12
-			// Code size: 903 (0x387)
+			// Code size: 915 (0x393)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope,
@@ -600,316 +600,320 @@
 
 			IL_007c: ldloc.0
 			IL_007d: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0082: switch (IL_009b, IL_0108, IL_01b1, IL_025a, IL_0306)
+			IL_0082: switch (IL_009b, IL_0114, IL_01bd, IL_0266, IL_0312)
 
-			IL_009b: ldc.i4.1
-			IL_009c: newarr [System.Runtime]System.Object
-			IL_00a1: dup
-			IL_00a2: ldc.i4.0
-			IL_00a3: ldarg.0
-			IL_00a4: ldc.i4.1
-			IL_00a5: ldelem.ref
-			IL_00a6: stelem.ref
-			IL_00a7: ldnull
-			IL_00a8: call object Modules.AsyncGenerator_YieldAwait/g::__js_call__(object[], object)
-			IL_00ad: stloc.s 6
-			IL_00af: ldloc.s 6
-			IL_00b1: stloc.1
-			IL_00b2: ldloc.1
-			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b8: stloc.s 6
-			IL_00ba: ldloc.s 6
-			IL_00bc: ldstr "next"
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00c6: stloc.s 6
-			IL_00c8: ldloc.0
-			IL_00c9: ldc.i4.1
-			IL_00ca: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_00cf: ldloc.0
-			IL_00d0: ldloc.s 6
-			IL_00d2: ldarg.0
-			IL_00d3: ldc.i4.1
+			IL_009b: ldarg.0
+			IL_009c: ldc.i4.1
+			IL_009d: ldelem.ref
+			IL_009e: castclass Modules.AsyncGenerator_YieldAwait/Scope
+			IL_00a3: ldfld object Modules.AsyncGenerator_YieldAwait/Scope::g
+			IL_00a8: ldc.i4.1
+			IL_00a9: newarr [System.Runtime]System.Object
+			IL_00ae: dup
+			IL_00af: ldc.i4.0
+			IL_00b0: ldarg.0
+			IL_00b1: ldc.i4.1
+			IL_00b2: ldelem.ref
+			IL_00b3: stelem.ref
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00b9: stloc.s 6
+			IL_00bb: ldloc.s 6
+			IL_00bd: stloc.1
+			IL_00be: ldloc.1
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c4: stloc.s 6
+			IL_00c6: ldloc.s 6
+			IL_00c8: ldstr "next"
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00d2: stloc.s 6
 			IL_00d4: ldloc.0
-			IL_00d5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_00da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_00df: ldloc.0
-			IL_00e0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_00e5: dup
-			IL_00e6: ldc.i4.0
-			IL_00e7: ldloc.1
-			IL_00e8: stelem.ref
-			IL_00e9: dup
-			IL_00ea: ldc.i4.1
-			IL_00eb: ldloc.2
-			IL_00ec: stelem.ref
-			IL_00ed: dup
-			IL_00ee: ldc.i4.2
-			IL_00ef: ldloc.3
-			IL_00f0: stelem.ref
+			IL_00d5: ldc.i4.1
+			IL_00d6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_00db: ldloc.0
+			IL_00dc: ldloc.s 6
+			IL_00de: ldarg.0
+			IL_00df: ldc.i4.1
+			IL_00e0: ldloc.0
+			IL_00e1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_00eb: ldloc.0
+			IL_00ec: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_00f1: dup
-			IL_00f2: ldc.i4.3
-			IL_00f3: ldloc.s 4
-			IL_00f5: stelem.ref
-			IL_00f6: dup
-			IL_00f7: ldc.i4.4
-			IL_00f8: ldloc.s 5
-			IL_00fa: stelem.ref
-			IL_00fb: pop
-			IL_00fc: ldloc.0
-			IL_00fd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0102: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0107: ret
-
+			IL_00f2: ldc.i4.0
+			IL_00f3: ldloc.1
+			IL_00f4: stelem.ref
+			IL_00f5: dup
+			IL_00f6: ldc.i4.1
+			IL_00f7: ldloc.2
+			IL_00f8: stelem.ref
+			IL_00f9: dup
+			IL_00fa: ldc.i4.2
+			IL_00fb: ldloc.3
+			IL_00fc: stelem.ref
+			IL_00fd: dup
+			IL_00fe: ldc.i4.3
+			IL_00ff: ldloc.s 4
+			IL_0101: stelem.ref
+			IL_0102: dup
+			IL_0103: ldc.i4.4
+			IL_0104: ldloc.s 5
+			IL_0106: stelem.ref
+			IL_0107: pop
 			IL_0108: ldloc.0
-			IL_0109: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited1
-			IL_010e: stloc.s 6
-			IL_0110: ldloc.s 6
-			IL_0112: stloc.2
-			IL_0113: ldstr "r1.value="
-			IL_0118: ldloc.2
-			IL_0119: ldstr "value"
-			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0128: stloc.s 7
-			IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012f: ldloc.s 7
-			IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0136: pop
-			IL_0137: ldstr "r1.done="
-			IL_013c: ldloc.2
-			IL_013d: ldstr "done"
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_014c: stloc.s 7
-			IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0153: ldloc.s 7
-			IL_0155: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_015a: pop
-			IL_015b: ldloc.1
-			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0161: stloc.s 6
-			IL_0163: ldloc.s 6
-			IL_0165: ldstr "next"
-			IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_016f: stloc.s 6
-			IL_0171: ldloc.0
-			IL_0172: ldc.i4.2
-			IL_0173: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: ldloc.0
-			IL_0179: ldloc.s 6
-			IL_017b: ldarg.0
-			IL_017c: ldc.i4.2
+			IL_0109: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_010e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0113: ret
+
+			IL_0114: ldloc.0
+			IL_0115: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited1
+			IL_011a: stloc.s 6
+			IL_011c: ldloc.s 6
+			IL_011e: stloc.2
+			IL_011f: ldstr "r1.value="
+			IL_0124: ldloc.2
+			IL_0125: ldstr "value"
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0134: stloc.s 7
+			IL_0136: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_013b: ldloc.s 7
+			IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0142: pop
+			IL_0143: ldstr "r1.done="
+			IL_0148: ldloc.2
+			IL_0149: ldstr "done"
+			IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0158: stloc.s 7
+			IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_015f: ldloc.s 7
+			IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0166: pop
+			IL_0167: ldloc.1
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016d: stloc.s 6
+			IL_016f: ldloc.s 6
+			IL_0171: ldstr "next"
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_017b: stloc.s 6
 			IL_017d: ldloc.0
-			IL_017e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0188: ldloc.0
-			IL_0189: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_018e: dup
-			IL_018f: ldc.i4.0
-			IL_0190: ldloc.1
-			IL_0191: stelem.ref
-			IL_0192: dup
-			IL_0193: ldc.i4.1
-			IL_0194: ldloc.2
-			IL_0195: stelem.ref
-			IL_0196: dup
-			IL_0197: ldc.i4.2
-			IL_0198: ldloc.3
-			IL_0199: stelem.ref
+			IL_017e: ldc.i4.2
+			IL_017f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0184: ldloc.0
+			IL_0185: ldloc.s 6
+			IL_0187: ldarg.0
+			IL_0188: ldc.i4.2
+			IL_0189: ldloc.0
+			IL_018a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_018f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0194: ldloc.0
+			IL_0195: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_019a: dup
-			IL_019b: ldc.i4.3
-			IL_019c: ldloc.s 4
-			IL_019e: stelem.ref
-			IL_019f: dup
-			IL_01a0: ldc.i4.4
-			IL_01a1: ldloc.s 5
-			IL_01a3: stelem.ref
-			IL_01a4: pop
-			IL_01a5: ldloc.0
-			IL_01a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01ab: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01b0: ret
-
+			IL_019b: ldc.i4.0
+			IL_019c: ldloc.1
+			IL_019d: stelem.ref
+			IL_019e: dup
+			IL_019f: ldc.i4.1
+			IL_01a0: ldloc.2
+			IL_01a1: stelem.ref
+			IL_01a2: dup
+			IL_01a3: ldc.i4.2
+			IL_01a4: ldloc.3
+			IL_01a5: stelem.ref
+			IL_01a6: dup
+			IL_01a7: ldc.i4.3
+			IL_01a8: ldloc.s 4
+			IL_01aa: stelem.ref
+			IL_01ab: dup
+			IL_01ac: ldc.i4.4
+			IL_01ad: ldloc.s 5
+			IL_01af: stelem.ref
+			IL_01b0: pop
 			IL_01b1: ldloc.0
-			IL_01b2: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited2
-			IL_01b7: stloc.s 6
-			IL_01b9: ldloc.s 6
-			IL_01bb: stloc.3
-			IL_01bc: ldstr "r2.value="
-			IL_01c1: ldloc.3
-			IL_01c2: ldstr "value"
-			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01d1: stloc.s 7
-			IL_01d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01d8: ldloc.s 7
-			IL_01da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01df: pop
-			IL_01e0: ldstr "r2.done="
-			IL_01e5: ldloc.3
-			IL_01e6: ldstr "done"
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_01f5: stloc.s 7
-			IL_01f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01fc: ldloc.s 7
-			IL_01fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0203: pop
-			IL_0204: ldloc.1
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_020a: stloc.s 6
-			IL_020c: ldloc.s 6
-			IL_020e: ldstr "next"
-			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0218: stloc.s 6
-			IL_021a: ldloc.0
-			IL_021b: ldc.i4.3
-			IL_021c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0221: ldloc.0
-			IL_0222: ldloc.s 6
-			IL_0224: ldarg.0
-			IL_0225: ldc.i4.3
+			IL_01b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01bc: ret
+
+			IL_01bd: ldloc.0
+			IL_01be: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited2
+			IL_01c3: stloc.s 6
+			IL_01c5: ldloc.s 6
+			IL_01c7: stloc.3
+			IL_01c8: ldstr "r2.value="
+			IL_01cd: ldloc.3
+			IL_01ce: ldstr "value"
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01dd: stloc.s 7
+			IL_01df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01e4: ldloc.s 7
+			IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01eb: pop
+			IL_01ec: ldstr "r2.done="
+			IL_01f1: ldloc.3
+			IL_01f2: ldstr "done"
+			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0201: stloc.s 7
+			IL_0203: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0208: ldloc.s 7
+			IL_020a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_020f: pop
+			IL_0210: ldloc.1
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0216: stloc.s 6
+			IL_0218: ldloc.s 6
+			IL_021a: ldstr "next"
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0224: stloc.s 6
 			IL_0226: ldloc.0
-			IL_0227: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_022c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0231: ldloc.0
-			IL_0232: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0237: dup
-			IL_0238: ldc.i4.0
-			IL_0239: ldloc.1
-			IL_023a: stelem.ref
-			IL_023b: dup
-			IL_023c: ldc.i4.1
-			IL_023d: ldloc.2
-			IL_023e: stelem.ref
-			IL_023f: dup
-			IL_0240: ldc.i4.2
-			IL_0241: ldloc.3
-			IL_0242: stelem.ref
+			IL_0227: ldc.i4.3
+			IL_0228: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_022d: ldloc.0
+			IL_022e: ldloc.s 6
+			IL_0230: ldarg.0
+			IL_0231: ldc.i4.3
+			IL_0232: ldloc.0
+			IL_0233: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0238: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_023d: ldloc.0
+			IL_023e: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0243: dup
-			IL_0244: ldc.i4.3
-			IL_0245: ldloc.s 4
-			IL_0247: stelem.ref
-			IL_0248: dup
-			IL_0249: ldc.i4.4
-			IL_024a: ldloc.s 5
-			IL_024c: stelem.ref
-			IL_024d: pop
-			IL_024e: ldloc.0
-			IL_024f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0254: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0259: ret
-
+			IL_0244: ldc.i4.0
+			IL_0245: ldloc.1
+			IL_0246: stelem.ref
+			IL_0247: dup
+			IL_0248: ldc.i4.1
+			IL_0249: ldloc.2
+			IL_024a: stelem.ref
+			IL_024b: dup
+			IL_024c: ldc.i4.2
+			IL_024d: ldloc.3
+			IL_024e: stelem.ref
+			IL_024f: dup
+			IL_0250: ldc.i4.3
+			IL_0251: ldloc.s 4
+			IL_0253: stelem.ref
+			IL_0254: dup
+			IL_0255: ldc.i4.4
+			IL_0256: ldloc.s 5
+			IL_0258: stelem.ref
+			IL_0259: pop
 			IL_025a: ldloc.0
-			IL_025b: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited3
-			IL_0260: stloc.s 6
-			IL_0262: ldloc.s 6
-			IL_0264: stloc.s 4
-			IL_0266: ldstr "r3.value="
-			IL_026b: ldloc.s 4
-			IL_026d: ldstr "value"
-			IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_027c: stloc.s 7
-			IL_027e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0283: ldloc.s 7
-			IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_028a: pop
-			IL_028b: ldstr "r3.done="
-			IL_0290: ldloc.s 4
-			IL_0292: ldstr "done"
-			IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02a1: stloc.s 7
-			IL_02a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02a8: ldloc.s 7
-			IL_02aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02af: pop
-			IL_02b0: ldloc.1
-			IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02b6: stloc.s 6
-			IL_02b8: ldloc.s 6
-			IL_02ba: ldstr "next"
-			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_02c4: stloc.s 6
-			IL_02c6: ldloc.0
-			IL_02c7: ldc.i4.4
-			IL_02c8: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02cd: ldloc.0
-			IL_02ce: ldloc.s 6
-			IL_02d0: ldarg.0
-			IL_02d1: ldc.i4.4
-			IL_02d2: ldloc.0
-			IL_02d3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_02dd: ldloc.0
-			IL_02de: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_02e3: dup
-			IL_02e4: ldc.i4.0
-			IL_02e5: ldloc.1
-			IL_02e6: stelem.ref
-			IL_02e7: dup
-			IL_02e8: ldc.i4.1
-			IL_02e9: ldloc.2
-			IL_02ea: stelem.ref
-			IL_02eb: dup
-			IL_02ec: ldc.i4.2
-			IL_02ed: ldloc.3
-			IL_02ee: stelem.ref
-			IL_02ef: dup
-			IL_02f0: ldc.i4.3
-			IL_02f1: ldloc.s 4
-			IL_02f3: stelem.ref
-			IL_02f4: dup
-			IL_02f5: ldc.i4.4
-			IL_02f6: ldloc.s 5
-			IL_02f8: stelem.ref
-			IL_02f9: pop
-			IL_02fa: ldloc.0
-			IL_02fb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0300: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0305: ret
+			IL_025b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0260: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0265: ret
 
+			IL_0266: ldloc.0
+			IL_0267: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited3
+			IL_026c: stloc.s 6
+			IL_026e: ldloc.s 6
+			IL_0270: stloc.s 4
+			IL_0272: ldstr "r3.value="
+			IL_0277: ldloc.s 4
+			IL_0279: ldstr "value"
+			IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0288: stloc.s 7
+			IL_028a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_028f: ldloc.s 7
+			IL_0291: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0296: pop
+			IL_0297: ldstr "r3.done="
+			IL_029c: ldloc.s 4
+			IL_029e: ldstr "done"
+			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02ad: stloc.s 7
+			IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02b4: ldloc.s 7
+			IL_02b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02bb: pop
+			IL_02bc: ldloc.1
+			IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c2: stloc.s 6
+			IL_02c4: ldloc.s 6
+			IL_02c6: ldstr "next"
+			IL_02cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_02d0: stloc.s 6
+			IL_02d2: ldloc.0
+			IL_02d3: ldc.i4.4
+			IL_02d4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02d9: ldloc.0
+			IL_02da: ldloc.s 6
+			IL_02dc: ldarg.0
+			IL_02dd: ldc.i4.4
+			IL_02de: ldloc.0
+			IL_02df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02e9: ldloc.0
+			IL_02ea: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_02ef: dup
+			IL_02f0: ldc.i4.0
+			IL_02f1: ldloc.1
+			IL_02f2: stelem.ref
+			IL_02f3: dup
+			IL_02f4: ldc.i4.1
+			IL_02f5: ldloc.2
+			IL_02f6: stelem.ref
+			IL_02f7: dup
+			IL_02f8: ldc.i4.2
+			IL_02f9: ldloc.3
+			IL_02fa: stelem.ref
+			IL_02fb: dup
+			IL_02fc: ldc.i4.3
+			IL_02fd: ldloc.s 4
+			IL_02ff: stelem.ref
+			IL_0300: dup
+			IL_0301: ldc.i4.4
+			IL_0302: ldloc.s 5
+			IL_0304: stelem.ref
+			IL_0305: pop
 			IL_0306: ldloc.0
-			IL_0307: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited4
-			IL_030c: stloc.s 6
-			IL_030e: ldloc.s 6
-			IL_0310: stloc.s 5
-			IL_0312: ldstr "r4.value="
-			IL_0317: ldloc.s 5
-			IL_0319: ldstr "value"
-			IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0328: stloc.s 7
-			IL_032a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_032f: ldloc.s 7
-			IL_0331: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0336: pop
-			IL_0337: ldstr "r4.done="
-			IL_033c: ldloc.s 5
-			IL_033e: ldstr "done"
-			IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_034d: stloc.s 7
-			IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0354: ldloc.s 7
-			IL_0356: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_035b: pop
-			IL_035c: ldloc.0
-			IL_035d: ldc.i4.m1
-			IL_035e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0363: ldloc.0
-			IL_0364: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0369: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_036e: ldarg.0
-			IL_036f: ldc.i4.1
-			IL_0370: newarr [System.Runtime]System.Object
-			IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_037a: pop
-			IL_037b: ldloc.0
-			IL_037c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0381: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0386: ret
+			IL_0307: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_030c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0311: ret
+
+			IL_0312: ldloc.0
+			IL_0313: ldfld object Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/Scope::_awaited4
+			IL_0318: stloc.s 6
+			IL_031a: ldloc.s 6
+			IL_031c: stloc.s 5
+			IL_031e: ldstr "r4.value="
+			IL_0323: ldloc.s 5
+			IL_0325: ldstr "value"
+			IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0334: stloc.s 7
+			IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033b: ldloc.s 7
+			IL_033d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0342: pop
+			IL_0343: ldstr "r4.done="
+			IL_0348: ldloc.s 5
+			IL_034a: ldstr "done"
+			IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0354: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0359: stloc.s 7
+			IL_035b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0360: ldloc.s 7
+			IL_0362: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0367: pop
+			IL_0368: ldloc.0
+			IL_0369: ldc.i4.m1
+			IL_036a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_036f: ldloc.0
+			IL_0370: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0375: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_037a: ldarg.0
+			IL_037b: ldc.i4.1
+			IL_037c: newarr [System.Runtime]System.Object
+			IL_0381: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0386: pop
+			IL_0387: ldloc.0
+			IL_0388: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_038d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0392: ret
 		} // end of method ArrowFunction_L10C2::__js_call__
 
 	} // end of class ArrowFunction_L10C2
@@ -927,7 +931,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x286f
+			// Method begins at RVA 0x287b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1022,7 +1026,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x288a
+		// Method begins at RVA 0x2896
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_AddObjectObject
+﻿// IL code: BinaryOperator_AddObjectObject
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20eb
+				// Method begins at RVA 0x20fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20cc
+			// Method begins at RVA 0x20dc
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -75,7 +75,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e2
+			// Method begins at RVA 0x20f2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,12 +101,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 112 (0x70)
+		// Code size: 126 (0x7e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_AddObjectObject/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_AddObjectObject/Scope::.ctor()
@@ -123,27 +124,33 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 1
-		IL_002d: box [System.Runtime]System.Double
-		IL_0032: ldc.r8 2
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
-		IL_0045: stloc.2
-		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004b: ldloc.2
-		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0051: pop
-		IL_0052: ldnull
-		IL_0053: ldstr "a:"
-		IL_0058: ldstr "b"
-		IL_005d: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
-		IL_0062: stloc.2
-		IL_0063: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0068: ldloc.2
-		IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006e: pop
-		IL_006f: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 1
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: ldc.r8 2
+		IL_0042: box [System.Runtime]System.Double
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_004c: stloc.2
+		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0052: ldloc.2
+		IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0058: pop
+		IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_005e: stloc.3
+		IL_005f: ldloc.1
+		IL_0060: ldloc.3
+		IL_0061: ldstr "a:"
+		IL_0066: ldstr "b"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0070: stloc.2
+		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0076: ldloc.2
+		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007c: pop
+		IL_007d: ret
 	} // end of method BinaryOperator_AddObjectObject::__js_module_init__
 
 } // end of class Modules.BinaryOperator_AddObjectObject
@@ -155,7 +162,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f4
+		// Method begins at RVA 0x2104
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2146
+				// Method begins at RVA 0x216a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20b0
+			// Method begins at RVA 0x20d4
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -108,7 +108,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213d
+			// Method begins at RVA 0x2161
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -134,12 +134,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 84 (0x54)
+		// Code size: 120 (0x78)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_EqualParameter/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_EqualParameter/Scope::.ctor()
@@ -156,19 +157,31 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 3
-		IL_002d: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
-		IL_0032: pop
-		IL_0033: ldnull
-		IL_0034: ldc.r8 5
-		IL_003d: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
-		IL_0042: pop
-		IL_0043: ldnull
-		IL_0044: ldc.r8 7
-		IL_004d: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
-		IL_0052: pop
-		IL_0053: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 3
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_003e: pop
+		IL_003f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0044: stloc.3
+		IL_0045: ldloc.1
+		IL_0046: ldloc.3
+		IL_0047: ldc.r8 5
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005a: pop
+		IL_005b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0060: stloc.3
+		IL_0061: ldloc.1
+		IL_0062: ldloc.3
+		IL_0063: ldc.r8 7
+		IL_006c: box [System.Runtime]System.Double
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0076: pop
+		IL_0077: ret
 	} // end of method BinaryOperator_EqualParameter::__js_module_init__
 
 } // end of class Modules.BinaryOperator_EqualParameter
@@ -180,7 +193,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214f
+		// Method begins at RVA 0x2173
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2124
+				// Method begins at RVA 0x2120
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -82,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211b
+			// Method begins at RVA 0x2117
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -108,7 +108,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 141 (0x8d)
+		// Code size: 140 (0x8c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope,
@@ -151,29 +151,28 @@
 		IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.s 4
-		IL_0056: brfalse IL_0070
+		IL_0056: brfalse IL_006f
 
-		IL_005b: ldloc.0
-		IL_005c: castclass Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope
-		IL_0061: ldnull
-		IL_0062: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
-		IL_0067: stloc.3
-		IL_0068: ldloc.3
-		IL_0069: stloc.s 6
-		IL_006b: br IL_0078
+		IL_005b: ldloc.1
+		IL_005c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0066: stloc.3
+		IL_0067: ldloc.3
+		IL_0068: stloc.s 6
+		IL_006a: br IL_0077
 
-		IL_0070: ldc.i4.0
-		IL_0071: box [System.Runtime]System.Boolean
-		IL_0076: stloc.s 6
+		IL_006f: ldc.i4.0
+		IL_0070: box [System.Runtime]System.Boolean
+		IL_0075: stloc.s 6
 
-		IL_0078: ldloc.s 6
-		IL_007a: stloc.2
-		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0080: ldloc.0
-		IL_0081: ldfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
-		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008b: pop
-		IL_008c: ret
+		IL_0077: ldloc.s 6
+		IL_0079: stloc.2
+		IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007f: ldloc.0
+		IL_0080: ldfld object Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope::x
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008a: pop
+		IL_008b: ret
 	} // end of method BinaryOperator_LogicalAnd_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalAnd_ShortCircuit
@@ -185,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212d
+		// Method begins at RVA 0x2129
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_LogicalOr_ArrayHasData
+﻿// IL code: BinaryOperator_LogicalOr_ArrayHasData
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218c
+					// Method begins at RVA 0x219c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2183
+				// Method begins at RVA 0x2193
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2108
+			// Method begins at RVA 0x2118
 			// Header size: 12
 			// Code size: 102 (0x66)
 			.maxstack 8
@@ -142,7 +142,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217a
+			// Method begins at RVA 0x218a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -168,13 +168,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 170 (0xaa)
+		// Code size: 187 (0xbb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ArrayHasData/Scope,
 			[1] object,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_LogicalOr_ArrayHasData/Scope::.ctor()
@@ -191,49 +191,54 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldnull
-		IL_0025: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
-		IL_002a: stloc.2
-		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0030: ldloc.2
-		IL_0031: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0036: pop
-		IL_0037: ldc.i4.0
-		IL_0038: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_003d: stloc.3
-		IL_003e: ldnull
-		IL_003f: ldloc.3
-		IL_0040: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
-		IL_0045: stloc.2
-		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004b: ldloc.2
-		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0051: pop
-		IL_0052: ldc.i4.3
-		IL_0053: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0058: dup
-		IL_0059: ldc.r8 1
-		IL_0062: box [System.Runtime]System.Double
-		IL_0067: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldnull
+		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0031: stloc.2
+		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0037: ldloc.2
+		IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_003d: pop
+		IL_003e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0043: stloc.3
+		IL_0044: ldloc.1
+		IL_0045: ldloc.3
+		IL_0046: ldc.i4.0
+		IL_0047: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0051: stloc.2
+		IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0057: ldloc.2
+		IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005d: pop
+		IL_005e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0063: stloc.3
+		IL_0064: ldloc.1
+		IL_0065: ldloc.3
+		IL_0066: ldc.i4.3
+		IL_0067: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 		IL_006c: dup
-		IL_006d: ldc.r8 2
+		IL_006d: ldc.r8 1
 		IL_0076: box [System.Runtime]System.Double
 		IL_007b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_0080: dup
-		IL_0081: ldc.r8 3
+		IL_0081: ldc.r8 2
 		IL_008a: box [System.Runtime]System.Double
 		IL_008f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0094: stloc.3
-		IL_0095: ldnull
-		IL_0096: ldloc.3
-		IL_0097: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
-		IL_009c: stloc.2
-		IL_009d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a2: ldloc.2
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: ret
+		IL_0094: dup
+		IL_0095: ldc.r8 3
+		IL_009e: box [System.Runtime]System.Double
+		IL_00a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00ad: stloc.2
+		IL_00ae: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b3: ldloc.2
+		IL_00b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b9: pop
+		IL_00ba: ret
 	} // end of method BinaryOperator_LogicalOr_ArrayHasData::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalOr_ArrayHasData
@@ -245,7 +250,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2195
+		// Method begins at RVA 0x21a5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2124
+				// Method begins at RVA 0x2120
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x20e8
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -82,7 +82,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211b
+			// Method begins at RVA 0x2117
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -108,7 +108,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 141 (0x8d)
+		// Code size: 140 (0x8c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope,
@@ -151,29 +151,28 @@
 		IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.s 4
-		IL_0056: brtrue IL_0070
+		IL_0056: brtrue IL_006f
 
-		IL_005b: ldloc.0
-		IL_005c: castclass Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope
-		IL_0061: ldnull
-		IL_0062: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
-		IL_0067: stloc.3
-		IL_0068: ldloc.3
-		IL_0069: stloc.s 6
-		IL_006b: br IL_0078
+		IL_005b: ldloc.1
+		IL_005c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0066: stloc.3
+		IL_0067: ldloc.3
+		IL_0068: stloc.s 6
+		IL_006a: br IL_0077
 
-		IL_0070: ldc.i4.1
-		IL_0071: box [System.Runtime]System.Boolean
-		IL_0076: stloc.s 6
+		IL_006f: ldc.i4.1
+		IL_0070: box [System.Runtime]System.Boolean
+		IL_0075: stloc.s 6
 
-		IL_0078: ldloc.s 6
-		IL_007a: stloc.2
-		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0080: ldloc.0
-		IL_0081: ldfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
-		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008b: pop
-		IL_008c: ret
+		IL_0077: ldloc.s 6
+		IL_0079: stloc.2
+		IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007f: ldloc.0
+		IL_0080: ldfld object Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope::x
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008a: pop
+		IL_008b: ret
 	} // end of method BinaryOperator_LogicalOr_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalOr_ShortCircuit
@@ -185,7 +184,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212d
+		// Method begins at RVA 0x2129
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20dd
+				// Method begins at RVA 0x20ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ca
+			// Method begins at RVA 0x20ec
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -71,7 +71,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20f6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -97,12 +97,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 110 (0x6e)
+		// Code size: 144 (0x90)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_MulObjectObject/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_MulObjectObject/Scope::.ctor()
@@ -119,25 +120,35 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 3
-		IL_002d: ldc.r8 4
-		IL_0036: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
-		IL_003b: stloc.2
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: ldloc.2
-		IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0047: pop
-		IL_0048: ldnull
-		IL_0049: ldc.r8 2.5
-		IL_0052: ldc.r8 4
-		IL_005b: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
-		IL_0060: stloc.2
-		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0066: ldloc.2
-		IL_0067: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006c: pop
-		IL_006d: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 3
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: ldc.r8 4
+		IL_0042: box [System.Runtime]System.Double
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_004c: stloc.2
+		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0052: ldloc.2
+		IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0058: pop
+		IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_005e: stloc.3
+		IL_005f: ldloc.1
+		IL_0060: ldloc.3
+		IL_0061: ldc.r8 2.5
+		IL_006a: box [System.Runtime]System.Double
+		IL_006f: ldc.r8 4
+		IL_0078: box [System.Runtime]System.Double
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0082: stloc.2
+		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0088: ldloc.2
+		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008e: pop
+		IL_008f: ret
 	} // end of method BinaryOperator_MulObjectObject::__js_module_init__
 
 } // end of class Modules.BinaryOperator_MulObjectObject
@@ -149,7 +160,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e6
+		// Method begins at RVA 0x2108
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
@@ -1,4 +1,4 @@
-// IL code: BinaryOperator_NumericRefinement_ExplicitNumberAssignment
+﻿// IL code: BinaryOperator_NumericRefinement_ExplicitNumberAssignment
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212c
+				// Method begins at RVA 0x2140
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20dc
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 59 (0x3b)
 			.maxstack 8
@@ -104,7 +104,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2123
+			// Method begins at RVA 0x2137
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -130,12 +130,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 126 (0x7e)
+		// Code size: 147 (0x93)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/Scope::.ctor()
@@ -152,33 +153,42 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 100
-		IL_002d: box [System.Runtime]System.Double
-		IL_0032: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
-		IL_0037: stloc.2
-		IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003d: ldloc.2
-		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0043: pop
-		IL_0044: ldnull
-		IL_0045: ldstr "100"
-		IL_004a: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
-		IL_004f: stloc.2
-		IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0055: ldloc.2
-		IL_0056: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005b: pop
-		IL_005c: ldnull
-		IL_005d: ldc.r8 0.0
-		IL_0066: box [System.Runtime]System.Double
-		IL_006b: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
-		IL_0070: stloc.2
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0076: ldloc.2
-		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007c: pop
-		IL_007d: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 100
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_003e: stloc.2
+		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0044: ldloc.2
+		IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004a: pop
+		IL_004b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0050: stloc.3
+		IL_0051: ldloc.1
+		IL_0052: ldloc.3
+		IL_0053: ldstr "100"
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005d: stloc.2
+		IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0063: ldloc.2
+		IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0069: pop
+		IL_006a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006f: stloc.3
+		IL_0070: ldloc.1
+		IL_0071: ldloc.3
+		IL_0072: ldc.r8 0.0
+		IL_007b: box [System.Runtime]System.Double
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0085: stloc.2
+		IL_0086: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008b: ldloc.2
+		IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0091: pop
+		IL_0092: ret
 	} // end of method BinaryOperator_NumericRefinement_ExplicitNumberAssignment::__js_module_init__
 
 } // end of class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment
@@ -190,7 +200,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2135
+		// Method begins at RVA 0x2149
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2115
+				// Method begins at RVA 0x2139
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20f8
 			// Header size: 12
 			// Code size: 44 (0x2c)
 			.maxstack 8
@@ -95,7 +95,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x210c
+			// Method begins at RVA 0x2130
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -121,12 +121,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 120 (0x78)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/Scope::.ctor()
@@ -143,31 +144,43 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 100
-		IL_002d: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
-		IL_0032: stloc.2
-		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0038: ldloc.2
-		IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_003e: pop
-		IL_003f: ldnull
-		IL_0040: ldc.r8 0.0
-		IL_0049: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
-		IL_004e: stloc.2
-		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0054: ldloc.2
-		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005a: pop
-		IL_005b: ldnull
-		IL_005c: ldc.r8 255
-		IL_0065: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
-		IL_006a: stloc.2
-		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0070: ldloc.2
-		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0076: pop
-		IL_0077: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 100
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_003e: stloc.2
+		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0044: ldloc.2
+		IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004a: pop
+		IL_004b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0050: stloc.3
+		IL_0051: ldloc.1
+		IL_0052: ldloc.3
+		IL_0053: ldc.r8 0.0
+		IL_005c: box [System.Runtime]System.Double
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0066: stloc.2
+		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006c: ldloc.2
+		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0072: pop
+		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0078: stloc.3
+		IL_0079: ldloc.1
+		IL_007a: ldloc.3
+		IL_007b: ldc.r8 255
+		IL_0084: box [System.Runtime]System.Double
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_008e: stloc.2
+		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0094: ldloc.2
+		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method BinaryOperator_NumericRefinement_ParameterReuseCSE::__js_module_init__
 
 } // end of class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE
@@ -179,7 +192,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x211e
+		// Method begins at RVA 0x2142
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2129
+				// Method begins at RVA 0x2128
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20f9
+			// Method begins at RVA 0x20f8
 			// Header size: 1
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x211f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,7 +105,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 157 (0x9d)
+		// Code size: 156 (0x9c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope,
@@ -147,36 +147,35 @@
 		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0053: stloc.s 4
 		IL_0055: ldloc.2
-		IL_0056: brfalse IL_0080
+		IL_0056: brfalse IL_007f
 
 		IL_005b: ldloc.2
 		IL_005c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0061: brtrue IL_0080
+		IL_0061: brtrue IL_007f
 
-		IL_0066: ldloc.0
-		IL_0067: castclass Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope
-		IL_006c: ldnull
-		IL_006d: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
-		IL_0072: stloc.3
-		IL_0073: ldloc.2
-		IL_0074: ldloc.3
-		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-		IL_007a: stloc.3
-		IL_007b: br IL_0082
+		IL_0066: ldloc.1
+		IL_0067: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0071: stloc.3
+		IL_0072: ldloc.2
+		IL_0073: ldloc.3
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+		IL_0079: stloc.3
+		IL_007a: br IL_0081
 
-		IL_0080: ldnull
-		IL_0081: stloc.3
+		IL_007f: ldnull
+		IL_0080: stloc.3
 
-		IL_0082: ldloc.s 4
-		IL_0084: ldloc.3
-		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008a: pop
-		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0090: ldloc.0
-		IL_0091: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
-		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009b: pop
-		IL_009c: ret
+		IL_0081: ldloc.s 4
+		IL_0083: ldloc.3
+		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0089: pop
+		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_008f: ldloc.0
+		IL_0090: ldfld object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope::called
+		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009a: pop
+		IL_009b: ret
 	} // end of method BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
@@ -188,7 +187,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2132
+		// Method begins at RVA 0x2131
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
@@ -302,12 +302,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 134 (0x86)
+		// Code size: 135 (0x87)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.BinaryOperator_StrictEqualCapturedVariable/Scope::.ctor()
@@ -332,36 +333,37 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldnull
-		IL_0034: ldftn object Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9::__js_call__(object, object)
-		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0053: ldc.i4.1
-		IL_0054: conv.r8
-		IL_0055: ldstr ""
-		IL_005a: ldc.i4.0
-		IL_005b: ldc.i4.1
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0066: stloc.2
-		IL_0067: ldloc.0
-		IL_0068: castclass Modules.BinaryOperator_StrictEqualCapturedVariable/Scope
-		IL_006d: ldnull
-		IL_006e: ldloc.2
-		IL_006f: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
-		IL_0074: pop
-		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007a: ldstr "done"
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldnull
+		IL_003a: ldftn object Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9::__js_call__(object, object)
+		IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0045: ldc.i4.1
+		IL_0046: newarr [System.Runtime]System.Object
+		IL_004b: dup
+		IL_004c: ldc.i4.0
+		IL_004d: ldloc.0
+		IL_004e: stelem.ref
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0059: ldc.i4.1
+		IL_005a: conv.r8
+		IL_005b: ldstr ""
+		IL_0060: ldc.i4.0
+		IL_0061: ldc.i4.1
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_006c: stloc.2
+		IL_006d: ldloc.1
+		IL_006e: ldloc.3
+		IL_006f: ldloc.2
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0075: pop
+		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007b: ldstr "done"
+		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0085: pop
+		IL_0086: ret
 	} // end of method BinaryOperator_StrictEqualCapturedVariable::__js_module_init__
 
 } // end of class Modules.BinaryOperator_StrictEqualCapturedVariable

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -244,7 +244,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 76 (0x4c)
+		// Code size: 75 (0x4b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope,
@@ -277,12 +277,11 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "Hello from global"
 		IL_0039: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope::GLOBAL_VALUE
-		IL_003e: ldloc.0
-		IL_003f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
-		IL_0044: ldnull
-		IL_0045: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
-		IL_004a: pop
-		IL_004b: ret
+		IL_003e: ldloc.1
+		IL_003f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0049: pop
+		IL_004a: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -234,7 +234,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 76 (0x4c)
+		// Code size: 75 (0x4b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope,
@@ -267,12 +267,11 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "Hello from global"
 		IL_0039: stfld string Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-		IL_003e: ldloc.0
-		IL_003f: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0044: ldnull
-		IL_0045: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_004a: pop
-		IL_004b: ret
+		IL_003e: ldloc.1
+		IL_003f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0049: pop
+		IL_004a: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x215e
+					// Method begins at RVA 0x215a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2167
+					// Method begins at RVA 0x2163
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x210c
+				// Method begins at RVA 0x2108
 				// Header size: 12
 				// Code size: 52 (0x34)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2155
+				// Method begins at RVA 0x2151
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -142,7 +142,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209c
 			// Header size: 12
 			// Code size: 96 (0x60)
 			.maxstack 8
@@ -207,7 +207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214c
+			// Method begins at RVA 0x2148
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -233,7 +233,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope,
@@ -263,12 +263,11 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
@@ -280,7 +279,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2170
+		// Method begins at RVA 0x216c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2146
+					// Method begins at RVA 0x2142
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x214f
+					// Method begins at RVA 0x214b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2100
+				// Method begins at RVA 0x20fc
 				// Header size: 12
 				// Code size: 40 (0x28)
 				.maxstack 8
@@ -111,7 +111,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x213d
+				// Method begins at RVA 0x2139
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -137,7 +137,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209c
 			// Header size: 12
 			// Code size: 83 (0x53)
 			.maxstack 8
@@ -197,7 +197,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x2130
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -223,7 +223,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope,
@@ -253,12 +253,11 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method Classes_ClassConstructor_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log
@@ -270,7 +269,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2158
+		// Method begins at RVA 0x2154
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -270,7 +270,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 76 (0x4c)
+		// Code size: 75 (0x4b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope,
@@ -303,12 +303,11 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "Hello from global"
 		IL_0039: stfld string Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope::GLOBAL_VALUE
-		IL_003e: ldloc.0
-		IL_003f: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0044: ldnull
-		IL_0045: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_004a: pop
-		IL_004b: ret
+		IL_003e: ldloc.1
+		IL_003f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0049: pop
+		IL_004a: ret
 	} // end of method Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217a
+					// Method begins at RVA 0x2176
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2183
+					// Method begins at RVA 0x217f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x212c
+				// Method begins at RVA 0x2128
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,7 +92,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2148
+				// Method begins at RVA 0x2144
 				// Header size: 1
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -127,7 +127,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2171
+				// Method begins at RVA 0x216d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209c
 			// Header size: 12
 			// Code size: 126 (0x7e)
 			.maxstack 8
@@ -232,7 +232,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2168
+			// Method begins at RVA 0x2164
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -258,7 +258,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope,
@@ -288,12 +288,11 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method Classes_ClassMethod_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariable_Log
@@ -305,7 +304,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218c
+		// Method begins at RVA 0x2188
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Classes_Inheritance_NestedClassExtendsGlobal
+﻿// IL code: Classes_Inheritance_NestedClassExtendsGlobal
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22d3
+					// Method begins at RVA 0x22db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22dc
+					// Method begins at RVA 0x22e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -63,7 +63,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x226b
+				// Method begins at RVA 0x2273
 				// Header size: 1
 				// Code size: 13 (0xd)
 				.maxstack 8
@@ -81,7 +81,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x227c
+				// Method begins at RVA 0x2284
 				// Header size: 12
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -113,7 +113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ca
+				// Method begins at RVA 0x22d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -136,7 +136,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2134
+			// Method begins at RVA 0x213c
 			// Header size: 12
 			// Code size: 291 (0x123)
 			.maxstack 8
@@ -269,7 +269,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22b8
+				// Method begins at RVA 0x22c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -289,7 +289,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22c1
+				// Method begins at RVA 0x22c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -310,7 +310,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2263
+			// Method begins at RVA 0x226b
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -326,7 +326,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22a4
+			// Method begins at RVA 0x22ac
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -352,7 +352,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22af
+			// Method begins at RVA 0x22b7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -378,7 +378,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 216 (0xd8)
+		// Code size: 221 (0xdd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope,
@@ -479,10 +479,11 @@
 		IL_00cd: stloc.3
 		IL_00ce: ldloc.3
 		IL_00cf: stloc.2
-		IL_00d0: ldnull
-		IL_00d1: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(object)
-		IL_00d6: pop
-		IL_00d7: ret
+		IL_00d0: ldloc.1
+		IL_00d1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00db: pop
+		IL_00dc: ret
 	} // end of method Classes_Inheritance_NestedClassExtendsGlobal::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_NestedClassExtendsGlobal
@@ -494,7 +495,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22e5
+		// Method begins at RVA 0x22ed
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x234c
+					// Method begins at RVA 0x2348
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2355
+					// Method begins at RVA 0x2351
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -68,7 +68,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22c0
+				// Method begins at RVA 0x22bc
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -92,7 +92,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x231c
+				// Method begins at RVA 0x2318
 				// Header size: 1
 				// Code size: 29 (0x1d)
 				.maxstack 8
@@ -121,7 +121,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x235e
+					// Method begins at RVA 0x235a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -141,7 +141,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2367
+					// Method begins at RVA 0x2363
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -167,7 +167,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x22dc
+				// Method begins at RVA 0x22d8
 				// Header size: 12
 				// Code size: 23 (0x17)
 				.maxstack 8
@@ -194,7 +194,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2300
+				// Method begins at RVA 0x22fc
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -229,7 +229,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2343
+				// Method begins at RVA 0x233f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -255,7 +255,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209c
 			// Header size: 12
 			// Code size: 531 (0x213)
 			.maxstack 8
@@ -510,7 +510,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x233a
+			// Method begins at RVA 0x2336
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -536,7 +536,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope,
@@ -566,12 +566,11 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method Classes_Inheritance_SuperCapturedScopeVar::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperCapturedScopeVar
@@ -583,7 +582,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2370
+		// Method begins at RVA 0x236c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
@@ -1,4 +1,4 @@
-// IL code: CoercionCSE_BoxedDoubleToNumber_NoCse
+﻿// IL code: CoercionCSE_BoxedDoubleToNumber_NoCse
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2158
+				// Method begins at RVA 0x216c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20fc
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -110,7 +110,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x214f
+			// Method begins at RVA 0x2163
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -136,13 +136,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 138 (0x8a)
+		// Code size: 157 (0x9d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/Scope,
 			[1] object,
 			[2] object,
-			[3] object
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/Scope::.ctor()
@@ -159,37 +159,44 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 5
-		IL_002d: box [System.Runtime]System.Double
-		IL_0032: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, object)
-		IL_0037: stloc.2
-		IL_0038: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003d: ldloc.2
-		IL_003e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0043: pop
-		IL_0044: ldnull
-		IL_0045: ldc.r8 3.14
-		IL_004e: box [System.Runtime]System.Double
-		IL_0053: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, object)
-		IL_0058: stloc.2
-		IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005e: ldloc.2
-		IL_005f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0064: pop
-		IL_0065: ldc.r8 2
-		IL_006e: neg
-		IL_006f: box [System.Runtime]System.Double
-		IL_0074: stloc.3
-		IL_0075: ldnull
-		IL_0076: ldloc.3
-		IL_0077: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, object)
-		IL_007c: stloc.2
-		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0082: ldloc.2
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0088: pop
-		IL_0089: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 5
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_003e: stloc.2
+		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0044: ldloc.2
+		IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004a: pop
+		IL_004b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0050: stloc.3
+		IL_0051: ldloc.1
+		IL_0052: ldloc.3
+		IL_0053: ldc.r8 3.14
+		IL_005c: box [System.Runtime]System.Double
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0066: stloc.2
+		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006c: ldloc.2
+		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0072: pop
+		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0078: stloc.3
+		IL_0079: ldloc.1
+		IL_007a: ldloc.3
+		IL_007b: ldc.r8 2
+		IL_0084: neg
+		IL_0085: box [System.Runtime]System.Double
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_008f: stloc.2
+		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0095: ldloc.2
+		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009b: pop
+		IL_009c: ret
 	} // end of method CoercionCSE_BoxedDoubleToNumber_NoCse::__js_module_init__
 
 } // end of class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse
@@ -201,7 +208,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2161
+		// Method begins at RVA 0x2175
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2273
+			// Method begins at RVA 0x2272
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -285,7 +285,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 275 (0x113)
+		// Code size: 274 (0x112)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Basic/Scope,
@@ -385,12 +385,11 @@
 		IL_00fa: ldstr "Log"
 		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_0104: pop
-		IL_0105: ldloc.0
-		IL_0106: castclass Modules.CommonJS_Require_Basic/Scope
-		IL_010b: ldnull
-		IL_010c: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
-		IL_0111: pop
-		IL_0112: ret
+		IL_0105: ldloc.1
+		IL_0106: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0110: pop
+		IL_0111: ret
 	} // end of method CommonJS_Require_Basic::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Basic
@@ -677,7 +676,7 @@
 	{
 		// Method begins at RVA 0x2170
 		// Header size: 12
-		// Code size: 247 (0xf7)
+		// Code size: 246 (0xf6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Dependency/Scope,
@@ -769,12 +768,11 @@
 		IL_00de: ldstr "Log"
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_00e8: pop
-		IL_00e9: ldloc.0
-		IL_00ea: castclass Modules.CommonJS_Require_Dependency/Scope
-		IL_00ef: ldnull
-		IL_00f0: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
-		IL_00f5: pop
-		IL_00f6: ret
+		IL_00e9: ldloc.1
+		IL_00ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00f4: pop
+		IL_00f5: ret
 	} // end of method CommonJS_Require_Dependency::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Dependency

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -110,7 +110,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2293
+			// Method begins at RVA 0x2292
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -347,7 +347,7 @@
 	{
 		// Method begins at RVA 0x208c
 		// Header size: 12
-		// Code size: 247 (0xf7)
+		// Code size: 246 (0xf6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.b/Scope,
@@ -439,12 +439,11 @@
 		IL_00de: ldstr "Log"
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_00e8: pop
-		IL_00e9: ldloc.0
-		IL_00ea: castclass Modules.b/Scope
-		IL_00ef: ldnull
-		IL_00f0: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
-		IL_00f5: pop
-		IL_00f6: ret
+		IL_00e9: ldloc.1
+		IL_00ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00f4: pop
+		IL_00f5: ret
 	} // end of method b::__js_module_init__
 
 } // end of class Modules.b
@@ -731,7 +730,7 @@
 	{
 		// Method begins at RVA 0x2190
 		// Header size: 12
-		// Code size: 247 (0xf7)
+		// Code size: 246 (0xf6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.helpers_b/Scope,
@@ -823,12 +822,11 @@
 		IL_00de: ldstr "Log"
 		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_00e8: pop
-		IL_00e9: ldloc.0
-		IL_00ea: castclass Modules.helpers_b/Scope
-		IL_00ef: ldnull
-		IL_00f0: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
-		IL_00f5: pop
-		IL_00f6: ret
+		IL_00e9: ldloc.1
+		IL_00ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00f4: pop
+		IL_00f5: ret
 	} // end of method helpers_b::__js_module_init__
 
 } // end of class Modules.helpers_b

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21a7
+						// Method begins at RVA 0x21a3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x219e
+					// Method begins at RVA 0x219a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b0
+					// Method begins at RVA 0x21ac
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2195
+				// Method begins at RVA 0x2191
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20f0
+			// Method begins at RVA 0x20ec
 			// Header size: 12
 			// Code size: 127 (0x7f)
 			.maxstack 8
@@ -202,7 +202,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x218c
+			// Method begins at RVA 0x2188
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -228,7 +228,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 89 (0x59)
+		// Code size: 88 (0x58)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope,
@@ -262,16 +262,15 @@
 		IL_003c: stloc.2
 		IL_003d: ldloc.2
 		IL_003e: stloc.1
-		IL_003f: ldloc.0
-		IL_0040: castclass Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope
-		IL_0045: ldnull
-		IL_0046: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
-		IL_004b: stloc.2
-		IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0051: ldloc.2
-		IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0057: pop
-		IL_0058: ret
+		IL_003f: ldloc.1
+		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004a: stloc.2
+		IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0050: ldloc.2
+		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0056: pop
+		IL_0057: ret
 	} // end of method CommonJS_Require_OptionalChain_InNestedFunction::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_OptionalChain_InNestedFunction
@@ -287,7 +286,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21b9
+			// Method begins at RVA 0x21b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -311,7 +310,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20b8
+		// Method begins at RVA 0x20b4
 		// Header size: 12
 		// Code size: 43 (0x2b)
 		.maxstack 8
@@ -346,7 +345,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c2
+		// Method begins at RVA 0x21be
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
@@ -1,4 +1,4 @@
-// IL code: CommonJS_Require_Shadowed_Parameter
+﻿// IL code: CommonJS_Require_Shadowed_Parameter
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x210f
+				// Method begins at RVA 0x2117
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20c8
+			// Method begins at RVA 0x20d0
 			// Header size: 12
 			// Code size: 21 (0x15)
 			.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2118
+				// Method begins at RVA 0x2120
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,7 +106,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x20f4
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -138,7 +138,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2106
+			// Method begins at RVA 0x210e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -164,12 +164,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 108 (0x6c)
+		// Code size: 115 (0x73)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Shadowed_Parameter/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Require_Shadowed_Parameter/Scope::.ctor()
@@ -186,34 +187,37 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldftn object Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18::__js_call__(object, object)
-		IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_002f: ldc.i4.1
-		IL_0030: newarr [System.Runtime]System.Object
-		IL_0035: dup
-		IL_0036: ldc.i4.0
-		IL_0037: ldloc.0
-		IL_0038: stelem.ref
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0043: ldc.i4.1
-		IL_0044: conv.r8
-		IL_0045: ldstr ""
-		IL_004a: ldc.i4.0
-		IL_004b: ldc.i4.1
-		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0056: stloc.2
-		IL_0057: ldnull
-		IL_0058: ldloc.2
-		IL_0059: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
-		IL_005e: stloc.2
-		IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0064: ldloc.2
-		IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006a: pop
-		IL_006b: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldnull
+		IL_002a: ldftn object Modules.CommonJS_Require_Shadowed_Parameter/ArrowFunction_L7C18::__js_call__(object, object)
+		IL_0030: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0035: ldc.i4.1
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.0
+		IL_003e: stelem.ref
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0049: ldc.i4.1
+		IL_004a: conv.r8
+		IL_004b: ldstr ""
+		IL_0050: ldc.i4.0
+		IL_0051: ldc.i4.1
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_005c: stloc.2
+		IL_005d: ldloc.1
+		IL_005e: ldloc.3
+		IL_005f: ldloc.2
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0065: stloc.2
+		IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006b: ldloc.2
+		IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0071: pop
+		IL_0072: ret
 	} // end of method CommonJS_Require_Shadowed_Parameter::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Shadowed_Parameter
@@ -225,7 +229,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2121
+		// Method begins at RVA 0x2129
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
@@ -108,7 +108,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 172 (0xac)
+		// Code size: 170 (0xaa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope,
@@ -150,37 +150,35 @@
 		IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 		IL_005c: stloc.s 5
 		IL_005e: ldloc.s 5
-		IL_0060: brfalse IL_007b
+		IL_0060: brfalse IL_007a
 
-		IL_0065: ldloc.0
-		IL_0066: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
-		IL_006b: ldnull
-		IL_006c: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
-		IL_0071: stloc.s 4
-		IL_0073: ldloc.s 4
-		IL_0075: stloc.2
-		IL_0076: br IL_008c
+		IL_0065: ldloc.1
+		IL_0066: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.s 4
+		IL_0074: stloc.2
+		IL_0075: br IL_008a
 
-		IL_007b: ldloc.0
-		IL_007c: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
-		IL_0081: ldnull
-		IL_0082: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
-		IL_0087: stloc.s 4
-		IL_0089: ldloc.s 4
-		IL_008b: stloc.2
+		IL_007a: ldloc.1
+		IL_007b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0085: stloc.s 4
+		IL_0087: ldloc.s 4
+		IL_0089: stloc.2
 
-		IL_008c: ldloc.2
-		IL_008d: stloc.3
-		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0093: ldloc.3
-		IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0099: pop
-		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009f: ldloc.0
-		IL_00a0: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
-		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00aa: pop
-		IL_00ab: ret
+		IL_008a: ldloc.2
+		IL_008b: stloc.3
+		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0091: ldloc.3
+		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0097: pop
+		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009d: ldloc.0
+		IL_009e: ldfld object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope::x
+		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a8: pop
+		IL_00a9: ret
 	} // end of method ControlFlow_Conditional_Ternary_ShortCircuit::__js_module_init__
 
 } // end of class Modules.ControlFlow_Conditional_Ternary_ShortCircuit

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
@@ -391,12 +391,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 93 (0x5d)
+		// Code size: 94 (0x5e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_ClosureCallback/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/Scope::.ctor()
@@ -421,23 +422,24 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldnull
-		IL_0034: ldftn object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
-		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_003f: ldc.i4.1
-		IL_0040: conv.r8
-		IL_0041: ldstr ""
-		IL_0046: ldc.i4.0
-		IL_0047: ldc.i4.1
-		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_004d: stloc.2
-		IL_004e: ldloc.0
-		IL_004f: castclass Modules.ControlFlow_ForOf_ClosureCallback/Scope
-		IL_0054: ldnull
-		IL_0055: ldloc.2
-		IL_0056: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
-		IL_005b: pop
-		IL_005c: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldnull
+		IL_003a: ldftn object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
+		IL_0040: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0045: ldc.i4.1
+		IL_0046: conv.r8
+		IL_0047: ldstr ""
+		IL_004c: ldc.i4.0
+		IL_004d: ldc.i4.1
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0053: stloc.2
+		IL_0054: ldloc.1
+		IL_0055: ldloc.3
+		IL_0056: ldloc.2
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005c: pop
+		IL_005d: ret
 	} // end of method ControlFlow_ForOf_ClosureCallback::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_ClosureCallback

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21bf
+					// Method begins at RVA 0x21bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2124
+				// Method begins at RVA 0x2120
 				// Header size: 12
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -83,7 +83,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x21d1
+						// Method begins at RVA 0x21cd
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -104,7 +104,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c8
+					// Method begins at RVA 0x21c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -128,7 +128,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2144
+				// Method begins at RVA 0x2140
 				// Header size: 12
 				// Code size: 93 (0x5d)
 				.maxstack 8
@@ -196,7 +196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b6
+				// Method begins at RVA 0x21b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -222,7 +222,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20b0
 			// Header size: 12
 			// Code size: 100 (0x64)
 			.maxstack 8
@@ -292,7 +292,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ad
+			// Method begins at RVA 0x21a9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -318,7 +318,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 85 (0x55)
+		// Code size: 84 (0x54)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope,
@@ -349,20 +349,19 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
-		IL_003f: stloc.2
-		IL_0040: ldc.i4.0
-		IL_0041: newarr [System.Runtime]System.Object
-		IL_0046: stloc.3
-		IL_0047: ldloc.2
-		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004d: ldloc.3
-		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0053: pop
-		IL_0054: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.2
+		IL_003f: ldc.i4.0
+		IL_0040: newarr [System.Runtime]System.Object
+		IL_0045: stloc.3
+		IL_0046: ldloc.2
+		IL_0047: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004c: ldloc.3
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0052: pop
+		IL_0053: ret
 	} // end of method ControlFlow_LabeledStatement_CapturesParentVar::__js_module_init__
 
 } // end of class Modules.ControlFlow_LabeledStatement_CapturesParentVar
@@ -374,7 +373,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21da
+		// Method begins at RVA 0x21d6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23cf
+				// Method begins at RVA 0x23bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23e1
+					// Method begins at RVA 0x23d1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -140,7 +140,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2330
+				// Method begins at RVA 0x2320
 				// Header size: 12
 				// Code size: 74 (0x4a)
 				.maxstack 8
@@ -185,7 +185,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d8
+				// Method begins at RVA 0x23c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -302,7 +302,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23f3
+					// Method begins at RVA 0x23e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -325,7 +325,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2388
+				// Method begins at RVA 0x2378
 				// Header size: 12
 				// Code size: 50 (0x32)
 				.maxstack 8
@@ -369,7 +369,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23ea
+				// Method begins at RVA 0x23da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -394,12 +394,13 @@
 			)
 			// Method begins at RVA 0x22c4
 			// Header size: 12
-			// Code size: 95 (0x5f)
+			// Code size: 79 (0x4f)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_Basics/g/Scope,
 				[1] object,
-				[2] object
+				[2] object,
+				[3] object[]
 			)
 
 			IL_0000: newobj instance void Modules.Function_Arguments_Basics/g/Scope::.ctor()
@@ -416,25 +417,18 @@
 			IL_0020: stloc.2
 			IL_0021: ldloc.2
 			IL_0022: stloc.1
-			IL_0023: ldnull
-			IL_0024: ldftn object Modules.Function_Arguments_Basics/g/inner::__js_call__(object)
-			IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_002f: ldc.i4.2
-			IL_0030: newarr [System.Runtime]System.Object
-			IL_0035: dup
-			IL_0036: ldc.i4.0
-			IL_0037: ldc.r8 1
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: stelem.ref
-			IL_0046: dup
-			IL_0047: ldc.i4.1
-			IL_0048: ldc.r8 2
-			IL_0051: box [System.Runtime]System.Double
-			IL_0056: stelem.ref
-			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-			IL_005c: pop
-			IL_005d: ldnull
-			IL_005e: ret
+			IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0028: stloc.3
+			IL_0029: ldloc.1
+			IL_002a: ldloc.3
+			IL_002b: ldc.r8 1
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: ldc.r8 2
+			IL_0042: box [System.Runtime]System.Double
+			IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_004c: pop
+			IL_004d: ldnull
+			IL_004e: ret
 		} // end of method g::__js_call__
 
 	} // end of class g
@@ -456,7 +450,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23c6
+			// Method begins at RVA 0x23b6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -482,14 +476,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 319 (0x13f)
+		// Code size: 320 (0x140)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Basics/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Arguments_Basics/Scope::.ctor()
@@ -538,67 +533,51 @@
 		IL_006e: stloc.s 4
 		IL_0070: ldloc.s 4
 		IL_0072: stloc.3
-		IL_0073: ldnull
-		IL_0074: ldftn object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
-		IL_007a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_007f: ldc.i4.3
-		IL_0080: newarr [System.Runtime]System.Object
-		IL_0085: dup
-		IL_0086: ldc.i4.0
-		IL_0087: ldc.r8 1
-		IL_0090: box [System.Runtime]System.Double
-		IL_0095: stelem.ref
-		IL_0096: dup
-		IL_0097: ldc.i4.1
-		IL_0098: ldc.r8 2
-		IL_00a1: box [System.Runtime]System.Double
-		IL_00a6: stelem.ref
-		IL_00a7: dup
-		IL_00a8: ldc.i4.2
-		IL_00a9: ldc.r8 3
-		IL_00b2: box [System.Runtime]System.Double
-		IL_00b7: stelem.ref
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_00bd: pop
-		IL_00be: ldnull
-		IL_00bf: ldftn object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
-		IL_00c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00ca: ldc.i4.1
-		IL_00cb: newarr [System.Runtime]System.Object
-		IL_00d0: dup
-		IL_00d1: ldc.i4.0
-		IL_00d2: ldc.r8 1
-		IL_00db: box [System.Runtime]System.Double
-		IL_00e0: stelem.ref
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_00e6: pop
-		IL_00e7: ldloc.0
-		IL_00e8: castclass Modules.Function_Arguments_Basics/Scope
-		IL_00ed: ldftn object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
-		IL_00f3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00f8: ldc.i4.3
-		IL_00f9: newarr [System.Runtime]System.Object
-		IL_00fe: dup
-		IL_00ff: ldc.i4.0
-		IL_0100: ldc.r8 7
-		IL_0109: box [System.Runtime]System.Double
-		IL_010e: stelem.ref
-		IL_010f: dup
-		IL_0110: ldc.i4.1
-		IL_0111: ldc.r8 8
-		IL_011a: box [System.Runtime]System.Double
-		IL_011f: stelem.ref
-		IL_0120: dup
-		IL_0121: ldc.i4.2
-		IL_0122: ldc.r8 9
-		IL_012b: box [System.Runtime]System.Double
-		IL_0130: stelem.ref
-		IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_0136: pop
-		IL_0137: ldnull
-		IL_0138: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
-		IL_013d: pop
-		IL_013e: ret
+		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0078: stloc.s 5
+		IL_007a: ldloc.1
+		IL_007b: ldloc.s 5
+		IL_007d: ldc.r8 1
+		IL_0086: box [System.Runtime]System.Double
+		IL_008b: ldc.r8 2
+		IL_0094: box [System.Runtime]System.Double
+		IL_0099: ldc.r8 3
+		IL_00a2: box [System.Runtime]System.Double
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_00ac: pop
+		IL_00ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b2: stloc.s 5
+		IL_00b4: ldloc.1
+		IL_00b5: ldloc.s 5
+		IL_00b7: ldc.r8 1
+		IL_00c0: box [System.Runtime]System.Double
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00ca: pop
+		IL_00cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00d0: stloc.s 5
+		IL_00d2: ldloc.2
+		IL_00d3: ldloc.s 5
+		IL_00d5: ldc.r8 7
+		IL_00de: box [System.Runtime]System.Double
+		IL_00e3: ldc.r8 8
+		IL_00ec: box [System.Runtime]System.Double
+		IL_00f1: ldc.r8 9
+		IL_00fa: box [System.Runtime]System.Double
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_0104: pop
+		IL_0105: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_010a: stloc.s 5
+		IL_010c: ldloc.3
+		IL_010d: ldloc.s 5
+		IL_010f: ldc.r8 1
+		IL_0118: box [System.Runtime]System.Double
+		IL_011d: ldc.r8 2
+		IL_0126: box [System.Runtime]System.Double
+		IL_012b: ldc.r8 3
+		IL_0134: box [System.Runtime]System.Double
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_013e: pop
+		IL_013f: ret
 	} // end of method Function_Arguments_Basics::__js_module_init__
 
 } // end of class Modules.Function_Arguments_Basics
@@ -610,7 +589,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23fc
+		// Method begins at RVA 0x23ec
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_Arguments_ComputedKey_TriggersBinding
+﻿// IL code: Function_Arguments_ComputedKey_TriggersBinding
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2141
+				// Method begins at RVA 0x212d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20cc
+			// Method begins at RVA 0x20b8
 			// Header size: 12
 			// Code size: 96 (0x60)
 			.maxstack 8
@@ -108,7 +108,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2138
+			// Method begins at RVA 0x2124
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -134,12 +134,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 111 (0x6f)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_ComputedKey_TriggersBinding/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Arguments_ComputedKey_TriggersBinding/Scope::.ctor()
@@ -156,29 +157,19 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldftn object Modules.Function_Arguments_ComputedKey_TriggersBinding/f::__js_call__(object)
-		IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_002f: ldc.i4.3
-		IL_0030: newarr [System.Runtime]System.Object
-		IL_0035: dup
-		IL_0036: ldc.i4.0
-		IL_0037: ldc.r8 1
-		IL_0040: box [System.Runtime]System.Double
-		IL_0045: stelem.ref
-		IL_0046: dup
-		IL_0047: ldc.i4.1
-		IL_0048: ldc.r8 2
-		IL_0051: box [System.Runtime]System.Double
-		IL_0056: stelem.ref
-		IL_0057: dup
-		IL_0058: ldc.i4.2
-		IL_0059: ldc.r8 3
-		IL_0062: box [System.Runtime]System.Double
-		IL_0067: stelem.ref
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_006d: pop
-		IL_006e: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 1
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: ldc.r8 2
+		IL_0042: box [System.Runtime]System.Double
+		IL_0047: ldc.r8 3
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method Function_Arguments_ComputedKey_TriggersBinding::__js_module_init__
 
 } // end of class Modules.Function_Arguments_ComputedKey_TriggersBinding
@@ -190,7 +181,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x214a
+		// Method begins at RVA 0x2136
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20e7
+				// Method begins at RVA 0x20e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209c
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -83,7 +83,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20de
+			// Method begins at RVA 0x20da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -109,7 +109,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope,
@@ -139,12 +139,11 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method Function_Arguments_NoFalsePositive_ObjectLiteralKey::__js_module_init__
 
 } // end of class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey
@@ -156,7 +155,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f0
+		// Method begins at RVA 0x20ec
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21a7
+				// Method begins at RVA 0x2197
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21b9
+					// Method begins at RVA 0x21a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b0
+				// Method begins at RVA 0x21a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x2100
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x219e
+			// Method begins at RVA 0x218e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,15 +192,16 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 179 (0xb3)
+		// Code size: 162 (0xa2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Basic/Scope,
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] object[]
+			[4] object[],
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[6] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_Basic/Scope::.ctor()
@@ -240,29 +241,23 @@
 		IL_006b: box [System.Runtime]System.Double
 		IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_0075: stloc.2
-		IL_0076: ldc.i4.0
-		IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_007c: stloc.s 4
-		IL_007e: ldloc.s 4
-		IL_0080: ldloc.2
-		IL_0081: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0086: ldloc.s 4
-		IL_0088: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_008d: stloc.s 5
-		IL_008f: ldloc.0
-		IL_0090: castclass Modules.Function_Call_Spread_Basic/Scope
-		IL_0095: ldftn object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
-		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00a0: ldc.i4.1
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldloc.0
-		IL_00a9: stelem.ref
-		IL_00aa: ldloc.s 5
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00b1: pop
-		IL_00b2: ret
+		IL_0076: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_007b: stloc.s 4
+		IL_007d: ldc.i4.0
+		IL_007e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0083: stloc.s 5
+		IL_0085: ldloc.s 5
+		IL_0087: ldloc.2
+		IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_008d: ldloc.s 5
+		IL_008f: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_0094: stloc.s 6
+		IL_0096: ldloc.1
+		IL_0097: ldloc.s 4
+		IL_0099: ldloc.s 6
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_00a0: pop
+		IL_00a1: ret
 	} // end of method Function_Call_Spread_Basic::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Basic
@@ -274,7 +269,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c2
+		// Method begins at RVA 0x21b2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x224c
+				// Method begins at RVA 0x225c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x225e
+					// Method begins at RVA 0x226e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2255
+				// Method begins at RVA 0x2265
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2148
+			// Method begins at RVA 0x2158
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -163,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2267
+				// Method begins at RVA 0x2277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -187,7 +187,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21e8
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -221,7 +221,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2270
+				// Method begins at RVA 0x2280
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -244,7 +244,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2203
+			// Method begins at RVA 0x2213
 			// Header size: 1
 			// Code size: 63 (0x3f)
 			.maxstack 8
@@ -286,7 +286,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2243
+			// Method begins at RVA 0x2253
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -312,7 +312,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 236 (0xec)
+		// Code size: 252 (0xfc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_EvaluationOrder/Scope,
@@ -320,9 +320,9 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] object[]
+			[5] object[],
+			[6] object[],
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/Scope::.ctor()
@@ -371,46 +371,49 @@
 		IL_006e: stloc.s 4
 		IL_0070: ldloc.s 4
 		IL_0072: stloc.3
-		IL_0073: ldnull
-		IL_0074: ldc.r8 1
-		IL_007d: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
-		IL_0082: stloc.s 4
-		IL_0084: ldc.i4.1
-		IL_0085: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_008a: dup
-		IL_008b: ldloc.s 4
-		IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0092: stloc.s 5
-		IL_0094: ldnull
-		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
-		IL_009a: stloc.s 6
-		IL_009c: ldloc.s 5
-		IL_009e: ldloc.s 6
-		IL_00a0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_00a5: ldnull
-		IL_00a6: ldc.r8 4
-		IL_00af: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
+		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0078: stloc.s 5
+		IL_007a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_007f: stloc.s 6
+		IL_0081: ldloc.2
+		IL_0082: ldloc.s 6
+		IL_0084: ldc.r8 1
+		IL_008d: box [System.Runtime]System.Double
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0097: stloc.s 4
+		IL_0099: ldc.i4.1
+		IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_009f: dup
+		IL_00a0: ldloc.s 4
+		IL_00a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_00a7: stloc.s 7
+		IL_00a9: ldloc.3
+		IL_00aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 		IL_00b4: stloc.s 4
-		IL_00b6: ldloc.s 5
+		IL_00b6: ldloc.s 7
 		IL_00b8: ldloc.s 4
-		IL_00ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_00bf: ldloc.s 5
-		IL_00c1: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_00c6: stloc.s 7
-		IL_00c8: ldloc.0
-		IL_00c9: castclass Modules.Function_Call_Spread_EvaluationOrder/Scope
-		IL_00ce: ldftn object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
-		IL_00d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00d9: ldc.i4.1
-		IL_00da: newarr [System.Runtime]System.Object
-		IL_00df: dup
-		IL_00e0: ldc.i4.0
-		IL_00e1: ldloc.0
-		IL_00e2: stelem.ref
-		IL_00e3: ldloc.s 7
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00ea: pop
-		IL_00eb: ret
+		IL_00ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_00bf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00c4: stloc.s 6
+		IL_00c6: ldloc.2
+		IL_00c7: ldloc.s 6
+		IL_00c9: ldc.r8 4
+		IL_00d2: box [System.Runtime]System.Double
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00dc: stloc.s 4
+		IL_00de: ldloc.s 7
+		IL_00e0: ldloc.s 4
+		IL_00e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_00e7: ldloc.s 7
+		IL_00e9: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_00ee: stloc.s 6
+		IL_00f0: ldloc.1
+		IL_00f1: ldloc.s 5
+		IL_00f3: ldloc.s 6
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_00fa: pop
+		IL_00fb: ret
 	} // end of method Function_Call_Spread_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_EvaluationOrder
@@ -422,7 +425,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2279
+		// Method begins at RVA 0x2289
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x21a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c9
+					// Method begins at RVA 0x21b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c0
+				// Method begins at RVA 0x21b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2120
+			// Method begins at RVA 0x2110
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ae
+			// Method begins at RVA 0x219e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,14 +192,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 194 (0xc2)
+		// Code size: 179 (0xb3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Middle/Scope,
 			[1] object,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] object[]
+			[3] object[],
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_Middle/Scope::.ctor()
@@ -224,46 +225,40 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0039: dup
-		IL_003a: ldc.r8 0.0
-		IL_0043: box [System.Runtime]System.Double
-		IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_004d: stloc.3
-		IL_004e: ldloc.3
-		IL_004f: ldc.i4.2
-		IL_0050: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0055: dup
-		IL_0056: ldc.r8 1
-		IL_005f: box [System.Runtime]System.Double
-		IL_0064: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0069: dup
-		IL_006a: ldc.r8 2
-		IL_0073: box [System.Runtime]System.Double
-		IL_0078: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_007d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0082: ldloc.3
-		IL_0083: ldc.r8 3
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0096: ldloc.3
-		IL_0097: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_009c: stloc.s 4
-		IL_009e: ldloc.0
-		IL_009f: castclass Modules.Function_Call_Spread_Middle/Scope
-		IL_00a4: ldftn object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
-		IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00af: ldc.i4.1
-		IL_00b0: newarr [System.Runtime]System.Object
-		IL_00b5: dup
-		IL_00b6: ldc.i4.0
-		IL_00b7: ldloc.0
-		IL_00b8: stelem.ref
-		IL_00b9: ldloc.s 4
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00c0: pop
-		IL_00c1: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldc.i4.1
+		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_003f: dup
+		IL_0040: ldc.r8 0.0
+		IL_0049: box [System.Runtime]System.Double
+		IL_004e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0053: stloc.s 4
+		IL_0055: ldloc.s 4
+		IL_0057: ldc.i4.2
+		IL_0058: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_005d: dup
+		IL_005e: ldc.r8 1
+		IL_0067: box [System.Runtime]System.Double
+		IL_006c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0071: dup
+		IL_0072: ldc.r8 2
+		IL_007b: box [System.Runtime]System.Double
+		IL_0080: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0085: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_008a: ldloc.s 4
+		IL_008c: ldc.r8 3
+		IL_0095: box [System.Runtime]System.Double
+		IL_009a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_009f: ldloc.s 4
+		IL_00a1: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_00a6: stloc.s 5
+		IL_00a8: ldloc.1
+		IL_00a9: ldloc.3
+		IL_00aa: ldloc.s 5
+		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_00b1: pop
+		IL_00b2: ret
 	} // end of method Function_Call_Spread_Middle::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Middle
@@ -275,7 +270,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d2
+		// Method begins at RVA 0x21c2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c3
+				// Method begins at RVA 0x21b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d5
+					// Method begins at RVA 0x21c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cc
+				// Method begins at RVA 0x21bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x212c
+			// Method begins at RVA 0x211c
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ba
+			// Method begins at RVA 0x21aa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,14 +192,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 206 (0xce)
+		// Code size: 192 (0xc0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Multiple/Scope,
 			[1] object,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] object[]
+			[3] object[],
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_Multiple/Scope::.ctor()
@@ -224,50 +225,44 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.0
-		IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0039: stloc.3
-		IL_003a: ldloc.3
-		IL_003b: ldc.i4.1
-		IL_003c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0041: dup
-		IL_0042: ldc.r8 1
-		IL_004b: box [System.Runtime]System.Double
-		IL_0050: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_005a: ldloc.3
-		IL_005b: ldc.i4.2
-		IL_005c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0061: dup
-		IL_0062: ldc.r8 2
-		IL_006b: box [System.Runtime]System.Double
-		IL_0070: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0075: dup
-		IL_0076: ldc.r8 3
-		IL_007f: box [System.Runtime]System.Double
-		IL_0084: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_0089: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_008e: ldloc.3
-		IL_008f: ldc.r8 4
-		IL_0098: box [System.Runtime]System.Double
-		IL_009d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_00a2: ldloc.3
-		IL_00a3: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_00a8: stloc.s 4
-		IL_00aa: ldloc.0
-		IL_00ab: castclass Modules.Function_Call_Spread_Multiple/Scope
-		IL_00b0: ldftn object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
-		IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00bb: ldc.i4.1
-		IL_00bc: newarr [System.Runtime]System.Object
-		IL_00c1: dup
-		IL_00c2: ldc.i4.0
-		IL_00c3: ldloc.0
-		IL_00c4: stelem.ref
-		IL_00c5: ldloc.s 4
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_00cc: pop
-		IL_00cd: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldc.i4.0
+		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_003f: stloc.s 4
+		IL_0041: ldloc.s 4
+		IL_0043: ldc.i4.1
+		IL_0044: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0049: dup
+		IL_004a: ldc.r8 1
+		IL_0053: box [System.Runtime]System.Double
+		IL_0058: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_005d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_0062: ldloc.s 4
+		IL_0064: ldc.i4.2
+		IL_0065: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_006a: dup
+		IL_006b: ldc.r8 2
+		IL_0074: box [System.Runtime]System.Double
+		IL_0079: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_007e: dup
+		IL_007f: ldc.r8 3
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0092: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_0097: ldloc.s 4
+		IL_0099: ldc.r8 4
+		IL_00a2: box [System.Runtime]System.Double
+		IL_00a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_00ac: ldloc.s 4
+		IL_00ae: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_00b3: stloc.s 5
+		IL_00b5: ldloc.1
+		IL_00b6: ldloc.3
+		IL_00b7: ldloc.s 5
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_00be: pop
+		IL_00bf: ret
 	} // end of method Function_Call_Spread_Multiple::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Multiple
@@ -279,7 +274,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21de
+		// Method begins at RVA 0x21ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
@@ -25,7 +25,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2167
+				// Method begins at RVA 0x2157
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -49,7 +49,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2179
+					// Method begins at RVA 0x2169
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2170
+				// Method begins at RVA 0x2160
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20d0
+			// Method begins at RVA 0x20c0
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -166,7 +166,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215e
+			// Method begins at RVA 0x214e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -192,14 +192,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 113 (0x71)
+		// Code size: 97 (0x61)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_StringIterable/Scope,
 			[1] object,
 			[2] object,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] object[]
+			[3] object[],
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_Call_Spread_StringIterable/Scope::.ctor()
@@ -224,29 +225,23 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.0
-		IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0039: stloc.3
-		IL_003a: ldloc.3
-		IL_003b: ldstr "ab"
-		IL_0040: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
-		IL_0045: ldloc.3
-		IL_0046: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
-		IL_004b: stloc.s 4
-		IL_004d: ldloc.0
-		IL_004e: castclass Modules.Function_Call_Spread_StringIterable/Scope
-		IL_0053: ldftn object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
-		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_005e: ldc.i4.1
-		IL_005f: newarr [System.Runtime]System.Object
-		IL_0064: dup
-		IL_0065: ldc.i4.0
-		IL_0066: ldloc.0
-		IL_0067: stelem.ref
-		IL_0068: ldloc.s 4
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-		IL_006f: pop
-		IL_0070: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldc.i4.0
+		IL_003a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_003f: stloc.s 4
+		IL_0041: ldloc.s 4
+		IL_0043: ldstr "ab"
+		IL_0048: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::PushRange(object)
+		IL_004d: ldloc.s 4
+		IL_004f: callvirt instance object[] [JavaScriptRuntime]JavaScriptRuntime.Array::ToArray()
+		IL_0054: stloc.s 5
+		IL_0056: ldloc.1
+		IL_0057: ldloc.3
+		IL_0058: ldloc.s 5
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_005f: pop
+		IL_0060: ret
 	} // end of method Function_Call_Spread_StringIterable::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_StringIterable
@@ -258,7 +253,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2182
+		// Method begins at RVA 0x2172
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20ce
+				// Method begins at RVA 0x20cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20bd
+			// Method begins at RVA 0x20bc
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -73,7 +73,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20c5
+			// Method begins at RVA 0x20c4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -99,7 +99,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Capture_HasScopesParameter/Scope,
@@ -133,16 +133,15 @@
 		IL_0034: ldc.r8 42
 		IL_003d: box [System.Runtime]System.Double
 		IL_0042: stfld object Modules.Function_Capture_HasScopesParameter/Scope::outerValue
-		IL_0047: ldloc.0
-		IL_0048: castclass Modules.Function_Capture_HasScopesParameter/Scope
-		IL_004d: ldnull
-		IL_004e: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
-		IL_0053: stloc.2
-		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0059: ldloc.2
-		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0047: ldloc.1
+		IL_0048: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0052: stloc.2
+		IL_0053: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0058: ldloc.2
+		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method Function_Capture_HasScopesParameter::__js_module_init__
 
 } // end of class Modules.Function_Capture_HasScopesParameter
@@ -154,7 +153,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20d7
+		// Method begins at RVA 0x20d6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d5
+					// Method begins at RVA 0x21dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2194
+				// Method begins at RVA 0x219c
 				// Header size: 12
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cc
+				// Method begins at RVA 0x21d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x213c
+			// Method begins at RVA 0x2144
 			// Header size: 12
 			// Code size: 75 (0x4b)
 			.maxstack 8
@@ -182,7 +182,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c3
+			// Method begins at RVA 0x21cb
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -208,14 +208,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 224 (0xe0)
+		// Code size: 230 (0xe6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope::.ctor()
@@ -240,53 +241,55 @@
 		IL_0030: stloc.s 4
 		IL_0032: ldloc.s 4
 		IL_0034: stloc.1
-		IL_0035: ldloc.0
-		IL_0036: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
-		IL_003b: ldnull
-		IL_003c: ldc.r8 10
-		IL_0045: box [System.Runtime]System.Double
-		IL_004a: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
-		IL_004f: stloc.s 4
-		IL_0051: ldloc.s 4
-		IL_0053: stloc.2
-		IL_0054: ldloc.2
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005a: stloc.s 4
-		IL_005c: ldloc.s 4
-		IL_005e: ldstr "multiply"
-		IL_0063: ldc.r8 5
-		IL_006c: box [System.Runtime]System.Double
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0076: stloc.s 4
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldstr "a.multiply(5):"
-		IL_0082: ldloc.s 4
-		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0089: pop
-		IL_008a: ldloc.0
-		IL_008b: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
-		IL_0090: ldnull
-		IL_0091: ldc.r8 3
-		IL_009a: box [System.Runtime]System.Double
-		IL_009f: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
-		IL_00a4: stloc.s 4
-		IL_00a6: ldloc.s 4
-		IL_00a8: stloc.3
-		IL_00a9: ldloc.3
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: stloc.s 4
-		IL_00b1: ldloc.s 4
-		IL_00b3: ldstr "multiply"
-		IL_00b8: ldc.r8 7
-		IL_00c1: box [System.Runtime]System.Double
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cb: stloc.s 4
-		IL_00cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d2: ldstr "b.multiply(7):"
-		IL_00d7: ldloc.s 4
-		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00de: pop
-		IL_00df: ret
+		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003a: stloc.s 5
+		IL_003c: ldloc.1
+		IL_003d: ldloc.s 5
+		IL_003f: ldc.r8 10
+		IL_0048: box [System.Runtime]System.Double
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0052: stloc.s 4
+		IL_0054: ldloc.s 4
+		IL_0056: stloc.2
+		IL_0057: ldloc.2
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005d: stloc.s 4
+		IL_005f: ldloc.s 4
+		IL_0061: ldstr "multiply"
+		IL_0066: ldc.r8 5
+		IL_006f: box [System.Runtime]System.Double
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0079: stloc.s 4
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldstr "a.multiply(5):"
+		IL_0085: ldloc.s 4
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008c: pop
+		IL_008d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0092: stloc.s 5
+		IL_0094: ldloc.1
+		IL_0095: ldloc.s 5
+		IL_0097: ldc.r8 3
+		IL_00a0: box [System.Runtime]System.Double
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00aa: stloc.s 4
+		IL_00ac: ldloc.s 4
+		IL_00ae: stloc.3
+		IL_00af: ldloc.3
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b5: stloc.s 4
+		IL_00b7: ldloc.s 4
+		IL_00b9: ldstr "multiply"
+		IL_00be: ldc.r8 7
+		IL_00c7: box [System.Runtime]System.Double
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00d1: stloc.s 4
+		IL_00d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d8: ldstr "b.multiply(7):"
+		IL_00dd: ldloc.s 4
+		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00e4: pop
+		IL_00e5: ret
 	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::__js_module_init__
 
 } // end of class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty
@@ -298,7 +301,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21de
+		// Method begins at RVA 0x21e6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21a2
+					// Method begins at RVA 0x21aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x214c
+				// Method begins at RVA 0x2154
 				// Header size: 12
 				// Code size: 56 (0x38)
 				.maxstack 8
@@ -94,7 +94,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2199
+				// Method begins at RVA 0x21a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -121,7 +121,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2100
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 62 (0x3e)
 			.maxstack 8
@@ -179,7 +179,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2190
+			// Method begins at RVA 0x2198
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -205,13 +205,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 163 (0xa3)
+		// Code size: 171 (0xab)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureMutatesOuterVariable/Scope,
 			[1] object,
 			[2] object,
-			[3] object
+			[3] object,
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_ClosureMutatesOuterVariable/Scope::.ctor()
@@ -236,42 +237,44 @@
 		IL_0030: stloc.3
 		IL_0031: ldloc.3
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_ClosureMutatesOuterVariable/Scope
-		IL_0039: ldnull
-		IL_003a: ldc.r8 10
-		IL_0043: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
-		IL_0048: stloc.3
-		IL_0049: ldloc.3
-		IL_004a: stloc.2
-		IL_004b: ldloc.2
-		IL_004c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0056: stloc.3
-		IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005c: ldstr "First increment:"
-		IL_0061: ldloc.3
-		IL_0062: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0067: pop
-		IL_0068: ldloc.2
-		IL_0069: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0073: stloc.3
-		IL_0074: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0079: ldstr "Second increment:"
-		IL_007e: ldloc.3
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0084: pop
-		IL_0085: ldloc.2
-		IL_0086: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0090: stloc.3
-		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0096: ldstr "Third increment:"
-		IL_009b: ldloc.3
-		IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00a1: pop
-		IL_00a2: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.s 4
+		IL_003a: ldloc.1
+		IL_003b: ldloc.s 4
+		IL_003d: ldc.r8 10
+		IL_0046: box [System.Runtime]System.Double
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0050: stloc.3
+		IL_0051: ldloc.3
+		IL_0052: stloc.2
+		IL_0053: ldloc.2
+		IL_0054: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005e: stloc.3
+		IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0064: ldstr "First increment:"
+		IL_0069: ldloc.3
+		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_006f: pop
+		IL_0070: ldloc.2
+		IL_0071: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_007b: stloc.3
+		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0081: ldstr "Second increment:"
+		IL_0086: ldloc.3
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008c: pop
+		IL_008d: ldloc.2
+		IL_008e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0098: stloc.3
+		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009e: ldstr "Third increment:"
+		IL_00a3: ldloc.3
+		IL_00a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a9: pop
+		IL_00aa: ret
 	} // end of method Function_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.Function_ClosureMutatesOuterVariable
@@ -283,7 +286,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ab
+		// Method begins at RVA 0x21b3
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2149
+					// Method begins at RVA 0x2141
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2121
+				// Method begins at RVA 0x2119
 				// Header size: 1
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2140
+				// Method begins at RVA 0x2138
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,9 +106,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209c
 			// Header size: 12
-			// Code size: 117 (0x75)
+			// Code size: 113 (0x71)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope,
@@ -148,26 +148,22 @@
 			IL_0042: ldfld object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope::flag
 			IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_004c: pop
-			IL_004d: ldc.i4.2
-			IL_004e: newarr [System.Runtime]System.Object
-			IL_0053: dup
-			IL_0054: ldc.i4.0
-			IL_0055: ldarg.0
-			IL_0056: stelem.ref
-			IL_0057: dup
-			IL_0058: ldc.i4.1
-			IL_0059: ldloc.0
-			IL_005a: stelem.ref
-			IL_005b: ldnull
-			IL_005c: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
-			IL_0061: pop
-			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0067: ldloc.0
-			IL_0068: ldfld object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope::flag
-			IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0072: pop
-			IL_0073: ldnull
-			IL_0074: ret
+			IL_004d: ldloc.1
+			IL_004e: ldc.i4.1
+			IL_004f: newarr [System.Runtime]System.Object
+			IL_0054: dup
+			IL_0055: ldc.i4.0
+			IL_0056: ldarg.0
+			IL_0057: stelem.ref
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_005d: pop
+			IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0063: ldloc.0
+			IL_0064: ldfld object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope::flag
+			IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_006e: pop
+			IL_006f: ldnull
+			IL_0070: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -186,7 +182,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2137
+			// Method begins at RVA 0x212f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -212,7 +208,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope,
@@ -242,12 +238,11 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method Function_Closure_CapturedBoolean_AssignAndRead::__js_module_init__
 
 } // end of class Modules.Function_Closure_CapturedBoolean_AssignAndRead
@@ -259,7 +254,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2152
+		// Method begins at RVA 0x214a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2170
+					// Method begins at RVA 0x2174
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2104
+				// Method begins at RVA 0x2108
 				// Header size: 12
 				// Code size: 78 (0x4e)
 				.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2167
+				// Method begins at RVA 0x216b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -115,7 +115,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2094
+			// Method begins at RVA 0x2098
 			// Header size: 12
 			// Code size: 97 (0x61)
 			.maxstack 8
@@ -176,7 +176,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x215e
+			// Method begins at RVA 0x2162
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -202,7 +202,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 53 (0x35)
+		// Code size: 58 (0x3a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_GlobalScope_NoClosure/Scope,
@@ -227,10 +227,11 @@
 		IL_0022: stloc.1
 		IL_0023: ldc.r8 10
 		IL_002c: stloc.2
-		IL_002d: ldnull
-		IL_002e: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(object)
-		IL_0033: pop
-		IL_0034: ret
+		IL_002d: ldloc.1
+		IL_002e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0038: pop
+		IL_0039: ret
 	} // end of method Function_Constructor_GlobalScope_NoClosure::__js_module_init__
 
 } // end of class Modules.Function_Constructor_GlobalScope_NoClosure
@@ -242,7 +243,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2179
+		// Method begins at RVA 0x217d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x214c
+					// Method begins at RVA 0x2160
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2143
+				// Method begins at RVA 0x2157
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x2100
 			// Header size: 12
 			// Code size: 66 (0x42)
 			.maxstack 8
@@ -121,7 +121,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x213a
+			// Method begins at RVA 0x214e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -147,12 +147,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 144 (0x90)
+		// Code size: 162 (0xa2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterExpression/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_DefaultParameterExpression/Scope::.ctor()
@@ -169,31 +170,37 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 5
-		IL_002d: box [System.Runtime]System.Double
-		IL_0032: ldnull
-		IL_0033: ldnull
-		IL_0034: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, object, object, object)
-		IL_0039: pop
-		IL_003a: ldnull
-		IL_003b: ldc.r8 5
-		IL_0044: box [System.Runtime]System.Double
-		IL_0049: ldc.r8 8
-		IL_0052: box [System.Runtime]System.Double
-		IL_0057: ldnull
-		IL_0058: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, object, object, object)
-		IL_005d: pop
-		IL_005e: ldnull
-		IL_005f: ldc.r8 5
-		IL_0068: box [System.Runtime]System.Double
-		IL_006d: ldc.r8 8
-		IL_0076: box [System.Runtime]System.Double
-		IL_007b: ldc.r8 20
-		IL_0084: box [System.Runtime]System.Double
-		IL_0089: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, object, object, object)
-		IL_008e: pop
-		IL_008f: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 5
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_003e: pop
+		IL_003f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0044: stloc.3
+		IL_0045: ldloc.1
+		IL_0046: ldloc.3
+		IL_0047: ldc.r8 5
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: ldc.r8 8
+		IL_005e: box [System.Runtime]System.Double
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0068: pop
+		IL_0069: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006e: stloc.3
+		IL_006f: ldloc.1
+		IL_0070: ldloc.3
+		IL_0071: ldc.r8 5
+		IL_007a: box [System.Runtime]System.Double
+		IL_007f: ldc.r8 8
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: ldc.r8 20
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_00a0: pop
+		IL_00a1: ret
 	} // end of method Function_DefaultParameterExpression::__js_module_init__
 
 } // end of class Modules.Function_DefaultParameterExpression
@@ -205,7 +212,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2155
+		// Method begins at RVA 0x2169
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2290
+					// Method begins at RVA 0x22c8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2287
+				// Method begins at RVA 0x22bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x21bc
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -110,7 +110,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22a2
+					// Method begins at RVA 0x22da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -128,7 +128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2299
+				// Method begins at RVA 0x22d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -153,7 +153,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21f8
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -200,7 +200,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22b4
+					// Method begins at RVA 0x22ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -218,7 +218,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22ab
+				// Method begins at RVA 0x22e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -244,7 +244,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2200
+			// Method begins at RVA 0x2238
 			// Header size: 12
 			// Code size: 114 (0x72)
 			.maxstack 8
@@ -316,7 +316,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x227e
+			// Method begins at RVA 0x22b6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -342,14 +342,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 295 (0x127)
+		// Code size: 351 (0x15f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterValue/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_DefaultParameterValue/Scope::.ctor()
@@ -390,58 +391,70 @@
 		IL_005e: stloc.s 4
 		IL_0060: ldloc.s 4
 		IL_0062: stloc.3
-		IL_0063: ldnull
-		IL_0064: ldnull
-		IL_0065: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
-		IL_006a: pop
-		IL_006b: ldnull
-		IL_006c: ldstr "Alice"
-		IL_0071: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
-		IL_0076: pop
-		IL_0077: ldnull
-		IL_0078: ldc.r8 5
-		IL_0081: box [System.Runtime]System.Double
-		IL_0086: ldnull
-		IL_0087: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, object, object)
-		IL_008c: pop
-		IL_008d: ldnull
+		IL_0063: ldloc.1
+		IL_0064: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_006e: pop
+		IL_006f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0074: stloc.s 5
+		IL_0076: ldloc.1
+		IL_0077: ldloc.s 5
+		IL_0079: ldstr "Alice"
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0083: pop
+		IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0089: stloc.s 5
+		IL_008b: ldloc.2
+		IL_008c: ldloc.s 5
 		IL_008e: ldc.r8 5
 		IL_0097: box [System.Runtime]System.Double
-		IL_009c: ldc.r8 15
-		IL_00a5: box [System.Runtime]System.Double
-		IL_00aa: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, object, object)
-		IL_00af: pop
-		IL_00b0: ldnull
-		IL_00b1: ldnull
-		IL_00b2: ldnull
-		IL_00b3: ldnull
-		IL_00b4: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
-		IL_00b9: pop
-		IL_00ba: ldnull
-		IL_00bb: ldc.r8 2
-		IL_00c4: box [System.Runtime]System.Double
-		IL_00c9: ldnull
-		IL_00ca: ldnull
-		IL_00cb: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
-		IL_00d0: pop
-		IL_00d1: ldnull
-		IL_00d2: ldc.r8 2
-		IL_00db: box [System.Runtime]System.Double
-		IL_00e0: ldc.r8 4
-		IL_00e9: box [System.Runtime]System.Double
-		IL_00ee: ldnull
-		IL_00ef: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
-		IL_00f4: pop
-		IL_00f5: ldnull
-		IL_00f6: ldc.r8 2
-		IL_00ff: box [System.Runtime]System.Double
-		IL_0104: ldc.r8 4
-		IL_010d: box [System.Runtime]System.Double
-		IL_0112: ldc.r8 3
-		IL_011b: box [System.Runtime]System.Double
-		IL_0120: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
-		IL_0125: pop
-		IL_0126: ret
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00a1: pop
+		IL_00a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a7: stloc.s 5
+		IL_00a9: ldloc.2
+		IL_00aa: ldloc.s 5
+		IL_00ac: ldc.r8 5
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: ldc.r8 15
+		IL_00c3: box [System.Runtime]System.Double
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00cd: pop
+		IL_00ce: ldloc.3
+		IL_00cf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00d9: pop
+		IL_00da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00df: stloc.s 5
+		IL_00e1: ldloc.3
+		IL_00e2: ldloc.s 5
+		IL_00e4: ldc.r8 2
+		IL_00ed: box [System.Runtime]System.Double
+		IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00f7: pop
+		IL_00f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00fd: stloc.s 5
+		IL_00ff: ldloc.3
+		IL_0100: ldloc.s 5
+		IL_0102: ldc.r8 2
+		IL_010b: box [System.Runtime]System.Double
+		IL_0110: ldc.r8 4
+		IL_0119: box [System.Runtime]System.Double
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0123: pop
+		IL_0124: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0129: stloc.s 5
+		IL_012b: ldloc.3
+		IL_012c: ldloc.s 5
+		IL_012e: ldc.r8 2
+		IL_0137: box [System.Runtime]System.Double
+		IL_013c: ldc.r8 4
+		IL_0145: box [System.Runtime]System.Double
+		IL_014a: ldc.r8 3
+		IL_0153: box [System.Runtime]System.Double
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_015d: pop
+		IL_015e: ret
 	} // end of method Function_DefaultParameterValue::__js_module_init__
 
 } // end of class Modules.Function_DefaultParameterValue
@@ -453,7 +466,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22bd
+		// Method begins at RVA 0x22f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
@@ -223,12 +223,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 91 (0x5b)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope::.ctor()
@@ -253,18 +254,19 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope
-		IL_0039: ldnull
-		IL_003a: ldc.r8 10
-		IL_0043: box [System.Runtime]System.Double
-		IL_0048: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
-		IL_004d: stloc.2
-		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0053: ldloc.2
-		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0059: pop
-		IL_005a: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldloc.1
+		IL_003a: ldloc.3
+		IL_003b: ldc.r8 10
+		IL_0044: box [System.Runtime]System.Double
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_004e: stloc.2
+		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0054: ldloc.2
+		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter::__js_module_init__
 
 } // end of class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212f
+				// Method begins at RVA 0x213d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,9 +44,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20dd
+			// Method begins at RVA 0x20dc
 			// Header size: 1
-			// Code size: 39 (0x27)
+			// Code size: 54 (0x36)
 			.maxstack 8
 
 			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
@@ -55,11 +55,18 @@
 			IL_0013: box [System.Runtime]System.Double
 			IL_0018: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 			IL_001d: pop
-			IL_001e: ldnull
-			IL_001f: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
-			IL_0024: pop
-			IL_0025: ldnull
-			IL_0026: ret
+			IL_001e: ldarg.0
+			IL_001f: ldfld object Modules.Function_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
+			IL_0024: ldc.i4.1
+			IL_0025: newarr [System.Runtime]System.Object
+			IL_002a: dup
+			IL_002b: ldc.i4.0
+			IL_002c: ldarg.0
+			IL_002d: stelem.ref
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0033: pop
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method helloWorldProxy::__js_call__
 
 	} // end of class helloWorldProxy
@@ -75,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2138
+				// Method begins at RVA 0x2146
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,7 +105,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2105
+			// Method begins at RVA 0x2113
 			// Header size: 1
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -133,7 +140,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2126
+			// Method begins at RVA 0x2134
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -159,7 +166,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 129 (0x81)
+		// Code size: 128 (0x80)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope,
@@ -202,18 +209,17 @@
 		IL_004e: ldloc.0
 		IL_004f: ldloc.2
 		IL_0050: stfld object Modules.Function_GlobalFunctionCallsGlobalFunction/Scope::helloWorld
-		IL_0055: ldloc.0
-		IL_0056: castclass Modules.Function_GlobalFunctionCallsGlobalFunction/Scope
-		IL_005b: ldnull
-		IL_005c: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
-		IL_0061: pop
-		IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0067: ldstr "finally is now"
-		IL_006c: ldc.r8 3
-		IL_0075: box [System.Runtime]System.Double
-		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_007f: pop
-		IL_0080: ret
+		IL_0055: ldloc.1
+		IL_0056: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0060: pop
+		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0066: ldstr "finally is now"
+		IL_006b: ldc.r8 3
+		IL_0074: box [System.Runtime]System.Double
+		IL_0079: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_007e: pop
+		IL_007f: ret
 	} // end of method Function_GlobalFunctionCallsGlobalFunction::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionCallsGlobalFunction
@@ -225,7 +231,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2141
+		// Method begins at RVA 0x214f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -166,7 +166,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 202 (0xca)
+		// Code size: 201 (0xc9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope,
@@ -228,37 +228,36 @@
 		IL_0080: stelem.ref
 		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
 		IL_0086: pop
-		IL_0087: ldloc.0
-		IL_0088: castclass Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope
-		IL_008d: ldnull
-		IL_008e: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
-		IL_0093: pop
-		IL_0094: ldloc.0
-		IL_0095: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
-		IL_009a: stloc.2
-		IL_009b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a0: ldc.i4.4
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldstr "End - counter:"
-		IL_00ad: stelem.ref
-		IL_00ae: dup
-		IL_00af: ldc.i4.1
-		IL_00b0: ldloc.2
-		IL_00b1: stelem.ref
-		IL_00b2: dup
-		IL_00b3: ldc.i4.2
-		IL_00b4: ldstr "message:"
-		IL_00b9: stelem.ref
-		IL_00ba: dup
-		IL_00bb: ldc.i4.3
-		IL_00bc: ldloc.0
-		IL_00bd: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
-		IL_00c2: stelem.ref
-		IL_00c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_00c8: pop
-		IL_00c9: ret
+		IL_0087: ldloc.1
+		IL_0088: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0092: pop
+		IL_0093: ldloc.0
+		IL_0094: ldfld object Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::counter
+		IL_0099: stloc.2
+		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009f: ldc.i4.4
+		IL_00a0: newarr [System.Runtime]System.Object
+		IL_00a5: dup
+		IL_00a6: ldc.i4.0
+		IL_00a7: ldstr "End - counter:"
+		IL_00ac: stelem.ref
+		IL_00ad: dup
+		IL_00ae: ldc.i4.1
+		IL_00af: ldloc.2
+		IL_00b0: stelem.ref
+		IL_00b1: dup
+		IL_00b2: ldc.i4.2
+		IL_00b3: ldstr "message:"
+		IL_00b8: stelem.ref
+		IL_00b9: dup
+		IL_00ba: ldc.i4.3
+		IL_00bb: ldloc.0
+		IL_00bc: ldfld string Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope::message
+		IL_00c1: stelem.ref
+		IL_00c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_00c7: pop
+		IL_00c8: ret
 	} // end of method Function_GlobalFunctionChangesGlobalVariableValue::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionChangesGlobalVariableValue

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2154
+					// Method begins at RVA 0x215d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x212b
+				// Method begins at RVA 0x2134
 				// Header size: 1
 				// Code size: 22 (0x16)
 				.maxstack 8
@@ -75,7 +75,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x214b
+				// Method begins at RVA 0x2154
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -98,9 +98,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20bc
+			// Method begins at RVA 0x20c0
 			// Header size: 12
-			// Code size: 99 (0x63)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/Scope,
@@ -131,18 +131,19 @@
 			IL_0038: ldstr "After nested function declaration"
 			IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0042: pop
-			IL_0043: ldnull
-			IL_0044: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
-			IL_0049: stloc.3
-			IL_004a: ldloc.3
-			IL_004b: stloc.2
-			IL_004c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0051: ldstr "Nested function returned:"
-			IL_0056: ldloc.2
-			IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_005c: pop
-			IL_005d: ldstr "outer result"
-			IL_0062: ret
+			IL_0043: ldloc.1
+			IL_0044: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_004e: stloc.3
+			IL_004f: ldloc.3
+			IL_0050: stloc.2
+			IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0056: ldstr "Nested function returned:"
+			IL_005b: ldloc.2
+			IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0061: pop
+			IL_0062: ldstr "outer result"
+			IL_0067: ret
 		} // end of method outerFunction::__js_call__
 
 	} // end of class outerFunction
@@ -162,7 +163,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2142
+			// Method begins at RVA 0x214b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -188,7 +189,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 94 (0x5e)
+		// Code size: 99 (0x63)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/Scope,
@@ -215,21 +216,22 @@
 		IL_0028: ldstr "Start"
 		IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_0032: pop
-		IL_0033: ldnull
-		IL_0034: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
-		IL_0039: stloc.3
-		IL_003a: ldloc.3
-		IL_003b: stloc.2
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: ldstr "Main result:"
-		IL_0046: ldloc.2
-		IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_004c: pop
-		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0052: ldstr "End"
-		IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005c: pop
-		IL_005d: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.3
+		IL_003f: ldloc.3
+		IL_0040: stloc.2
+		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0046: ldstr "Main result:"
+		IL_004b: ldloc.2
+		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0051: pop
+		IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0057: ldstr "End"
+		IL_005c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0061: pop
+		IL_0062: ret
 	} // end of method Function_GlobalFunctionDeclaresAndCallsNestedFunction::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction
@@ -241,7 +243,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x215d
+		// Method begins at RVA 0x2166
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20f4
+				// Method begins at RVA 0x20f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20bc
+			// Method begins at RVA 0x20bb
 			// Header size: 1
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -88,7 +88,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20eb
+			// Method begins at RVA 0x20ea
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -114,7 +114,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 96 (0x60)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope,
@@ -151,12 +151,11 @@
 		IL_003f: ldc.r8 42
 		IL_0048: box [System.Runtime]System.Double
 		IL_004d: stfld object Modules.Function_GlobalFunctionLogsGlobalVariable/Scope::globalNumber
-		IL_0052: ldloc.0
-		IL_0053: castclass Modules.Function_GlobalFunctionLogsGlobalVariable/Scope
-		IL_0058: ldnull
-		IL_0059: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
-		IL_005e: pop
-		IL_005f: ret
+		IL_0052: ldloc.1
+		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005d: pop
+		IL_005e: ret
 	} // end of method Function_GlobalFunctionLogsGlobalVariable::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionLogsGlobalVariable
@@ -168,7 +167,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20fd
+		// Method begins at RVA 0x20fc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21c0
+					// Method begins at RVA 0x21c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2130
+				// Method begins at RVA 0x2134
 				// Header size: 12
 				// Code size: 114 (0x72)
 				.maxstack 8
@@ -115,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21b7
+				// Method begins at RVA 0x21bb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -142,7 +142,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20ec
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -201,7 +201,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ae
+			// Method begins at RVA 0x21b2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -227,14 +227,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 138 (0x8a)
+		// Code size: 141 (0x8d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::.ctor()
@@ -263,27 +264,28 @@
 		IL_0036: ldc.r8 10
 		IL_003f: box [System.Runtime]System.Double
 		IL_0044: stfld object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope::outerVar
-		IL_0049: ldloc.0
-		IL_004a: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
-		IL_004f: ldnull
-		IL_0050: ldc.r8 7
-		IL_0059: box [System.Runtime]System.Double
-		IL_005e: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
-		IL_0063: stloc.s 4
-		IL_0065: ldloc.s 4
-		IL_0067: stloc.2
-		IL_0068: ldloc.2
-		IL_0069: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_0073: stloc.s 4
-		IL_0075: ldloc.s 4
-		IL_0077: stloc.3
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldstr "Result:"
-		IL_0082: ldloc.3
-		IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0088: pop
-		IL_0089: ret
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.s 5
+		IL_0050: ldloc.1
+		IL_0051: ldloc.s 5
+		IL_0053: ldc.r8 7
+		IL_005c: box [System.Runtime]System.Double
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0066: stloc.s 4
+		IL_0068: ldloc.s 4
+		IL_006a: stloc.2
+		IL_006b: ldloc.2
+		IL_006c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0076: stloc.s 4
+		IL_0078: ldloc.s 4
+		IL_007a: stloc.3
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldstr "Result:"
+		IL_0085: ldloc.3
+		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008b: pop
+		IL_008c: ret
 	} // end of method Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
@@ -295,7 +297,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21c9
+		// Method begins at RVA 0x21cd
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x218b
+					// Method begins at RVA 0x218f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2182
+				// Method begins at RVA 0x2186
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x2114
 			// Header size: 12
 			// Code size: 93 (0x5d)
 			.maxstack 8
@@ -130,7 +130,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2179
+			// Method begins at RVA 0x217d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -156,16 +156,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 177 (0xb1)
+		// Code size: 182 (0xb6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithArrayIteration/Scope,
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[6] string
+			[3] object,
+			[4] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_GlobalFunctionWithArrayIteration/Scope::.ctor()
@@ -201,27 +199,26 @@
 		IL_0071: box [System.Runtime]System.Double
 		IL_0076: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_007b: stloc.2
-		IL_007c: ldnull
-		IL_007d: ldloc.2
-		IL_007e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0088: stloc.s 5
-		IL_008a: ldloc.s 5
+		IL_007c: ldloc.1
+		IL_007d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0082: ldloc.2
+		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0088: stloc.s 4
+		IL_008a: ldloc.s 4
 		IL_008c: stloc.3
 		IL_008d: ldloc.3
-		IL_008e: ldc.i4.1
-		IL_008f: newarr [System.Runtime]System.Object
-		IL_0094: dup
-		IL_0095: ldc.i4.0
-		IL_0096: ldstr ","
-		IL_009b: stelem.ref
-		IL_009c: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-		IL_00a1: stloc.s 6
-		IL_00a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a8: ldloc.s 6
-		IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00af: pop
-		IL_00b0: ret
+		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0093: stloc.s 4
+		IL_0095: ldloc.s 4
+		IL_0097: ldstr "join"
+		IL_009c: ldstr ","
+		IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00a6: stloc.s 4
+		IL_00a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ad: ldloc.s 4
+		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b4: pop
+		IL_00b5: ret
 	} // end of method Function_GlobalFunctionWithArrayIteration::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithArrayIteration
@@ -233,7 +230,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2194
+		// Method begins at RVA 0x2198
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b2
+				// Method begins at RVA 0x2492
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2207
+			// Method begins at RVA 0x22e8
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -70,7 +70,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23bb
+				// Method begins at RVA 0x249b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -95,7 +95,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2220
+			// Method begins at RVA 0x2301
 			// Header size: 1
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -125,7 +125,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c4
+				// Method begins at RVA 0x24a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -151,7 +151,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x223f
+			// Method begins at RVA 0x2320
 			// Header size: 1
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -197,7 +197,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23cd
+				// Method begins at RVA 0x24ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,7 +224,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x2358
 			// Header size: 12
 			// Code size: 64 (0x40)
 			.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d6
+				// Method begins at RVA 0x24b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -303,7 +303,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22c4
+			// Method begins at RVA 0x23a4
 			// Header size: 12
 			// Code size: 74 (0x4a)
 			.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23df
+				// Method begins at RVA 0x24bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -388,7 +388,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x231c
+			// Method begins at RVA 0x23fc
 			// Header size: 12
 			// Code size: 129 (0x81)
 			.maxstack 8
@@ -471,7 +471,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23a9
+			// Method begins at RVA 0x2489
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -497,7 +497,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 427 (0x1ab)
+		// Code size: 652 (0x28c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithMultipleParameters/Scope,
@@ -507,7 +507,8 @@
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object
+			[7] object,
+			[8] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/Scope::.ctor()
@@ -584,46 +585,136 @@
 		IL_00bd: stloc.s 7
 		IL_00bf: ldloc.s 7
 		IL_00c1: stloc.s 6
-		IL_00c3: ldnull
-		IL_00c4: ldc.r8 1
-		IL_00cd: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
-		IL_00d2: pop
-		IL_00d3: ldnull
-		IL_00d4: ldc.r8 1
-		IL_00dd: ldc.r8 2
-		IL_00e6: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
-		IL_00eb: pop
-		IL_00ec: ldnull
-		IL_00ed: ldc.r8 1
-		IL_00f6: ldc.r8 2
-		IL_00ff: ldc.r8 3
-		IL_0108: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
-		IL_010d: pop
-		IL_010e: ldnull
-		IL_010f: ldc.r8 1
-		IL_0118: ldc.r8 2
-		IL_0121: ldc.r8 3
-		IL_012a: ldc.r8 4
-		IL_0133: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
-		IL_0138: pop
-		IL_0139: ldnull
-		IL_013a: ldc.r8 1
-		IL_0143: ldc.r8 2
-		IL_014c: ldc.r8 3
-		IL_0155: ldc.r8 4
-		IL_015e: ldc.r8 5
-		IL_0167: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
-		IL_016c: pop
-		IL_016d: ldnull
-		IL_016e: ldc.r8 1
-		IL_0177: ldc.r8 2
-		IL_0180: ldc.r8 3
-		IL_0189: ldc.r8 4
-		IL_0192: ldc.r8 5
-		IL_019b: ldc.r8 6
-		IL_01a4: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
-		IL_01a9: pop
-		IL_01aa: ret
+		IL_00c3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00c8: stloc.s 8
+		IL_00ca: ldloc.1
+		IL_00cb: ldloc.s 8
+		IL_00cd: ldc.r8 1
+		IL_00d6: box [System.Runtime]System.Double
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00e0: pop
+		IL_00e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e6: stloc.s 8
+		IL_00e8: ldloc.2
+		IL_00e9: ldloc.s 8
+		IL_00eb: ldc.r8 1
+		IL_00f4: box [System.Runtime]System.Double
+		IL_00f9: ldc.r8 2
+		IL_0102: box [System.Runtime]System.Double
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_010c: pop
+		IL_010d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0112: stloc.s 8
+		IL_0114: ldloc.3
+		IL_0115: ldloc.s 8
+		IL_0117: ldc.r8 1
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: ldc.r8 2
+		IL_012e: box [System.Runtime]System.Double
+		IL_0133: ldc.r8 3
+		IL_013c: box [System.Runtime]System.Double
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_0146: pop
+		IL_0147: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_014c: stloc.s 8
+		IL_014e: ldloc.s 4
+		IL_0150: ldloc.s 8
+		IL_0152: ldc.i4.4
+		IL_0153: newarr [System.Runtime]System.Object
+		IL_0158: dup
+		IL_0159: ldc.i4.0
+		IL_015a: ldc.r8 1
+		IL_0163: box [System.Runtime]System.Double
+		IL_0168: stelem.ref
+		IL_0169: dup
+		IL_016a: ldc.i4.1
+		IL_016b: ldc.r8 2
+		IL_0174: box [System.Runtime]System.Double
+		IL_0179: stelem.ref
+		IL_017a: dup
+		IL_017b: ldc.i4.2
+		IL_017c: ldc.r8 3
+		IL_0185: box [System.Runtime]System.Double
+		IL_018a: stelem.ref
+		IL_018b: dup
+		IL_018c: ldc.i4.3
+		IL_018d: ldc.r8 4
+		IL_0196: box [System.Runtime]System.Double
+		IL_019b: stelem.ref
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01a1: pop
+		IL_01a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a7: stloc.s 8
+		IL_01a9: ldloc.s 5
+		IL_01ab: ldloc.s 8
+		IL_01ad: ldc.i4.5
+		IL_01ae: newarr [System.Runtime]System.Object
+		IL_01b3: dup
+		IL_01b4: ldc.i4.0
+		IL_01b5: ldc.r8 1
+		IL_01be: box [System.Runtime]System.Double
+		IL_01c3: stelem.ref
+		IL_01c4: dup
+		IL_01c5: ldc.i4.1
+		IL_01c6: ldc.r8 2
+		IL_01cf: box [System.Runtime]System.Double
+		IL_01d4: stelem.ref
+		IL_01d5: dup
+		IL_01d6: ldc.i4.2
+		IL_01d7: ldc.r8 3
+		IL_01e0: box [System.Runtime]System.Double
+		IL_01e5: stelem.ref
+		IL_01e6: dup
+		IL_01e7: ldc.i4.3
+		IL_01e8: ldc.r8 4
+		IL_01f1: box [System.Runtime]System.Double
+		IL_01f6: stelem.ref
+		IL_01f7: dup
+		IL_01f8: ldc.i4.4
+		IL_01f9: ldc.r8 5
+		IL_0202: box [System.Runtime]System.Double
+		IL_0207: stelem.ref
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_020d: pop
+		IL_020e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0213: stloc.s 8
+		IL_0215: ldloc.s 6
+		IL_0217: ldloc.s 8
+		IL_0219: ldc.i4.6
+		IL_021a: newarr [System.Runtime]System.Object
+		IL_021f: dup
+		IL_0220: ldc.i4.0
+		IL_0221: ldc.r8 1
+		IL_022a: box [System.Runtime]System.Double
+		IL_022f: stelem.ref
+		IL_0230: dup
+		IL_0231: ldc.i4.1
+		IL_0232: ldc.r8 2
+		IL_023b: box [System.Runtime]System.Double
+		IL_0240: stelem.ref
+		IL_0241: dup
+		IL_0242: ldc.i4.2
+		IL_0243: ldc.r8 3
+		IL_024c: box [System.Runtime]System.Double
+		IL_0251: stelem.ref
+		IL_0252: dup
+		IL_0253: ldc.i4.3
+		IL_0254: ldc.r8 4
+		IL_025d: box [System.Runtime]System.Double
+		IL_0262: stelem.ref
+		IL_0263: dup
+		IL_0264: ldc.i4.4
+		IL_0265: ldc.r8 5
+		IL_026e: box [System.Runtime]System.Double
+		IL_0273: stelem.ref
+		IL_0274: dup
+		IL_0275: ldc.i4.5
+		IL_0276: ldc.r8 6
+		IL_027f: box [System.Runtime]System.Double
+		IL_0284: stelem.ref
+		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_028a: pop
+		IL_028b: ret
 	} // end of method Function_GlobalFunctionWithMultipleParameters::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithMultipleParameters
@@ -635,7 +726,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23e8
+		// Method begins at RVA 0x24c8
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20a9
+				// Method begins at RVA 0x20b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x208c
+			// Method begins at RVA 0x2093
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -73,7 +73,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x20a7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -99,12 +99,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 48 (0x30)
+		// Code size: 55 (0x37)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithParameter/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_GlobalFunctionWithParameter/Scope::.ctor()
@@ -121,11 +122,14 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "Hello, Jroc!"
-		IL_0029: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "Hello, Jroc!"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ret
 	} // end of method Function_GlobalFunctionWithParameter::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithParameter
@@ -137,7 +141,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20b2
+		// Method begins at RVA 0x20b9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_HelloWorld
+﻿// IL code: Function_HelloWorld
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20a3
+				// Method begins at RVA 0x20a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2087
+			// Method begins at RVA 0x208c
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -71,7 +71,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x209a
+			// Method begins at RVA 0x209f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -97,7 +97,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 43 (0x2b)
+		// Code size: 48 (0x30)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_HelloWorld/Scope,
@@ -119,10 +119,11 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
-		IL_0029: pop
-		IL_002a: ret
+		IL_0023: ldloc.1
+		IL_0024: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_002e: pop
+		IL_002f: ret
 	} // end of method Function_HelloWorld::__js_module_init__
 
 } // end of class Modules.Function_HelloWorld
@@ -134,7 +135,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20ac
+		// Method begins at RVA 0x20b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_IIFE_Recursive
+﻿// IL code: Function_IIFE_Recursive
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -26,7 +26,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2229
+					// Method begins at RVA 0x2232
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2232
+					// Method begins at RVA 0x223b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -67,7 +67,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2220
+				// Method begins at RVA 0x2229
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -94,7 +94,7 @@
 			)
 			// Method begins at RVA 0x2154
 			// Header size: 12
-			// Code size: 183 (0xb7)
+			// Code size: 192 (0xc0)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -103,7 +103,8 @@
 				[3] class Modules.Function_IIFE_Recursive/walk/Scope/Block_L9C51,
 				[4] object,
 				[5] object,
-				[6] object
+				[6] object[],
+				[7] object
 			)
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentCallee()
@@ -141,7 +142,7 @@
 				IL_005e: ldstr "length"
 				IL_0063: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_0068: clt
-				IL_006a: brfalse IL_00b5
+				IL_006a: brfalse IL_00be
 
 				IL_006f: newobj instance void Modules.Function_IIFE_Recursive/walk/Scope/Block_L9C51::.ctor()
 				IL_0074: stloc.3
@@ -151,24 +152,27 @@
 				IL_0080: ldloc.2
 				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 				IL_0086: stloc.s 4
-				IL_0088: ldarg.2
-				IL_0089: ldc.r8 1
-				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0097: stloc.s 6
-				IL_0099: ldnull
-				IL_009a: ldloc.s 4
-				IL_009c: ldloc.s 6
-				IL_009e: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
-				IL_00a3: pop
-				IL_00a4: ldloc.2
-				IL_00a5: ldc.r8 1
-				IL_00ae: add
-				IL_00af: stloc.2
-				IL_00b0: br IL_0052
+				IL_0088: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+				IL_008d: stloc.s 6
+				IL_008f: ldarg.2
+				IL_0090: ldc.r8 1
+				IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_009e: stloc.s 7
+				IL_00a0: ldloc.0
+				IL_00a1: ldloc.s 6
+				IL_00a3: ldloc.s 4
+				IL_00a5: ldloc.s 7
+				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_00ac: pop
+				IL_00ad: ldloc.2
+				IL_00ae: ldc.r8 1
+				IL_00b7: add
+				IL_00b8: stloc.2
+				IL_00b9: br IL_0052
 			// end loop
 
-			IL_00b5: ldnull
-			IL_00b6: ret
+			IL_00be: ldnull
+			IL_00bf: ret
 		} // end of method walk::__js_call__
 
 	} // end of class walk
@@ -180,7 +184,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2217
+			// Method begins at RVA 0x2220
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -305,7 +309,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x223b
+		// Method begins at RVA 0x2244
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20e7
+				// Method begins at RVA 0x20f3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20c0
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -77,7 +77,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20de
+			// Method begins at RVA 0x20ea
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -103,14 +103,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 86 (0x56)
+		// Code size: 100 (0x64)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_IsEven_CompareResultToTrue/Scope,
 			[1] object,
 			[2] object,
-			[3] bool,
-			[4] object
+			[3] object[],
+			[4] bool,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Function_IsEven_CompareResultToTrue/Scope::.ctor()
@@ -127,23 +128,27 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 4
-		IL_002d: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
-		IL_0032: stloc.2
-		IL_0033: ldloc.2
-		IL_0034: ldc.i4.1
-		IL_0035: box [System.Runtime]System.Boolean
-		IL_003a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
-		IL_003f: stloc.3
-		IL_0040: ldloc.3
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 4
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_003e: stloc.2
+		IL_003f: ldloc.2
+		IL_0040: ldc.i4.1
 		IL_0041: box [System.Runtime]System.Boolean
-		IL_0046: stloc.s 4
-		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+		IL_004b: stloc.s 4
 		IL_004d: ldloc.s 4
-		IL_004f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0054: pop
-		IL_0055: ret
+		IL_004f: box [System.Runtime]System.Boolean
+		IL_0054: stloc.s 5
+		IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_005b: ldloc.s 5
+		IL_005d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0062: pop
+		IL_0063: ret
 	} // end of method Function_IsEven_CompareResultToTrue::__js_module_init__
 
 } // end of class Modules.Function_IsEven_CompareResultToTrue
@@ -155,7 +160,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20f0
+		// Method begins at RVA 0x20fc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_MaxParameters_16
+﻿// IL code: Function_MaxParameters_16
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2181
+				// Method begins at RVA 0x21c6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -57,7 +57,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2174
+			// Method begins at RVA 0x21b9
 			// Header size: 1
 			// Code size: 3 (0x3)
 			.maxstack 8
@@ -81,7 +81,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2178
+			// Method begins at RVA 0x21bd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -107,12 +107,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 280 (0x118)
-		.maxstack 18
+		// Code size: 349 (0x15d)
+		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_MaxParameters_16/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_MaxParameters_16/Scope::.ctor()
@@ -129,46 +130,99 @@
 		IL_0021: stloc.2
 		IL_0022: ldloc.2
 		IL_0023: stloc.1
-		IL_0024: ldnull
-		IL_0025: ldc.r8 1
-		IL_002e: box [System.Runtime]System.Double
-		IL_0033: ldc.r8 2
-		IL_003c: box [System.Runtime]System.Double
-		IL_0041: ldc.r8 3
-		IL_004a: box [System.Runtime]System.Double
-		IL_004f: ldc.r8 4
-		IL_0058: box [System.Runtime]System.Double
-		IL_005d: ldc.r8 5
-		IL_0066: box [System.Runtime]System.Double
-		IL_006b: ldc.r8 6
-		IL_0074: box [System.Runtime]System.Double
-		IL_0079: ldc.r8 7
+		IL_0024: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0029: stloc.3
+		IL_002a: ldloc.1
+		IL_002b: ldloc.3
+		IL_002c: ldc.i4.s 16
+		IL_002e: newarr [System.Runtime]System.Object
+		IL_0033: dup
+		IL_0034: ldc.i4.0
+		IL_0035: ldc.r8 1
+		IL_003e: box [System.Runtime]System.Double
+		IL_0043: stelem.ref
+		IL_0044: dup
+		IL_0045: ldc.i4.1
+		IL_0046: ldc.r8 2
+		IL_004f: box [System.Runtime]System.Double
+		IL_0054: stelem.ref
+		IL_0055: dup
+		IL_0056: ldc.i4.2
+		IL_0057: ldc.r8 3
+		IL_0060: box [System.Runtime]System.Double
+		IL_0065: stelem.ref
+		IL_0066: dup
+		IL_0067: ldc.i4.3
+		IL_0068: ldc.r8 4
+		IL_0071: box [System.Runtime]System.Double
+		IL_0076: stelem.ref
+		IL_0077: dup
+		IL_0078: ldc.i4.4
+		IL_0079: ldc.r8 5
 		IL_0082: box [System.Runtime]System.Double
-		IL_0087: ldc.r8 8
-		IL_0090: box [System.Runtime]System.Double
-		IL_0095: ldc.r8 9
-		IL_009e: box [System.Runtime]System.Double
-		IL_00a3: ldc.r8 10
-		IL_00ac: box [System.Runtime]System.Double
-		IL_00b1: ldc.r8 11
-		IL_00ba: box [System.Runtime]System.Double
-		IL_00bf: ldc.r8 12
-		IL_00c8: box [System.Runtime]System.Double
-		IL_00cd: ldc.r8 13
-		IL_00d6: box [System.Runtime]System.Double
-		IL_00db: ldc.r8 14
-		IL_00e4: box [System.Runtime]System.Double
-		IL_00e9: ldc.r8 15
-		IL_00f2: box [System.Runtime]System.Double
-		IL_00f7: ldc.r8 16
-		IL_0100: box [System.Runtime]System.Double
-		IL_0105: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
-		IL_010a: stloc.2
-		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0110: ldloc.2
-		IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0116: pop
-		IL_0117: ret
+		IL_0087: stelem.ref
+		IL_0088: dup
+		IL_0089: ldc.i4.5
+		IL_008a: ldc.r8 6
+		IL_0093: box [System.Runtime]System.Double
+		IL_0098: stelem.ref
+		IL_0099: dup
+		IL_009a: ldc.i4.6
+		IL_009b: ldc.r8 7
+		IL_00a4: box [System.Runtime]System.Double
+		IL_00a9: stelem.ref
+		IL_00aa: dup
+		IL_00ab: ldc.i4.7
+		IL_00ac: ldc.r8 8
+		IL_00b5: box [System.Runtime]System.Double
+		IL_00ba: stelem.ref
+		IL_00bb: dup
+		IL_00bc: ldc.i4.8
+		IL_00bd: ldc.r8 9
+		IL_00c6: box [System.Runtime]System.Double
+		IL_00cb: stelem.ref
+		IL_00cc: dup
+		IL_00cd: ldc.i4.s 9
+		IL_00cf: ldc.r8 10
+		IL_00d8: box [System.Runtime]System.Double
+		IL_00dd: stelem.ref
+		IL_00de: dup
+		IL_00df: ldc.i4.s 10
+		IL_00e1: ldc.r8 11
+		IL_00ea: box [System.Runtime]System.Double
+		IL_00ef: stelem.ref
+		IL_00f0: dup
+		IL_00f1: ldc.i4.s 11
+		IL_00f3: ldc.r8 12
+		IL_00fc: box [System.Runtime]System.Double
+		IL_0101: stelem.ref
+		IL_0102: dup
+		IL_0103: ldc.i4.s 12
+		IL_0105: ldc.r8 13
+		IL_010e: box [System.Runtime]System.Double
+		IL_0113: stelem.ref
+		IL_0114: dup
+		IL_0115: ldc.i4.s 13
+		IL_0117: ldc.r8 14
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: stelem.ref
+		IL_0126: dup
+		IL_0127: ldc.i4.s 14
+		IL_0129: ldc.r8 15
+		IL_0132: box [System.Runtime]System.Double
+		IL_0137: stelem.ref
+		IL_0138: dup
+		IL_0139: ldc.i4.s 15
+		IL_013b: ldc.r8 16
+		IL_0144: box [System.Runtime]System.Double
+		IL_0149: stelem.ref
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_014f: stloc.2
+		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0155: ldloc.2
+		IL_0156: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015b: pop
+		IL_015c: ret
 	} // end of method Function_MaxParameters_16::__js_module_init__
 
 } // end of class Modules.Function_MaxParameters_16
@@ -180,7 +234,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x218a
+		// Method begins at RVA 0x21cf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2179
+					// Method begins at RVA 0x2175
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2108
+				// Method begins at RVA 0x2104
 				// Header size: 12
 				// Code size: 83 (0x53)
 				.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2170
+				// Method begins at RVA 0x216c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -130,7 +130,7 @@
 			)
 			// Method begins at RVA 0x20a8
 			// Header size: 12
-			// Code size: 82 (0x52)
+			// Code size: 78 (0x4e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope,
@@ -164,21 +164,17 @@
 			IL_0030: ldloc.0
 			IL_0031: ldstr "I am outer"
 			IL_0036: stfld string Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope::outerVar
-			IL_003b: ldc.i4.2
-			IL_003c: newarr [System.Runtime]System.Object
-			IL_0041: dup
-			IL_0042: ldc.i4.0
-			IL_0043: ldarg.0
-			IL_0044: stelem.ref
-			IL_0045: dup
-			IL_0046: ldc.i4.1
-			IL_0047: ldloc.0
-			IL_0048: stelem.ref
-			IL_0049: ldnull
-			IL_004a: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
-			IL_004f: pop
-			IL_0050: ldnull
-			IL_0051: ret
+			IL_003b: ldloc.1
+			IL_003c: ldc.i4.1
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldarg.0
+			IL_0045: stelem.ref
+			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_004b: pop
+			IL_004c: ldnull
+			IL_004d: ret
 		} // end of method testFunction::__js_call__
 
 	} // end of class testFunction
@@ -200,7 +196,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2167
+			// Method begins at RVA 0x2163
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -226,7 +222,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 76 (0x4c)
+		// Code size: 75 (0x4b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope,
@@ -259,12 +255,11 @@
 		IL_0033: ldloc.0
 		IL_0034: ldstr "I am global"
 		IL_0039: stfld string Modules.Function_NestedFunctionAccessesMultipleScopes/Scope::globalVar
-		IL_003e: ldloc.0
-		IL_003f: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
-		IL_0044: ldnull
-		IL_0045: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_004a: pop
-		IL_004b: ret
+		IL_003e: ldloc.1
+		IL_003f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0049: pop
+		IL_004a: ret
 	} // end of method Function_NestedFunctionAccessesMultipleScopes::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionAccessesMultipleScopes
@@ -276,7 +271,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2182
+		// Method begins at RVA 0x217e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -199,7 +199,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 93 (0x5d)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionLogsOuterParameter/Scope,
@@ -231,22 +231,23 @@
 		IL_0030: stloc.3
 		IL_0031: ldloc.3
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_NestedFunctionLogsOuterParameter/Scope
-		IL_0039: ldnull
-		IL_003a: ldstr "Value from outer"
-		IL_003f: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
-		IL_0044: stloc.3
-		IL_0045: ldloc.3
-		IL_0046: stloc.2
-		IL_0047: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_004c: stloc.s 4
-		IL_004e: ldloc.2
-		IL_004f: ldloc.s 4
-		IL_0051: ldstr "Value from inner"
-		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_005b: pop
-		IL_005c: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.s 4
+		IL_003a: ldloc.1
+		IL_003b: ldloc.s 4
+		IL_003d: ldstr "Value from outer"
+		IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0047: stloc.3
+		IL_0048: ldloc.3
+		IL_0049: stloc.2
+		IL_004a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004f: stloc.s 4
+		IL_0051: ldloc.2
+		IL_0052: ldloc.s 4
+		IL_0054: ldstr "Value from inner"
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method Function_NestedFunctionLogsOuterParameter::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionLogsOuterParameter

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2191
+					// Method begins at RVA 0x218d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x212f
+				// Method begins at RVA 0x212b
 				// Header size: 1
 				// Code size: 28 (0x1c)
 				.maxstack 8
@@ -73,7 +73,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x219a
+					// Method begins at RVA 0x2196
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -97,7 +97,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x214c
+				// Method begins at RVA 0x2148
 				// Header size: 12
 				// Code size: 39 (0x27)
 				.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2188
+				// Method begins at RVA 0x2184
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -167,7 +167,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x20ac
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 119 (0x77)
 			.maxstack 8
@@ -252,7 +252,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x217f
+			// Method begins at RVA 0x217b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -278,7 +278,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 77 (0x4d)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewExpression_CapturesOuterCtor/Scope,
@@ -308,16 +308,15 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_NewExpression_CapturesOuterCtor/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
-		IL_003f: stloc.2
-		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0045: ldloc.2
-		IL_0046: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_004b: pop
-		IL_004c: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.2
+		IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0044: ldloc.2
+		IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method Function_NewExpression_CapturesOuterCtor::__js_module_init__
 
 } // end of class Modules.Function_NewExpression_CapturesOuterCtor
@@ -329,7 +328,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21a3
+		// Method begins at RVA 0x219f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2169
+					// Method begins at RVA 0x216d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2120
+				// Method begins at RVA 0x2124
 				// Header size: 12
 				// Code size: 43 (0x2b)
 				.maxstack 8
@@ -86,7 +86,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2160
+				// Method begins at RVA 0x2164
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -112,7 +112,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20b8
 			// Header size: 12
 			// Code size: 95 (0x5f)
 			.maxstack 8
@@ -182,7 +182,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2157
+			// Method begins at RVA 0x215b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -208,7 +208,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 88 (0x58)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewTarget_Arrow_Inherits/Scope,
@@ -245,11 +245,11 @@
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
 		IL_0049: pop
 		IL_004a: ldloc.0
-		IL_004b: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
-		IL_0050: ldnull
-		IL_0051: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
-		IL_0056: pop
-		IL_0057: ret
+		IL_004b: ldfld object Modules.Function_NewTarget_Arrow_Inherits/Scope::Outer
+		IL_0050: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method Function_NewTarget_Arrow_Inherits::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_Arrow_Inherits
@@ -261,7 +261,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2172
+		// Method begins at RVA 0x2176
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2123
+				// Method begins at RVA 0x2127
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20b4
+			// Method begins at RVA 0x20b8
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -112,7 +112,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x211a
+			// Method begins at RVA 0x211e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -138,7 +138,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 88 (0x58)
+		// Code size: 92 (0x5c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewTarget_NewVsCall/Scope,
@@ -175,11 +175,11 @@
 		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
 		IL_0049: pop
 		IL_004a: ldloc.0
-		IL_004b: castclass Modules.Function_NewTarget_NewVsCall/Scope
-		IL_0050: ldnull
-		IL_0051: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
-		IL_0056: pop
-		IL_0057: ret
+		IL_004b: ldfld object Modules.Function_NewTarget_NewVsCall/Scope::C
+		IL_0050: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005a: pop
+		IL_005b: ret
 	} // end of method Function_NewTarget_NewVsCall::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_NewVsCall
@@ -191,7 +191,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x212c
+		// Method begins at RVA 0x2130
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20b8
+				// Method begins at RVA 0x20c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a5
+			// Method begins at RVA 0x20b6
 			// Header size: 1
 			// Code size: 9 (0x9)
 			.maxstack 8
@@ -71,7 +71,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20af
+			// Method begins at RVA 0x20c0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -97,12 +97,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 73 (0x49)
+		// Code size: 90 (0x5a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NoCapture_NoScopesParameter/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_NoCapture_NoScopesParameter/Scope::.ctor()
@@ -119,16 +120,21 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldc.r8 5
-		IL_002d: ldc.r8 3
-		IL_0036: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
-		IL_003b: stloc.2
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: ldloc.2
-		IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0047: pop
-		IL_0048: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldc.r8 5
+		IL_0034: box [System.Runtime]System.Double
+		IL_0039: ldc.r8 3
+		IL_0042: box [System.Runtime]System.Double
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_004c: stloc.2
+		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0052: ldloc.2
+		IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0058: pop
+		IL_0059: ret
 	} // end of method Function_NoCapture_NoScopesParameter::__js_module_init__
 
 } // end of class Modules.Function_NoCapture_NoScopesParameter
@@ -140,7 +146,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20c1
+		// Method begins at RVA 0x20d2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
@@ -26,7 +26,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x229f
+				// Method begins at RVA 0x22b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -50,7 +50,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2148
+			// Method begins at RVA 0x215c
 			// Header size: 12
 			// Code size: 72 (0x48)
 			.maxstack 8
@@ -111,7 +111,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x22b1
+					// Method begins at RVA 0x22c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -134,7 +134,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a8
+				// Method begins at RVA 0x22bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -158,7 +158,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x219c
+			// Method begins at RVA 0x21b0
 			// Header size: 12
 			// Code size: 238 (0xee)
 			.maxstack 8
@@ -285,7 +285,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2296
+			// Method begins at RVA 0x22aa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -311,14 +311,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 233 (0xe9)
+		// Code size: 253 (0xfd)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterDestructuring_Object/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_ParameterDestructuring_Object/Scope::.ctor()
@@ -347,55 +347,59 @@
 		IL_003d: stloc.3
 		IL_003e: ldloc.3
 		IL_003f: stloc.2
-		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0045: dup
-		IL_0046: ldstr "a"
-		IL_004b: ldc.r8 10
-		IL_0054: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0059: dup
-		IL_005a: ldstr "b"
-		IL_005f: ldc.r8 20
-		IL_0068: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_006d: stloc.s 4
-		IL_006f: ldnull
-		IL_0070: ldloc.s 4
-		IL_0072: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
-		IL_0077: pop
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_007d: dup
-		IL_007e: ldstr "host"
-		IL_0083: ldstr "example.com"
-		IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_008d: stloc.s 4
-		IL_008f: ldnull
-		IL_0090: ldloc.s 4
-		IL_0092: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
-		IL_0097: pop
-		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_009d: dup
-		IL_009e: ldstr "host"
-		IL_00a3: ldstr "api.test.com"
-		IL_00a8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00ad: dup
-		IL_00ae: ldstr "port"
-		IL_00b3: ldc.r8 3000
-		IL_00bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0045: stloc.s 4
+		IL_0047: ldloc.1
+		IL_0048: ldloc.s 4
+		IL_004a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_004f: dup
+		IL_0050: ldstr "a"
+		IL_0055: ldc.r8 10
+		IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0063: dup
+		IL_0064: ldstr "b"
+		IL_0069: ldc.r8 20
+		IL_0072: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_007c: pop
+		IL_007d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0082: stloc.s 4
+		IL_0084: ldloc.2
+		IL_0085: ldloc.s 4
+		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_008c: dup
+		IL_008d: ldstr "host"
+		IL_0092: ldstr "example.com"
+		IL_0097: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00a1: pop
+		IL_00a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a7: stloc.s 4
+		IL_00a9: ldloc.2
+		IL_00aa: ldloc.s 4
+		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00b1: dup
+		IL_00b2: ldstr "host"
+		IL_00b7: ldstr "api.test.com"
+		IL_00bc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
 		IL_00c1: dup
-		IL_00c2: ldstr "secure"
-		IL_00c7: ldc.i4.1
-		IL_00c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_00cd: stloc.s 4
-		IL_00cf: ldnull
-		IL_00d0: ldloc.s 4
-		IL_00d2: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
-		IL_00d7: pop
-		IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00dd: stloc.s 4
-		IL_00df: ldnull
-		IL_00e0: ldloc.s 4
-		IL_00e2: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
-		IL_00e7: pop
-		IL_00e8: ret
+		IL_00c2: ldstr "port"
+		IL_00c7: ldc.r8 3000
+		IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00d5: dup
+		IL_00d6: ldstr "secure"
+		IL_00db: ldc.i4.1
+		IL_00dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00e6: pop
+		IL_00e7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ec: stloc.s 4
+		IL_00ee: ldloc.2
+		IL_00ef: ldloc.s 4
+		IL_00f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00fb: pop
+		IL_00fc: ret
 	} // end of method Function_ParameterDestructuring_Object::__js_module_init__
 
 } // end of class Modules.Function_ParameterDestructuring_Object
@@ -407,7 +411,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22ba
+		// Method begins at RVA 0x22ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23de
+				// Method begins at RVA 0x23fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a4
+			// Method begins at RVA 0x21c0
 			// Header size: 12
 			// Code size: 173 (0xad)
 			.maxstack 8
@@ -114,7 +114,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23e7
+				// Method begins at RVA 0x2403
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -139,7 +139,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2260
+			// Method begins at RVA 0x227c
 			// Header size: 12
 			// Code size: 173 (0xad)
 			.maxstack 8
@@ -210,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f0
+				// Method begins at RVA 0x240c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -235,7 +235,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x231c
+			// Method begins at RVA 0x2338
 			// Header size: 12
 			// Code size: 173 (0xad)
 			.maxstack 8
@@ -314,7 +314,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23d5
+			// Method begins at RVA 0x23f1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -340,7 +340,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 327 (0x147)
+		// Code size: 354 (0x162)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/Scope,
@@ -349,7 +349,8 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[7] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/Scope::.ctor()
@@ -419,37 +420,46 @@
 		IL_00cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_00d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 		IL_00d5: stloc.s 4
-		IL_00d7: ldnull
-		IL_00d8: ldloc.s 4
-		IL_00da: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_00df: ldc.r8 30
-		IL_00e8: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_00ed: stloc.s 5
-		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f4: ldloc.s 5
-		IL_00f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fb: pop
-		IL_00fc: ldnull
-		IL_00fd: ldloc.s 4
-		IL_00ff: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0104: ldc.r8 45
-		IL_010d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0112: stloc.s 5
-		IL_0114: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0119: ldloc.s 5
-		IL_011b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0120: pop
-		IL_0121: ldnull
-		IL_0122: ldloc.s 4
-		IL_0124: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0129: ldc.r8 60
-		IL_0132: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0137: stloc.s 5
-		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013e: ldloc.s 5
-		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0145: pop
-		IL_0146: ret
+		IL_00d7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00dc: stloc.s 7
+		IL_00de: ldloc.1
+		IL_00df: ldloc.s 7
+		IL_00e1: ldloc.s 4
+		IL_00e3: ldc.r8 30
+		IL_00ec: box [System.Runtime]System.Double
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00f6: stloc.s 5
+		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fd: ldloc.s 5
+		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0104: pop
+		IL_0105: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_010a: stloc.s 7
+		IL_010c: ldloc.2
+		IL_010d: ldloc.s 7
+		IL_010f: ldloc.s 4
+		IL_0111: ldc.r8 45
+		IL_011a: box [System.Runtime]System.Double
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0124: stloc.s 5
+		IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012b: ldloc.s 5
+		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0132: pop
+		IL_0133: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0138: stloc.s 7
+		IL_013a: ldloc.3
+		IL_013b: ldloc.s 7
+		IL_013d: ldloc.s 4
+		IL_013f: ldc.r8 60
+		IL_0148: box [System.Runtime]System.Double
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0152: stloc.s 5
+		IL_0154: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0159: ldloc.s 5
+		IL_015b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0160: pop
+		IL_0161: ret
 	} // end of method Function_ParameterTypeInference_DirectRotateArrayArgument::__js_module_init__
 
 } // end of class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument
@@ -461,7 +471,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23f9
+		// Method begins at RVA 0x2415
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature
+﻿// IL code: Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20df
+				// Method begins at RVA 0x20e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20c4
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -75,7 +75,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d6
+			// Method begins at RVA 0x20da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -101,12 +101,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 97 (0x61)
+		// Code size: 104 (0x68)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scope::.ctor()
@@ -129,18 +130,21 @@
 		IL_002a: ldc.i4.1
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
 		IL_0030: pop
-		IL_0031: ldnull
-		IL_0032: ldc.r8 1
-		IL_003b: box [System.Runtime]System.Double
-		IL_0040: ldc.r8 2
-		IL_0049: box [System.Runtime]System.Double
-		IL_004e: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
-		IL_0053: stloc.2
-		IL_0054: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0059: ldloc.2
-		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005f: pop
-		IL_0060: ret
+		IL_0031: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0036: stloc.3
+		IL_0037: ldloc.1
+		IL_0038: ldloc.3
+		IL_0039: ldc.r8 1
+		IL_0042: box [System.Runtime]System.Double
+		IL_0047: ldc.r8 2
+		IL_0050: box [System.Runtime]System.Double
+		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_005a: stloc.2
+		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0060: ldloc.2
+		IL_0061: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0066: pop
+		IL_0067: ret
 	} // end of method Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature::__js_module_init__
 
 } // end of class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature
@@ -152,7 +156,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e8
+		// Method begins at RVA 0x20ec
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e0
+				// Method begins at RVA 0x21a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f2
+					// Method begins at RVA 0x21b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e9
+				// Method begins at RVA 0x21ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -86,7 +86,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2160
+			// Method begins at RVA 0x2124
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -152,7 +152,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d7
+			// Method begins at RVA 0x219b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -178,12 +178,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 260 (0x104)
+		// Code size: 198 (0xc6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Basic/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_RestParameters_Basic/Scope::.ctor()
@@ -208,68 +209,45 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_0039: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0044: ldc.i4.3
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldc.r8 1
-		IL_0055: box [System.Runtime]System.Double
-		IL_005a: stelem.ref
-		IL_005b: dup
-		IL_005c: ldc.i4.1
-		IL_005d: ldc.r8 2
-		IL_0066: box [System.Runtime]System.Double
-		IL_006b: stelem.ref
-		IL_006c: dup
-		IL_006d: ldc.i4.2
-		IL_006e: ldc.r8 3
-		IL_0077: box [System.Runtime]System.Double
-		IL_007c: stelem.ref
-		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_0082: stloc.2
-		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0088: ldloc.2
-		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008e: pop
-		IL_008f: ldloc.0
-		IL_0090: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_0095: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_009b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00a0: ldc.i4.2
-		IL_00a1: newarr [System.Runtime]System.Object
-		IL_00a6: dup
-		IL_00a7: ldc.i4.0
-		IL_00a8: ldc.r8 10
-		IL_00b1: box [System.Runtime]System.Double
-		IL_00b6: stelem.ref
-		IL_00b7: dup
-		IL_00b8: ldc.i4.1
-		IL_00b9: ldc.r8 20
-		IL_00c2: box [System.Runtime]System.Double
-		IL_00c7: stelem.ref
-		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_00cd: stloc.2
-		IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d3: ldloc.2
-		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d9: pop
-		IL_00da: ldloc.0
-		IL_00db: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_00e0: ldftn object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_00e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00eb: ldc.i4.0
-		IL_00ec: newarr [System.Runtime]System.Object
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_00f6: stloc.2
-		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fc: ldloc.2
-		IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0102: pop
-		IL_0103: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldloc.1
+		IL_003a: ldloc.3
+		IL_003b: ldc.r8 1
+		IL_0044: box [System.Runtime]System.Double
+		IL_0049: ldc.r8 2
+		IL_0052: box [System.Runtime]System.Double
+		IL_0057: ldc.r8 3
+		IL_0060: box [System.Runtime]System.Double
+		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_006a: stloc.2
+		IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0070: ldloc.2
+		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0076: pop
+		IL_0077: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_007c: stloc.3
+		IL_007d: ldloc.1
+		IL_007e: ldloc.3
+		IL_007f: ldc.r8 10
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: ldc.r8 20
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00a0: stloc.2
+		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a6: ldloc.2
+		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ac: pop
+		IL_00ad: ldloc.1
+		IL_00ae: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00b8: stloc.2
+		IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00be: ldloc.2
+		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c4: pop
+		IL_00c5: ret
 	} // end of method Function_RestParameters_Basic::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_Basic
@@ -281,7 +259,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21fb
+		// Method begins at RVA 0x21bf
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Function_RestParameters_Empty
+﻿// IL code: Function_RestParameters_Empty
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x217c
+					// Method begins at RVA 0x2150
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2173
+				// Method begins at RVA 0x2147
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -63,7 +63,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20e8
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 118 (0x76)
 			.maxstack 8
@@ -121,7 +121,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x216a
+			// Method begins at RVA 0x213e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -147,12 +147,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 140 (0x8c)
+		// Code size: 96 (0x60)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Empty/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_RestParameters_Empty/Scope::.ctor()
@@ -169,44 +170,27 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldftn object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
-		IL_002a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_002f: ldc.i4.0
-		IL_0030: newarr [System.Runtime]System.Object
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldftn object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
-		IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0047: ldc.i4.1
-		IL_0048: newarr [System.Runtime]System.Object
-		IL_004d: dup
-		IL_004e: ldc.i4.0
-		IL_004f: ldstr "hello"
-		IL_0054: stelem.ref
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_005a: pop
-		IL_005b: ldnull
-		IL_005c: ldftn object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
-		IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0067: ldc.i4.3
-		IL_0068: newarr [System.Runtime]System.Object
-		IL_006d: dup
-		IL_006e: ldc.i4.0
-		IL_006f: ldstr "a"
-		IL_0074: stelem.ref
-		IL_0075: dup
-		IL_0076: ldc.i4.1
-		IL_0077: ldstr "b"
-		IL_007c: stelem.ref
-		IL_007d: dup
-		IL_007e: ldc.i4.2
-		IL_007f: ldstr "c"
-		IL_0084: stelem.ref
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0, object[])
-		IL_008a: pop
-		IL_008b: ret
+		IL_0023: ldloc.1
+		IL_0024: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_002e: pop
+		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0034: stloc.3
+		IL_0035: ldloc.1
+		IL_0036: ldloc.3
+		IL_0037: ldstr "hello"
+		IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0041: pop
+		IL_0042: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0047: stloc.3
+		IL_0048: ldloc.1
+		IL_0049: ldloc.3
+		IL_004a: ldstr "a"
+		IL_004f: ldstr "b"
+		IL_0054: ldstr "c"
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_005e: pop
+		IL_005f: ret
 	} // end of method Function_RestParameters_Empty::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_Empty
@@ -218,7 +202,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2185
+		// Method begins at RVA 0x2159
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21db
+				// Method begins at RVA 0x21a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21ed
+					// Method begins at RVA 0x21b9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e4
+				// Method begins at RVA 0x21b0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x215c
+			// Method begins at RVA 0x2128
 			// Header size: 12
 			// Code size: 106 (0x6a)
 			.maxstack 8
@@ -159,7 +159,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d2
+			// Method begins at RVA 0x219e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -185,12 +185,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 255 (0xff)
+		// Code size: 201 (0xc9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_MultipleNamed/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_RestParameters_MultipleNamed/Scope::.ctor()
@@ -215,83 +216,64 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_0039: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0044: ldc.i4.5
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldstr "["
-		IL_0051: stelem.ref
-		IL_0052: dup
-		IL_0053: ldc.i4.1
-		IL_0054: ldstr "]"
-		IL_0059: stelem.ref
-		IL_005a: dup
-		IL_005b: ldc.i4.2
-		IL_005c: ldstr "a"
-		IL_0061: stelem.ref
-		IL_0062: dup
-		IL_0063: ldc.i4.3
-		IL_0064: ldstr "b"
-		IL_0069: stelem.ref
-		IL_006a: dup
-		IL_006b: ldc.i4.4
-		IL_006c: ldstr "c"
-		IL_0071: stelem.ref
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_0077: stloc.2
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldloc.2
-		IL_007e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0083: pop
-		IL_0084: ldloc.0
-		IL_0085: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_008a: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_0090: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_0095: ldc.i4.3
-		IL_0096: newarr [System.Runtime]System.Object
-		IL_009b: dup
-		IL_009c: ldc.i4.0
-		IL_009d: ldstr "<"
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.1
-		IL_00a5: ldstr ">"
-		IL_00aa: stelem.ref
-		IL_00ab: dup
-		IL_00ac: ldc.i4.2
-		IL_00ad: ldstr "hello"
-		IL_00b2: stelem.ref
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_00b8: stloc.2
-		IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00be: ldloc.2
-		IL_00bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c4: pop
-		IL_00c5: ldloc.0
-		IL_00c6: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_00cb: ldftn object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2::.ctor(object, native int)
-		IL_00d6: ldc.i4.2
-		IL_00d7: newarr [System.Runtime]System.Object
-		IL_00dc: dup
-		IL_00dd: ldc.i4.0
-		IL_00de: ldstr "{"
-		IL_00e3: stelem.ref
-		IL_00e4: dup
-		IL_00e5: ldc.i4.1
-		IL_00e6: ldstr "}"
-		IL_00eb: stelem.ref
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2, object[])
-		IL_00f1: stloc.2
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f7: ldloc.2
-		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fd: pop
-		IL_00fe: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldloc.1
+		IL_003a: ldloc.3
+		IL_003b: ldc.i4.5
+		IL_003c: newarr [System.Runtime]System.Object
+		IL_0041: dup
+		IL_0042: ldc.i4.0
+		IL_0043: ldstr "["
+		IL_0048: stelem.ref
+		IL_0049: dup
+		IL_004a: ldc.i4.1
+		IL_004b: ldstr "]"
+		IL_0050: stelem.ref
+		IL_0051: dup
+		IL_0052: ldc.i4.2
+		IL_0053: ldstr "a"
+		IL_0058: stelem.ref
+		IL_0059: dup
+		IL_005a: ldc.i4.3
+		IL_005b: ldstr "b"
+		IL_0060: stelem.ref
+		IL_0061: dup
+		IL_0062: ldc.i4.4
+		IL_0063: ldstr "c"
+		IL_0068: stelem.ref
+		IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_006e: stloc.2
+		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0074: ldloc.2
+		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007a: pop
+		IL_007b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0080: stloc.3
+		IL_0081: ldloc.1
+		IL_0082: ldloc.3
+		IL_0083: ldstr "<"
+		IL_0088: ldstr ">"
+		IL_008d: ldstr "hello"
+		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_0097: stloc.2
+		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009d: ldloc.2
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a9: stloc.3
+		IL_00aa: ldloc.1
+		IL_00ab: ldloc.3
+		IL_00ac: ldstr "{"
+		IL_00b1: ldstr "}"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00bb: stloc.2
+		IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c1: ldloc.2
+		IL_00c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c7: pop
+		IL_00c8: ret
 	} // end of method Function_RestParameters_MultipleNamed::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_MultipleNamed
@@ -303,7 +285,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21f6
+		// Method begins at RVA 0x21c2
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21e7
+				// Method begins at RVA 0x21b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2202
+						// Method begins at RVA 0x21ce
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21f9
+					// Method begins at RVA 0x21c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -82,7 +82,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f0
+				// Method begins at RVA 0x21bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -109,7 +109,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x214c
+			// Method begins at RVA 0x2118
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -189,7 +189,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21de
+			// Method begins at RVA 0x21aa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -215,12 +215,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 239 (0xef)
+		// Code size: 188 (0xbc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_WithNamedParams/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_RestParameters_WithNamedParams/Scope::.ctor()
@@ -245,75 +246,59 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_0039: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_003f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0044: ldc.i4.4
-		IL_0045: newarr [System.Runtime]System.Object
-		IL_004a: dup
-		IL_004b: ldc.i4.0
-		IL_004c: ldstr "-"
-		IL_0051: stelem.ref
-		IL_0052: dup
-		IL_0053: ldc.i4.1
-		IL_0054: ldstr "a"
-		IL_0059: stelem.ref
-		IL_005a: dup
-		IL_005b: ldc.i4.2
-		IL_005c: ldstr "b"
-		IL_0061: stelem.ref
-		IL_0062: dup
-		IL_0063: ldc.i4.3
-		IL_0064: ldstr "c"
-		IL_0069: stelem.ref
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_006f: stloc.2
-		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0075: ldloc.2
-		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007b: pop
-		IL_007c: ldloc.0
-		IL_007d: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_0082: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_0088: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_008d: ldc.i4.3
-		IL_008e: newarr [System.Runtime]System.Object
-		IL_0093: dup
-		IL_0094: ldc.i4.0
-		IL_0095: ldstr " "
-		IL_009a: stelem.ref
-		IL_009b: dup
-		IL_009c: ldc.i4.1
-		IL_009d: ldstr "hello"
-		IL_00a2: stelem.ref
-		IL_00a3: dup
-		IL_00a4: ldc.i4.2
-		IL_00a5: ldstr "world"
-		IL_00aa: stelem.ref
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_00b0: stloc.2
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b6: ldloc.2
-		IL_00b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bc: pop
-		IL_00bd: ldloc.0
-		IL_00be: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_00c3: ldftn object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_00ce: ldc.i4.1
-		IL_00cf: newarr [System.Runtime]System.Object
-		IL_00d4: dup
-		IL_00d5: ldc.i4.0
-		IL_00d6: ldstr ","
-		IL_00db: stelem.ref
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeDirectWithArgs(class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1, object[])
-		IL_00e1: stloc.2
-		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e7: ldloc.2
-		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ed: pop
-		IL_00ee: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldloc.1
+		IL_003a: ldloc.3
+		IL_003b: ldc.i4.4
+		IL_003c: newarr [System.Runtime]System.Object
+		IL_0041: dup
+		IL_0042: ldc.i4.0
+		IL_0043: ldstr "-"
+		IL_0048: stelem.ref
+		IL_0049: dup
+		IL_004a: ldc.i4.1
+		IL_004b: ldstr "a"
+		IL_0050: stelem.ref
+		IL_0051: dup
+		IL_0052: ldc.i4.2
+		IL_0053: ldstr "b"
+		IL_0058: stelem.ref
+		IL_0059: dup
+		IL_005a: ldc.i4.3
+		IL_005b: ldstr "c"
+		IL_0060: stelem.ref
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0066: stloc.2
+		IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006c: ldloc.2
+		IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0072: pop
+		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0078: stloc.3
+		IL_0079: ldloc.1
+		IL_007a: ldloc.3
+		IL_007b: ldstr " "
+		IL_0080: ldstr "hello"
+		IL_0085: ldstr "world"
+		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+		IL_008f: stloc.2
+		IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0095: ldloc.2
+		IL_0096: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009b: pop
+		IL_009c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a1: stloc.3
+		IL_00a2: ldloc.1
+		IL_00a3: ldloc.3
+		IL_00a4: ldstr ","
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00ae: stloc.2
+		IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b4: ldloc.2
+		IL_00b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ba: pop
+		IL_00bb: ret
 	} // end of method Function_RestParameters_WithNamedParams::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_WithNamedParams
@@ -325,7 +310,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220b
+		// Method begins at RVA 0x21d7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2201
+					// Method begins at RVA 0x2209
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x21c0
+				// Method begins at RVA 0x21c8
 				// Header size: 12
 				// Code size: 35 (0x23)
 				.maxstack 8
@@ -91,7 +91,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21f8
+				// Method begins at RVA 0x2200
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -118,7 +118,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2158
+			// Method begins at RVA 0x2160
 			// Header size: 12
 			// Code size: 92 (0x5c)
 			.maxstack 8
@@ -187,7 +187,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ef
+			// Method begins at RVA 0x21f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -213,14 +213,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 251 (0xfb)
+		// Code size: 257 (0x101)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnObjectWithClosure/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Function_ReturnObjectWithClosure/Scope::.ctor()
@@ -245,60 +246,62 @@
 		IL_0030: stloc.s 4
 		IL_0032: ldloc.s 4
 		IL_0034: stloc.1
-		IL_0035: ldloc.0
-		IL_0036: castclass Modules.Function_ReturnObjectWithClosure/Scope
-		IL_003b: ldnull
-		IL_003c: ldc.r8 10
-		IL_0045: box [System.Runtime]System.Double
-		IL_004a: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
-		IL_004f: stloc.s 4
-		IL_0051: ldloc.s 4
-		IL_0053: stloc.2
-		IL_0054: ldloc.2
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005a: stloc.s 4
-		IL_005c: ldloc.s 4
-		IL_005e: ldstr "multiply"
-		IL_0063: ldc.r8 5
-		IL_006c: box [System.Runtime]System.Double
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0076: stloc.s 4
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldstr "multiply(5):"
-		IL_0082: ldloc.s 4
-		IL_0084: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0089: pop
-		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008f: ldstr "factor:"
-		IL_0094: ldloc.2
-		IL_0095: ldstr "factor"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00a4: pop
-		IL_00a5: ldloc.0
-		IL_00a6: castclass Modules.Function_ReturnObjectWithClosure/Scope
-		IL_00ab: ldnull
-		IL_00ac: ldc.r8 3
-		IL_00b5: box [System.Runtime]System.Double
-		IL_00ba: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
-		IL_00bf: stloc.s 4
-		IL_00c1: ldloc.s 4
-		IL_00c3: stloc.3
-		IL_00c4: ldloc.3
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ca: stloc.s 4
-		IL_00cc: ldloc.s 4
-		IL_00ce: ldstr "multiply"
-		IL_00d3: ldc.r8 7
-		IL_00dc: box [System.Runtime]System.Double
-		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e6: stloc.s 4
-		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ed: ldstr "calc2.multiply(7):"
-		IL_00f2: ldloc.s 4
-		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00f9: pop
-		IL_00fa: ret
+		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003a: stloc.s 5
+		IL_003c: ldloc.1
+		IL_003d: ldloc.s 5
+		IL_003f: ldc.r8 10
+		IL_0048: box [System.Runtime]System.Double
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0052: stloc.s 4
+		IL_0054: ldloc.s 4
+		IL_0056: stloc.2
+		IL_0057: ldloc.2
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_005d: stloc.s 4
+		IL_005f: ldloc.s 4
+		IL_0061: ldstr "multiply"
+		IL_0066: ldc.r8 5
+		IL_006f: box [System.Runtime]System.Double
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0079: stloc.s 4
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldstr "multiply(5):"
+		IL_0085: ldloc.s 4
+		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_008c: pop
+		IL_008d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0092: ldstr "factor:"
+		IL_0097: ldloc.2
+		IL_0098: ldstr "factor"
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00a7: pop
+		IL_00a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ad: stloc.s 5
+		IL_00af: ldloc.1
+		IL_00b0: ldloc.s 5
+		IL_00b2: ldc.r8 3
+		IL_00bb: box [System.Runtime]System.Double
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00c5: stloc.s 4
+		IL_00c7: ldloc.s 4
+		IL_00c9: stloc.3
+		IL_00ca: ldloc.3
+		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d0: stloc.s 4
+		IL_00d2: ldloc.s 4
+		IL_00d4: ldstr "multiply"
+		IL_00d9: ldc.r8 7
+		IL_00e2: box [System.Runtime]System.Double
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ec: stloc.s 4
+		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f3: ldstr "calc2.multiply(7):"
+		IL_00f8: ldloc.s 4
+		IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ff: pop
+		IL_0100: ret
 	} // end of method Function_ReturnObjectWithClosure::__js_module_init__
 
 } // end of class Modules.Function_ReturnObjectWithClosure
@@ -310,7 +313,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x220a
+		// Method begins at RVA 0x2212
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20c9
+				// Method begins at RVA 0x20d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a5
+			// Method begins at RVA 0x20b1
 			// Header size: 1
 			// Code size: 26 (0x1a)
 			.maxstack 8
@@ -71,7 +71,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20cc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -97,7 +97,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 73 (0x49)
+		// Code size: 85 (0x55)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnsStaticValueAndLogs/Scope,
@@ -122,20 +122,24 @@
 		IL_0020: stloc.3
 		IL_0021: ldloc.3
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
-		IL_0029: stloc.s 4
-		IL_002b: ldloc.s 4
-		IL_002d: stloc.2
-		IL_002e: ldloc.2
-		IL_002f: box [System.Runtime]System.Double
-		IL_0034: stloc.s 5
-		IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_003b: ldstr "Output:"
-		IL_0040: ldloc.s 5
-		IL_0042: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0047: pop
-		IL_0048: ret
+		IL_0023: ldloc.1
+		IL_0024: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_002e: stloc.3
+		IL_002f: ldloc.3
+		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0035: stloc.s 4
+		IL_0037: ldloc.s 4
+		IL_0039: stloc.2
+		IL_003a: ldloc.2
+		IL_003b: box [System.Runtime]System.Double
+		IL_0040: stloc.s 5
+		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0047: ldstr "Output:"
+		IL_004c: ldloc.s 5
+		IL_004e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0053: pop
+		IL_0054: ret
 	} // end of method Function_ReturnsStaticValueAndLogs::__js_module_init__
 
 } // end of class Modules.Function_ReturnsStaticValueAndLogs
@@ -147,7 +151,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20d2
+		// Method begins at RVA 0x20de
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x237f
+				// Method begins at RVA 0x237b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21e0
+			// Method begins at RVA 0x21dc
 			// Header size: 12
 			// Code size: 394 (0x18a)
 			.maxstack 8
@@ -223,7 +223,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2376
+			// Method begins at RVA 0x2372
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -249,7 +249,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 388 (0x184)
+		// Code size: 383 (0x17f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_BasicNext/Scope,
@@ -282,108 +282,103 @@
 		IL_002e: stloc.s 7
 		IL_0030: ldloc.s 7
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_BasicNext/g::__js_call__(object[], object)
-		IL_0043: stloc.s 7
-		IL_0045: ldloc.s 7
-		IL_0047: stloc.2
-		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004d: ldstr "aftercall"
-		IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0057: pop
-		IL_0058: ldloc.2
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005e: stloc.s 7
-		IL_0060: ldloc.s 7
-		IL_0062: ldstr "next"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_006c: stloc.s 7
-		IL_006e: ldloc.s 7
-		IL_0070: stloc.3
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0076: ldloc.3
-		IL_0077: ldstr "value"
-		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0081: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0086: pop
-		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008c: ldloc.3
-		IL_008d: ldstr "done"
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0097: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_009c: pop
-		IL_009d: ldloc.2
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a3: stloc.s 7
-		IL_00a5: ldloc.s 7
-		IL_00a7: ldstr "next"
-		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00b1: stloc.s 7
-		IL_00b3: ldloc.s 7
-		IL_00b5: stloc.s 4
-		IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bc: ldloc.s 4
-		IL_00be: ldstr "value"
-		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cd: pop
-		IL_00ce: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d3: ldloc.s 4
-		IL_00d5: ldstr "done"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e4: pop
-		IL_00e5: ldloc.2
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00eb: stloc.s 7
-		IL_00ed: ldloc.s 7
-		IL_00ef: ldstr "next"
-		IL_00f4: ldc.r8 42
-		IL_00fd: box [System.Runtime]System.Double
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0107: stloc.s 7
-		IL_0109: ldloc.s 7
-		IL_010b: stloc.s 5
-		IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0112: ldloc.s 5
-		IL_0114: ldstr "value"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0123: pop
-		IL_0124: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0129: ldloc.s 5
-		IL_012b: ldstr "done"
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013a: pop
-		IL_013b: ldloc.2
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0141: stloc.s 7
-		IL_0143: ldloc.s 7
-		IL_0145: ldstr "next"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_014f: stloc.s 7
-		IL_0151: ldloc.s 7
-		IL_0153: stloc.s 6
-		IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015a: ldloc.s 6
-		IL_015c: ldstr "value"
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016b: pop
-		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0171: ldloc.s 6
-		IL_0173: ldstr "done"
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0182: pop
-		IL_0183: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 7
+		IL_0040: ldloc.s 7
+		IL_0042: stloc.2
+		IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0048: ldstr "aftercall"
+		IL_004d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0052: pop
+		IL_0053: ldloc.2
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0059: stloc.s 7
+		IL_005b: ldloc.s 7
+		IL_005d: ldstr "next"
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0067: stloc.s 7
+		IL_0069: ldloc.s 7
+		IL_006b: stloc.3
+		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0071: ldloc.3
+		IL_0072: ldstr "value"
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0081: pop
+		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0087: ldloc.3
+		IL_0088: ldstr "done"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0097: pop
+		IL_0098: ldloc.2
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_009e: stloc.s 7
+		IL_00a0: ldloc.s 7
+		IL_00a2: ldstr "next"
+		IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00ac: stloc.s 7
+		IL_00ae: ldloc.s 7
+		IL_00b0: stloc.s 4
+		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b7: ldloc.s 4
+		IL_00b9: ldstr "value"
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c8: pop
+		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ce: ldloc.s 4
+		IL_00d0: ldstr "done"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00df: pop
+		IL_00e0: ldloc.2
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e6: stloc.s 7
+		IL_00e8: ldloc.s 7
+		IL_00ea: ldstr "next"
+		IL_00ef: ldc.r8 42
+		IL_00f8: box [System.Runtime]System.Double
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0102: stloc.s 7
+		IL_0104: ldloc.s 7
+		IL_0106: stloc.s 5
+		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010d: ldloc.s 5
+		IL_010f: ldstr "value"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0119: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011e: pop
+		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0124: ldloc.s 5
+		IL_0126: ldstr "done"
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0130: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0135: pop
+		IL_0136: ldloc.2
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013c: stloc.s 7
+		IL_013e: ldloc.s 7
+		IL_0140: ldstr "next"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_014a: stloc.s 7
+		IL_014c: ldloc.s 7
+		IL_014e: stloc.s 6
+		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0155: ldloc.s 6
+		IL_0157: ldstr "value"
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0166: pop
+		IL_0167: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016c: ldloc.s 6
+		IL_016e: ldstr "done"
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017d: pop
+		IL_017e: ret
 	} // end of method Generator_BasicNext::__js_module_init__
 
 } // end of class Modules.Generator_BasicNext
@@ -395,7 +390,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2388
+		// Method begins at RVA 0x2384
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_Constructor.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_Constructor.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2208
+				// Method begins at RVA 0x2200
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2110
+			// Method begins at RVA 0x2108
 			// Header size: 12
 			// Code size: 227 (0xe3)
 			.maxstack 8
@@ -161,7 +161,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ff
+			// Method begins at RVA 0x21f7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -187,7 +187,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 180 (0xb4)
+		// Code size: 170 (0xaa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_Prototype_Constructor/Scope,
@@ -220,55 +220,45 @@
 		IL_002e: stloc.s 5
 		IL_0030: ldloc.s 5
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
-		IL_0043: stloc.s 5
-		IL_0045: ldloc.s 5
-		IL_0047: stloc.2
-		IL_0048: ldc.i4.1
-		IL_0049: newarr [System.Runtime]System.Object
-		IL_004e: dup
-		IL_004f: ldc.i4.0
-		IL_0050: ldloc.0
-		IL_0051: stelem.ref
-		IL_0052: ldnull
-		IL_0053: call object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
-		IL_0058: stloc.s 5
-		IL_005a: ldloc.s 5
-		IL_005c: stloc.3
-		IL_005d: ldloc.2
-		IL_005e: ldstr "constructor"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0068: stloc.s 4
-		IL_006a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006f: ldloc.s 4
-		IL_0071: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007b: pop
-		IL_007c: ldloc.2
-		IL_007d: ldstr "constructor"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0087: stloc.s 5
-		IL_0089: ldloc.s 5
-		IL_008b: ldloc.3
-		IL_008c: ldstr "constructor"
-		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0096: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_009b: stloc.s 6
-		IL_009d: ldloc.s 6
-		IL_009f: box [System.Runtime]System.Boolean
-		IL_00a4: stloc.s 7
-		IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ab: ldloc.s 7
-		IL_00ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b2: pop
-		IL_00b3: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 5
+		IL_0040: ldloc.s 5
+		IL_0042: stloc.2
+		IL_0043: ldloc.1
+		IL_0044: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004e: stloc.s 5
+		IL_0050: ldloc.s 5
+		IL_0052: stloc.3
+		IL_0053: ldloc.2
+		IL_0054: ldstr "constructor"
+		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_005e: stloc.s 4
+		IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0065: ldloc.s 4
+		IL_0067: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0071: pop
+		IL_0072: ldloc.2
+		IL_0073: ldstr "constructor"
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_007d: stloc.s 5
+		IL_007f: ldloc.s 5
+		IL_0081: ldloc.3
+		IL_0082: ldstr "constructor"
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0091: stloc.s 6
+		IL_0093: ldloc.s 6
+		IL_0095: box [System.Runtime]System.Boolean
+		IL_009a: stloc.s 7
+		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a1: ldloc.s 7
+		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a8: pop
+		IL_00a9: ret
 	} // end of method Generator_Prototype_Constructor::__js_module_init__
 
 } // end of class Modules.Generator_Prototype_Constructor
@@ -280,7 +270,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2211
+		// Method begins at RVA 0x2209
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2298
+				// Method begins at RVA 0x2290
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21a0
+			// Method begins at RVA 0x2198
 			// Header size: 12
 			// Code size: 227 (0xe3)
 			.maxstack 8
@@ -161,7 +161,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x228f
+			// Method begins at RVA 0x2287
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -187,7 +187,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 323 (0x143)
+		// Code size: 313 (0x139)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_Prototype_ToStringTag/Scope,
@@ -218,93 +218,83 @@
 		IL_002e: stloc.s 5
 		IL_0030: ldloc.s 5
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
-		IL_0043: stloc.s 5
-		IL_0045: ldloc.s 5
-		IL_0047: stloc.2
-		IL_0048: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_004d: ldstr "prototype"
-		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0057: ldstr "toString"
-		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0066: stloc.s 5
-		IL_0068: ldloc.s 5
-		IL_006a: ldstr "call"
-		IL_006f: ldloc.2
-		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0075: stloc.s 5
-		IL_0077: ldloc.s 5
-		IL_0079: stloc.3
-		IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007f: ldloc.3
-		IL_0080: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0085: pop
-		IL_0086: ldc.i4.1
-		IL_0087: newarr [System.Runtime]System.Object
-		IL_008c: dup
-		IL_008d: ldc.i4.0
-		IL_008e: ldloc.0
-		IL_008f: stelem.ref
-		IL_0090: ldnull
-		IL_0091: call object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
-		IL_0096: stloc.s 5
-		IL_0098: ldloc.s 5
-		IL_009a: stloc.s 4
-		IL_009c: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_00a1: ldstr "prototype"
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 5
+		IL_0040: ldloc.s 5
+		IL_0042: stloc.2
+		IL_0043: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0048: ldstr "prototype"
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0052: ldstr "toString"
+		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0061: stloc.s 5
+		IL_0063: ldloc.s 5
+		IL_0065: ldstr "call"
+		IL_006a: ldloc.2
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0070: stloc.s 5
+		IL_0072: ldloc.s 5
+		IL_0074: stloc.3
+		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007a: ldloc.3
+		IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0080: pop
+		IL_0081: ldloc.1
+		IL_0082: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_008c: stloc.s 5
+		IL_008e: ldloc.s 5
+		IL_0090: stloc.s 4
+		IL_0092: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0097: ldstr "prototype"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00a1: ldstr "toString"
 		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ab: ldstr "toString"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ba: stloc.s 5
-		IL_00bc: ldloc.s 5
-		IL_00be: ldstr "call"
-		IL_00c3: ldloc.s 4
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00ca: stloc.s 5
-		IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d1: ldloc.s 5
-		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d8: pop
-		IL_00d9: ldloc.s 4
-		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e0: stloc.s 5
-		IL_00e2: ldloc.s 5
-		IL_00e4: ldstr "next"
-		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00ee: pop
-		IL_00ef: ldloc.s 4
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f6: stloc.s 5
-		IL_00f8: ldloc.s 5
-		IL_00fa: ldstr "next"
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0104: pop
-		IL_0105: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_010a: ldstr "prototype"
+		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00b0: stloc.s 5
+		IL_00b2: ldloc.s 5
+		IL_00b4: ldstr "call"
+		IL_00b9: ldloc.s 4
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c0: stloc.s 5
+		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c7: ldloc.s 5
+		IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ce: pop
+		IL_00cf: ldloc.s 4
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d6: stloc.s 5
+		IL_00d8: ldloc.s 5
+		IL_00da: ldstr "next"
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00e4: pop
+		IL_00e5: ldloc.s 4
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ec: stloc.s 5
+		IL_00ee: ldloc.s 5
+		IL_00f0: ldstr "next"
+		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00fa: pop
+		IL_00fb: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0100: ldstr "prototype"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010a: ldstr "toString"
 		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0114: ldstr "toString"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0123: stloc.s 5
-		IL_0125: ldloc.s 5
-		IL_0127: ldstr "call"
-		IL_012c: ldloc.s 4
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0133: stloc.s 5
-		IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013a: ldloc.s 5
-		IL_013c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0141: pop
-		IL_0142: ret
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0119: stloc.s 5
+		IL_011b: ldloc.s 5
+		IL_011d: ldstr "call"
+		IL_0122: ldloc.s 4
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0129: stloc.s 5
+		IL_012b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0130: ldloc.s 5
+		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0137: pop
+		IL_0138: ret
 	} // end of method Generator_Prototype_ToStringTag::__js_module_init__
 
 } // end of class Modules.Generator_Prototype_ToStringTag
@@ -316,7 +306,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22a1
+		// Method begins at RVA 0x2299
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b2
+					// Method begins at RVA 0x29aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29bb
+					// Method begins at RVA 0x29b3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29c4
+					// Method begins at RVA 0x29bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a9
+				// Method begins at RVA 0x29a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x23b0
 			// Header size: 12
 			// Code size: 736 (0x2e0)
 			.maxstack 8
@@ -420,7 +420,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29d6
+					// Method begins at RVA 0x29ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -440,7 +440,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29df
+					// Method begins at RVA 0x29d7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -460,7 +460,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29e8
+					// Method begins at RVA 0x29e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -478,7 +478,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29cd
+				// Method begins at RVA 0x29c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -502,7 +502,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26a4
+			// Method begins at RVA 0x269c
 			// Header size: 12
 			// Code size: 752 (0x2f0)
 			.maxstack 8
@@ -822,7 +822,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29a0
+			// Method begins at RVA 0x2998
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -848,7 +848,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 859 (0x35b)
+		// Code size: 849 (0x351)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/Scope,
@@ -905,235 +905,225 @@
 		IL_005b: stloc.s 12
 		IL_005d: ldloc.s 12
 		IL_005f: stloc.2
-		IL_0060: ldc.i4.1
-		IL_0061: newarr [System.Runtime]System.Object
-		IL_0066: dup
-		IL_0067: ldc.i4.0
-		IL_0068: ldloc.0
-		IL_0069: stelem.ref
-		IL_006a: ldnull
-		IL_006b: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1::__js_call__(object[], object)
-		IL_0070: stloc.s 12
-		IL_0072: ldloc.s 12
-		IL_0074: stloc.3
-		IL_0075: ldloc.3
-		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007b: stloc.s 12
-		IL_007d: ldloc.s 12
-		IL_007f: ldstr "next"
-		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0089: stloc.s 12
-		IL_008b: ldloc.s 12
-		IL_008d: stloc.s 4
-		IL_008f: ldstr "it1.r1.value="
-		IL_0094: ldloc.s 4
-		IL_0096: ldstr "value"
-		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00a5: stloc.s 13
-		IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ac: ldloc.s 13
-		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b3: pop
-		IL_00b4: ldstr "it1.r1.done="
-		IL_00b9: ldloc.s 4
-		IL_00bb: ldstr "done"
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00ca: stloc.s 13
-		IL_00cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d1: ldloc.s 13
-		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d8: pop
-		IL_00d9: ldloc.3
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00df: stloc.s 12
-		IL_00e1: ldloc.s 12
-		IL_00e3: ldstr "return"
-		IL_00e8: ldstr "R1"
-		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00f2: stloc.s 12
-		IL_00f4: ldloc.s 12
-		IL_00f6: stloc.s 5
-		IL_00f8: ldstr "it1.r2.value="
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldstr "value"
-		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_010e: stloc.s 13
-		IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0115: ldloc.s 13
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011c: pop
-		IL_011d: ldstr "it1.r2.done="
-		IL_0122: ldloc.s 5
-		IL_0124: ldstr "done"
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0133: stloc.s 13
-		IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013a: ldloc.s 13
-		IL_013c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0141: pop
-		IL_0142: ldloc.3
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0148: stloc.s 12
-		IL_014a: ldloc.s 12
-		IL_014c: ldstr "next"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0156: stloc.s 12
-		IL_0158: ldloc.s 12
-		IL_015a: stloc.s 6
-		IL_015c: ldstr "it1.r3.value="
-		IL_0161: ldloc.s 6
-		IL_0163: ldstr "value"
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0172: stloc.s 13
-		IL_0174: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0179: ldloc.s 13
-		IL_017b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0180: pop
-		IL_0181: ldstr "it1.r3.done="
-		IL_0186: ldloc.s 6
-		IL_0188: ldstr "done"
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0197: stloc.s 13
-		IL_0199: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019e: ldloc.s 13
-		IL_01a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a5: pop
-		IL_01a6: ldc.i4.1
-		IL_01a7: newarr [System.Runtime]System.Object
-		IL_01ac: dup
-		IL_01ad: ldc.i4.0
-		IL_01ae: ldloc.0
-		IL_01af: stelem.ref
-		IL_01b0: ldnull
-		IL_01b1: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2::__js_call__(object[], object)
-		IL_01b6: stloc.s 12
-		IL_01b8: ldloc.s 12
-		IL_01ba: stloc.s 7
-		IL_01bc: ldloc.s 7
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c3: stloc.s 12
-		IL_01c5: ldloc.s 12
-		IL_01c7: ldstr "next"
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_01d1: stloc.s 12
-		IL_01d3: ldloc.s 12
-		IL_01d5: stloc.s 8
-		IL_01d7: ldstr "it2.r1.value="
-		IL_01dc: ldloc.s 8
-		IL_01de: ldstr "value"
-		IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01ed: stloc.s 13
-		IL_01ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f4: ldloc.s 13
-		IL_01f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01fb: pop
-		IL_01fc: ldstr "it2.r1.done="
-		IL_0201: ldloc.s 8
-		IL_0203: ldstr "done"
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0212: stloc.s 13
-		IL_0214: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0219: ldloc.s 13
-		IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0220: pop
-		IL_0221: ldloc.s 7
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0228: stloc.s 12
-		IL_022a: ldloc.s 12
-		IL_022c: ldstr "throw"
-		IL_0231: ldstr "E2"
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_023b: stloc.s 12
-		IL_023d: ldloc.s 12
-		IL_023f: stloc.s 9
-		IL_0241: ldstr "it2.r2.value="
-		IL_0246: ldloc.s 9
-		IL_0248: ldstr "value"
-		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0257: stloc.s 13
-		IL_0259: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_025e: ldloc.s 13
-		IL_0260: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0265: pop
-		IL_0266: ldstr "it2.r2.done="
-		IL_026b: ldloc.s 9
-		IL_026d: ldstr "done"
-		IL_0272: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_027c: stloc.s 13
-		IL_027e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0283: ldloc.s 13
-		IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_028a: pop
-		IL_028b: ldloc.s 7
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0292: stloc.s 12
-		IL_0294: ldloc.s 12
-		IL_0296: ldstr "return"
-		IL_029b: ldstr "R2"
-		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02a5: stloc.s 12
-		IL_02a7: ldloc.s 12
-		IL_02a9: stloc.s 10
-		IL_02ab: ldstr "it2.r3.value="
-		IL_02b0: ldloc.s 10
-		IL_02b2: ldstr "value"
-		IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02c1: stloc.s 13
-		IL_02c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c8: ldloc.s 13
-		IL_02ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02cf: pop
-		IL_02d0: ldstr "it2.r3.done="
-		IL_02d5: ldloc.s 10
-		IL_02d7: ldstr "done"
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_02e6: stloc.s 13
-		IL_02e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ed: ldloc.s 13
-		IL_02ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02f4: pop
-		IL_02f5: ldloc.s 7
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fc: stloc.s 12
-		IL_02fe: ldloc.s 12
-		IL_0300: ldstr "next"
-		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_030a: stloc.s 12
-		IL_030c: ldloc.s 12
-		IL_030e: stloc.s 11
-		IL_0310: ldstr "it2.r4.value="
-		IL_0315: ldloc.s 11
-		IL_0317: ldstr "value"
-		IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0326: stloc.s 13
-		IL_0328: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_032d: ldloc.s 13
-		IL_032f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0334: pop
-		IL_0335: ldstr "it2.r4.done="
-		IL_033a: ldloc.s 11
-		IL_033c: ldstr "done"
-		IL_0341: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_034b: stloc.s 13
-		IL_034d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0352: ldloc.s 13
-		IL_0354: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0359: pop
-		IL_035a: ret
+		IL_0060: ldloc.1
+		IL_0061: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_006b: stloc.s 12
+		IL_006d: ldloc.s 12
+		IL_006f: stloc.3
+		IL_0070: ldloc.3
+		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0076: stloc.s 12
+		IL_0078: ldloc.s 12
+		IL_007a: ldstr "next"
+		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0084: stloc.s 12
+		IL_0086: ldloc.s 12
+		IL_0088: stloc.s 4
+		IL_008a: ldstr "it1.r1.value="
+		IL_008f: ldloc.s 4
+		IL_0091: ldstr "value"
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00a0: stloc.s 13
+		IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a7: ldloc.s 13
+		IL_00a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ae: pop
+		IL_00af: ldstr "it1.r1.done="
+		IL_00b4: ldloc.s 4
+		IL_00b6: ldstr "done"
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00c5: stloc.s 13
+		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cc: ldloc.s 13
+		IL_00ce: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d3: pop
+		IL_00d4: ldloc.3
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00da: stloc.s 12
+		IL_00dc: ldloc.s 12
+		IL_00de: ldstr "return"
+		IL_00e3: ldstr "R1"
+		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00ed: stloc.s 12
+		IL_00ef: ldloc.s 12
+		IL_00f1: stloc.s 5
+		IL_00f3: ldstr "it1.r2.value="
+		IL_00f8: ldloc.s 5
+		IL_00fa: ldstr "value"
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0109: stloc.s 13
+		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0110: ldloc.s 13
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0117: pop
+		IL_0118: ldstr "it1.r2.done="
+		IL_011d: ldloc.s 5
+		IL_011f: ldstr "done"
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_012e: stloc.s 13
+		IL_0130: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0135: ldloc.s 13
+		IL_0137: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_013c: pop
+		IL_013d: ldloc.3
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0143: stloc.s 12
+		IL_0145: ldloc.s 12
+		IL_0147: ldstr "next"
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0151: stloc.s 12
+		IL_0153: ldloc.s 12
+		IL_0155: stloc.s 6
+		IL_0157: ldstr "it1.r3.value="
+		IL_015c: ldloc.s 6
+		IL_015e: ldstr "value"
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_016d: stloc.s 13
+		IL_016f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0174: ldloc.s 13
+		IL_0176: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017b: pop
+		IL_017c: ldstr "it1.r3.done="
+		IL_0181: ldloc.s 6
+		IL_0183: ldstr "done"
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0192: stloc.s 13
+		IL_0194: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0199: ldloc.s 13
+		IL_019b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a0: pop
+		IL_01a1: ldloc.2
+		IL_01a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_01ac: stloc.s 12
+		IL_01ae: ldloc.s 12
+		IL_01b0: stloc.s 7
+		IL_01b2: ldloc.s 7
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01b9: stloc.s 12
+		IL_01bb: ldloc.s 12
+		IL_01bd: ldstr "next"
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_01c7: stloc.s 12
+		IL_01c9: ldloc.s 12
+		IL_01cb: stloc.s 8
+		IL_01cd: ldstr "it2.r1.value="
+		IL_01d2: ldloc.s 8
+		IL_01d4: ldstr "value"
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01e3: stloc.s 13
+		IL_01e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ea: ldloc.s 13
+		IL_01ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f1: pop
+		IL_01f2: ldstr "it2.r1.done="
+		IL_01f7: ldloc.s 8
+		IL_01f9: ldstr "done"
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0208: stloc.s 13
+		IL_020a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_020f: ldloc.s 13
+		IL_0211: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0216: pop
+		IL_0217: ldloc.s 7
+		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021e: stloc.s 12
+		IL_0220: ldloc.s 12
+		IL_0222: ldstr "throw"
+		IL_0227: ldstr "E2"
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0231: stloc.s 12
+		IL_0233: ldloc.s 12
+		IL_0235: stloc.s 9
+		IL_0237: ldstr "it2.r2.value="
+		IL_023c: ldloc.s 9
+		IL_023e: ldstr "value"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_024d: stloc.s 13
+		IL_024f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0254: ldloc.s 13
+		IL_0256: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_025b: pop
+		IL_025c: ldstr "it2.r2.done="
+		IL_0261: ldloc.s 9
+		IL_0263: ldstr "done"
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0272: stloc.s 13
+		IL_0274: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0279: ldloc.s 13
+		IL_027b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0280: pop
+		IL_0281: ldloc.s 7
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0288: stloc.s 12
+		IL_028a: ldloc.s 12
+		IL_028c: ldstr "return"
+		IL_0291: ldstr "R2"
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_029b: stloc.s 12
+		IL_029d: ldloc.s 12
+		IL_029f: stloc.s 10
+		IL_02a1: ldstr "it2.r3.value="
+		IL_02a6: ldloc.s 10
+		IL_02a8: ldstr "value"
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02b7: stloc.s 13
+		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02be: ldloc.s 13
+		IL_02c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c5: pop
+		IL_02c6: ldstr "it2.r3.done="
+		IL_02cb: ldloc.s 10
+		IL_02cd: ldstr "done"
+		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02dc: stloc.s 13
+		IL_02de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e3: ldloc.s 13
+		IL_02e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ea: pop
+		IL_02eb: ldloc.s 7
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02f2: stloc.s 12
+		IL_02f4: ldloc.s 12
+		IL_02f6: ldstr "next"
+		IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0300: stloc.s 12
+		IL_0302: ldloc.s 12
+		IL_0304: stloc.s 11
+		IL_0306: ldstr "it2.r4.value="
+		IL_030b: ldloc.s 11
+		IL_030d: ldstr "value"
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_031c: stloc.s 13
+		IL_031e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0323: ldloc.s 13
+		IL_0325: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_032a: pop
+		IL_032b: ldstr "it2.r4.done="
+		IL_0330: ldloc.s 11
+		IL_0332: ldstr "done"
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0341: stloc.s 13
+		IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0348: ldloc.s 13
+		IL_034a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_034f: pop
+		IL_0350: ret
 	} // end of method Generator_TryCatchFinally_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ReturnWhileSuspended
@@ -1145,7 +1135,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29f1
+		// Method begins at RVA 0x29e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2565
+					// Method begins at RVA 0x2561
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x256e
+					// Method begins at RVA 0x256a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2577
+					// Method begins at RVA 0x2573
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x255c
+				// Method begins at RVA 0x2558
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2238
+			// Method begins at RVA 0x2234
 			// Header size: 12
 			// Code size: 783 (0x30f)
 			.maxstack 8
@@ -425,7 +425,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2553
+			// Method begins at RVA 0x254f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -451,7 +451,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 475 (0x1db)
+		// Code size: 470 (0x1d6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/Scope,
@@ -485,135 +485,130 @@
 		IL_002e: stloc.s 7
 		IL_0030: ldloc.s 7
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g::__js_call__(object[], object)
-		IL_0043: stloc.s 7
-		IL_0045: ldloc.s 7
-		IL_0047: stloc.2
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.s 7
-		IL_0050: ldloc.s 7
-		IL_0052: ldstr "next"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005c: stloc.s 7
-		IL_005e: ldloc.s 7
-		IL_0060: stloc.3
-		IL_0061: ldstr "r1.value="
-		IL_0066: ldloc.3
-		IL_0067: ldstr "value"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0076: stloc.s 8
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldloc.s 8
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ldstr "r1.done="
-		IL_008a: ldloc.3
-		IL_008b: ldstr "done"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_009a: stloc.s 8
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a1: ldloc.s 8
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: ldloc.2
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: stloc.s 7
-		IL_00b1: ldloc.s 7
-		IL_00b3: ldstr "throw"
-		IL_00b8: ldstr "boom"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c2: stloc.s 7
-		IL_00c4: ldloc.s 7
-		IL_00c6: stloc.s 4
-		IL_00c8: ldstr "r2.value="
-		IL_00cd: ldloc.s 4
-		IL_00cf: ldstr "value"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00de: stloc.s 8
-		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e5: ldloc.s 8
-		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ec: pop
-		IL_00ed: ldstr "r2.done="
-		IL_00f2: ldloc.s 4
-		IL_00f4: ldstr "done"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0103: stloc.s 8
-		IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010a: ldloc.s 8
-		IL_010c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0111: pop
-		IL_0112: ldloc.2
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0118: stloc.s 7
-		IL_011a: ldloc.s 7
-		IL_011c: ldstr "next"
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0126: stloc.s 7
-		IL_0128: ldloc.s 7
-		IL_012a: stloc.s 5
-		IL_012c: ldstr "r3.value="
-		IL_0131: ldloc.s 5
-		IL_0133: ldstr "value"
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0142: stloc.s 8
-		IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0149: ldloc.s 8
-		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0150: pop
-		IL_0151: ldstr "r3.done="
-		IL_0156: ldloc.s 5
-		IL_0158: ldstr "done"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0167: stloc.s 8
-		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016e: ldloc.s 8
-		IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0175: pop
-		IL_0176: ldloc.2
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017c: stloc.s 7
-		IL_017e: ldloc.s 7
-		IL_0180: ldstr "next"
-		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_018a: stloc.s 7
-		IL_018c: ldloc.s 7
-		IL_018e: stloc.s 6
-		IL_0190: ldstr "r4.value="
-		IL_0195: ldloc.s 6
-		IL_0197: ldstr "value"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01a6: stloc.s 8
-		IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ad: ldloc.s 8
-		IL_01af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01b4: pop
-		IL_01b5: ldstr "r4.done="
-		IL_01ba: ldloc.s 6
-		IL_01bc: ldstr "done"
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01cb: stloc.s 8
-		IL_01cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d2: ldloc.s 8
-		IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d9: pop
-		IL_01da: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 7
+		IL_0040: ldloc.s 7
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0049: stloc.s 7
+		IL_004b: ldloc.s 7
+		IL_004d: ldstr "next"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: stloc.s 7
+		IL_0059: ldloc.s 7
+		IL_005b: stloc.3
+		IL_005c: ldstr "r1.value="
+		IL_0061: ldloc.3
+		IL_0062: ldstr "value"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0071: stloc.s 8
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: ldloc.s 8
+		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007f: pop
+		IL_0080: ldstr "r1.done="
+		IL_0085: ldloc.3
+		IL_0086: ldstr "done"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0095: stloc.s 8
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldloc.s 8
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00aa: stloc.s 7
+		IL_00ac: ldloc.s 7
+		IL_00ae: ldstr "throw"
+		IL_00b3: ldstr "boom"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00bd: stloc.s 7
+		IL_00bf: ldloc.s 7
+		IL_00c1: stloc.s 4
+		IL_00c3: ldstr "r2.value="
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldstr "value"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00d9: stloc.s 8
+		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e0: ldloc.s 8
+		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e7: pop
+		IL_00e8: ldstr "r2.done="
+		IL_00ed: ldloc.s 4
+		IL_00ef: ldstr "done"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00fe: stloc.s 8
+		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0105: ldloc.s 8
+		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010c: pop
+		IL_010d: ldloc.2
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0113: stloc.s 7
+		IL_0115: ldloc.s 7
+		IL_0117: ldstr "next"
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0121: stloc.s 7
+		IL_0123: ldloc.s 7
+		IL_0125: stloc.s 5
+		IL_0127: ldstr "r3.value="
+		IL_012c: ldloc.s 5
+		IL_012e: ldstr "value"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_013d: stloc.s 8
+		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0144: ldloc.s 8
+		IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014b: pop
+		IL_014c: ldstr "r3.done="
+		IL_0151: ldloc.s 5
+		IL_0153: ldstr "done"
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0162: stloc.s 8
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: ldloc.s 8
+		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0170: pop
+		IL_0171: ldloc.2
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0177: stloc.s 7
+		IL_0179: ldloc.s 7
+		IL_017b: ldstr "next"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0185: stloc.s 7
+		IL_0187: ldloc.s 7
+		IL_0189: stloc.s 6
+		IL_018b: ldstr "r4.value="
+		IL_0190: ldloc.s 6
+		IL_0192: ldstr "value"
+		IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01a1: stloc.s 8
+		IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a8: ldloc.s 8
+		IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01af: pop
+		IL_01b0: ldstr "r4.done="
+		IL_01b5: ldloc.s 6
+		IL_01b7: ldstr "done"
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01c6: stloc.s 8
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cd: ldloc.s 8
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ret
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields
@@ -625,7 +620,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2580
+		// Method begins at RVA 0x257c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2584
+						// Method begins at RVA 0x2580
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x258d
+						// Method begins at RVA 0x2589
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2596
+						// Method begins at RVA 0x2592
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x257b
+					// Method begins at RVA 0x2577
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -104,7 +104,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x259f
+					// Method begins at RVA 0x259b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -122,7 +122,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2572
+				// Method begins at RVA 0x256e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -146,7 +146,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d4
+			// Method begins at RVA 0x21d0
 			// Header size: 12
 			// Code size: 905 (0x389)
 			.maxstack 8
@@ -514,7 +514,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2569
+			// Method begins at RVA 0x2565
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -540,7 +540,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 375 (0x177)
+		// Code size: 370 (0x172)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/Scope,
@@ -573,106 +573,101 @@
 		IL_002e: stloc.s 6
 		IL_0030: ldloc.s 6
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g::__js_call__(object[], object)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.s 6
-		IL_0047: stloc.2
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.s 6
-		IL_0050: ldloc.s 6
-		IL_0052: ldstr "next"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005c: stloc.s 6
-		IL_005e: ldloc.s 6
-		IL_0060: stloc.3
-		IL_0061: ldstr "r1.value="
-		IL_0066: ldloc.3
-		IL_0067: ldstr "value"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0076: stloc.s 7
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldloc.s 7
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ldstr "r1.done="
-		IL_008a: ldloc.3
-		IL_008b: ldstr "done"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_009a: stloc.s 7
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a1: ldloc.s 7
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: ldloc.2
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: stloc.s 6
-		IL_00b1: ldloc.s 6
-		IL_00b3: ldstr "throw"
-		IL_00b8: ldstr "boom"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c2: stloc.s 6
-		IL_00c4: ldloc.s 6
-		IL_00c6: stloc.s 4
-		IL_00c8: ldstr "r2.value="
-		IL_00cd: ldloc.s 4
-		IL_00cf: ldstr "value"
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00de: stloc.s 7
-		IL_00e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e5: ldloc.s 7
-		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ec: pop
-		IL_00ed: ldstr "r2.done="
-		IL_00f2: ldloc.s 4
-		IL_00f4: ldstr "done"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0103: stloc.s 7
-		IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010a: ldloc.s 7
-		IL_010c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0111: pop
-		IL_0112: ldloc.2
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0118: stloc.s 6
-		IL_011a: ldloc.s 6
-		IL_011c: ldstr "next"
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0126: stloc.s 6
-		IL_0128: ldloc.s 6
-		IL_012a: stloc.s 5
-		IL_012c: ldstr "r3.value="
-		IL_0131: ldloc.s 5
-		IL_0133: ldstr "value"
-		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0142: stloc.s 7
-		IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0149: ldloc.s 7
-		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0150: pop
-		IL_0151: ldstr "r3.done="
-		IL_0156: ldloc.s 5
-		IL_0158: ldstr "done"
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0167: stloc.s 7
-		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016e: ldloc.s 7
-		IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0175: pop
-		IL_0176: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 6
+		IL_0040: ldloc.s 6
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0049: stloc.s 6
+		IL_004b: ldloc.s 6
+		IL_004d: ldstr "next"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: stloc.s 6
+		IL_0059: ldloc.s 6
+		IL_005b: stloc.3
+		IL_005c: ldstr "r1.value="
+		IL_0061: ldloc.3
+		IL_0062: ldstr "value"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0071: stloc.s 7
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: ldloc.s 7
+		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007f: pop
+		IL_0080: ldstr "r1.done="
+		IL_0085: ldloc.3
+		IL_0086: ldstr "done"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0095: stloc.s 7
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldloc.s 7
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00aa: stloc.s 6
+		IL_00ac: ldloc.s 6
+		IL_00ae: ldstr "throw"
+		IL_00b3: ldstr "boom"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00bd: stloc.s 6
+		IL_00bf: ldloc.s 6
+		IL_00c1: stloc.s 4
+		IL_00c3: ldstr "r2.value="
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldstr "value"
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00d9: stloc.s 7
+		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e0: ldloc.s 7
+		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e7: pop
+		IL_00e8: ldstr "r2.done="
+		IL_00ed: ldloc.s 4
+		IL_00ef: ldstr "done"
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00fe: stloc.s 7
+		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0105: ldloc.s 7
+		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010c: pop
+		IL_010d: ldloc.2
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0113: stloc.s 6
+		IL_0115: ldloc.s 6
+		IL_0117: ldstr "next"
+		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0121: stloc.s 6
+		IL_0123: ldloc.s 6
+		IL_0125: stloc.s 5
+		IL_0127: ldstr "r3.value="
+		IL_012c: ldloc.s 5
+		IL_012e: ldstr "value"
+		IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_013d: stloc.s 7
+		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0144: ldloc.s 7
+		IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014b: pop
+		IL_014c: ldstr "r3.done="
+		IL_0151: ldloc.s 5
+		IL_0153: ldstr "done"
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0162: stloc.s 7
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: ldloc.s 7
+		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0170: pop
+		IL_0171: ret
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_Nested::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested
@@ -684,7 +679,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25a8
+		// Method begins at RVA 0x25a4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2474
+					// Method begins at RVA 0x2470
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x247d
+					// Method begins at RVA 0x2479
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -62,7 +62,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2486
+					// Method begins at RVA 0x2482
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x246b
+				// Method begins at RVA 0x2467
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -104,7 +104,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2210
+			// Method begins at RVA 0x220c
 			// Header size: 12
 			// Code size: 582 (0x246)
 			.maxstack 8
@@ -364,7 +364,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248f
+				// Method begins at RVA 0x248b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -384,7 +384,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2498
+				// Method begins at RVA 0x2494
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -405,7 +405,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2462
+			// Method begins at RVA 0x245e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -431,7 +431,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 420 (0x1a4)
+		// Code size: 415 (0x19f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope,
@@ -469,136 +469,131 @@
 		IL_002e: stloc.s 11
 		IL_0030: ldloc.s 11
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g::__js_call__(object[], object)
-		IL_0043: stloc.s 11
-		IL_0045: ldloc.s 11
-		IL_0047: stloc.2
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.s 11
-		IL_0050: ldloc.s 11
-		IL_0052: ldstr "next"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005c: stloc.s 11
-		IL_005e: ldloc.s 11
-		IL_0060: stloc.3
-		IL_0061: ldstr "r1.value="
-		IL_0066: ldloc.3
-		IL_0067: ldstr "value"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0076: stloc.s 12
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldloc.s 12
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ldstr "r1.done="
-		IL_008a: ldloc.3
-		IL_008b: ldstr "done"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_009a: stloc.s 12
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a1: ldloc.s 12
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 11
+		IL_0040: ldloc.s 11
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0049: stloc.s 11
+		IL_004b: ldloc.s 11
+		IL_004d: ldstr "next"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: stloc.s 11
+		IL_0059: ldloc.s 11
+		IL_005b: stloc.3
+		IL_005c: ldstr "r1.value="
+		IL_0061: ldloc.3
+		IL_0062: ldstr "value"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0071: stloc.s 12
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: ldloc.s 12
+		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007f: pop
+		IL_0080: ldstr "r1.done="
+		IL_0085: ldloc.3
+		IL_0086: ldstr "done"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0095: stloc.s 12
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldloc.s 12
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
 		.try
 		{
-			IL_00a9: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope/Block_L21C4::.ctor()
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.2
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b6: stloc.s 11
-			IL_00b8: ldloc.s 11
-			IL_00ba: ldstr "throw"
-			IL_00bf: ldstr "boom"
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c9: pop
-			IL_00ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00cf: ldstr "throw-returned"
-			IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00d9: pop
-			IL_00da: leave IL_013c
+			IL_00a4: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope/Block_L21C4::.ctor()
+			IL_00a9: stloc.s 4
+			IL_00ab: ldloc.2
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b1: stloc.s 11
+			IL_00b3: ldloc.s 11
+			IL_00b5: ldstr "throw"
+			IL_00ba: ldstr "boom"
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c4: pop
+			IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ca: ldstr "throw-returned"
+			IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00d4: pop
+			IL_00d5: leave IL_0137
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00df: stloc.s 5
-			IL_00e1: ldloc.s 5
-			IL_00e3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00e8: dup
-			IL_00e9: brtrue IL_00ff
+			IL_00da: stloc.s 5
+			IL_00dc: ldloc.s 5
+			IL_00de: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00e3: dup
+			IL_00e4: brtrue IL_00fa
 
-			IL_00ee: pop
-			IL_00ef: ldloc.s 5
-			IL_00f1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00f6: dup
-			IL_00f7: brtrue IL_010b
+			IL_00e9: pop
+			IL_00ea: ldloc.s 5
+			IL_00ec: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00f1: dup
+			IL_00f2: brtrue IL_0106
 
-			IL_00fc: pop
-			IL_00fd: rethrow
+			IL_00f7: pop
+			IL_00f8: rethrow
 
-			IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0104: stloc.s 6
-			IL_0106: br IL_010d
+			IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00ff: stloc.s 6
+			IL_0101: br IL_0108
 
-			IL_010b: stloc.s 6
+			IL_0106: stloc.s 6
 
-			IL_010d: ldloc.s 6
-			IL_010f: stloc.s 11
-			IL_0111: ldloc.s 11
-			IL_0113: stloc.s 7
-			IL_0115: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope/Block_L24C12::.ctor()
-			IL_011a: stloc.s 8
-			IL_011c: ldstr "caught="
-			IL_0121: ldloc.s 7
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0128: stloc.s 12
-			IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012f: ldloc.s 12
-			IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0136: pop
-			IL_0137: leave IL_013c
+			IL_0108: ldloc.s 6
+			IL_010a: stloc.s 11
+			IL_010c: ldloc.s 11
+			IL_010e: stloc.s 7
+			IL_0110: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope/Block_L24C12::.ctor()
+			IL_0115: stloc.s 8
+			IL_0117: ldstr "caught="
+			IL_011c: ldloc.s 7
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0123: stloc.s 12
+			IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012a: ldloc.s 12
+			IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0131: pop
+			IL_0132: leave IL_0137
 		} // end handler
 
-		IL_013c: ldloc.2
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0142: stloc.s 11
-		IL_0144: ldloc.s 11
-		IL_0146: ldstr "next"
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0150: stloc.s 11
-		IL_0152: ldloc.s 11
-		IL_0154: stloc.s 9
-		IL_0156: ldstr "r2.value="
-		IL_015b: ldloc.s 9
-		IL_015d: ldstr "value"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_016c: stloc.s 12
-		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0173: ldloc.s 12
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017a: pop
-		IL_017b: ldstr "r2.done="
-		IL_0180: ldloc.s 9
-		IL_0182: ldstr "done"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0191: stloc.s 12
-		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0198: ldloc.s 12
-		IL_019a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019f: pop
-		IL_01a0: ldnull
-		IL_01a1: stloc.s 10
-		IL_01a3: ret
+		IL_0137: ldloc.2
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: stloc.s 11
+		IL_013f: ldloc.s 11
+		IL_0141: ldstr "next"
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_014b: stloc.s 11
+		IL_014d: ldloc.s 11
+		IL_014f: stloc.s 9
+		IL_0151: ldstr "r2.value="
+		IL_0156: ldloc.s 9
+		IL_0158: ldstr "value"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0167: stloc.s 12
+		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016e: ldloc.s 12
+		IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0175: pop
+		IL_0176: ldstr "r2.done="
+		IL_017b: ldloc.s 9
+		IL_017d: ldstr "done"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_018c: stloc.s 12
+		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0193: ldloc.s 12
+		IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019a: pop
+		IL_019b: ldnull
+		IL_019c: stloc.s 10
+		IL_019e: ret
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow
@@ -610,7 +605,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24a1
+		// Method begins at RVA 0x249d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x259a
+						// Method begins at RVA 0x2596
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x25a3
+						// Method begins at RVA 0x259f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -64,7 +64,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2591
+					// Method begins at RVA 0x258d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -84,7 +84,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25ac
+					// Method begins at RVA 0x25a8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -102,7 +102,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2588
+				// Method begins at RVA 0x2584
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -126,7 +126,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2240
+			// Method begins at RVA 0x223c
 			// Header size: 12
 			// Code size: 819 (0x333)
 			.maxstack 8
@@ -463,7 +463,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x257f
+			// Method begins at RVA 0x257b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -489,7 +489,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 484 (0x1e4)
+		// Code size: 479 (0x1df)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/Scope,
@@ -523,136 +523,131 @@
 		IL_002e: stloc.s 7
 		IL_0030: ldloc.s 7
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g::__js_call__(object[], object)
-		IL_0043: stloc.s 7
-		IL_0045: ldloc.s 7
-		IL_0047: stloc.2
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.s 7
-		IL_0050: ldloc.s 7
-		IL_0052: ldstr "next"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005c: stloc.s 7
-		IL_005e: ldloc.s 7
-		IL_0060: stloc.3
-		IL_0061: ldstr "r1.value="
-		IL_0066: ldloc.3
-		IL_0067: ldstr "value"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0076: stloc.s 8
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldloc.s 8
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ldstr "r1.done="
-		IL_008a: ldloc.3
-		IL_008b: ldstr "done"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_009a: stloc.s 8
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a1: ldloc.s 8
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: ldloc.2
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: stloc.s 7
-		IL_00b1: ldloc.s 7
-		IL_00b3: ldstr "next"
-		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00bd: stloc.s 7
-		IL_00bf: ldloc.s 7
-		IL_00c1: stloc.s 4
-		IL_00c3: ldstr "r2.value="
-		IL_00c8: ldloc.s 4
-		IL_00ca: ldstr "value"
-		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00d9: stloc.s 8
-		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e0: ldloc.s 8
-		IL_00e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e7: pop
-		IL_00e8: ldstr "r2.done="
-		IL_00ed: ldloc.s 4
-		IL_00ef: ldstr "done"
-		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00fe: stloc.s 8
-		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0105: ldloc.s 8
-		IL_0107: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010c: pop
-		IL_010d: ldloc.2
-		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0113: stloc.s 7
-		IL_0115: ldloc.s 7
-		IL_0117: ldstr "return"
-		IL_011c: ldc.r8 99
-		IL_0125: box [System.Runtime]System.Double
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_012f: stloc.s 7
-		IL_0131: ldloc.s 7
-		IL_0133: stloc.s 5
-		IL_0135: ldstr "r3.value="
-		IL_013a: ldloc.s 5
-		IL_013c: ldstr "value"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_014b: stloc.s 8
-		IL_014d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0152: ldloc.s 8
-		IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0159: pop
-		IL_015a: ldstr "r3.done="
-		IL_015f: ldloc.s 5
-		IL_0161: ldstr "done"
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0170: stloc.s 8
-		IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0177: ldloc.s 8
-		IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017e: pop
-		IL_017f: ldloc.2
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0185: stloc.s 7
-		IL_0187: ldloc.s 7
-		IL_0189: ldstr "next"
-		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0193: stloc.s 7
-		IL_0195: ldloc.s 7
-		IL_0197: stloc.s 6
-		IL_0199: ldstr "r4.value="
-		IL_019e: ldloc.s 6
-		IL_01a0: ldstr "value"
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01af: stloc.s 8
-		IL_01b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b6: ldloc.s 8
-		IL_01b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01bd: pop
-		IL_01be: ldstr "r4.done="
-		IL_01c3: ldloc.s 6
-		IL_01c5: ldstr "done"
-		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01d4: stloc.s 8
-		IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01db: ldloc.s 8
-		IL_01dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01e2: pop
-		IL_01e3: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 7
+		IL_0040: ldloc.s 7
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0049: stloc.s 7
+		IL_004b: ldloc.s 7
+		IL_004d: ldstr "next"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: stloc.s 7
+		IL_0059: ldloc.s 7
+		IL_005b: stloc.3
+		IL_005c: ldstr "r1.value="
+		IL_0061: ldloc.3
+		IL_0062: ldstr "value"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0071: stloc.s 8
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: ldloc.s 8
+		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007f: pop
+		IL_0080: ldstr "r1.done="
+		IL_0085: ldloc.3
+		IL_0086: ldstr "done"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0095: stloc.s 8
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldloc.s 8
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00aa: stloc.s 7
+		IL_00ac: ldloc.s 7
+		IL_00ae: ldstr "next"
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00b8: stloc.s 7
+		IL_00ba: ldloc.s 7
+		IL_00bc: stloc.s 4
+		IL_00be: ldstr "r2.value="
+		IL_00c3: ldloc.s 4
+		IL_00c5: ldstr "value"
+		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00d4: stloc.s 8
+		IL_00d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00db: ldloc.s 8
+		IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e2: pop
+		IL_00e3: ldstr "r2.done="
+		IL_00e8: ldloc.s 4
+		IL_00ea: ldstr "done"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00f9: stloc.s 8
+		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0100: ldloc.s 8
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: ldloc.2
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010e: stloc.s 7
+		IL_0110: ldloc.s 7
+		IL_0112: ldstr "return"
+		IL_0117: ldc.r8 99
+		IL_0120: box [System.Runtime]System.Double
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_012a: stloc.s 7
+		IL_012c: ldloc.s 7
+		IL_012e: stloc.s 5
+		IL_0130: ldstr "r3.value="
+		IL_0135: ldloc.s 5
+		IL_0137: ldstr "value"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0146: stloc.s 8
+		IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014d: ldloc.s 8
+		IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0154: pop
+		IL_0155: ldstr "r3.done="
+		IL_015a: ldloc.s 5
+		IL_015c: ldstr "done"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_016b: stloc.s 8
+		IL_016d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0172: ldloc.s 8
+		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0179: pop
+		IL_017a: ldloc.2
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0180: stloc.s 7
+		IL_0182: ldloc.s 7
+		IL_0184: ldstr "next"
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_018e: stloc.s 7
+		IL_0190: ldloc.s 7
+		IL_0192: stloc.s 6
+		IL_0194: ldstr "r4.value="
+		IL_0199: ldloc.s 6
+		IL_019b: ldstr "value"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01aa: stloc.s 8
+		IL_01ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b1: ldloc.s 8
+		IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b8: pop
+		IL_01b9: ldstr "r4.done="
+		IL_01be: ldloc.s 6
+		IL_01c0: ldstr "done"
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01cf: stloc.s 8
+		IL_01d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d6: ldloc.s 8
+		IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01dd: pop
+		IL_01de: ret
 	} // end of method Generator_TryFinally_Nested_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended
@@ -664,7 +659,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25b5
+		// Method begins at RVA 0x25b1
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x23fd
+					// Method begins at RVA 0x23f9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2406
+					// Method begins at RVA 0x2402
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f4
+				// Method begins at RVA 0x23f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21dc
+			// Method begins at RVA 0x21d8
 			// Header size: 12
 			// Code size: 515 (0x203)
 			.maxstack 8
@@ -310,7 +310,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23eb
+			// Method begins at RVA 0x23e7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -336,7 +336,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 384 (0x180)
+		// Code size: 379 (0x17b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_ReturnWhileSuspended/Scope,
@@ -369,107 +369,102 @@
 		IL_002e: stloc.s 6
 		IL_0030: ldloc.s 6
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_TryFinally_ReturnWhileSuspended/g::__js_call__(object[], object)
-		IL_0043: stloc.s 6
-		IL_0045: ldloc.s 6
-		IL_0047: stloc.2
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.s 6
-		IL_0050: ldloc.s 6
-		IL_0052: ldstr "next"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005c: stloc.s 6
-		IL_005e: ldloc.s 6
-		IL_0060: stloc.3
-		IL_0061: ldstr "r1.value="
-		IL_0066: ldloc.3
-		IL_0067: ldstr "value"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0076: stloc.s 7
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldloc.s 7
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ldstr "r1.done="
-		IL_008a: ldloc.3
-		IL_008b: ldstr "done"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_009a: stloc.s 7
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a1: ldloc.s 7
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: ldloc.2
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: stloc.s 6
-		IL_00b1: ldloc.s 6
-		IL_00b3: ldstr "return"
-		IL_00b8: ldc.r8 123
-		IL_00c1: box [System.Runtime]System.Double
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00cb: stloc.s 6
-		IL_00cd: ldloc.s 6
-		IL_00cf: stloc.s 4
-		IL_00d1: ldstr "r2.value="
-		IL_00d6: ldloc.s 4
-		IL_00d8: ldstr "value"
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_00e7: stloc.s 7
-		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ee: ldloc.s 7
-		IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f5: pop
-		IL_00f6: ldstr "r2.done="
-		IL_00fb: ldloc.s 4
-		IL_00fd: ldstr "done"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_010c: stloc.s 7
-		IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0113: ldloc.s 7
-		IL_0115: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011a: pop
-		IL_011b: ldloc.2
-		IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0121: stloc.s 6
-		IL_0123: ldloc.s 6
-		IL_0125: ldstr "next"
-		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_012f: stloc.s 6
-		IL_0131: ldloc.s 6
-		IL_0133: stloc.s 5
-		IL_0135: ldstr "r3.value="
-		IL_013a: ldloc.s 5
-		IL_013c: ldstr "value"
-		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_014b: stloc.s 7
-		IL_014d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0152: ldloc.s 7
-		IL_0154: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0159: pop
-		IL_015a: ldstr "r3.done="
-		IL_015f: ldloc.s 5
-		IL_0161: ldstr "done"
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0170: stloc.s 7
-		IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0177: ldloc.s 7
-		IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017e: pop
-		IL_017f: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 6
+		IL_0040: ldloc.s 6
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0049: stloc.s 6
+		IL_004b: ldloc.s 6
+		IL_004d: ldstr "next"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: stloc.s 6
+		IL_0059: ldloc.s 6
+		IL_005b: stloc.3
+		IL_005c: ldstr "r1.value="
+		IL_0061: ldloc.3
+		IL_0062: ldstr "value"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0071: stloc.s 7
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: ldloc.s 7
+		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007f: pop
+		IL_0080: ldstr "r1.done="
+		IL_0085: ldloc.3
+		IL_0086: ldstr "done"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0095: stloc.s 7
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldloc.s 7
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: ldloc.2
+		IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00aa: stloc.s 6
+		IL_00ac: ldloc.s 6
+		IL_00ae: ldstr "return"
+		IL_00b3: ldc.r8 123
+		IL_00bc: box [System.Runtime]System.Double
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c6: stloc.s 6
+		IL_00c8: ldloc.s 6
+		IL_00ca: stloc.s 4
+		IL_00cc: ldstr "r2.value="
+		IL_00d1: ldloc.s 4
+		IL_00d3: ldstr "value"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_00e2: stloc.s 7
+		IL_00e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e9: ldloc.s 7
+		IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f0: pop
+		IL_00f1: ldstr "r2.done="
+		IL_00f6: ldloc.s 4
+		IL_00f8: ldstr "done"
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0107: stloc.s 7
+		IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010e: ldloc.s 7
+		IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0115: pop
+		IL_0116: ldloc.2
+		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011c: stloc.s 6
+		IL_011e: ldloc.s 6
+		IL_0120: ldstr "next"
+		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_012a: stloc.s 6
+		IL_012c: ldloc.s 6
+		IL_012e: stloc.s 5
+		IL_0130: ldstr "r3.value="
+		IL_0135: ldloc.s 5
+		IL_0137: ldstr "value"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0146: stloc.s 7
+		IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014d: ldloc.s 7
+		IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0154: pop
+		IL_0155: ldstr "r3.done="
+		IL_015a: ldloc.s 5
+		IL_015c: ldstr "done"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_016b: stloc.s 7
+		IL_016d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0172: ldloc.s 7
+		IL_0174: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0179: pop
+		IL_017a: ret
 	} // end of method Generator_TryFinally_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_ReturnWhileSuspended
@@ -481,7 +476,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x240f
+		// Method begins at RVA 0x240b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2421
+					// Method begins at RVA 0x241d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x242a
+					// Method begins at RVA 0x2426
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2418
+				// Method begins at RVA 0x2414
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2210
+			// Method begins at RVA 0x220c
 			// Header size: 12
 			// Code size: 499 (0x1f3)
 			.maxstack 8
@@ -307,7 +307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2433
+				// Method begins at RVA 0x242f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -327,7 +327,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x243c
+				// Method begins at RVA 0x2438
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -348,7 +348,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x240f
+			// Method begins at RVA 0x240b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -374,7 +374,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 420 (0x1a4)
+		// Code size: 415 (0x19f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_ThrowWhileSuspended/Scope,
@@ -412,136 +412,131 @@
 		IL_002e: stloc.s 11
 		IL_0030: ldloc.s 11
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_TryFinally_ThrowWhileSuspended/g::__js_call__(object[], object)
-		IL_0043: stloc.s 11
-		IL_0045: ldloc.s 11
-		IL_0047: stloc.2
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.s 11
-		IL_0050: ldloc.s 11
-		IL_0052: ldstr "next"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005c: stloc.s 11
-		IL_005e: ldloc.s 11
-		IL_0060: stloc.3
-		IL_0061: ldstr "r1.value="
-		IL_0066: ldloc.3
-		IL_0067: ldstr "value"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0076: stloc.s 12
-		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007d: ldloc.s 12
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: ldstr "r1.done="
-		IL_008a: ldloc.3
-		IL_008b: ldstr "done"
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_009a: stloc.s 12
-		IL_009c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a1: ldloc.s 12
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 11
+		IL_0040: ldloc.s 11
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0049: stloc.s 11
+		IL_004b: ldloc.s 11
+		IL_004d: ldstr "next"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: stloc.s 11
+		IL_0059: ldloc.s 11
+		IL_005b: stloc.3
+		IL_005c: ldstr "r1.value="
+		IL_0061: ldloc.3
+		IL_0062: ldstr "value"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0071: stloc.s 12
+		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0078: ldloc.s 12
+		IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007f: pop
+		IL_0080: ldstr "r1.done="
+		IL_0085: ldloc.3
+		IL_0086: ldstr "done"
+		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0095: stloc.s 12
+		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009c: ldloc.s 12
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
 		.try
 		{
-			IL_00a9: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/Scope/Block_L19C4::.ctor()
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.2
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b6: stloc.s 11
-			IL_00b8: ldloc.s 11
-			IL_00ba: ldstr "throw"
-			IL_00bf: ldstr "boom"
-			IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00c9: pop
-			IL_00ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00cf: ldstr "throw-returned"
-			IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00d9: pop
-			IL_00da: leave IL_013c
+			IL_00a4: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/Scope/Block_L19C4::.ctor()
+			IL_00a9: stloc.s 4
+			IL_00ab: ldloc.2
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b1: stloc.s 11
+			IL_00b3: ldloc.s 11
+			IL_00b5: ldstr "throw"
+			IL_00ba: ldstr "boom"
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00c4: pop
+			IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ca: ldstr "throw-returned"
+			IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00d4: pop
+			IL_00d5: leave IL_0137
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00df: stloc.s 5
-			IL_00e1: ldloc.s 5
-			IL_00e3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00e8: dup
-			IL_00e9: brtrue IL_00ff
+			IL_00da: stloc.s 5
+			IL_00dc: ldloc.s 5
+			IL_00de: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00e3: dup
+			IL_00e4: brtrue IL_00fa
 
-			IL_00ee: pop
-			IL_00ef: ldloc.s 5
-			IL_00f1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00f6: dup
-			IL_00f7: brtrue IL_010b
+			IL_00e9: pop
+			IL_00ea: ldloc.s 5
+			IL_00ec: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00f1: dup
+			IL_00f2: brtrue IL_0106
 
-			IL_00fc: pop
-			IL_00fd: rethrow
+			IL_00f7: pop
+			IL_00f8: rethrow
 
-			IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0104: stloc.s 6
-			IL_0106: br IL_010d
+			IL_00fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00ff: stloc.s 6
+			IL_0101: br IL_0108
 
-			IL_010b: stloc.s 6
+			IL_0106: stloc.s 6
 
-			IL_010d: ldloc.s 6
-			IL_010f: stloc.s 11
-			IL_0111: ldloc.s 11
-			IL_0113: stloc.s 7
-			IL_0115: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/Scope/Block_L22C12::.ctor()
-			IL_011a: stloc.s 8
-			IL_011c: ldstr "caught="
-			IL_0121: ldloc.s 7
-			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0128: stloc.s 12
-			IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_012f: ldloc.s 12
-			IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0136: pop
-			IL_0137: leave IL_013c
+			IL_0108: ldloc.s 6
+			IL_010a: stloc.s 11
+			IL_010c: ldloc.s 11
+			IL_010e: stloc.s 7
+			IL_0110: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/Scope/Block_L22C12::.ctor()
+			IL_0115: stloc.s 8
+			IL_0117: ldstr "caught="
+			IL_011c: ldloc.s 7
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0123: stloc.s 12
+			IL_0125: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012a: ldloc.s 12
+			IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0131: pop
+			IL_0132: leave IL_0137
 		} // end handler
 
-		IL_013c: ldloc.2
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0142: stloc.s 11
-		IL_0144: ldloc.s 11
-		IL_0146: ldstr "next"
-		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0150: stloc.s 11
-		IL_0152: ldloc.s 11
-		IL_0154: stloc.s 9
-		IL_0156: ldstr "r2.value="
-		IL_015b: ldloc.s 9
-		IL_015d: ldstr "value"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_016c: stloc.s 12
-		IL_016e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0173: ldloc.s 12
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017a: pop
-		IL_017b: ldstr "r2.done="
-		IL_0180: ldloc.s 9
-		IL_0182: ldstr "done"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0191: stloc.s 12
-		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0198: ldloc.s 12
-		IL_019a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019f: pop
-		IL_01a0: ldnull
-		IL_01a1: stloc.s 10
-		IL_01a3: ret
+		IL_0137: ldloc.2
+		IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013d: stloc.s 11
+		IL_013f: ldloc.s 11
+		IL_0141: ldstr "next"
+		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_014b: stloc.s 11
+		IL_014d: ldloc.s 11
+		IL_014f: stloc.s 9
+		IL_0151: ldstr "r2.value="
+		IL_0156: ldloc.s 9
+		IL_0158: ldstr "value"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0167: stloc.s 12
+		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016e: ldloc.s 12
+		IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0175: pop
+		IL_0176: ldstr "r2.done="
+		IL_017b: ldloc.s 9
+		IL_017d: ldstr "done"
+		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_018c: stloc.s 12
+		IL_018e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0193: ldloc.s 12
+		IL_0195: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019a: pop
+		IL_019b: ldnull
+		IL_019c: stloc.s 10
+		IL_019e: ret
 	} // end of method Generator_TryFinally_ThrowWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_ThrowWhileSuspended
@@ -553,7 +548,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2445
+		// Method begins at RVA 0x2441
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24cf
+				// Method begins at RVA 0x24cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21c4
+			// Method begins at RVA 0x21c0
 			// Header size: 12
 			// Code size: 758 (0x2f6)
 			.maxstack 8
@@ -361,7 +361,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24c6
+			// Method begins at RVA 0x24c2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -387,7 +387,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 358 (0x166)
+		// Code size: 353 (0x161)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_ArrayBasic/Scope,
@@ -420,102 +420,97 @@
 		IL_002e: stloc.s 7
 		IL_0030: ldloc.s 7
 		IL_0032: stloc.1
-		IL_0033: ldc.i4.1
-		IL_0034: newarr [System.Runtime]System.Object
-		IL_0039: dup
-		IL_003a: ldc.i4.0
-		IL_003b: ldloc.0
-		IL_003c: stelem.ref
-		IL_003d: ldnull
-		IL_003e: call object Modules.Generator_YieldStar_ArrayBasic/g::__js_call__(object[], object)
-		IL_0043: stloc.s 7
-		IL_0045: ldloc.s 7
-		IL_0047: stloc.2
-		IL_0048: ldloc.2
-		IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004e: stloc.s 7
-		IL_0050: ldloc.s 7
-		IL_0052: ldstr "next"
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_005c: stloc.s 7
-		IL_005e: ldloc.s 7
-		IL_0060: stloc.3
-		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0066: ldloc.3
-		IL_0067: ldstr "value"
-		IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0071: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0076: pop
-		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007c: ldloc.3
-		IL_007d: ldstr "done"
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0087: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008c: pop
-		IL_008d: ldloc.2
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0093: stloc.s 7
-		IL_0095: ldloc.s 7
-		IL_0097: ldstr "next"
-		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00a1: stloc.s 7
-		IL_00a3: ldloc.s 7
-		IL_00a5: stloc.s 4
-		IL_00a7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ac: ldloc.s 4
-		IL_00ae: ldstr "value"
-		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bd: pop
-		IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c3: ldloc.s 4
-		IL_00c5: ldstr "done"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d4: pop
-		IL_00d5: ldloc.2
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: stloc.s 7
-		IL_00dd: ldloc.s 7
-		IL_00df: ldstr "next"
-		IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00e9: stloc.s 7
-		IL_00eb: ldloc.s 7
-		IL_00ed: stloc.s 5
-		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f4: ldloc.s 5
-		IL_00f6: ldstr "value"
-		IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0100: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0105: pop
-		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010b: ldloc.s 5
-		IL_010d: ldstr "done"
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011c: pop
-		IL_011d: ldloc.2
-		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0123: stloc.s 7
-		IL_0125: ldloc.s 7
-		IL_0127: ldstr "next"
-		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0131: stloc.s 7
-		IL_0133: ldloc.s 7
-		IL_0135: stloc.s 6
-		IL_0137: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013c: ldloc.s 6
-		IL_013e: ldstr "value"
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014d: pop
-		IL_014e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0153: ldloc.s 6
-		IL_0155: ldstr "done"
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0164: pop
-		IL_0165: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: stloc.s 7
+		IL_0040: ldloc.s 7
+		IL_0042: stloc.2
+		IL_0043: ldloc.2
+		IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0049: stloc.s 7
+		IL_004b: ldloc.s 7
+		IL_004d: ldstr "next"
+		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0057: stloc.s 7
+		IL_0059: ldloc.s 7
+		IL_005b: stloc.3
+		IL_005c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0061: ldloc.3
+		IL_0062: ldstr "value"
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0071: pop
+		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0077: ldloc.3
+		IL_0078: ldstr "done"
+		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0087: pop
+		IL_0088: ldloc.2
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008e: stloc.s 7
+		IL_0090: ldloc.s 7
+		IL_0092: ldstr "next"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_009c: stloc.s 7
+		IL_009e: ldloc.s 7
+		IL_00a0: stloc.s 4
+		IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a7: ldloc.s 4
+		IL_00a9: ldstr "value"
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b8: pop
+		IL_00b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00be: ldloc.s 4
+		IL_00c0: ldstr "done"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00cf: pop
+		IL_00d0: ldloc.2
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d6: stloc.s 7
+		IL_00d8: ldloc.s 7
+		IL_00da: ldstr "next"
+		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00e4: stloc.s 7
+		IL_00e6: ldloc.s 7
+		IL_00e8: stloc.s 5
+		IL_00ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ef: ldloc.s 5
+		IL_00f1: ldstr "value"
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0100: pop
+		IL_0101: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0106: ldloc.s 5
+		IL_0108: ldstr "done"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0117: pop
+		IL_0118: ldloc.2
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_011e: stloc.s 7
+		IL_0120: ldloc.s 7
+		IL_0122: ldstr "next"
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_012c: stloc.s 7
+		IL_012e: ldloc.s 7
+		IL_0130: stloc.s 6
+		IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0137: ldloc.s 6
+		IL_0139: ldstr "value"
+		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0143: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0148: pop
+		IL_0149: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014e: ldloc.s 6
+		IL_0150: ldstr "done"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015f: pop
+		IL_0160: ret
 	} // end of method Generator_YieldStar_ArrayBasic::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_ArrayBasic
@@ -527,7 +522,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24d8
+		// Method begins at RVA 0x24d4
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x265e
+				// Method begins at RVA 0x2666
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21f4
+			// Method begins at RVA 0x21f0
 			// Header size: 12
 			// Code size: 333 (0x14d)
 			.maxstack 8
@@ -200,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2667
+				// Method begins at RVA 0x266f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,9 +224,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2350
+			// Method begins at RVA 0x234c
 			// Header size: 12
-			// Code size: 761 (0x2f9)
+			// Code size: 773 (0x305)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_YieldStar_NestedGenerator/outer/Scope,
@@ -293,252 +293,256 @@
 
 			IL_0068: ldloc.0
 			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_006e: switch (IL_007f, IL_0137, IL_0272)
+			IL_006e: switch (IL_007f, IL_0143, IL_027e)
 
-			IL_007f: ldc.i4.1
-			IL_0080: newarr [System.Runtime]System.Object
-			IL_0085: dup
-			IL_0086: ldc.i4.0
-			IL_0087: ldarg.0
-			IL_0088: ldc.i4.1
-			IL_0089: ldelem.ref
-			IL_008a: stelem.ref
-			IL_008b: ldnull
-			IL_008c: call object Modules.Generator_YieldStar_NestedGenerator/inner::__js_call__(object[], object)
-			IL_0091: stloc.s 4
-			IL_0093: ldloc.s 4
-			IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.s 5
-			IL_009e: brtrue IL_019c
+			IL_007f: ldarg.0
+			IL_0080: ldc.i4.1
+			IL_0081: ldelem.ref
+			IL_0082: castclass Modules.Generator_YieldStar_NestedGenerator/Scope
+			IL_0087: ldfld object Modules.Generator_YieldStar_NestedGenerator/Scope::inner
+			IL_008c: ldc.i4.1
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldarg.0
+			IL_0095: ldc.i4.1
+			IL_0096: ldelem.ref
+			IL_0097: stelem.ref
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_009d: stloc.s 4
+			IL_009f: ldloc.s 4
+			IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00a6: stloc.s 5
+			IL_00a8: ldloc.s 5
+			IL_00aa: brtrue IL_01a8
 
-			IL_00a3: ldloc.s 4
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
-			IL_00aa: stloc.s 4
-			IL_00ac: ldloc.0
-			IL_00ad: ldc.r8 1
-			IL_00b6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_00bb: ldloc.0
-			IL_00bc: ldloc.s 4
-			IL_00be: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_00c3: ldloc.0
-			IL_00c4: ldc.r8 0.0
-			IL_00cd: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00d2: ldloc.s 4
-			IL_00d4: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00d9: stloc.s 6
-			IL_00db: ldloc.0
-			IL_00dc: ldloc.s 6
-			IL_00de: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00af: ldloc.s 4
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
+			IL_00b6: stloc.s 4
+			IL_00b8: ldloc.0
+			IL_00b9: ldc.r8 1
+			IL_00c2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_00c7: ldloc.0
+			IL_00c8: ldloc.s 4
+			IL_00ca: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_00cf: ldloc.0
+			IL_00d0: ldc.r8 0.0
+			IL_00d9: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00de: ldloc.s 4
+			IL_00e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.0
+			IL_00e8: ldloc.s 6
+			IL_00ea: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
 
-			IL_00e3: ldloc.0
-			IL_00e4: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00e9: stloc.s 6
-			IL_00eb: ldloc.0
-			IL_00ec: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
-			IL_00f1: stloc.s 7
-			IL_00f3: ldloc.s 6
-			IL_00f5: ldloc.s 7
-			IL_00f7: clt
-			IL_00f9: brfalse IL_0179
+			IL_00ef: ldloc.0
+			IL_00f0: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00f5: stloc.s 6
+			IL_00f7: ldloc.0
+			IL_00f8: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00fd: stloc.s 7
+			IL_00ff: ldloc.s 6
+			IL_0101: ldloc.s 7
+			IL_0103: clt
+			IL_0105: brfalse IL_0185
 
-			IL_00fe: ldloc.0
-			IL_00ff: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0104: stloc.s 4
-			IL_0106: ldloc.s 4
-			IL_0108: ldloc.s 6
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_010f: stloc.s 4
-			IL_0111: ldloc.s 6
-			IL_0113: ldc.r8 1
-			IL_011c: add
-			IL_011d: stloc.s 6
-			IL_011f: ldloc.0
-			IL_0120: ldloc.s 6
-			IL_0122: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_0127: ldloc.0
-			IL_0128: ldc.i4.1
-			IL_0129: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_012e: ldloc.s 4
-			IL_0130: ldc.i4.0
-			IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0136: ret
+			IL_010a: ldloc.0
+			IL_010b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_0110: stloc.s 4
+			IL_0112: ldloc.s 4
+			IL_0114: ldloc.s 6
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_011b: stloc.s 4
+			IL_011d: ldloc.s 6
+			IL_011f: ldc.r8 1
+			IL_0128: add
+			IL_0129: stloc.s 6
+			IL_012b: ldloc.0
+			IL_012c: ldloc.s 6
+			IL_012e: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_0133: ldloc.0
+			IL_0134: ldc.i4.1
+			IL_0135: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_013a: ldloc.s 4
+			IL_013c: ldc.i4.0
+			IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0142: ret
 
-			IL_0137: ldloc.0
-			IL_0138: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_013d: brfalse IL_0156
+			IL_0143: ldloc.0
+			IL_0144: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0149: brfalse IL_0162
 
-			IL_0142: ldloc.0
-			IL_0143: ldc.i4.1
-			IL_0144: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0149: ldloc.0
-			IL_014a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_014e: ldloc.0
 			IL_014f: ldc.i4.1
-			IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0155: ret
+			IL_0150: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0155: ldloc.0
+			IL_0156: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_015b: ldc.i4.1
+			IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0161: ret
 
-			IL_0156: ldloc.0
-			IL_0157: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_015c: brfalse IL_0174
+			IL_0162: ldloc.0
+			IL_0163: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0168: brfalse IL_0180
 
-			IL_0161: ldloc.0
-			IL_0162: ldc.i4.0
-			IL_0163: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0168: ldloc.0
-			IL_0169: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0173: throw
+			IL_016d: ldloc.0
+			IL_016e: ldc.i4.0
+			IL_016f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0174: ldloc.0
+			IL_0175: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_017a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_017f: throw
 
-			IL_0174: br IL_00e3
+			IL_0180: br IL_00ef
 
-			IL_0179: ldloc.0
-			IL_017a: ldc.r8 0.0
-			IL_0183: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_0188: ldloc.0
-			IL_0189: ldc.i4.0
-			IL_018a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_018f: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0194: ldnull
-			IL_0195: stloc.s 4
-			IL_0197: br IL_02b6
+			IL_0185: ldloc.0
+			IL_0186: ldc.r8 0.0
+			IL_018f: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_0194: ldloc.0
+			IL_0195: ldc.i4.0
+			IL_0196: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_019b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01a0: ldnull
+			IL_01a1: stloc.s 4
+			IL_01a3: br IL_02c2
 
-			IL_019c: ldloc.0
-			IL_019d: ldc.r8 2
-			IL_01a6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_01ab: ldloc.0
-			IL_01ac: ldloc.s 5
-			IL_01ae: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01b3: ldc.i4.0
-			IL_01b4: stloc.2
+			IL_01a8: ldloc.0
+			IL_01a9: ldc.r8 2
+			IL_01b2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01b7: ldloc.0
+			IL_01b8: ldloc.s 5
+			IL_01ba: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01bf: ldc.i4.0
+			IL_01c0: stloc.2
 
-			IL_01b5: ldloc.0
-			IL_01b6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01bb: stloc.s 4
-			IL_01bd: ldloc.0
-			IL_01be: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01c3: stloc.3
-			IL_01c4: ldloc.3
-			IL_01c5: brtrue IL_01dc
+			IL_01c1: ldloc.0
+			IL_01c2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01c7: stloc.s 4
+			IL_01c9: ldloc.0
+			IL_01ca: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01cf: stloc.3
+			IL_01d0: ldloc.3
+			IL_01d1: brtrue IL_01e8
 
-			IL_01ca: ldloc.0
-			IL_01cb: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_01d0: stloc.3
-			IL_01d1: ldloc.3
-			IL_01d2: brtrue IL_020f
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_01dc: stloc.3
+			IL_01dd: ldloc.3
+			IL_01de: brtrue IL_021b
 
-			IL_01d7: br IL_0242
+			IL_01e3: br IL_024e
 
-			IL_01dc: ldc.i4.1
-			IL_01dd: stloc.2
-			IL_01de: ldloc.0
-			IL_01df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_01e4: stloc.s 8
-			IL_01e6: ldloc.0
-			IL_01e7: ldc.i4.0
-			IL_01e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01ed: ldc.i4.1
-			IL_01ee: newarr [System.Runtime]System.Object
-			IL_01f3: dup
-			IL_01f4: ldc.i4.0
-			IL_01f5: ldloc.s 8
-			IL_01f7: stelem.ref
-			IL_01f8: stloc.s 9
-			IL_01fa: ldloc.s 4
-			IL_01fc: ldstr "return"
-			IL_0201: ldloc.s 9
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0208: stloc.s 4
-			IL_020a: br IL_025a
+			IL_01e8: ldc.i4.1
+			IL_01e9: stloc.2
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_01f0: stloc.s 8
+			IL_01f2: ldloc.0
+			IL_01f3: ldc.i4.0
+			IL_01f4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01f9: ldc.i4.1
+			IL_01fa: newarr [System.Runtime]System.Object
+			IL_01ff: dup
+			IL_0200: ldc.i4.0
+			IL_0201: ldloc.s 8
+			IL_0203: stelem.ref
+			IL_0204: stloc.s 9
+			IL_0206: ldloc.s 4
+			IL_0208: ldstr "return"
+			IL_020d: ldloc.s 9
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0214: stloc.s 4
+			IL_0216: br IL_0266
 
-			IL_020f: ldc.i4.0
-			IL_0210: stloc.2
-			IL_0211: ldloc.0
-			IL_0212: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0217: stloc.s 10
-			IL_0219: ldloc.0
-			IL_021a: ldc.i4.0
-			IL_021b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0220: ldc.i4.1
-			IL_0221: newarr [System.Runtime]System.Object
-			IL_0226: dup
-			IL_0227: ldc.i4.0
-			IL_0228: ldloc.s 10
-			IL_022a: stelem.ref
-			IL_022b: stloc.s 9
-			IL_022d: ldloc.s 4
-			IL_022f: ldstr "throw"
-			IL_0234: ldloc.s 9
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_023b: stloc.s 4
-			IL_023d: br IL_025a
+			IL_021b: ldc.i4.0
+			IL_021c: stloc.2
+			IL_021d: ldloc.0
+			IL_021e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0223: stloc.s 10
+			IL_0225: ldloc.0
+			IL_0226: ldc.i4.0
+			IL_0227: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_022c: ldc.i4.1
+			IL_022d: newarr [System.Runtime]System.Object
+			IL_0232: dup
+			IL_0233: ldc.i4.0
+			IL_0234: ldloc.s 10
+			IL_0236: stelem.ref
+			IL_0237: stloc.s 9
+			IL_0239: ldloc.s 4
+			IL_023b: ldstr "throw"
+			IL_0240: ldloc.s 9
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0247: stloc.s 4
+			IL_0249: br IL_0266
 
-			IL_0242: ldc.i4.0
-			IL_0243: stloc.2
-			IL_0244: ldloc.0
-			IL_0245: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
-			IL_024a: stloc.s 11
-			IL_024c: ldloc.s 4
-			IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
-			IL_0253: stloc.s 4
-			IL_0255: br IL_025a
+			IL_024e: ldc.i4.0
+			IL_024f: stloc.2
+			IL_0250: ldloc.0
+			IL_0251: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
+			IL_0256: stloc.s 11
+			IL_0258: ldloc.s 4
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
+			IL_025f: stloc.s 4
+			IL_0261: br IL_0266
 
-			IL_025a: ldloc.s 4
-			IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0261: stloc.3
-			IL_0262: ldloc.3
-			IL_0263: brtrue IL_0277
+			IL_0266: ldloc.s 4
+			IL_0268: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_026d: stloc.3
+			IL_026e: ldloc.3
+			IL_026f: brtrue IL_0283
 
-			IL_0268: ldloc.0
-			IL_0269: ldc.i4.2
-			IL_026a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_026f: ldloc.s 4
-			IL_0271: ret
+			IL_0274: ldloc.0
+			IL_0275: ldc.i4.2
+			IL_0276: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_027b: ldloc.s 4
+			IL_027d: ret
 
-			IL_0272: br IL_01b5
+			IL_027e: br IL_01c1
 
-			IL_0277: ldloc.s 4
-			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_027e: stloc.s 4
-			IL_0280: ldloc.0
-			IL_0281: ldc.r8 0.0
-			IL_028a: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_028f: ldloc.0
-			IL_0290: ldc.i4.0
-			IL_0291: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0296: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_029b: ldloc.2
-			IL_029c: brtrue IL_02a6
+			IL_0283: ldloc.s 4
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_028a: stloc.s 4
+			IL_028c: ldloc.0
+			IL_028d: ldc.r8 0.0
+			IL_0296: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_029b: ldloc.0
+			IL_029c: ldc.i4.0
+			IL_029d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a2: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_02a7: ldloc.2
+			IL_02a8: brtrue IL_02b2
 
-			IL_02a1: br IL_02b6
+			IL_02ad: br IL_02c2
 
-			IL_02a6: ldloc.0
-			IL_02a7: ldc.i4.1
-			IL_02a8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02ad: ldloc.s 4
-			IL_02af: ldc.i4.1
-			IL_02b0: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02b5: ret
+			IL_02b2: ldloc.0
+			IL_02b3: ldc.i4.1
+			IL_02b4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02b9: ldloc.s 4
+			IL_02bb: ldc.i4.1
+			IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02c1: ret
 
-			IL_02b6: ldloc.0
-			IL_02b7: ldloc.s 4
-			IL_02b9: stfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
-			IL_02be: ldstr "r="
-			IL_02c3: ldloc.0
-			IL_02c4: ldfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02ce: stloc.s 12
-			IL_02d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02d5: ldloc.s 12
-			IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02dc: pop
-			IL_02dd: ldloc.0
-			IL_02de: ldc.i4.1
-			IL_02df: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02e4: ldc.r8 4
-			IL_02ed: box [System.Runtime]System.Double
-			IL_02f2: ldc.i4.1
-			IL_02f3: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02f8: ret
+			IL_02c2: ldloc.0
+			IL_02c3: ldloc.s 4
+			IL_02c5: stfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
+			IL_02ca: ldstr "r="
+			IL_02cf: ldloc.0
+			IL_02d0: ldfld object Modules.Generator_YieldStar_NestedGenerator/outer/Scope::r
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02da: stloc.s 12
+			IL_02dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e1: ldloc.s 12
+			IL_02e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02e8: pop
+			IL_02e9: ldloc.0
+			IL_02ea: ldc.i4.1
+			IL_02eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02f0: ldc.r8 4
+			IL_02f9: box [System.Runtime]System.Double
+			IL_02fe: ldc.i4.1
+			IL_02ff: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0304: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -559,7 +563,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2655
+			// Method begins at RVA 0x265d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -585,7 +589,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 408 (0x198)
+		// Code size: 403 (0x193)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_NestedGenerator/Scope,
@@ -637,102 +641,97 @@
 		IL_0060: stloc.s 7
 		IL_0062: ldloc.s 7
 		IL_0064: stloc.1
-		IL_0065: ldc.i4.1
-		IL_0066: newarr [System.Runtime]System.Object
-		IL_006b: dup
-		IL_006c: ldc.i4.0
-		IL_006d: ldloc.0
-		IL_006e: stelem.ref
-		IL_006f: ldnull
-		IL_0070: call object Modules.Generator_YieldStar_NestedGenerator/outer::__js_call__(object[], object)
-		IL_0075: stloc.s 7
-		IL_0077: ldloc.s 7
-		IL_0079: stloc.2
-		IL_007a: ldloc.2
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: stloc.s 7
-		IL_0082: ldloc.s 7
-		IL_0084: ldstr "next"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_008e: stloc.s 7
-		IL_0090: ldloc.s 7
-		IL_0092: stloc.3
-		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0098: ldloc.3
-		IL_0099: ldstr "value"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ae: ldloc.3
-		IL_00af: ldstr "done"
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00be: pop
-		IL_00bf: ldloc.2
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c5: stloc.s 7
-		IL_00c7: ldloc.s 7
-		IL_00c9: ldstr "next"
-		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00d3: stloc.s 7
-		IL_00d5: ldloc.s 7
-		IL_00d7: stloc.s 4
-		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00de: ldloc.s 4
-		IL_00e0: ldstr "value"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ef: pop
-		IL_00f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f5: ldloc.s 4
-		IL_00f7: ldstr "done"
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0101: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0106: pop
-		IL_0107: ldloc.2
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010d: stloc.s 7
-		IL_010f: ldloc.s 7
-		IL_0111: ldstr "next"
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_011b: stloc.s 7
-		IL_011d: ldloc.s 7
-		IL_011f: stloc.s 5
-		IL_0121: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0126: ldloc.s 5
-		IL_0128: ldstr "value"
-		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0132: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0137: pop
-		IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013d: ldloc.s 5
-		IL_013f: ldstr "done"
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0149: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014e: pop
-		IL_014f: ldloc.2
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0155: stloc.s 7
-		IL_0157: ldloc.s 7
-		IL_0159: ldstr "next"
-		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0163: stloc.s 7
-		IL_0165: ldloc.s 7
-		IL_0167: stloc.s 6
-		IL_0169: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016e: ldloc.s 6
-		IL_0170: ldstr "value"
-		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_017a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017f: pop
-		IL_0180: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0185: ldloc.s 6
-		IL_0187: ldstr "done"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0191: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0196: pop
-		IL_0197: ret
+		IL_0065: ldloc.1
+		IL_0066: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0070: stloc.s 7
+		IL_0072: ldloc.s 7
+		IL_0074: stloc.2
+		IL_0075: ldloc.2
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007b: stloc.s 7
+		IL_007d: ldloc.s 7
+		IL_007f: ldstr "next"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0089: stloc.s 7
+		IL_008b: ldloc.s 7
+		IL_008d: stloc.3
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: ldloc.3
+		IL_0094: ldstr "value"
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a9: ldloc.3
+		IL_00aa: ldstr "done"
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b9: pop
+		IL_00ba: ldloc.2
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c0: stloc.s 7
+		IL_00c2: ldloc.s 7
+		IL_00c4: ldstr "next"
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00ce: stloc.s 7
+		IL_00d0: ldloc.s 7
+		IL_00d2: stloc.s 4
+		IL_00d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00d9: ldloc.s 4
+		IL_00db: ldstr "value"
+		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ea: pop
+		IL_00eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f0: ldloc.s 4
+		IL_00f2: ldstr "done"
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0101: pop
+		IL_0102: ldloc.2
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0108: stloc.s 7
+		IL_010a: ldloc.s 7
+		IL_010c: ldstr "next"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0116: stloc.s 7
+		IL_0118: ldloc.s 7
+		IL_011a: stloc.s 5
+		IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0121: ldloc.s 5
+		IL_0123: ldstr "value"
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0132: pop
+		IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0138: ldloc.s 5
+		IL_013a: ldstr "done"
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0149: pop
+		IL_014a: ldloc.2
+		IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0150: stloc.s 7
+		IL_0152: ldloc.s 7
+		IL_0154: ldstr "next"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_015e: stloc.s 7
+		IL_0160: ldloc.s 7
+		IL_0162: stloc.s 6
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: ldloc.s 6
+		IL_016b: ldstr "value"
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_017a: pop
+		IL_017b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0180: ldloc.s 6
+		IL_0182: ldstr "done"
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0191: pop
+		IL_0192: ret
 	} // end of method Generator_YieldStar_NestedGenerator::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_NestedGenerator
@@ -744,7 +743,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2670
+		// Method begins at RVA 0x2678
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
@@ -24,7 +24,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2621
+				// Method begins at RVA 0x2629
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -48,7 +48,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21bc
+			// Method begins at RVA 0x21b8
 			// Header size: 12
 			// Code size: 339 (0x153)
 			.maxstack 8
@@ -213,7 +213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262a
+				// Method begins at RVA 0x2632
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -237,9 +237,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x231c
+			// Method begins at RVA 0x2318
 			// Header size: 12
-			// Code size: 752 (0x2f0)
+			// Code size: 764 (0x2fc)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_YieldStar_PassNextValue/outer/Scope,
@@ -306,251 +306,255 @@
 
 			IL_0068: ldloc.0
 			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_006e: switch (IL_007f, IL_0137, IL_0272)
+			IL_006e: switch (IL_007f, IL_0143, IL_027e)
 
-			IL_007f: ldc.i4.1
-			IL_0080: newarr [System.Runtime]System.Object
-			IL_0085: dup
-			IL_0086: ldc.i4.0
-			IL_0087: ldarg.0
-			IL_0088: ldc.i4.1
-			IL_0089: ldelem.ref
-			IL_008a: stelem.ref
-			IL_008b: ldnull
-			IL_008c: call object Modules.Generator_YieldStar_PassNextValue/inner::__js_call__(object[], object)
-			IL_0091: stloc.s 4
-			IL_0093: ldloc.s 4
-			IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_009a: stloc.s 5
-			IL_009c: ldloc.s 5
-			IL_009e: brtrue IL_019c
+			IL_007f: ldarg.0
+			IL_0080: ldc.i4.1
+			IL_0081: ldelem.ref
+			IL_0082: castclass Modules.Generator_YieldStar_PassNextValue/Scope
+			IL_0087: ldfld object Modules.Generator_YieldStar_PassNextValue/Scope::inner
+			IL_008c: ldc.i4.1
+			IL_008d: newarr [System.Runtime]System.Object
+			IL_0092: dup
+			IL_0093: ldc.i4.0
+			IL_0094: ldarg.0
+			IL_0095: ldc.i4.1
+			IL_0096: ldelem.ref
+			IL_0097: stelem.ref
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_009d: stloc.s 4
+			IL_009f: ldloc.s 4
+			IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00a6: stloc.s 5
+			IL_00a8: ldloc.s 5
+			IL_00aa: brtrue IL_01a8
 
-			IL_00a3: ldloc.s 4
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
-			IL_00aa: stloc.s 4
-			IL_00ac: ldloc.0
-			IL_00ad: ldc.r8 1
-			IL_00b6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_00bb: ldloc.0
-			IL_00bc: ldloc.s 4
-			IL_00be: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_00c3: ldloc.0
-			IL_00c4: ldc.r8 0.0
-			IL_00cd: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00d2: ldloc.s 4
-			IL_00d4: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00d9: stloc.s 6
-			IL_00db: ldloc.0
-			IL_00dc: ldloc.s 6
-			IL_00de: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00af: ldloc.s 4
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
+			IL_00b6: stloc.s 4
+			IL_00b8: ldloc.0
+			IL_00b9: ldc.r8 1
+			IL_00c2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_00c7: ldloc.0
+			IL_00c8: ldloc.s 4
+			IL_00ca: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_00cf: ldloc.0
+			IL_00d0: ldc.r8 0.0
+			IL_00d9: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00de: ldloc.s 4
+			IL_00e0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.0
+			IL_00e8: ldloc.s 6
+			IL_00ea: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
 
-			IL_00e3: ldloc.0
-			IL_00e4: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00e9: stloc.s 6
-			IL_00eb: ldloc.0
-			IL_00ec: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
-			IL_00f1: stloc.s 7
-			IL_00f3: ldloc.s 6
-			IL_00f5: ldloc.s 7
-			IL_00f7: clt
-			IL_00f9: brfalse IL_0179
+			IL_00ef: ldloc.0
+			IL_00f0: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00f5: stloc.s 6
+			IL_00f7: ldloc.0
+			IL_00f8: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00fd: stloc.s 7
+			IL_00ff: ldloc.s 6
+			IL_0101: ldloc.s 7
+			IL_0103: clt
+			IL_0105: brfalse IL_0185
 
-			IL_00fe: ldloc.0
-			IL_00ff: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0104: stloc.s 4
-			IL_0106: ldloc.s 4
-			IL_0108: ldloc.s 6
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_010f: stloc.s 4
-			IL_0111: ldloc.s 6
-			IL_0113: ldc.r8 1
-			IL_011c: add
-			IL_011d: stloc.s 6
-			IL_011f: ldloc.0
-			IL_0120: ldloc.s 6
-			IL_0122: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_0127: ldloc.0
-			IL_0128: ldc.i4.1
-			IL_0129: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_012e: ldloc.s 4
-			IL_0130: ldc.i4.0
-			IL_0131: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0136: ret
+			IL_010a: ldloc.0
+			IL_010b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_0110: stloc.s 4
+			IL_0112: ldloc.s 4
+			IL_0114: ldloc.s 6
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_011b: stloc.s 4
+			IL_011d: ldloc.s 6
+			IL_011f: ldc.r8 1
+			IL_0128: add
+			IL_0129: stloc.s 6
+			IL_012b: ldloc.0
+			IL_012c: ldloc.s 6
+			IL_012e: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_0133: ldloc.0
+			IL_0134: ldc.i4.1
+			IL_0135: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_013a: ldloc.s 4
+			IL_013c: ldc.i4.0
+			IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0142: ret
 
-			IL_0137: ldloc.0
-			IL_0138: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_013d: brfalse IL_0156
+			IL_0143: ldloc.0
+			IL_0144: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_0149: brfalse IL_0162
 
-			IL_0142: ldloc.0
-			IL_0143: ldc.i4.1
-			IL_0144: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0149: ldloc.0
-			IL_014a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_014e: ldloc.0
 			IL_014f: ldc.i4.1
-			IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0155: ret
+			IL_0150: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0155: ldloc.0
+			IL_0156: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_015b: ldc.i4.1
+			IL_015c: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0161: ret
 
-			IL_0156: ldloc.0
-			IL_0157: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_015c: brfalse IL_0174
+			IL_0162: ldloc.0
+			IL_0163: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0168: brfalse IL_0180
 
-			IL_0161: ldloc.0
-			IL_0162: ldc.i4.0
-			IL_0163: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0168: ldloc.0
-			IL_0169: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0173: throw
+			IL_016d: ldloc.0
+			IL_016e: ldc.i4.0
+			IL_016f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0174: ldloc.0
+			IL_0175: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_017a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_017f: throw
 
-			IL_0174: br IL_00e3
+			IL_0180: br IL_00ef
 
-			IL_0179: ldloc.0
-			IL_017a: ldc.r8 0.0
-			IL_0183: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_0188: ldloc.0
-			IL_0189: ldc.i4.0
-			IL_018a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_018f: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0194: ldnull
-			IL_0195: stloc.s 4
-			IL_0197: br IL_02b6
+			IL_0185: ldloc.0
+			IL_0186: ldc.r8 0.0
+			IL_018f: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_0194: ldloc.0
+			IL_0195: ldc.i4.0
+			IL_0196: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_019b: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01a0: ldnull
+			IL_01a1: stloc.s 4
+			IL_01a3: br IL_02c2
 
-			IL_019c: ldloc.0
-			IL_019d: ldc.r8 2
-			IL_01a6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_01ab: ldloc.0
-			IL_01ac: ldloc.s 5
-			IL_01ae: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01b3: ldc.i4.0
-			IL_01b4: stloc.2
+			IL_01a8: ldloc.0
+			IL_01a9: ldc.r8 2
+			IL_01b2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01b7: ldloc.0
+			IL_01b8: ldloc.s 5
+			IL_01ba: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01bf: ldc.i4.0
+			IL_01c0: stloc.2
 
-			IL_01b5: ldloc.0
-			IL_01b6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01bb: stloc.s 4
-			IL_01bd: ldloc.0
-			IL_01be: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01c3: stloc.3
-			IL_01c4: ldloc.3
-			IL_01c5: brtrue IL_01dc
+			IL_01c1: ldloc.0
+			IL_01c2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01c7: stloc.s 4
+			IL_01c9: ldloc.0
+			IL_01ca: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01cf: stloc.3
+			IL_01d0: ldloc.3
+			IL_01d1: brtrue IL_01e8
 
-			IL_01ca: ldloc.0
-			IL_01cb: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_01d0: stloc.3
-			IL_01d1: ldloc.3
-			IL_01d2: brtrue IL_020f
+			IL_01d6: ldloc.0
+			IL_01d7: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_01dc: stloc.3
+			IL_01dd: ldloc.3
+			IL_01de: brtrue IL_021b
 
-			IL_01d7: br IL_0242
+			IL_01e3: br IL_024e
 
-			IL_01dc: ldc.i4.1
-			IL_01dd: stloc.2
-			IL_01de: ldloc.0
-			IL_01df: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_01e4: stloc.s 8
-			IL_01e6: ldloc.0
-			IL_01e7: ldc.i4.0
-			IL_01e8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01ed: ldc.i4.1
-			IL_01ee: newarr [System.Runtime]System.Object
-			IL_01f3: dup
-			IL_01f4: ldc.i4.0
-			IL_01f5: ldloc.s 8
-			IL_01f7: stelem.ref
-			IL_01f8: stloc.s 9
-			IL_01fa: ldloc.s 4
-			IL_01fc: ldstr "return"
-			IL_0201: ldloc.s 9
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0208: stloc.s 4
-			IL_020a: br IL_025a
+			IL_01e8: ldc.i4.1
+			IL_01e9: stloc.2
+			IL_01ea: ldloc.0
+			IL_01eb: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_01f0: stloc.s 8
+			IL_01f2: ldloc.0
+			IL_01f3: ldc.i4.0
+			IL_01f4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01f9: ldc.i4.1
+			IL_01fa: newarr [System.Runtime]System.Object
+			IL_01ff: dup
+			IL_0200: ldc.i4.0
+			IL_0201: ldloc.s 8
+			IL_0203: stelem.ref
+			IL_0204: stloc.s 9
+			IL_0206: ldloc.s 4
+			IL_0208: ldstr "return"
+			IL_020d: ldloc.s 9
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0214: stloc.s 4
+			IL_0216: br IL_0266
 
-			IL_020f: ldc.i4.0
-			IL_0210: stloc.2
-			IL_0211: ldloc.0
-			IL_0212: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0217: stloc.s 10
-			IL_0219: ldloc.0
-			IL_021a: ldc.i4.0
-			IL_021b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0220: ldc.i4.1
-			IL_0221: newarr [System.Runtime]System.Object
-			IL_0226: dup
-			IL_0227: ldc.i4.0
-			IL_0228: ldloc.s 10
-			IL_022a: stelem.ref
-			IL_022b: stloc.s 9
-			IL_022d: ldloc.s 4
-			IL_022f: ldstr "throw"
-			IL_0234: ldloc.s 9
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_023b: stloc.s 4
-			IL_023d: br IL_025a
+			IL_021b: ldc.i4.0
+			IL_021c: stloc.2
+			IL_021d: ldloc.0
+			IL_021e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0223: stloc.s 10
+			IL_0225: ldloc.0
+			IL_0226: ldc.i4.0
+			IL_0227: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_022c: ldc.i4.1
+			IL_022d: newarr [System.Runtime]System.Object
+			IL_0232: dup
+			IL_0233: ldc.i4.0
+			IL_0234: ldloc.s 10
+			IL_0236: stelem.ref
+			IL_0237: stloc.s 9
+			IL_0239: ldloc.s 4
+			IL_023b: ldstr "throw"
+			IL_0240: ldloc.s 9
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0247: stloc.s 4
+			IL_0249: br IL_0266
 
-			IL_0242: ldc.i4.0
-			IL_0243: stloc.2
-			IL_0244: ldloc.0
-			IL_0245: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
-			IL_024a: stloc.s 11
-			IL_024c: ldloc.s 4
-			IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
-			IL_0253: stloc.s 4
-			IL_0255: br IL_025a
+			IL_024e: ldc.i4.0
+			IL_024f: stloc.2
+			IL_0250: ldloc.0
+			IL_0251: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
+			IL_0256: stloc.s 11
+			IL_0258: ldloc.s 4
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
+			IL_025f: stloc.s 4
+			IL_0261: br IL_0266
 
-			IL_025a: ldloc.s 4
-			IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0261: stloc.3
-			IL_0262: ldloc.3
-			IL_0263: brtrue IL_0277
+			IL_0266: ldloc.s 4
+			IL_0268: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_026d: stloc.3
+			IL_026e: ldloc.3
+			IL_026f: brtrue IL_0283
 
-			IL_0268: ldloc.0
-			IL_0269: ldc.i4.2
-			IL_026a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_026f: ldloc.s 4
-			IL_0271: ret
+			IL_0274: ldloc.0
+			IL_0275: ldc.i4.2
+			IL_0276: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_027b: ldloc.s 4
+			IL_027d: ret
 
-			IL_0272: br IL_01b5
+			IL_027e: br IL_01c1
 
-			IL_0277: ldloc.s 4
-			IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_027e: stloc.s 4
-			IL_0280: ldloc.0
-			IL_0281: ldc.r8 0.0
-			IL_028a: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_028f: ldloc.0
-			IL_0290: ldc.i4.0
-			IL_0291: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0296: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_029b: ldloc.2
-			IL_029c: brtrue IL_02a6
+			IL_0283: ldloc.s 4
+			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_028a: stloc.s 4
+			IL_028c: ldloc.0
+			IL_028d: ldc.r8 0.0
+			IL_0296: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_029b: ldloc.0
+			IL_029c: ldc.i4.0
+			IL_029d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a2: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_02a7: ldloc.2
+			IL_02a8: brtrue IL_02b2
 
-			IL_02a1: br IL_02b6
+			IL_02ad: br IL_02c2
 
-			IL_02a6: ldloc.0
-			IL_02a7: ldc.i4.1
-			IL_02a8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02ad: ldloc.s 4
-			IL_02af: ldc.i4.1
-			IL_02b0: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02b5: ret
+			IL_02b2: ldloc.0
+			IL_02b3: ldc.i4.1
+			IL_02b4: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02b9: ldloc.s 4
+			IL_02bb: ldc.i4.1
+			IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02c1: ret
 
-			IL_02b6: ldloc.0
-			IL_02b7: ldloc.s 4
-			IL_02b9: stfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
-			IL_02be: ldstr "r="
-			IL_02c3: ldloc.0
-			IL_02c4: ldfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02ce: stloc.s 12
-			IL_02d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02d5: ldloc.s 12
-			IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02dc: pop
-			IL_02dd: ldloc.0
-			IL_02de: ldc.i4.1
-			IL_02df: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02e4: ldstr "done"
-			IL_02e9: ldc.i4.1
-			IL_02ea: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02ef: ret
+			IL_02c2: ldloc.0
+			IL_02c3: ldloc.s 4
+			IL_02c5: stfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
+			IL_02ca: ldstr "r="
+			IL_02cf: ldloc.0
+			IL_02d0: ldfld object Modules.Generator_YieldStar_PassNextValue/outer/Scope::r
+			IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02da: stloc.s 12
+			IL_02dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e1: ldloc.s 12
+			IL_02e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02e8: pop
+			IL_02e9: ldloc.0
+			IL_02ea: ldc.i4.1
+			IL_02eb: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02f0: ldstr "done"
+			IL_02f5: ldc.i4.1
+			IL_02f6: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02fb: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -571,7 +575,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2618
+			// Method begins at RVA 0x2620
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -597,7 +601,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 350 (0x15e)
+		// Code size: 345 (0x159)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_PassNextValue/Scope,
@@ -648,83 +652,78 @@
 		IL_0060: stloc.s 6
 		IL_0062: ldloc.s 6
 		IL_0064: stloc.1
-		IL_0065: ldc.i4.1
-		IL_0066: newarr [System.Runtime]System.Object
-		IL_006b: dup
-		IL_006c: ldc.i4.0
-		IL_006d: ldloc.0
-		IL_006e: stelem.ref
-		IL_006f: ldnull
-		IL_0070: call object Modules.Generator_YieldStar_PassNextValue/outer::__js_call__(object[], object)
-		IL_0075: stloc.s 6
-		IL_0077: ldloc.s 6
-		IL_0079: stloc.2
-		IL_007a: ldloc.2
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: stloc.s 6
-		IL_0082: ldloc.s 6
-		IL_0084: ldstr "next"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_008e: stloc.s 6
-		IL_0090: ldloc.s 6
-		IL_0092: stloc.3
-		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0098: ldloc.3
-		IL_0099: ldstr "value"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ae: ldloc.3
-		IL_00af: ldstr "done"
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00be: pop
-		IL_00bf: ldloc.2
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c5: stloc.s 6
-		IL_00c7: ldloc.s 6
-		IL_00c9: ldstr "next"
-		IL_00ce: ldc.r8 42
-		IL_00d7: box [System.Runtime]System.Double
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e1: stloc.s 6
-		IL_00e3: ldloc.s 6
-		IL_00e5: stloc.s 4
-		IL_00e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ec: ldloc.s 4
-		IL_00ee: ldstr "value"
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fd: pop
-		IL_00fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0103: ldloc.s 4
-		IL_0105: ldstr "done"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0114: pop
-		IL_0115: ldloc.2
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011b: stloc.s 6
-		IL_011d: ldloc.s 6
-		IL_011f: ldstr "next"
-		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0129: stloc.s 6
-		IL_012b: ldloc.s 6
-		IL_012d: stloc.s 5
-		IL_012f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0134: ldloc.s 5
-		IL_0136: ldstr "value"
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0140: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0145: pop
-		IL_0146: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_014b: ldloc.s 5
-		IL_014d: ldstr "done"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0157: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_015c: pop
-		IL_015d: ret
+		IL_0065: ldloc.1
+		IL_0066: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0070: stloc.s 6
+		IL_0072: ldloc.s 6
+		IL_0074: stloc.2
+		IL_0075: ldloc.2
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007b: stloc.s 6
+		IL_007d: ldloc.s 6
+		IL_007f: ldstr "next"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0089: stloc.s 6
+		IL_008b: ldloc.s 6
+		IL_008d: stloc.3
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: ldloc.3
+		IL_0094: ldstr "value"
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a9: ldloc.3
+		IL_00aa: ldstr "done"
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b9: pop
+		IL_00ba: ldloc.2
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c0: stloc.s 6
+		IL_00c2: ldloc.s 6
+		IL_00c4: ldstr "next"
+		IL_00c9: ldc.r8 42
+		IL_00d2: box [System.Runtime]System.Double
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00dc: stloc.s 6
+		IL_00de: ldloc.s 6
+		IL_00e0: stloc.s 4
+		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e7: ldloc.s 4
+		IL_00e9: ldstr "value"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f8: pop
+		IL_00f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fe: ldloc.s 4
+		IL_0100: ldstr "done"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010f: pop
+		IL_0110: ldloc.2
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.s 6
+		IL_0118: ldloc.s 6
+		IL_011a: ldstr "next"
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0124: stloc.s 6
+		IL_0126: ldloc.s 6
+		IL_0128: stloc.s 5
+		IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012f: ldloc.s 5
+		IL_0131: ldstr "value"
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0140: pop
+		IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0146: ldloc.s 5
+		IL_0148: ldstr "done"
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0157: pop
+		IL_0158: ret
 	} // end of method Generator_YieldStar_PassNextValue::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_PassNextValue
@@ -736,7 +735,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2633
+		// Method begins at RVA 0x263b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x262e
+				// Method begins at RVA 0x2636
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2174
+			// Method begins at RVA 0x2170
 			// Header size: 12
 			// Code size: 333 (0x14d)
 			.maxstack 8
@@ -200,7 +200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2637
+				// Method begins at RVA 0x263f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -224,9 +224,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22cc
 			// Header size: 12
-			// Code size: 841 (0x349)
+			// Code size: 853 (0x355)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Generator_YieldStar_ReturnForwards/outer/Scope,
@@ -293,285 +293,289 @@
 
 			IL_0068: ldloc.0
 			IL_0069: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_006e: switch (IL_0083, IL_013b, IL_0276, IL_02fd)
+			IL_006e: switch (IL_0083, IL_0147, IL_0282, IL_0309)
 
-			IL_0083: ldc.i4.1
-			IL_0084: newarr [System.Runtime]System.Object
-			IL_0089: dup
-			IL_008a: ldc.i4.0
-			IL_008b: ldarg.0
-			IL_008c: ldc.i4.1
-			IL_008d: ldelem.ref
-			IL_008e: stelem.ref
-			IL_008f: ldnull
-			IL_0090: call object Modules.Generator_YieldStar_ReturnForwards/inner::__js_call__(object[], object)
-			IL_0095: stloc.s 4
-			IL_0097: ldloc.s 4
-			IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_009e: stloc.s 5
-			IL_00a0: ldloc.s 5
-			IL_00a2: brtrue IL_01a0
+			IL_0083: ldarg.0
+			IL_0084: ldc.i4.1
+			IL_0085: ldelem.ref
+			IL_0086: castclass Modules.Generator_YieldStar_ReturnForwards/Scope
+			IL_008b: ldfld object Modules.Generator_YieldStar_ReturnForwards/Scope::inner
+			IL_0090: ldc.i4.1
+			IL_0091: newarr [System.Runtime]System.Object
+			IL_0096: dup
+			IL_0097: ldc.i4.0
+			IL_0098: ldarg.0
+			IL_0099: ldc.i4.1
+			IL_009a: ldelem.ref
+			IL_009b: stelem.ref
+			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00a1: stloc.s 4
+			IL_00a3: ldloc.s 4
+			IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_00aa: stloc.s 5
+			IL_00ac: ldloc.s 5
+			IL_00ae: brtrue IL_01ac
 
-			IL_00a7: ldloc.s 4
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
-			IL_00ae: stloc.s 4
-			IL_00b0: ldloc.0
-			IL_00b1: ldc.r8 1
-			IL_00ba: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_00bf: ldloc.0
-			IL_00c0: ldloc.s 4
-			IL_00c2: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_00c7: ldloc.0
-			IL_00c8: ldc.r8 0.0
-			IL_00d1: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00d6: ldloc.s 4
-			IL_00d8: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
-			IL_00dd: stloc.s 6
-			IL_00df: ldloc.0
-			IL_00e0: ldloc.s 6
-			IL_00e2: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_00b3: ldloc.s 4
+			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::NormalizeForOfIterable(object)
+			IL_00ba: stloc.s 4
+			IL_00bc: ldloc.0
+			IL_00bd: ldc.r8 1
+			IL_00c6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_00cb: ldloc.0
+			IL_00cc: ldloc.s 4
+			IL_00ce: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_00d3: ldloc.0
+			IL_00d4: ldc.r8 0.0
+			IL_00dd: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00e2: ldloc.s 4
+			IL_00e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+			IL_00e9: stloc.s 6
+			IL_00eb: ldloc.0
+			IL_00ec: ldloc.s 6
+			IL_00ee: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
 
-			IL_00e7: ldloc.0
-			IL_00e8: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_00ed: stloc.s 6
-			IL_00ef: ldloc.0
-			IL_00f0: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
-			IL_00f5: stloc.s 7
-			IL_00f7: ldloc.s 6
-			IL_00f9: ldloc.s 7
-			IL_00fb: clt
-			IL_00fd: brfalse IL_017d
+			IL_00f3: ldloc.0
+			IL_00f4: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_00f9: stloc.s 6
+			IL_00fb: ldloc.0
+			IL_00fc: ldfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarLength
+			IL_0101: stloc.s 7
+			IL_0103: ldloc.s 6
+			IL_0105: ldloc.s 7
+			IL_0107: clt
+			IL_0109: brfalse IL_0189
 
-			IL_0102: ldloc.0
-			IL_0103: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0108: stloc.s 4
-			IL_010a: ldloc.s 4
-			IL_010c: ldloc.s 6
-			IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0113: stloc.s 4
-			IL_0115: ldloc.s 6
-			IL_0117: ldc.r8 1
-			IL_0120: add
-			IL_0121: stloc.s 6
-			IL_0123: ldloc.0
-			IL_0124: ldloc.s 6
-			IL_0126: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
-			IL_012b: ldloc.0
-			IL_012c: ldc.i4.1
-			IL_012d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0132: ldloc.s 4
-			IL_0134: ldc.i4.0
-			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_013a: ret
+			IL_010e: ldloc.0
+			IL_010f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_0114: stloc.s 4
+			IL_0116: ldloc.s 4
+			IL_0118: ldloc.s 6
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_011f: stloc.s 4
+			IL_0121: ldloc.s 6
+			IL_0123: ldc.r8 1
+			IL_012c: add
+			IL_012d: stloc.s 6
+			IL_012f: ldloc.0
+			IL_0130: ldloc.s 6
+			IL_0132: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarIndex
+			IL_0137: ldloc.0
+			IL_0138: ldc.i4.1
+			IL_0139: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_013e: ldloc.s 4
+			IL_0140: ldc.i4.0
+			IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0146: ret
 
-			IL_013b: ldloc.0
-			IL_013c: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0141: brfalse IL_015a
+			IL_0147: ldloc.0
+			IL_0148: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_014d: brfalse IL_0166
 
-			IL_0146: ldloc.0
-			IL_0147: ldc.i4.1
-			IL_0148: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_014d: ldloc.0
-			IL_014e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0152: ldloc.0
 			IL_0153: ldc.i4.1
-			IL_0154: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0159: ret
+			IL_0154: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_0159: ldloc.0
+			IL_015a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_015f: ldc.i4.1
+			IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0165: ret
 
-			IL_015a: ldloc.0
-			IL_015b: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0160: brfalse IL_0178
+			IL_0166: ldloc.0
+			IL_0167: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_016c: brfalse IL_0184
 
-			IL_0165: ldloc.0
-			IL_0166: ldc.i4.0
-			IL_0167: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_016c: ldloc.0
-			IL_016d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0172: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0177: throw
+			IL_0171: ldloc.0
+			IL_0172: ldc.i4.0
+			IL_0173: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0178: ldloc.0
+			IL_0179: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_017e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0183: throw
 
-			IL_0178: br IL_00e7
+			IL_0184: br IL_00f3
 
-			IL_017d: ldloc.0
-			IL_017e: ldc.r8 0.0
-			IL_0187: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_018c: ldloc.0
-			IL_018d: ldc.i4.0
-			IL_018e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0193: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_0198: ldnull
-			IL_0199: stloc.s 4
-			IL_019b: br IL_02ba
+			IL_0189: ldloc.0
+			IL_018a: ldc.r8 0.0
+			IL_0193: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_0198: ldloc.0
+			IL_0199: ldc.i4.0
+			IL_019a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_019f: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01a4: ldnull
+			IL_01a5: stloc.s 4
+			IL_01a7: br IL_02c6
 
-			IL_01a0: ldloc.0
-			IL_01a1: ldc.r8 2
-			IL_01aa: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_01af: ldloc.0
-			IL_01b0: ldloc.s 5
-			IL_01b2: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01b7: ldc.i4.0
-			IL_01b8: stloc.2
+			IL_01ac: ldloc.0
+			IL_01ad: ldc.r8 2
+			IL_01b6: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_01bb: ldloc.0
+			IL_01bc: ldloc.s 5
+			IL_01be: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01c3: ldc.i4.0
+			IL_01c4: stloc.2
 
-			IL_01b9: ldloc.0
-			IL_01ba: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_01bf: stloc.s 4
-			IL_01c1: ldloc.0
-			IL_01c2: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01c7: stloc.3
-			IL_01c8: ldloc.3
-			IL_01c9: brtrue IL_01e0
+			IL_01c5: ldloc.0
+			IL_01c6: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_01cb: stloc.s 4
+			IL_01cd: ldloc.0
+			IL_01ce: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01d3: stloc.3
+			IL_01d4: ldloc.3
+			IL_01d5: brtrue IL_01ec
 
-			IL_01ce: ldloc.0
-			IL_01cf: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_01d4: stloc.3
-			IL_01d5: ldloc.3
-			IL_01d6: brtrue IL_0213
+			IL_01da: ldloc.0
+			IL_01db: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_01e0: stloc.3
+			IL_01e1: ldloc.3
+			IL_01e2: brtrue IL_021f
 
-			IL_01db: br IL_0246
+			IL_01e7: br IL_0252
 
-			IL_01e0: ldc.i4.1
-			IL_01e1: stloc.2
-			IL_01e2: ldloc.0
-			IL_01e3: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
-			IL_01e8: stloc.s 8
-			IL_01ea: ldloc.0
-			IL_01eb: ldc.i4.0
-			IL_01ec: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_01f1: ldc.i4.1
-			IL_01f2: newarr [System.Runtime]System.Object
-			IL_01f7: dup
-			IL_01f8: ldc.i4.0
-			IL_01f9: ldloc.s 8
-			IL_01fb: stelem.ref
-			IL_01fc: stloc.s 9
-			IL_01fe: ldloc.s 4
-			IL_0200: ldstr "return"
-			IL_0205: ldloc.s 9
-			IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_020c: stloc.s 4
-			IL_020e: br IL_025e
+			IL_01ec: ldc.i4.1
+			IL_01ed: stloc.2
+			IL_01ee: ldloc.0
+			IL_01ef: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_01f4: stloc.s 8
+			IL_01f6: ldloc.0
+			IL_01f7: ldc.i4.0
+			IL_01f8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_01fd: ldc.i4.1
+			IL_01fe: newarr [System.Runtime]System.Object
+			IL_0203: dup
+			IL_0204: ldc.i4.0
+			IL_0205: ldloc.s 8
+			IL_0207: stelem.ref
+			IL_0208: stloc.s 9
+			IL_020a: ldloc.s 4
+			IL_020c: ldstr "return"
+			IL_0211: ldloc.s 9
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0218: stloc.s 4
+			IL_021a: br IL_026a
 
-			IL_0213: ldc.i4.0
-			IL_0214: stloc.2
-			IL_0215: ldloc.0
-			IL_0216: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_021b: stloc.s 10
-			IL_021d: ldloc.0
-			IL_021e: ldc.i4.0
-			IL_021f: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0224: ldc.i4.1
-			IL_0225: newarr [System.Runtime]System.Object
-			IL_022a: dup
-			IL_022b: ldc.i4.0
-			IL_022c: ldloc.s 10
-			IL_022e: stelem.ref
-			IL_022f: stloc.s 9
-			IL_0231: ldloc.s 4
-			IL_0233: ldstr "throw"
-			IL_0238: ldloc.s 9
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_023f: stloc.s 4
-			IL_0241: br IL_025e
+			IL_021f: ldc.i4.0
+			IL_0220: stloc.2
+			IL_0221: ldloc.0
+			IL_0222: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0227: stloc.s 10
+			IL_0229: ldloc.0
+			IL_022a: ldc.i4.0
+			IL_022b: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_0230: ldc.i4.1
+			IL_0231: newarr [System.Runtime]System.Object
+			IL_0236: dup
+			IL_0237: ldc.i4.0
+			IL_0238: ldloc.s 10
+			IL_023a: stelem.ref
+			IL_023b: stloc.s 9
+			IL_023d: ldloc.s 4
+			IL_023f: ldstr "throw"
+			IL_0244: ldloc.s 9
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_024b: stloc.s 4
+			IL_024d: br IL_026a
 
-			IL_0246: ldc.i4.0
-			IL_0247: stloc.2
-			IL_0248: ldloc.0
-			IL_0249: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
-			IL_024e: stloc.s 11
-			IL_0250: ldloc.s 4
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
-			IL_0257: stloc.s 4
-			IL_0259: br IL_025e
+			IL_0252: ldc.i4.0
+			IL_0253: stloc.2
+			IL_0254: ldloc.0
+			IL_0255: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeValue
+			IL_025a: stloc.s 11
+			IL_025c: ldloc.s 4
+			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNextForYieldStar(object)
+			IL_0263: stloc.s 4
+			IL_0265: br IL_026a
 
-			IL_025e: ldloc.s 4
-			IL_0260: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0265: stloc.3
-			IL_0266: ldloc.3
-			IL_0267: brtrue IL_027b
+			IL_026a: ldloc.s 4
+			IL_026c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0271: stloc.3
+			IL_0272: ldloc.3
+			IL_0273: brtrue IL_0287
 
-			IL_026c: ldloc.0
-			IL_026d: ldc.i4.2
-			IL_026e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_0273: ldloc.s 4
-			IL_0275: ret
+			IL_0278: ldloc.0
+			IL_0279: ldc.i4.2
+			IL_027a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_027f: ldloc.s 4
+			IL_0281: ret
 
-			IL_0276: br IL_01b9
+			IL_0282: br IL_01c5
 
-			IL_027b: ldloc.s 4
-			IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0282: stloc.s 4
-			IL_0284: ldloc.0
-			IL_0285: ldc.r8 0.0
-			IL_028e: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
-			IL_0293: ldloc.0
-			IL_0294: ldc.i4.0
-			IL_0295: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_029a: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
-			IL_029f: ldloc.2
-			IL_02a0: brtrue IL_02aa
+			IL_0287: ldloc.s 4
+			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_028e: stloc.s 4
+			IL_0290: ldloc.0
+			IL_0291: ldc.r8 0.0
+			IL_029a: stfld float64 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarMode
+			IL_029f: ldloc.0
+			IL_02a0: ldc.i4.0
+			IL_02a1: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_02a6: stfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_yieldStarTarget
+			IL_02ab: ldloc.2
+			IL_02ac: brtrue IL_02b6
 
-			IL_02a5: br IL_02ba
+			IL_02b1: br IL_02c6
 
-			IL_02aa: ldloc.0
-			IL_02ab: ldc.i4.1
-			IL_02ac: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_02b1: ldloc.s 4
-			IL_02b3: ldc.i4.1
-			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02b9: ret
+			IL_02b6: ldloc.0
+			IL_02b7: ldc.i4.1
+			IL_02b8: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_02bd: ldloc.s 4
+			IL_02bf: ldc.i4.1
+			IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_02c5: ret
 
-			IL_02ba: ldloc.0
-			IL_02bb: ldloc.s 4
-			IL_02bd: stfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
-			IL_02c2: ldstr "r="
-			IL_02c7: ldloc.0
-			IL_02c8: ldfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
-			IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02d2: stloc.s 12
-			IL_02d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02d9: ldloc.s 12
-			IL_02db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02e0: pop
-			IL_02e1: ldloc.0
-			IL_02e2: ldc.i4.3
-			IL_02e3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
-			IL_02e8: ldc.r8 2
-			IL_02f1: box [System.Runtime]System.Double
-			IL_02f6: ldc.i4.0
-			IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_02fc: ret
+			IL_02c6: ldloc.0
+			IL_02c7: ldloc.s 4
+			IL_02c9: stfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
+			IL_02ce: ldstr "r="
+			IL_02d3: ldloc.0
+			IL_02d4: ldfld object Modules.Generator_YieldStar_ReturnForwards/outer/Scope::r
+			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02de: stloc.s 12
+			IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e5: ldloc.s 12
+			IL_02e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02ec: pop
+			IL_02ed: ldloc.0
+			IL_02ee: ldc.i4.3
+			IL_02ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_genState
+			IL_02f4: ldc.r8 2
+			IL_02fd: box [System.Runtime]System.Double
+			IL_0302: ldc.i4.0
+			IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0308: ret
 
-			IL_02fd: ldloc.0
-			IL_02fe: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
-			IL_0303: brfalse IL_031c
+			IL_0309: ldloc.0
+			IL_030a: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasReturn
+			IL_030f: brfalse IL_0328
 
-			IL_0308: ldloc.0
-			IL_0309: ldc.i4.1
-			IL_030a: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_030f: ldloc.0
-			IL_0310: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0314: ldloc.0
 			IL_0315: ldc.i4.1
-			IL_0316: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_031b: ret
+			IL_0316: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_031b: ldloc.0
+			IL_031c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_returnValue
+			IL_0321: ldc.i4.1
+			IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0327: ret
 
-			IL_031c: ldloc.0
-			IL_031d: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_0322: brfalse IL_033a
+			IL_0328: ldloc.0
+			IL_0329: ldfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
+			IL_032e: brfalse IL_0346
 
-			IL_0327: ldloc.0
-			IL_0328: ldc.i4.0
-			IL_0329: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
-			IL_032e: ldloc.0
-			IL_032f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
-			IL_0334: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0339: throw
-
+			IL_0333: ldloc.0
+			IL_0334: ldc.i4.0
+			IL_0335: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_hasResumeException
 			IL_033a: ldloc.0
-			IL_033b: ldc.i4.1
-			IL_033c: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
-			IL_0341: ldnull
-			IL_0342: ldc.i4.1
-			IL_0343: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
-			IL_0348: ret
+			IL_033b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_resumeException
+			IL_0340: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0345: throw
+
+			IL_0346: ldloc.0
+			IL_0347: ldc.i4.1
+			IL_0348: stfld bool [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope::_done
+			IL_034d: ldnull
+			IL_034e: ldc.i4.1
+			IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.IteratorResultObject [JavaScriptRuntime]JavaScriptRuntime.IteratorResult::Create(object, bool)
+			IL_0354: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -592,7 +596,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2625
+			// Method begins at RVA 0x262d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -618,7 +622,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 278 (0x116)
+		// Code size: 273 (0x111)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_ReturnForwards/Scope,
@@ -668,62 +672,57 @@
 		IL_0060: stloc.s 5
 		IL_0062: ldloc.s 5
 		IL_0064: stloc.1
-		IL_0065: ldc.i4.1
-		IL_0066: newarr [System.Runtime]System.Object
-		IL_006b: dup
-		IL_006c: ldc.i4.0
-		IL_006d: ldloc.0
-		IL_006e: stelem.ref
-		IL_006f: ldnull
-		IL_0070: call object Modules.Generator_YieldStar_ReturnForwards/outer::__js_call__(object[], object)
-		IL_0075: stloc.s 5
-		IL_0077: ldloc.s 5
-		IL_0079: stloc.2
-		IL_007a: ldloc.2
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: stloc.s 5
-		IL_0082: ldloc.s 5
-		IL_0084: ldstr "next"
-		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_008e: stloc.s 5
-		IL_0090: ldloc.s 5
-		IL_0092: stloc.3
-		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0098: ldloc.3
-		IL_0099: ldstr "value"
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a8: pop
-		IL_00a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ae: ldloc.3
-		IL_00af: ldstr "done"
-		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00be: pop
-		IL_00bf: ldloc.2
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c5: stloc.s 5
-		IL_00c7: ldloc.s 5
-		IL_00c9: ldstr "return"
-		IL_00ce: ldc.r8 123
-		IL_00d7: box [System.Runtime]System.Double
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00e1: stloc.s 5
-		IL_00e3: ldloc.s 5
-		IL_00e5: stloc.s 4
-		IL_00e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ec: ldloc.s 4
-		IL_00ee: ldstr "value"
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fd: pop
-		IL_00fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0103: ldloc.s 4
-		IL_0105: ldstr "done"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0114: pop
-		IL_0115: ret
+		IL_0065: ldloc.1
+		IL_0066: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0070: stloc.s 5
+		IL_0072: ldloc.s 5
+		IL_0074: stloc.2
+		IL_0075: ldloc.2
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_007b: stloc.s 5
+		IL_007d: ldloc.s 5
+		IL_007f: ldstr "next"
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0089: stloc.s 5
+		IL_008b: ldloc.s 5
+		IL_008d: stloc.3
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: ldloc.3
+		IL_0094: ldstr "value"
+		IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a3: pop
+		IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a9: ldloc.3
+		IL_00aa: ldstr "done"
+		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b9: pop
+		IL_00ba: ldloc.2
+		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00c0: stloc.s 5
+		IL_00c2: ldloc.s 5
+		IL_00c4: ldstr "return"
+		IL_00c9: ldc.r8 123
+		IL_00d2: box [System.Runtime]System.Double
+		IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00dc: stloc.s 5
+		IL_00de: ldloc.s 5
+		IL_00e0: stloc.s 4
+		IL_00e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e7: ldloc.s 4
+		IL_00e9: ldstr "value"
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f8: pop
+		IL_00f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fe: ldloc.s 4
+		IL_0100: ldstr "done"
+		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010f: pop
+		IL_0110: ret
 	} // end of method Generator_YieldStar_ReturnForwards::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_ReturnForwards
@@ -735,7 +734,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2640
+		// Method begins at RVA 0x2648
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2d54
+					// Method begins at RVA 0x2d6c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -54,7 +54,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2430
+				// Method begins at RVA 0x2440
 				// Header size: 12
 				// Code size: 270 (0x10e)
 				.maxstack 8
@@ -172,7 +172,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d4b
+				// Method begins at RVA 0x2d63
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -199,7 +199,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 15 00 00 02
 			)
-			// Method begins at RVA 0x2348
+			// Method begins at RVA 0x2358
 			// Header size: 12
 			// Code size: 107 (0x6b)
 			.maxstack 8
@@ -273,7 +273,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d5d
+				// Method begins at RVA 0x2d75
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -297,7 +297,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c0
+			// Method begins at RVA 0x23d0
 			// Header size: 12
 			// Code size: 97 (0x61)
 			.maxstack 8
@@ -363,7 +363,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d42
+			// Method begins at RVA 0x2d5a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -485,7 +485,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d7a
+				// Method begins at RVA 0x2d92
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -511,7 +511,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x254c
+			// Method begins at RVA 0x255c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -541,7 +541,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d83
+				// Method begins at RVA 0x2d9b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -567,7 +567,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x256b
+			// Method begins at RVA 0x257b
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -590,7 +590,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d8c
+				// Method begins at RVA 0x2da4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -616,7 +616,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2573
+			// Method begins at RVA 0x2583
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -639,7 +639,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d95
+				// Method begins at RVA 0x2dad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -665,7 +665,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x257c
+			// Method begins at RVA 0x258c
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -703,7 +703,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2d9e
+				// Method begins at RVA 0x2db6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -729,7 +729,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x25b4
+			// Method begins at RVA 0x25c4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -763,7 +763,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2db0
+					// Method begins at RVA 0x2dc8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -781,7 +781,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2da7
+				// Method begins at RVA 0x2dbf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -807,7 +807,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x25d4
+			// Method begins at RVA 0x25e4
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -882,7 +882,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2db9
+				// Method begins at RVA 0x2dd1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -906,7 +906,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x266c
+			// Method begins at RVA 0x267c
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -980,7 +980,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2dc2
+				// Method begins at RVA 0x2dda
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1005,7 +1005,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26f1
+			// Method begins at RVA 0x2701
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1033,7 +1033,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2def
+					// Method begins at RVA 0x2e07
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1057,7 +1057,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c6b
+				// Method begins at RVA 0x2c84
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1083,7 +1083,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2df8
+					// Method begins at RVA 0x2e10
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1107,7 +1107,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c7a
+				// Method begins at RVA 0x2c93
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1137,7 +1137,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e25
+						// Method begins at RVA 0x2e3d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1161,7 +1161,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2d21
+					// Method begins at RVA 0x2d39
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -1195,7 +1195,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e1c
+					// Method begins at RVA 0x2e34
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1220,7 +1220,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c8c
+				// Method begins at RVA 0x2ca4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -1313,7 +1313,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2dd4
+					// Method begins at RVA 0x2dec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1333,7 +1333,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ddd
+					// Method begins at RVA 0x2df5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1353,7 +1353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2de6
+					// Method begins at RVA 0x2dfe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1377,7 +1377,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e0a
+						// Method begins at RVA 0x2e22
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1397,7 +1397,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2e13
+						// Method begins at RVA 0x2e2b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1415,7 +1415,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e01
+					// Method begins at RVA 0x2e19
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1435,7 +1435,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e2e
+					// Method begins at RVA 0x2e46
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1455,7 +1455,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2e37
+					// Method begins at RVA 0x2e4f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1477,7 +1477,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2dcb
+				// Method begins at RVA 0x2de3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1504,7 +1504,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x26fc
+			// Method begins at RVA 0x270c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2029,7 +2029,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2e40
+				// Method begins at RVA 0x2e58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2057,41 +2057,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2c18
+			// Method begins at RVA 0x2c28
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -2121,7 +2126,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2d66
+			// Method begins at RVA 0x2d7e
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2150,7 +2155,7 @@
 	{
 		// Method begins at RVA 0x2114
 		// Header size: 12
-		// Code size: 552 (0x228)
+		// Code size: 568 (0x238)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope,
@@ -2158,7 +2163,8 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object
+			[5] object,
+			[6] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::.ctor()
@@ -2294,90 +2300,93 @@
 		IL_0142: ldloc.s 5
 		IL_0144: stloc.s 4
 		IL_0146: ldloc.0
-		IL_0147: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_014c: ldnull
-		IL_014d: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0152: pop
-		IL_0153: ldc.i4.1
-		IL_0154: newarr [System.Runtime]System.Object
-		IL_0159: dup
-		IL_015a: ldc.i4.0
-		IL_015b: ldloc.0
-		IL_015c: stelem.ref
-		IL_015d: ldc.i4.0
-		IL_015e: ldelem.ref
-		IL_015f: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0164: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_016f: ldc.i4.0
-		IL_0170: conv.r8
-		IL_0171: ldstr ""
-		IL_0176: ldc.i4.0
-		IL_0177: ldc.i4.1
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_017d: stloc.s 5
-		IL_017f: ldloc.0
-		IL_0180: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0185: ldnull
-		IL_0186: ldstr "value"
-		IL_018b: ldloc.s 5
-		IL_018d: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
-		IL_0192: pop
-		IL_0193: ldc.i4.1
-		IL_0194: newarr [System.Runtime]System.Object
-		IL_0199: dup
-		IL_019a: ldc.i4.0
-		IL_019b: ldloc.0
-		IL_019c: stelem.ref
-		IL_019d: ldc.i4.0
-		IL_019e: ldelem.ref
-		IL_019f: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01a4: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01af: ldc.i4.0
-		IL_01b0: conv.r8
-		IL_01b1: ldstr ""
-		IL_01b6: ldc.i4.0
-		IL_01b7: ldc.i4.1
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01bd: stloc.s 5
-		IL_01bf: ldloc.0
-		IL_01c0: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01c5: ldnull
-		IL_01c6: ldstr "inc"
-		IL_01cb: ldloc.s 5
-		IL_01cd: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
-		IL_01d2: pop
-		IL_01d3: ldc.i4.1
-		IL_01d4: newarr [System.Runtime]System.Object
-		IL_01d9: dup
-		IL_01da: ldc.i4.0
-		IL_01db: ldloc.0
-		IL_01dc: stelem.ref
-		IL_01dd: ldc.i4.0
-		IL_01de: ldelem.ref
-		IL_01df: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01e4: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_01ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01ef: ldc.i4.0
-		IL_01f0: conv.r8
-		IL_01f1: ldstr ""
-		IL_01f6: ldc.i4.0
-		IL_01f7: ldc.i4.1
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01fd: stloc.s 5
-		IL_01ff: ldloc.0
-		IL_0200: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0205: ldnull
-		IL_0206: ldstr "default"
-		IL_020b: ldloc.s 5
-		IL_020d: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object, object)
-		IL_0212: pop
-		IL_0213: ldloc.0
-		IL_0214: ldc.r8 1
-		IL_021d: box [System.Runtime]System.Double
-		IL_0222: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::'value'
-		IL_0227: ret
+		IL_0147: ldfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::__jroc_esm_mark
+		IL_014c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0156: pop
+		IL_0157: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_015c: stloc.s 6
+		IL_015e: ldc.i4.1
+		IL_015f: newarr [System.Runtime]System.Object
+		IL_0164: dup
+		IL_0165: ldc.i4.0
+		IL_0166: ldloc.0
+		IL_0167: stelem.ref
+		IL_0168: ldc.i4.0
+		IL_0169: ldelem.ref
+		IL_016a: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_016f: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+		IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_017a: ldc.i4.0
+		IL_017b: conv.r8
+		IL_017c: ldstr ""
+		IL_0181: ldc.i4.0
+		IL_0182: ldc.i4.1
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0188: stloc.s 5
+		IL_018a: ldloc.s 4
+		IL_018c: ldloc.s 6
+		IL_018e: ldstr "value"
+		IL_0193: ldloc.s 5
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_019a: pop
+		IL_019b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a0: stloc.s 6
+		IL_01a2: ldc.i4.1
+		IL_01a3: newarr [System.Runtime]System.Object
+		IL_01a8: dup
+		IL_01a9: ldc.i4.0
+		IL_01aa: ldloc.0
+		IL_01ab: stelem.ref
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldelem.ref
+		IL_01ae: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_01b3: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+		IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01be: ldc.i4.0
+		IL_01bf: conv.r8
+		IL_01c0: ldstr ""
+		IL_01c5: ldc.i4.0
+		IL_01c6: ldc.i4.1
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01cc: stloc.s 5
+		IL_01ce: ldloc.s 4
+		IL_01d0: ldloc.s 6
+		IL_01d2: ldstr "inc"
+		IL_01d7: ldloc.s 5
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01de: pop
+		IL_01df: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01e4: stloc.s 6
+		IL_01e6: ldc.i4.1
+		IL_01e7: newarr [System.Runtime]System.Object
+		IL_01ec: dup
+		IL_01ed: ldc.i4.0
+		IL_01ee: ldloc.0
+		IL_01ef: stelem.ref
+		IL_01f0: ldc.i4.0
+		IL_01f1: ldelem.ref
+		IL_01f2: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
+		IL_01f7: ldftn object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+		IL_01fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0202: ldc.i4.0
+		IL_0203: conv.r8
+		IL_0204: ldstr ""
+		IL_0209: ldc.i4.0
+		IL_020a: ldc.i4.1
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0210: stloc.s 5
+		IL_0212: ldloc.s 4
+		IL_0214: ldloc.s 6
+		IL_0216: ldstr "default"
+		IL_021b: ldloc.s 5
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0222: pop
+		IL_0223: ldloc.0
+		IL_0224: ldc.r8 1
+		IL_022d: box [System.Runtime]System.Double
+		IL_0232: stfld object Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::'value'
+		IL_0237: ret
 	} // end of method Import_DynamicImport_Esm_Namespace_Lib::__js_module_init__
 
 } // end of class Modules.Import_DynamicImport_Esm_Namespace_Lib
@@ -2389,7 +2398,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2e49
+		// Method begins at RVA 0x2e61
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32e3
+					// Method begins at RVA 0x3317
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32da
+				// Method begins at RVA 0x330e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x23b8
+			// Method begins at RVA 0x23dc
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32ec
+				// Method begins at RVA 0x3320
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2450
+			// Method begins at RVA 0x2474
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32f5
+				// Method begins at RVA 0x3329
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24d5
+			// Method begins at RVA 0x24f9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3322
+					// Method begins at RVA 0x3356
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a4f
+				// Method begins at RVA 0x2a7c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x332b
+					// Method begins at RVA 0x335f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a5e
+				// Method begins at RVA 0x2a8b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3358
+						// Method begins at RVA 0x338c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2b05
+					// Method begins at RVA 0x2b31
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x334f
+					// Method begins at RVA 0x3383
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a70
+				// Method begins at RVA 0x2a9c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3307
+					// Method begins at RVA 0x333b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3310
+					// Method begins at RVA 0x3344
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3319
+					// Method begins at RVA 0x334d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x333d
+						// Method begins at RVA 0x3371
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3346
+						// Method begins at RVA 0x337a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3334
+					// Method begins at RVA 0x3368
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3361
+					// Method begins at RVA 0x3395
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x336a
+					// Method begins at RVA 0x339e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32fe
+				// Method begins at RVA 0x3332
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x24e0
+			// Method begins at RVA 0x2504
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3373
+				// Method begins at RVA 0x33a7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x29fc
+			// Method begins at RVA 0x2a20
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportNamedFrom/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportNamedFrom/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportNamedFrom/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x32d1
+			// Method begins at RVA 0x3305
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 360 (0x168)
+		// Code size: 382 (0x17e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom/Scope,
@@ -1504,50 +1509,56 @@
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_ExportNamedFrom_LibB.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 6
-		IL_00f8: ldloc.s 6
-		IL_00fa: stloc.s 5
-		IL_00fc: ldnull
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldstr "value"
-		IL_0104: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0109: stloc.s 6
-		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0110: ldstr "value:"
-		IL_0115: ldloc.s 6
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_011c: pop
-		IL_011d: ldnull
-		IL_011e: ldloc.s 5
-		IL_0120: ldstr "doubled"
-		IL_0125: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, object)
-		IL_012a: stloc.s 6
-		IL_012c: ldc.i4.1
-		IL_012d: newarr [System.Runtime]System.Object
-		IL_0132: dup
-		IL_0133: ldc.i4.0
-		IL_0134: ldc.r8 5
-		IL_013d: box [System.Runtime]System.Double
-		IL_0142: stelem.ref
-		IL_0143: stloc.s 7
-		IL_0145: ldloc.s 6
-		IL_0147: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_014c: ldloc.s 7
-		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0153: stloc.s 6
-		IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015a: ldstr "doubled:"
-		IL_015f: ldloc.s 6
-		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0166: pop
-		IL_0167: ret
+		IL_00df: ldfld object Modules.Import_ExportNamedFrom/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_ExportNamedFrom_LibB.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 6
+		IL_00fc: ldloc.s 6
+		IL_00fe: stloc.s 5
+		IL_0100: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0105: stloc.s 7
+		IL_0107: ldloc.2
+		IL_0108: ldloc.s 7
+		IL_010a: ldloc.s 5
+		IL_010c: ldstr "value"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0116: stloc.s 6
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011d: ldstr "value:"
+		IL_0122: ldloc.s 6
+		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0129: pop
+		IL_012a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_012f: stloc.s 7
+		IL_0131: ldloc.2
+		IL_0132: ldloc.s 7
+		IL_0134: ldloc.s 5
+		IL_0136: ldstr "doubled"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0140: stloc.s 6
+		IL_0142: ldc.i4.1
+		IL_0143: newarr [System.Runtime]System.Object
+		IL_0148: dup
+		IL_0149: ldc.i4.0
+		IL_014a: ldc.r8 5
+		IL_0153: box [System.Runtime]System.Double
+		IL_0158: stelem.ref
+		IL_0159: stloc.s 7
+		IL_015b: ldloc.s 6
+		IL_015d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0162: ldloc.s 7
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0169: stloc.s 6
+		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0170: ldstr "doubled:"
+		IL_0175: ldloc.s 6
+		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_017c: pop
+		IL_017d: ret
 	} // end of method Import_ExportNamedFrom::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom
@@ -1567,7 +1578,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3385
+				// Method begins at RVA 0x33b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1593,7 +1604,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2b26
+			// Method begins at RVA 0x2b52
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -1618,7 +1629,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x338e
+				// Method begins at RVA 0x33c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1644,7 +1655,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2b38
+			// Method begins at RVA 0x2b64
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -1673,7 +1684,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a0
+					// Method begins at RVA 0x33d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1691,7 +1702,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3397
+				// Method begins at RVA 0x33cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1717,7 +1728,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2b4c
+			// Method begins at RVA 0x2b78
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1792,7 +1803,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33a9
+				// Method begins at RVA 0x33dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1816,7 +1827,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2be4
+			// Method begins at RVA 0x2c10
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1890,7 +1901,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33b2
+				// Method begins at RVA 0x33e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1915,7 +1926,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c69
+			// Method begins at RVA 0x2c95
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1943,7 +1954,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33df
+					// Method begins at RVA 0x3413
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1967,7 +1978,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x31e3
+				// Method begins at RVA 0x3218
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1993,7 +2004,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33e8
+					// Method begins at RVA 0x341c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2017,7 +2028,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x31f2
+				// Method begins at RVA 0x3227
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2047,7 +2058,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3415
+						// Method begins at RVA 0x3449
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2071,7 +2082,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3299
+					// Method begins at RVA 0x32cd
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2105,7 +2116,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x340c
+					// Method begins at RVA 0x3440
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2130,7 +2141,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3204
+				// Method begins at RVA 0x3238
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2223,7 +2234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c4
+					// Method begins at RVA 0x33f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2243,7 +2254,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33cd
+					// Method begins at RVA 0x3401
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2263,7 +2274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d6
+					// Method begins at RVA 0x340a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2287,7 +2298,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33fa
+						// Method begins at RVA 0x342e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2307,7 +2318,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3403
+						// Method begins at RVA 0x3437
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2325,7 +2336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33f1
+					// Method begins at RVA 0x3425
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2345,7 +2356,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x341e
+					// Method begins at RVA 0x3452
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2365,7 +2376,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3427
+					// Method begins at RVA 0x345b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2387,7 +2398,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33bb
+				// Method begins at RVA 0x33ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2414,7 +2425,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2c74
+			// Method begins at RVA 0x2ca0
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2939,7 +2950,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3430
+				// Method begins at RVA 0x3464
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2967,41 +2978,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3190
+			// Method begins at RVA 0x31bc
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3026,7 +3042,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x337c
+			// Method begins at RVA 0x33b0
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3050,9 +3066,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21c4
+		// Method begins at RVA 0x21dc
 		// Header size: 12
-		// Code size: 385 (0x181)
+		// Code size: 397 (0x18d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom_LibB/Scope,
@@ -3060,7 +3076,8 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object
+			[5] object,
+			[6] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibB/Scope::.ctor()
@@ -3154,68 +3171,70 @@
 		IL_00da: ldloc.s 5
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_ExportNamedFrom_LibA.cjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 5
-		IL_00f8: ldloc.0
-		IL_00f9: ldloc.s 5
-		IL_00fb: stfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mod_0
-		IL_0100: ldc.i4.1
-		IL_0101: newarr [System.Runtime]System.Object
-		IL_0106: dup
-		IL_0107: ldc.i4.0
-		IL_0108: ldloc.0
-		IL_0109: stelem.ref
-		IL_010a: ldc.i4.0
-		IL_010b: ldelem.ref
-		IL_010c: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0111: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_011c: ldc.i4.0
-		IL_011d: conv.r8
-		IL_011e: ldstr ""
-		IL_0123: ldc.i4.0
-		IL_0124: ldc.i4.1
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_012a: stloc.s 5
-		IL_012c: ldloc.0
-		IL_012d: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0132: ldnull
-		IL_0133: ldstr "value"
-		IL_0138: ldloc.s 5
-		IL_013a: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object, object)
-		IL_013f: pop
-		IL_0140: ldc.i4.1
-		IL_0141: newarr [System.Runtime]System.Object
-		IL_0146: dup
-		IL_0147: ldc.i4.0
-		IL_0148: ldloc.0
-		IL_0149: stelem.ref
-		IL_014a: ldc.i4.0
-		IL_014b: ldelem.ref
-		IL_014c: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0151: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_0157: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_015c: ldc.i4.0
-		IL_015d: conv.r8
-		IL_015e: ldstr ""
-		IL_0163: ldc.i4.0
-		IL_0164: ldc.i4.1
-		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_016a: stloc.s 5
-		IL_016c: ldloc.0
-		IL_016d: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0172: ldnull
-		IL_0173: ldstr "doubled"
-		IL_0178: ldloc.s 5
-		IL_017a: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object, object)
-		IL_017f: pop
-		IL_0180: ret
+		IL_00df: ldfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_ExportNamedFrom_LibA.cjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 5
+		IL_00fc: ldloc.0
+		IL_00fd: ldloc.s 5
+		IL_00ff: stfld object Modules.Import_ExportNamedFrom_LibB/Scope::__jroc_esm_mod_0
+		IL_0104: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0109: stloc.s 6
+		IL_010b: ldc.i4.1
+		IL_010c: newarr [System.Runtime]System.Object
+		IL_0111: dup
+		IL_0112: ldc.i4.0
+		IL_0113: ldloc.0
+		IL_0114: stelem.ref
+		IL_0115: ldc.i4.0
+		IL_0116: ldelem.ref
+		IL_0117: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+		IL_011c: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+		IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0127: ldc.i4.0
+		IL_0128: conv.r8
+		IL_0129: ldstr ""
+		IL_012e: ldc.i4.0
+		IL_012f: ldc.i4.1
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0135: stloc.s 5
+		IL_0137: ldloc.s 4
+		IL_0139: ldloc.s 6
+		IL_013b: ldstr "value"
+		IL_0140: ldloc.s 5
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0147: pop
+		IL_0148: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_014d: stloc.s 6
+		IL_014f: ldc.i4.1
+		IL_0150: newarr [System.Runtime]System.Object
+		IL_0155: dup
+		IL_0156: ldc.i4.0
+		IL_0157: ldloc.0
+		IL_0158: stelem.ref
+		IL_0159: ldc.i4.0
+		IL_015a: ldelem.ref
+		IL_015b: castclass Modules.Import_ExportNamedFrom_LibB/Scope
+		IL_0160: ldftn object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+		IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_016b: ldc.i4.0
+		IL_016c: conv.r8
+		IL_016d: ldstr ""
+		IL_0172: ldc.i4.0
+		IL_0173: ldc.i4.1
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0179: stloc.s 5
+		IL_017b: ldloc.s 4
+		IL_017d: ldloc.s 6
+		IL_017f: ldstr "doubled"
+		IL_0184: ldloc.s 5
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_018b: pop
+		IL_018c: ret
 	} // end of method Import_ExportNamedFrom_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom_LibB
@@ -3235,7 +3254,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3442
+				// Method begins at RVA 0x3476
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3259,7 +3278,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x32ba
+			// Method begins at RVA 0x32ee
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -3281,7 +3300,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3439
+			// Method begins at RVA 0x346d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3305,7 +3324,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2354
+		// Method begins at RVA 0x2378
 		// Header size: 12
 		// Code size: 86 (0x56)
 		.maxstack 8
@@ -3355,7 +3374,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x344b
+		// Method begins at RVA 0x347f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x349b
+					// Method begins at RVA 0x34bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3492
+				// Method begins at RVA 0x34b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2530
+			// Method begins at RVA 0x2538
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34a4
+				// Method begins at RVA 0x34c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25c8
+			// Method begins at RVA 0x25d0
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34ad
+				// Method begins at RVA 0x34d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x264d
+			// Method begins at RVA 0x2655
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34da
+					// Method begins at RVA 0x34fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bc7
+				// Method begins at RVA 0x2bd8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34e3
+					// Method begins at RVA 0x3507
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bd6
+				// Method begins at RVA 0x2be7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3510
+						// Method begins at RVA 0x3534
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2c7d
+					// Method begins at RVA 0x2c8d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3507
+					// Method begins at RVA 0x352b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2be8
+				// Method begins at RVA 0x2bf8
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34bf
+					// Method begins at RVA 0x34e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34c8
+					// Method begins at RVA 0x34ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34d1
+					// Method begins at RVA 0x34f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34f5
+						// Method begins at RVA 0x3519
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x34fe
+						// Method begins at RVA 0x3522
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34ec
+					// Method begins at RVA 0x3510
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3519
+					// Method begins at RVA 0x353d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3522
+					// Method begins at RVA 0x3546
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34b6
+				// Method begins at RVA 0x34da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2658
+			// Method begins at RVA 0x2660
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x352b
+				// Method begins at RVA 0x354f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2b74
+			// Method begins at RVA 0x2b7c
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportStarFrom/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFrom/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportStarFrom/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFrom/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3489
+			// Method begins at RVA 0x34ad
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 443 (0x1bb)
+		// Code size: 446 (0x1be)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom/Scope,
@@ -1504,68 +1509,67 @@
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_ExportStarFrom/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_ExportStarFrom_LibB.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 7
-		IL_00f8: ldloc.s 7
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.0
-		IL_00fd: castclass Modules.Import_ExportStarFrom/Scope
-		IL_0102: ldnull
-		IL_0103: ldloc.s 5
-		IL_0105: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
-		IL_010a: stloc.s 7
-		IL_010c: ldloc.s 7
-		IL_010e: stloc.s 6
-		IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0115: ldstr "own:"
-		IL_011a: ldloc.s 6
-		IL_011c: ldstr "own"
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_012b: pop
-		IL_012c: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0131: ldstr "prototype"
-		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_013b: ldstr "hasOwnProperty"
-		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_014a: stloc.s 7
-		IL_014c: ldloc.s 7
-		IL_014e: ldstr "call"
-		IL_0153: ldloc.s 6
-		IL_0155: ldstr "inherited"
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_015f: stloc.s 7
-		IL_0161: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0166: ldstr "hasInherited:"
-		IL_016b: ldloc.s 7
-		IL_016d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0172: pop
-		IL_0173: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0178: ldstr "prototype"
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0182: ldstr "hasOwnProperty"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0191: stloc.s 7
-		IL_0193: ldloc.s 7
-		IL_0195: ldstr "call"
-		IL_019a: ldloc.s 6
-		IL_019c: ldstr "default"
-		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01a6: stloc.s 7
-		IL_01a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ad: ldstr "hasDefault:"
-		IL_01b2: ldloc.s 7
-		IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01b9: pop
-		IL_01ba: ret
+		IL_00df: ldfld object Modules.Import_ExportStarFrom/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_ExportStarFrom_LibB.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 7
+		IL_00fc: ldloc.s 7
+		IL_00fe: stloc.s 5
+		IL_0100: ldloc.3
+		IL_0101: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0106: ldloc.s 5
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_010d: stloc.s 7
+		IL_010f: ldloc.s 7
+		IL_0111: stloc.s 6
+		IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0118: ldstr "own:"
+		IL_011d: ldloc.s 6
+		IL_011f: ldstr "own"
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_012e: pop
+		IL_012f: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0134: ldstr "prototype"
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013e: ldstr "hasOwnProperty"
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_014d: stloc.s 7
+		IL_014f: ldloc.s 7
+		IL_0151: ldstr "call"
+		IL_0156: ldloc.s 6
+		IL_0158: ldstr "inherited"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0162: stloc.s 7
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: ldstr "hasInherited:"
+		IL_016e: ldloc.s 7
+		IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0175: pop
+		IL_0176: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_017b: ldstr "prototype"
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0185: ldstr "hasOwnProperty"
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0194: stloc.s 7
+		IL_0196: ldloc.s 7
+		IL_0198: ldstr "call"
+		IL_019d: ldloc.s 6
+		IL_019f: ldstr "default"
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01a9: stloc.s 7
+		IL_01ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01b0: ldstr "hasDefault:"
+		IL_01b5: ldloc.s 7
+		IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01bc: pop
+		IL_01bd: ret
 	} // end of method Import_ExportStarFrom::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFrom
@@ -1589,7 +1593,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3573
+					// Method begins at RVA 0x3597
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1607,7 +1611,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x356a
+				// Method begins at RVA 0x358e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1633,7 +1637,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2ca0
+			// Method begins at RVA 0x2cb0
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1708,7 +1712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x357c
+				// Method begins at RVA 0x35a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1732,7 +1736,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d38
+			// Method begins at RVA 0x2d48
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1806,7 +1810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3585
+				// Method begins at RVA 0x35a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1831,7 +1835,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2dbd
+			// Method begins at RVA 0x2dcd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1859,7 +1863,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35b2
+					// Method begins at RVA 0x35d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1883,7 +1887,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3391
+				// Method begins at RVA 0x33b4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1909,7 +1913,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35bb
+					// Method begins at RVA 0x35df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1933,7 +1937,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33a0
+				// Method begins at RVA 0x33c3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1963,7 +1967,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35e8
+						// Method begins at RVA 0x360c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1987,7 +1991,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3465
+					// Method begins at RVA 0x3489
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2021,7 +2025,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35df
+					// Method begins at RVA 0x3603
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2046,7 +2050,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33d0
+				// Method begins at RVA 0x33f4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2139,7 +2143,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3597
+					// Method begins at RVA 0x35bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2159,7 +2163,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35a0
+					// Method begins at RVA 0x35c4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2179,7 +2183,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35a9
+					// Method begins at RVA 0x35cd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2203,7 +2207,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35cd
+						// Method begins at RVA 0x35f1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2223,7 +2227,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x35d6
+						// Method begins at RVA 0x35fa
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2241,7 +2245,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35c4
+					// Method begins at RVA 0x35e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2261,7 +2265,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35f1
+					// Method begins at RVA 0x3615
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2281,7 +2285,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35fa
+					// Method begins at RVA 0x361e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2303,7 +2307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x358e
+				// Method begins at RVA 0x35b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2330,7 +2334,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2dc8
+			// Method begins at RVA 0x2dd8
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2855,7 +2859,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3603
+				// Method begins at RVA 0x3627
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2883,41 +2887,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x32e4
+			// Method begins at RVA 0x32f4
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -2937,7 +2946,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3561
+					// Method begins at RVA 0x3585
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2961,7 +2970,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33af
+				// Method begins at RVA 0x33d2
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -2996,7 +3005,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3558
+				// Method begins at RVA 0x357c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3023,14 +3032,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3338
+			// Method begins at RVA 0x3350
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope,
-				[1] object,
-				[2] object
+				[1] object[],
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::.ctor()
@@ -3038,37 +3048,44 @@
 			IL_0006: ldloc.0
 			IL_0007: ldarg.2
 			IL_0008: stfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
-			IL_000d: ldloc.0
-			IL_000e: ldfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
-			IL_0013: stloc.1
-			IL_0014: ldc.i4.2
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: dup
-			IL_001f: ldc.i4.1
-			IL_0020: ldloc.0
-			IL_0021: stelem.ref
-			IL_0022: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-			IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_002d: ldc.i4.0
-			IL_002e: conv.r8
-			IL_002f: ldstr ""
-			IL_0034: ldc.i4.0
-			IL_0035: ldc.i4.1
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_003b: stloc.2
-			IL_003c: ldarg.0
-			IL_003d: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_0042: ldnull
-			IL_0043: ldloc.1
-			IL_0044: ldloc.2
-			IL_0045: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
-			IL_004a: pop
-			IL_004b: ldnull
-			IL_004c: ret
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: stelem.ref
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: ldfld object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::__k
+			IL_001e: stloc.2
+			IL_001f: ldc.i4.2
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldarg.0
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
+			IL_002b: ldloc.0
+			IL_002c: stelem.ref
+			IL_002d: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+			IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0038: ldc.i4.0
+			IL_0039: conv.r8
+			IL_003a: ldstr ""
+			IL_003f: ldc.i4.0
+			IL_0040: ldc.i4.1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0046: stloc.3
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_export
+			IL_004d: ldloc.1
+			IL_004e: ldloc.2
+			IL_004f: ldloc.3
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method FunctionExpression_L10C3::__js_call__
 
 	} // end of class FunctionExpression_L10C3
@@ -3092,7 +3109,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3546
+					// Method begins at RVA 0x356a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3112,7 +3129,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x354f
+					// Method begins at RVA 0x3573
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3130,7 +3147,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x353d
+				// Method begins at RVA 0x3561
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3157,7 +3174,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3534
+			// Method begins at RVA 0x3558
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3181,9 +3198,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2218
+		// Method begins at RVA 0x221c
 		// Header size: 12
-		// Code size: 632 (0x278)
+		// Code size: 636 (0x27c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom_LibB/Scope,
@@ -3297,153 +3314,153 @@
 		IL_00db: ldloc.s 9
 		IL_00dd: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_export
 		IL_00e2: ldloc.0
-		IL_00e3: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_00e8: ldnull
-		IL_00e9: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
-		IL_00ee: pop
-		IL_00ef: ldarg.1
-		IL_00f0: ldstr "./Import_ExportStarFrom_LibA.cjs"
-		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00fa: stloc.s 9
-		IL_00fc: ldloc.0
-		IL_00fd: ldloc.s 9
-		IL_00ff: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
-		IL_0104: ldloc.0
-		IL_0105: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
-		IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
-		IL_010f: stloc.s 4
-		// loop start (head: IL_0111)
-			IL_0111: ldloc.s 4
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-			IL_0118: stloc.s 9
-			IL_011a: ldloc.s 9
-			IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0121: stloc.s 10
-			IL_0123: ldloc.s 10
-			IL_0125: brtrue IL_0277
+		IL_00e3: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mark
+		IL_00e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00f2: pop
+		IL_00f3: ldarg.1
+		IL_00f4: ldstr "./Import_ExportStarFrom_LibA.cjs"
+		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fe: stloc.s 9
+		IL_0100: ldloc.0
+		IL_0101: ldloc.s 9
+		IL_0103: stfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
+		IL_0108: ldloc.0
+		IL_0109: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
+		IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
+		IL_0113: stloc.s 4
+		// loop start (head: IL_0115)
+			IL_0115: ldloc.s 4
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+			IL_011c: stloc.s 9
+			IL_011e: ldloc.s 9
+			IL_0120: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0125: stloc.s 10
+			IL_0127: ldloc.s 10
+			IL_0129: brtrue IL_027b
 
-			IL_012a: ldloc.s 9
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0131: stloc.s 9
-			IL_0133: ldloc.s 9
-			IL_0135: stloc.s 5
-			IL_0137: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47::.ctor()
-			IL_013c: stloc.s 6
-			IL_013e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-			IL_0143: ldstr "prototype"
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_014d: ldstr "hasOwnProperty"
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015c: stloc.s 9
-			IL_015e: ldloc.s 9
-			IL_0160: ldstr "call"
-			IL_0165: ldloc.0
-			IL_0166: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
-			IL_016b: ldloc.s 5
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0172: stloc.s 9
-			IL_0174: ldloc.s 9
-			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_017b: ldc.i4.0
-			IL_017c: ceq
-			IL_017e: stloc.s 10
-			IL_0180: ldloc.s 10
-			IL_0182: brfalse IL_0193
+			IL_012e: ldloc.s 9
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0135: stloc.s 9
+			IL_0137: ldloc.s 9
+			IL_0139: stloc.s 5
+			IL_013b: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47::.ctor()
+			IL_0140: stloc.s 6
+			IL_0142: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+			IL_0147: ldstr "prototype"
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0151: ldstr "hasOwnProperty"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0160: stloc.s 9
+			IL_0162: ldloc.s 9
+			IL_0164: ldstr "call"
+			IL_0169: ldloc.0
+			IL_016a: ldfld object Modules.Import_ExportStarFrom_LibB/Scope::__jroc_esm_mod_0
+			IL_016f: ldloc.s 5
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0176: stloc.s 9
+			IL_0178: ldloc.s 9
+			IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_017f: ldc.i4.0
+			IL_0180: ceq
+			IL_0182: stloc.s 10
+			IL_0184: ldloc.s 10
+			IL_0186: brfalse IL_0197
 
-			IL_0187: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L8C81::.ctor()
-			IL_018c: stloc.s 7
-			IL_018e: br IL_0272
+			IL_018b: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L8C81::.ctor()
+			IL_0190: stloc.s 7
+			IL_0192: br IL_0276
 
-			IL_0193: ldloc.s 5
-			IL_0195: ldstr "default"
-			IL_019a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_019f: stloc.s 10
-			IL_01a1: ldloc.s 10
-			IL_01a3: box [System.Runtime]System.Boolean
-			IL_01a8: stloc.s 11
-			IL_01aa: ldloc.s 11
-			IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b1: stloc.s 10
-			IL_01b3: ldloc.s 10
-			IL_01b5: brtrue IL_01da
+			IL_0197: ldloc.s 5
+			IL_0199: ldstr "default"
+			IL_019e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01a3: stloc.s 10
+			IL_01a5: ldloc.s 10
+			IL_01a7: box [System.Runtime]System.Boolean
+			IL_01ac: stloc.s 11
+			IL_01ae: ldloc.s 11
+			IL_01b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01b5: stloc.s 10
+			IL_01b7: ldloc.s 10
+			IL_01b9: brtrue IL_01de
 
-			IL_01ba: ldloc.s 5
-			IL_01bc: ldstr "__esModule"
-			IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01c6: stloc.s 10
-			IL_01c8: ldloc.s 10
-			IL_01ca: box [System.Runtime]System.Boolean
-			IL_01cf: stloc.s 12
-			IL_01d1: ldloc.s 12
-			IL_01d3: stloc.s 14
-			IL_01d5: br IL_01de
+			IL_01be: ldloc.s 5
+			IL_01c0: ldstr "__esModule"
+			IL_01c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01ca: stloc.s 10
+			IL_01cc: ldloc.s 10
+			IL_01ce: box [System.Runtime]System.Boolean
+			IL_01d3: stloc.s 12
+			IL_01d5: ldloc.s 12
+			IL_01d7: stloc.s 14
+			IL_01d9: br IL_01e2
 
-			IL_01da: ldloc.s 11
-			IL_01dc: stloc.s 14
+			IL_01de: ldloc.s 11
+			IL_01e0: stloc.s 14
 
-			IL_01de: ldloc.s 14
-			IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01e5: stloc.s 10
-			IL_01e7: ldloc.s 10
-			IL_01e9: brtrue IL_020e
+			IL_01e2: ldloc.s 14
+			IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01e9: stloc.s 10
+			IL_01eb: ldloc.s 10
+			IL_01ed: brtrue IL_0212
 
-			IL_01ee: ldloc.s 5
-			IL_01f0: ldstr "module.exports"
-			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01fa: stloc.s 10
-			IL_01fc: ldloc.s 10
-			IL_01fe: box [System.Runtime]System.Boolean
-			IL_0203: stloc.s 11
-			IL_0205: ldloc.s 11
-			IL_0207: stloc.s 14
-			IL_0209: br IL_020e
+			IL_01f2: ldloc.s 5
+			IL_01f4: ldstr "module.exports"
+			IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01fe: stloc.s 10
+			IL_0200: ldloc.s 10
+			IL_0202: box [System.Runtime]System.Boolean
+			IL_0207: stloc.s 11
+			IL_0209: ldloc.s 11
+			IL_020b: stloc.s 14
+			IL_020d: br IL_0212
 
-			IL_020e: ldloc.s 14
-			IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0215: stloc.s 10
-			IL_0217: ldloc.s 10
-			IL_0219: brfalse IL_022a
+			IL_0212: ldloc.s 14
+			IL_0214: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0219: stloc.s 10
+			IL_021b: ldloc.s 10
+			IL_021d: brfalse IL_022e
 
-			IL_021e: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L9C116::.ctor()
-			IL_0223: stloc.s 8
-			IL_0225: br IL_0272
+			IL_0222: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope/Block_L7C47/Block_L9C116::.ctor()
+			IL_0227: stloc.s 8
+			IL_0229: br IL_0276
 
-			IL_022a: ldc.i4.1
-			IL_022b: newarr [System.Runtime]System.Object
-			IL_0230: dup
-			IL_0231: ldc.i4.0
-			IL_0232: ldloc.0
-			IL_0233: stelem.ref
-			IL_0234: ldc.i4.0
-			IL_0235: ldelem.ref
-			IL_0236: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_023b: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
-			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0246: ldc.i4.1
-			IL_0247: conv.r8
-			IL_0248: ldstr ""
-			IL_024d: ldc.i4.0
-			IL_024e: ldc.i4.1
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0254: stloc.s 9
-			IL_0256: ldc.i4.1
-			IL_0257: newarr [System.Runtime]System.Object
-			IL_025c: dup
-			IL_025d: ldc.i4.0
-			IL_025e: ldloc.s 5
-			IL_0260: stelem.ref
-			IL_0261: stloc.s 16
-			IL_0263: ldloc.s 9
-			IL_0265: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_026a: ldloc.s 16
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0271: pop
+			IL_022e: ldc.i4.1
+			IL_022f: newarr [System.Runtime]System.Object
+			IL_0234: dup
+			IL_0235: ldc.i4.0
+			IL_0236: ldloc.0
+			IL_0237: stelem.ref
+			IL_0238: ldc.i4.0
+			IL_0239: ldelem.ref
+			IL_023a: castclass Modules.Import_ExportStarFrom_LibB/Scope
+			IL_023f: ldftn object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
+			IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_024a: ldc.i4.1
+			IL_024b: conv.r8
+			IL_024c: ldstr ""
+			IL_0251: ldc.i4.0
+			IL_0252: ldc.i4.1
+			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0258: stloc.s 9
+			IL_025a: ldc.i4.1
+			IL_025b: newarr [System.Runtime]System.Object
+			IL_0260: dup
+			IL_0261: ldc.i4.0
+			IL_0262: ldloc.s 5
+			IL_0264: stelem.ref
+			IL_0265: stloc.s 16
+			IL_0267: ldloc.s 9
+			IL_0269: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_026e: ldloc.s 16
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0275: pop
 
-			IL_0272: br IL_0111
+			IL_0276: br IL_0115
 		// end loop
 
-		IL_0277: ret
+		IL_027b: ret
 	} // end of method Import_ExportStarFrom_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFrom_LibB
@@ -3463,7 +3480,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3615
+				// Method begins at RVA 0x3639
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3486,7 +3503,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3486
+			// Method begins at RVA 0x34aa
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -3511,7 +3528,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x360c
+			// Method begins at RVA 0x3630
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3535,7 +3552,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x249c
+		// Method begins at RVA 0x24a4
 		// Header size: 12
 		// Code size: 133 (0x85)
 		.maxstack 8
@@ -3605,7 +3622,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x361e
+		// Method begins at RVA 0x3642
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47c0
+					// Method begins at RVA 0x4834
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x47b7
+				// Method begins at RVA 0x482b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x28a0
+			// Method begins at RVA 0x28dc
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x47c9
+				// Method begins at RVA 0x483d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2938
+			// Method begins at RVA 0x2974
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x47d2
+				// Method begins at RVA 0x4846
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29bd
+			// Method begins at RVA 0x29f9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47ff
+					// Method begins at RVA 0x4873
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f37
+				// Method begins at RVA 0x2f7c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4808
+					// Method begins at RVA 0x487c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f46
+				// Method begins at RVA 0x2f8b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4835
+						// Method begins at RVA 0x48a9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fed
+					// Method begins at RVA 0x3031
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x482c
+					// Method begins at RVA 0x48a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2f58
+				// Method begins at RVA 0x2f9c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47e4
+					// Method begins at RVA 0x4858
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47ed
+					// Method begins at RVA 0x4861
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x47f6
+					// Method begins at RVA 0x486a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x481a
+						// Method begins at RVA 0x488e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4823
+						// Method begins at RVA 0x4897
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4811
+					// Method begins at RVA 0x4885
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x483e
+					// Method begins at RVA 0x48b2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4847
+					// Method begins at RVA 0x48bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x47db
+				// Method begins at RVA 0x484f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x29c8
+			// Method begins at RVA 0x2a04
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4850
+				// Method begins at RVA 0x48c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 31 00 00 02
 			)
-			// Method begins at RVA 0x2ee4
+			// Method begins at RVA 0x2f20
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportStarFromMultiHop/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x47ae
+			// Method begins at RVA 0x4822
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 352 (0x160)
+		// Code size: 383 (0x17f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop/Scope,
@@ -1409,7 +1414,8 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object
+			[6] object,
+			[7] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop/Scope::.ctor()
@@ -1503,47 +1509,56 @@
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_ExportStarFromMultiHop_LibC.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 6
-		IL_00f8: ldloc.s 6
-		IL_00fa: stloc.s 5
-		IL_00fc: ldnull
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldstr "alpha"
-		IL_0104: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0109: stloc.s 6
-		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0110: ldstr "alpha:"
-		IL_0115: ldloc.s 6
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_011c: pop
-		IL_011d: ldnull
-		IL_011e: ldloc.s 5
-		IL_0120: ldstr "beta"
-		IL_0125: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
-		IL_012a: stloc.s 6
-		IL_012c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0131: ldstr "beta:"
-		IL_0136: ldloc.s 6
-		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_013d: pop
-		IL_013e: ldnull
-		IL_013f: ldloc.s 5
-		IL_0141: ldstr "gamma"
-		IL_0146: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, object)
-		IL_014b: stloc.s 6
-		IL_014d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0152: ldstr "gamma:"
-		IL_0157: ldloc.s 6
-		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_015e: pop
-		IL_015f: ret
+		IL_00df: ldfld object Modules.Import_ExportStarFromMultiHop/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_ExportStarFromMultiHop_LibC.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 6
+		IL_00fc: ldloc.s 6
+		IL_00fe: stloc.s 5
+		IL_0100: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0105: stloc.s 7
+		IL_0107: ldloc.2
+		IL_0108: ldloc.s 7
+		IL_010a: ldloc.s 5
+		IL_010c: ldstr "alpha"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0116: stloc.s 6
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011d: ldstr "alpha:"
+		IL_0122: ldloc.s 6
+		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0129: pop
+		IL_012a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_012f: stloc.s 7
+		IL_0131: ldloc.2
+		IL_0132: ldloc.s 7
+		IL_0134: ldloc.s 5
+		IL_0136: ldstr "beta"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0140: stloc.s 6
+		IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0147: ldstr "beta:"
+		IL_014c: ldloc.s 6
+		IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0153: pop
+		IL_0154: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0159: stloc.s 7
+		IL_015b: ldloc.2
+		IL_015c: ldloc.s 7
+		IL_015e: ldloc.s 5
+		IL_0160: ldstr "gamma"
+		IL_0165: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_016a: stloc.s 6
+		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0171: ldstr "gamma:"
+		IL_0176: ldloc.s 6
+		IL_0178: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_017d: pop
+		IL_017e: ret
 	} // end of method Import_ExportStarFromMultiHop::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop
@@ -1567,7 +1582,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4898
+					// Method begins at RVA 0x490c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1585,7 +1600,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x488f
+				// Method begins at RVA 0x4903
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1611,7 +1626,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3010
+			// Method begins at RVA 0x3054
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1686,7 +1701,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48a1
+				// Method begins at RVA 0x4915
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1710,7 +1725,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30a8
+			// Method begins at RVA 0x30ec
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1784,7 +1799,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48aa
+				// Method begins at RVA 0x491e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1809,7 +1824,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x312d
+			// Method begins at RVA 0x3171
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1837,7 +1852,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48d7
+					// Method begins at RVA 0x494b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1861,7 +1876,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3701
+				// Method begins at RVA 0x3758
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1887,7 +1902,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48e0
+					// Method begins at RVA 0x4954
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1911,7 +1926,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3710
+				// Method begins at RVA 0x3767
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -1941,7 +1956,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x490d
+						// Method begins at RVA 0x4981
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1965,7 +1980,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x37d5
+					// Method begins at RVA 0x382d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -1999,7 +2014,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4904
+					// Method begins at RVA 0x4978
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2024,7 +2039,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3740
+				// Method begins at RVA 0x3798
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2117,7 +2132,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48bc
+					// Method begins at RVA 0x4930
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2137,7 +2152,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48c5
+					// Method begins at RVA 0x4939
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2157,7 +2172,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48ce
+					// Method begins at RVA 0x4942
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2181,7 +2196,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x48f2
+						// Method begins at RVA 0x4966
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2201,7 +2216,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x48fb
+						// Method begins at RVA 0x496f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2219,7 +2234,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x48e9
+					// Method begins at RVA 0x495d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2239,7 +2254,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4916
+					// Method begins at RVA 0x498a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2259,7 +2274,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x491f
+					// Method begins at RVA 0x4993
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2281,7 +2296,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x48b3
+				// Method begins at RVA 0x4927
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2308,7 +2323,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3138
+			// Method begins at RVA 0x317c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2833,7 +2848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4928
+				// Method begins at RVA 0x499c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2861,41 +2876,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x3654
+			// Method begins at RVA 0x3698
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -2915,7 +2935,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4886
+					// Method begins at RVA 0x48fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2939,7 +2959,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x371f
+				// Method begins at RVA 0x3776
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -2974,7 +2994,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x487d
+				// Method begins at RVA 0x48f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3001,14 +3021,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 44 00 00 02
 			)
-			// Method begins at RVA 0x36a8
+			// Method begins at RVA 0x36f4
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope,
-				[1] object,
-				[2] object
+				[1] object[],
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::.ctor()
@@ -3016,37 +3037,44 @@
 			IL_0006: ldloc.0
 			IL_0007: ldarg.2
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
-			IL_000d: ldloc.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
-			IL_0013: stloc.1
-			IL_0014: ldc.i4.2
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: dup
-			IL_001f: ldc.i4.1
-			IL_0020: ldloc.0
-			IL_0021: stelem.ref
-			IL_0022: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-			IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_002d: ldc.i4.0
-			IL_002e: conv.r8
-			IL_002f: ldstr ""
-			IL_0034: ldc.i4.0
-			IL_0035: ldc.i4.1
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_003b: stloc.2
-			IL_003c: ldarg.0
-			IL_003d: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_0042: ldnull
-			IL_0043: ldloc.1
-			IL_0044: ldloc.2
-			IL_0045: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
-			IL_004a: pop
-			IL_004b: ldnull
-			IL_004c: ret
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: stelem.ref
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::__k
+			IL_001e: stloc.2
+			IL_001f: ldc.i4.2
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldarg.0
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
+			IL_002b: ldloc.0
+			IL_002c: stelem.ref
+			IL_002d: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+			IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0038: ldc.i4.0
+			IL_0039: conv.r8
+			IL_003a: ldstr ""
+			IL_003f: ldc.i4.0
+			IL_0040: ldc.i4.1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0046: stloc.3
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_export
+			IL_004d: ldloc.1
+			IL_004e: ldloc.2
+			IL_004f: ldloc.3
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method FunctionExpression_L10C3::__js_call__
 
 	} // end of class FunctionExpression_L10C3
@@ -3070,7 +3098,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x486b
+					// Method begins at RVA 0x48df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3090,7 +3118,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4874
+					// Method begins at RVA 0x48e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3108,7 +3136,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4862
+				// Method begins at RVA 0x48d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3135,7 +3163,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4859
+			// Method begins at RVA 0x48cd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3159,9 +3187,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21bc
+		// Method begins at RVA 0x21dc
 		// Header size: 12
-		// Code size: 632 (0x278)
+		// Code size: 636 (0x27c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibC/Scope,
@@ -3275,153 +3303,153 @@
 		IL_00db: ldloc.s 9
 		IL_00dd: stfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_export
 		IL_00e2: ldloc.0
-		IL_00e3: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_00e8: ldnull
-		IL_00e9: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
-		IL_00ee: pop
-		IL_00ef: ldarg.1
-		IL_00f0: ldstr "./Import_ExportStarFromMultiHop_LibB.mjs"
-		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00fa: stloc.s 9
-		IL_00fc: ldloc.0
-		IL_00fd: ldloc.s 9
-		IL_00ff: stfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
-		IL_0104: ldloc.0
-		IL_0105: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
-		IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
-		IL_010f: stloc.s 4
-		// loop start (head: IL_0111)
-			IL_0111: ldloc.s 4
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-			IL_0118: stloc.s 9
-			IL_011a: ldloc.s 9
-			IL_011c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0121: stloc.s 10
-			IL_0123: ldloc.s 10
-			IL_0125: brtrue IL_0277
+		IL_00e3: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mark
+		IL_00e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00f2: pop
+		IL_00f3: ldarg.1
+		IL_00f4: ldstr "./Import_ExportStarFromMultiHop_LibB.mjs"
+		IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fe: stloc.s 9
+		IL_0100: ldloc.0
+		IL_0101: ldloc.s 9
+		IL_0103: stfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
+		IL_0108: ldloc.0
+		IL_0109: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
+		IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
+		IL_0113: stloc.s 4
+		// loop start (head: IL_0115)
+			IL_0115: ldloc.s 4
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+			IL_011c: stloc.s 9
+			IL_011e: ldloc.s 9
+			IL_0120: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_0125: stloc.s 10
+			IL_0127: ldloc.s 10
+			IL_0129: brtrue IL_027b
 
-			IL_012a: ldloc.s 9
-			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0131: stloc.s 9
-			IL_0133: ldloc.s 9
-			IL_0135: stloc.s 5
-			IL_0137: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47::.ctor()
-			IL_013c: stloc.s 6
-			IL_013e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-			IL_0143: ldstr "prototype"
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_014d: ldstr "hasOwnProperty"
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015c: stloc.s 9
-			IL_015e: ldloc.s 9
-			IL_0160: ldstr "call"
-			IL_0165: ldloc.0
-			IL_0166: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
-			IL_016b: ldloc.s 5
-			IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0172: stloc.s 9
-			IL_0174: ldloc.s 9
-			IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_017b: ldc.i4.0
-			IL_017c: ceq
-			IL_017e: stloc.s 10
-			IL_0180: ldloc.s 10
-			IL_0182: brfalse IL_0193
+			IL_012e: ldloc.s 9
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_0135: stloc.s 9
+			IL_0137: ldloc.s 9
+			IL_0139: stloc.s 5
+			IL_013b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47::.ctor()
+			IL_0140: stloc.s 6
+			IL_0142: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+			IL_0147: ldstr "prototype"
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0151: ldstr "hasOwnProperty"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0160: stloc.s 9
+			IL_0162: ldloc.s 9
+			IL_0164: ldstr "call"
+			IL_0169: ldloc.0
+			IL_016a: ldfld object Modules.Import_ExportStarFromMultiHop_LibC/Scope::__jroc_esm_mod_0
+			IL_016f: ldloc.s 5
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0176: stloc.s 9
+			IL_0178: ldloc.s 9
+			IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_017f: ldc.i4.0
+			IL_0180: ceq
+			IL_0182: stloc.s 10
+			IL_0184: ldloc.s 10
+			IL_0186: brfalse IL_0197
 
-			IL_0187: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L8C81::.ctor()
-			IL_018c: stloc.s 7
-			IL_018e: br IL_0272
+			IL_018b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L8C81::.ctor()
+			IL_0190: stloc.s 7
+			IL_0192: br IL_0276
 
-			IL_0193: ldloc.s 5
-			IL_0195: ldstr "default"
-			IL_019a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_019f: stloc.s 10
-			IL_01a1: ldloc.s 10
-			IL_01a3: box [System.Runtime]System.Boolean
-			IL_01a8: stloc.s 11
-			IL_01aa: ldloc.s 11
-			IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b1: stloc.s 10
-			IL_01b3: ldloc.s 10
-			IL_01b5: brtrue IL_01da
+			IL_0197: ldloc.s 5
+			IL_0199: ldstr "default"
+			IL_019e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01a3: stloc.s 10
+			IL_01a5: ldloc.s 10
+			IL_01a7: box [System.Runtime]System.Boolean
+			IL_01ac: stloc.s 11
+			IL_01ae: ldloc.s 11
+			IL_01b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01b5: stloc.s 10
+			IL_01b7: ldloc.s 10
+			IL_01b9: brtrue IL_01de
 
-			IL_01ba: ldloc.s 5
-			IL_01bc: ldstr "__esModule"
-			IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01c6: stloc.s 10
-			IL_01c8: ldloc.s 10
-			IL_01ca: box [System.Runtime]System.Boolean
-			IL_01cf: stloc.s 12
-			IL_01d1: ldloc.s 12
-			IL_01d3: stloc.s 14
-			IL_01d5: br IL_01de
+			IL_01be: ldloc.s 5
+			IL_01c0: ldstr "__esModule"
+			IL_01c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01ca: stloc.s 10
+			IL_01cc: ldloc.s 10
+			IL_01ce: box [System.Runtime]System.Boolean
+			IL_01d3: stloc.s 12
+			IL_01d5: ldloc.s 12
+			IL_01d7: stloc.s 14
+			IL_01d9: br IL_01e2
 
-			IL_01da: ldloc.s 11
-			IL_01dc: stloc.s 14
+			IL_01de: ldloc.s 11
+			IL_01e0: stloc.s 14
 
-			IL_01de: ldloc.s 14
-			IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01e5: stloc.s 10
-			IL_01e7: ldloc.s 10
-			IL_01e9: brtrue IL_020e
+			IL_01e2: ldloc.s 14
+			IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01e9: stloc.s 10
+			IL_01eb: ldloc.s 10
+			IL_01ed: brtrue IL_0212
 
-			IL_01ee: ldloc.s 5
-			IL_01f0: ldstr "module.exports"
-			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01fa: stloc.s 10
-			IL_01fc: ldloc.s 10
-			IL_01fe: box [System.Runtime]System.Boolean
-			IL_0203: stloc.s 11
-			IL_0205: ldloc.s 11
-			IL_0207: stloc.s 14
-			IL_0209: br IL_020e
+			IL_01f2: ldloc.s 5
+			IL_01f4: ldstr "module.exports"
+			IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01fe: stloc.s 10
+			IL_0200: ldloc.s 10
+			IL_0202: box [System.Runtime]System.Boolean
+			IL_0207: stloc.s 11
+			IL_0209: ldloc.s 11
+			IL_020b: stloc.s 14
+			IL_020d: br IL_0212
 
-			IL_020e: ldloc.s 14
-			IL_0210: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0215: stloc.s 10
-			IL_0217: ldloc.s 10
-			IL_0219: brfalse IL_022a
+			IL_0212: ldloc.s 14
+			IL_0214: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0219: stloc.s 10
+			IL_021b: ldloc.s 10
+			IL_021d: brfalse IL_022e
 
-			IL_021e: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L9C116::.ctor()
-			IL_0223: stloc.s 8
-			IL_0225: br IL_0272
+			IL_0222: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope/Block_L7C47/Block_L9C116::.ctor()
+			IL_0227: stloc.s 8
+			IL_0229: br IL_0276
 
-			IL_022a: ldc.i4.1
-			IL_022b: newarr [System.Runtime]System.Object
-			IL_0230: dup
-			IL_0231: ldc.i4.0
-			IL_0232: ldloc.0
-			IL_0233: stelem.ref
-			IL_0234: ldc.i4.0
-			IL_0235: ldelem.ref
-			IL_0236: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_023b: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
-			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0246: ldc.i4.1
-			IL_0247: conv.r8
-			IL_0248: ldstr ""
-			IL_024d: ldc.i4.0
-			IL_024e: ldc.i4.1
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0254: stloc.s 9
-			IL_0256: ldc.i4.1
-			IL_0257: newarr [System.Runtime]System.Object
-			IL_025c: dup
-			IL_025d: ldc.i4.0
-			IL_025e: ldloc.s 5
-			IL_0260: stelem.ref
-			IL_0261: stloc.s 16
-			IL_0263: ldloc.s 9
-			IL_0265: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_026a: ldloc.s 16
-			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_0271: pop
+			IL_022e: ldc.i4.1
+			IL_022f: newarr [System.Runtime]System.Object
+			IL_0234: dup
+			IL_0235: ldc.i4.0
+			IL_0236: ldloc.0
+			IL_0237: stelem.ref
+			IL_0238: ldc.i4.0
+			IL_0239: ldelem.ref
+			IL_023a: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
+			IL_023f: ldftn object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
+			IL_0245: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_024a: ldc.i4.1
+			IL_024b: conv.r8
+			IL_024c: ldstr ""
+			IL_0251: ldc.i4.0
+			IL_0252: ldc.i4.1
+			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0258: stloc.s 9
+			IL_025a: ldc.i4.1
+			IL_025b: newarr [System.Runtime]System.Object
+			IL_0260: dup
+			IL_0261: ldc.i4.0
+			IL_0262: ldloc.s 5
+			IL_0264: stelem.ref
+			IL_0265: stloc.s 16
+			IL_0267: ldloc.s 9
+			IL_0269: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_026e: ldloc.s 16
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0275: pop
 
-			IL_0272: br IL_0111
+			IL_0276: br IL_0115
 		// end loop
 
-		IL_0277: ret
+		IL_027b: ret
 	} // end of method Import_ExportStarFromMultiHop_LibC::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop_LibC
@@ -3441,7 +3469,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4945
+				// Method begins at RVA 0x49b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3467,7 +3495,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x37f8
+			// Method begins at RVA 0x3850
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3501,7 +3529,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4984
+					// Method begins at RVA 0x49f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3519,7 +3547,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x497b
+				// Method begins at RVA 0x49ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3545,7 +3573,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3818
+			// Method begins at RVA 0x3870
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -3620,7 +3648,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x498d
+				// Method begins at RVA 0x4a01
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3644,7 +3672,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x38b0
+			// Method begins at RVA 0x3908
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -3718,7 +3746,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4996
+				// Method begins at RVA 0x4a0a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3743,7 +3771,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3935
+			// Method begins at RVA 0x398d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3771,7 +3799,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49c3
+					// Method begins at RVA 0x4a37
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3795,7 +3823,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f09
+				// Method begins at RVA 0x3f74
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3821,7 +3849,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49cc
+					// Method begins at RVA 0x4a40
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3845,7 +3873,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f18
+				// Method begins at RVA 0x3f83
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3875,7 +3903,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x49f9
+						// Method begins at RVA 0x4a6d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3899,7 +3927,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3fdd
+					// Method begins at RVA 0x4049
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -3933,7 +3961,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49f0
+					// Method begins at RVA 0x4a64
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3958,7 +3986,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f48
+				// Method begins at RVA 0x3fb4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4051,7 +4079,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49a8
+					// Method begins at RVA 0x4a1c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4071,7 +4099,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49b1
+					// Method begins at RVA 0x4a25
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4091,7 +4119,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49ba
+					// Method begins at RVA 0x4a2e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4115,7 +4143,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x49de
+						// Method begins at RVA 0x4a52
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4135,7 +4163,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x49e7
+						// Method begins at RVA 0x4a5b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4153,7 +4181,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x49d5
+					// Method begins at RVA 0x4a49
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4173,7 +4201,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a02
+					// Method begins at RVA 0x4a76
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4193,7 +4221,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a0b
+					// Method begins at RVA 0x4a7f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4215,7 +4243,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x499f
+				// Method begins at RVA 0x4a13
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4242,7 +4270,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3940
+			// Method begins at RVA 0x3998
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -4767,7 +4795,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a14
+				// Method begins at RVA 0x4a88
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4795,41 +4823,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3e5c
+			// Method begins at RVA 0x3eb4
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -4849,7 +4882,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4972
+					// Method begins at RVA 0x49e6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4873,7 +4906,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3f27
+				// Method begins at RVA 0x3f92
 				// Header size: 1
 				// Code size: 32 (0x20)
 				.maxstack 8
@@ -4908,7 +4941,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4969
+				// Method begins at RVA 0x49dd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4935,14 +4968,15 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 5c 00 00 02
 			)
-			// Method begins at RVA 0x3eb0
+			// Method begins at RVA 0x3f10
 			// Header size: 12
-			// Code size: 77 (0x4d)
+			// Code size: 88 (0x58)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope,
-				[1] object,
-				[2] object
+				[1] object[],
+				[2] object,
+				[3] object
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::.ctor()
@@ -4950,37 +4984,44 @@
 			IL_0006: ldloc.0
 			IL_0007: ldarg.2
 			IL_0008: stfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
-			IL_000d: ldloc.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
-			IL_0013: stloc.1
-			IL_0014: ldc.i4.2
-			IL_0015: newarr [System.Runtime]System.Object
-			IL_001a: dup
-			IL_001b: ldc.i4.0
-			IL_001c: ldarg.0
-			IL_001d: stelem.ref
-			IL_001e: dup
-			IL_001f: ldc.i4.1
-			IL_0020: ldloc.0
-			IL_0021: stelem.ref
-			IL_0022: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
-			IL_0028: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_002d: ldc.i4.0
-			IL_002e: conv.r8
-			IL_002f: ldstr ""
-			IL_0034: ldc.i4.0
-			IL_0035: ldc.i4.1
-			IL_0036: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_003b: stloc.2
-			IL_003c: ldarg.0
-			IL_003d: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_0042: ldnull
-			IL_0043: ldloc.1
-			IL_0044: ldloc.2
-			IL_0045: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
-			IL_004a: pop
-			IL_004b: ldnull
-			IL_004c: ret
+			IL_000d: ldc.i4.1
+			IL_000e: newarr [System.Runtime]System.Object
+			IL_0013: dup
+			IL_0014: ldc.i4.0
+			IL_0015: ldarg.0
+			IL_0016: stelem.ref
+			IL_0017: stloc.1
+			IL_0018: ldloc.0
+			IL_0019: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::__k
+			IL_001e: stloc.2
+			IL_001f: ldc.i4.2
+			IL_0020: newarr [System.Runtime]System.Object
+			IL_0025: dup
+			IL_0026: ldc.i4.0
+			IL_0027: ldarg.0
+			IL_0028: stelem.ref
+			IL_0029: dup
+			IL_002a: ldc.i4.1
+			IL_002b: ldloc.0
+			IL_002c: stelem.ref
+			IL_002d: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
+			IL_0033: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_0038: ldc.i4.0
+			IL_0039: conv.r8
+			IL_003a: ldstr ""
+			IL_003f: ldc.i4.0
+			IL_0040: ldc.i4.1
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0046: stloc.3
+			IL_0047: ldarg.0
+			IL_0048: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_export
+			IL_004d: ldloc.1
+			IL_004e: ldloc.2
+			IL_004f: ldloc.3
+			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0055: pop
+			IL_0056: ldnull
+			IL_0057: ret
 		} // end of method FunctionExpression_L11C3::__js_call__
 
 	} // end of class FunctionExpression_L11C3
@@ -5005,7 +5046,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4957
+					// Method begins at RVA 0x49cb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5025,7 +5066,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4960
+					// Method begins at RVA 0x49d4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5043,7 +5084,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x494e
+				// Method begins at RVA 0x49c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5071,7 +5112,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4931
+			// Method begins at RVA 0x49a5
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5098,9 +5139,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2440
+		// Method begins at RVA 0x2464
 		// Header size: 12
-		// Code size: 707 (0x2c3)
+		// Code size: 719 (0x2cf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibB/Scope,
@@ -5113,13 +5154,13 @@
 			[7] class Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L9C81,
 			[8] class Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L10C116,
 			[9] object,
-			[10] bool,
-			[11] object,
+			[10] object[],
+			[11] bool,
 			[12] object,
 			[13] object,
 			[14] object,
 			[15] object,
-			[16] object[]
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope::.ctor()
@@ -5214,181 +5255,183 @@
 		IL_00db: ldloc.s 9
 		IL_00dd: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_export
 		IL_00e2: ldloc.0
-		IL_00e3: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_00e8: ldnull
-		IL_00e9: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_00ee: pop
-		IL_00ef: ldc.i4.1
-		IL_00f0: newarr [System.Runtime]System.Object
-		IL_00f5: dup
-		IL_00f6: ldc.i4.0
-		IL_00f7: ldloc.0
-		IL_00f8: stelem.ref
-		IL_00f9: ldc.i4.0
-		IL_00fa: ldelem.ref
-		IL_00fb: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0100: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_010b: ldc.i4.0
-		IL_010c: conv.r8
-		IL_010d: ldstr ""
-		IL_0112: ldc.i4.0
-		IL_0113: ldc.i4.1
-		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0119: stloc.s 9
-		IL_011b: ldloc.0
-		IL_011c: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0121: ldnull
-		IL_0122: ldstr "gamma"
-		IL_0127: ldloc.s 9
-		IL_0129: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
-		IL_012e: pop
-		IL_012f: ldarg.1
-		IL_0130: ldstr "./Import_ExportStarFromMultiHop_LibA.mjs"
-		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_013a: stloc.s 9
-		IL_013c: ldloc.0
-		IL_013d: ldloc.s 9
-		IL_013f: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
-		IL_0144: ldloc.0
-		IL_0145: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
-		IL_014a: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
-		IL_014f: stloc.s 4
-		// loop start (head: IL_0151)
-			IL_0151: ldloc.s 4
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-			IL_0158: stloc.s 9
-			IL_015a: ldloc.s 9
-			IL_015c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-			IL_0161: stloc.s 10
-			IL_0163: ldloc.s 10
-			IL_0165: brtrue IL_02b7
+		IL_00e3: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mark
+		IL_00e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00f2: pop
+		IL_00f3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00f8: stloc.s 10
+		IL_00fa: ldc.i4.1
+		IL_00fb: newarr [System.Runtime]System.Object
+		IL_0100: dup
+		IL_0101: ldc.i4.0
+		IL_0102: ldloc.0
+		IL_0103: stelem.ref
+		IL_0104: ldc.i4.0
+		IL_0105: ldelem.ref
+		IL_0106: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+		IL_010b: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+		IL_0111: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0116: ldc.i4.0
+		IL_0117: conv.r8
+		IL_0118: ldstr ""
+		IL_011d: ldc.i4.0
+		IL_011e: ldc.i4.1
+		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0124: stloc.s 9
+		IL_0126: ldloc.0
+		IL_0127: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_export
+		IL_012c: ldloc.s 10
+		IL_012e: ldstr "gamma"
+		IL_0133: ldloc.s 9
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_013a: pop
+		IL_013b: ldarg.1
+		IL_013c: ldstr "./Import_ExportStarFromMultiHop_LibA.mjs"
+		IL_0141: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_0146: stloc.s 9
+		IL_0148: ldloc.0
+		IL_0149: ldloc.s 9
+		IL_014b: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
+		IL_0150: ldloc.0
+		IL_0151: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
+		IL_0156: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::EnumerateObjectProperties(object)
+		IL_015b: stloc.s 4
+		// loop start (head: IL_015d)
+			IL_015d: ldloc.s 4
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+			IL_0164: stloc.s 9
+			IL_0166: ldloc.s 9
+			IL_0168: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+			IL_016d: stloc.s 11
+			IL_016f: ldloc.s 11
+			IL_0171: brtrue IL_02c3
 
-			IL_016a: ldloc.s 9
-			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-			IL_0171: stloc.s 9
-			IL_0173: ldloc.s 9
-			IL_0175: stloc.s 5
-			IL_0177: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47::.ctor()
-			IL_017c: stloc.s 6
-			IL_017e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-			IL_0183: ldstr "prototype"
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_018d: ldstr "hasOwnProperty"
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_019c: stloc.s 9
-			IL_019e: ldloc.s 9
-			IL_01a0: ldstr "call"
-			IL_01a5: ldloc.0
-			IL_01a6: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
-			IL_01ab: ldloc.s 5
-			IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
-			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01bb: ldc.i4.0
-			IL_01bc: ceq
-			IL_01be: stloc.s 10
-			IL_01c0: ldloc.s 10
-			IL_01c2: brfalse IL_01d3
+			IL_0176: ldloc.s 9
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+			IL_017d: stloc.s 9
+			IL_017f: ldloc.s 9
+			IL_0181: stloc.s 5
+			IL_0183: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47::.ctor()
+			IL_0188: stloc.s 6
+			IL_018a: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+			IL_018f: ldstr "prototype"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0199: ldstr "hasOwnProperty"
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a8: stloc.s 9
+			IL_01aa: ldloc.s 9
+			IL_01ac: ldstr "call"
+			IL_01b1: ldloc.0
+			IL_01b2: ldfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::__jroc_esm_mod_0
+			IL_01b7: ldloc.s 5
+			IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01be: stloc.s 9
+			IL_01c0: ldloc.s 9
+			IL_01c2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01c7: ldc.i4.0
+			IL_01c8: ceq
+			IL_01ca: stloc.s 11
+			IL_01cc: ldloc.s 11
+			IL_01ce: brfalse IL_01df
 
-			IL_01c7: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L9C81::.ctor()
-			IL_01cc: stloc.s 7
-			IL_01ce: br IL_02b2
+			IL_01d3: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L9C81::.ctor()
+			IL_01d8: stloc.s 7
+			IL_01da: br IL_02be
 
-			IL_01d3: ldloc.s 5
-			IL_01d5: ldstr "default"
-			IL_01da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01df: stloc.s 10
-			IL_01e1: ldloc.s 10
-			IL_01e3: box [System.Runtime]System.Boolean
-			IL_01e8: stloc.s 11
-			IL_01ea: ldloc.s 11
-			IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01f1: stloc.s 10
-			IL_01f3: ldloc.s 10
-			IL_01f5: brtrue IL_021a
+			IL_01df: ldloc.s 5
+			IL_01e1: ldstr "default"
+			IL_01e6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01eb: stloc.s 11
+			IL_01ed: ldloc.s 11
+			IL_01ef: box [System.Runtime]System.Boolean
+			IL_01f4: stloc.s 12
+			IL_01f6: ldloc.s 12
+			IL_01f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01fd: stloc.s 11
+			IL_01ff: ldloc.s 11
+			IL_0201: brtrue IL_0226
 
-			IL_01fa: ldloc.s 5
-			IL_01fc: ldstr "__esModule"
-			IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0206: stloc.s 10
-			IL_0208: ldloc.s 10
-			IL_020a: box [System.Runtime]System.Boolean
-			IL_020f: stloc.s 12
-			IL_0211: ldloc.s 12
-			IL_0213: stloc.s 14
-			IL_0215: br IL_021e
+			IL_0206: ldloc.s 5
+			IL_0208: ldstr "__esModule"
+			IL_020d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0212: stloc.s 11
+			IL_0214: ldloc.s 11
+			IL_0216: box [System.Runtime]System.Boolean
+			IL_021b: stloc.s 13
+			IL_021d: ldloc.s 13
+			IL_021f: stloc.s 15
+			IL_0221: br IL_022a
 
-			IL_021a: ldloc.s 11
-			IL_021c: stloc.s 14
+			IL_0226: ldloc.s 12
+			IL_0228: stloc.s 15
 
-			IL_021e: ldloc.s 14
-			IL_0220: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0225: stloc.s 10
-			IL_0227: ldloc.s 10
-			IL_0229: brtrue IL_024e
+			IL_022a: ldloc.s 15
+			IL_022c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0231: stloc.s 11
+			IL_0233: ldloc.s 11
+			IL_0235: brtrue IL_025a
 
-			IL_022e: ldloc.s 5
-			IL_0230: ldstr "module.exports"
-			IL_0235: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_023a: stloc.s 10
-			IL_023c: ldloc.s 10
-			IL_023e: box [System.Runtime]System.Boolean
-			IL_0243: stloc.s 11
-			IL_0245: ldloc.s 11
-			IL_0247: stloc.s 14
-			IL_0249: br IL_024e
+			IL_023a: ldloc.s 5
+			IL_023c: ldstr "module.exports"
+			IL_0241: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0246: stloc.s 11
+			IL_0248: ldloc.s 11
+			IL_024a: box [System.Runtime]System.Boolean
+			IL_024f: stloc.s 12
+			IL_0251: ldloc.s 12
+			IL_0253: stloc.s 15
+			IL_0255: br IL_025a
 
-			IL_024e: ldloc.s 14
-			IL_0250: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0255: stloc.s 10
-			IL_0257: ldloc.s 10
-			IL_0259: brfalse IL_026a
+			IL_025a: ldloc.s 15
+			IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0261: stloc.s 11
+			IL_0263: ldloc.s 11
+			IL_0265: brfalse IL_0276
 
-			IL_025e: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L10C116::.ctor()
-			IL_0263: stloc.s 8
-			IL_0265: br IL_02b2
+			IL_026a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope/Block_L8C47/Block_L10C116::.ctor()
+			IL_026f: stloc.s 8
+			IL_0271: br IL_02be
 
-			IL_026a: ldc.i4.1
-			IL_026b: newarr [System.Runtime]System.Object
-			IL_0270: dup
-			IL_0271: ldc.i4.0
-			IL_0272: ldloc.0
-			IL_0273: stelem.ref
-			IL_0274: ldc.i4.0
-			IL_0275: ldelem.ref
-			IL_0276: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_027b: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
-			IL_0281: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0286: ldc.i4.1
-			IL_0287: conv.r8
-			IL_0288: ldstr ""
-			IL_028d: ldc.i4.0
-			IL_028e: ldc.i4.1
-			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0294: stloc.s 9
-			IL_0296: ldc.i4.1
-			IL_0297: newarr [System.Runtime]System.Object
-			IL_029c: dup
-			IL_029d: ldc.i4.0
-			IL_029e: ldloc.s 5
-			IL_02a0: stelem.ref
-			IL_02a1: stloc.s 16
-			IL_02a3: ldloc.s 9
-			IL_02a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_02aa: ldloc.s 16
-			IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-			IL_02b1: pop
+			IL_0276: ldc.i4.1
+			IL_0277: newarr [System.Runtime]System.Object
+			IL_027c: dup
+			IL_027d: ldc.i4.0
+			IL_027e: ldloc.0
+			IL_027f: stelem.ref
+			IL_0280: ldc.i4.0
+			IL_0281: ldelem.ref
+			IL_0282: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
+			IL_0287: ldftn object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
+			IL_028d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0292: ldc.i4.1
+			IL_0293: conv.r8
+			IL_0294: ldstr ""
+			IL_0299: ldc.i4.0
+			IL_029a: ldc.i4.1
+			IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_02a0: stloc.s 9
+			IL_02a2: ldc.i4.1
+			IL_02a3: newarr [System.Runtime]System.Object
+			IL_02a8: dup
+			IL_02a9: ldc.i4.0
+			IL_02aa: ldloc.s 5
+			IL_02ac: stelem.ref
+			IL_02ad: stloc.s 10
+			IL_02af: ldloc.s 9
+			IL_02b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_02b6: ldloc.s 10
+			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_02bd: pop
 
-			IL_02b2: br IL_0151
+			IL_02be: br IL_015d
 		// end loop
 
-		IL_02b7: ldloc.0
-		IL_02b8: ldstr "g"
-		IL_02bd: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::gamma
-		IL_02c2: ret
+		IL_02c3: ldloc.0
+		IL_02c4: ldstr "g"
+		IL_02c9: stfld object Modules.Import_ExportStarFromMultiHop_LibB/Scope::gamma
+		IL_02ce: ret
 	} // end of method Import_ExportStarFromMultiHop_LibB::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop_LibB
@@ -5408,7 +5451,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a3c
+				// Method begins at RVA 0x4ab0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5434,7 +5477,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4000
+			// Method begins at RVA 0x406c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5464,7 +5507,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a45
+				// Method begins at RVA 0x4ab9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5490,7 +5533,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4020
+			// Method begins at RVA 0x408c
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5524,7 +5567,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a57
+					// Method begins at RVA 0x4acb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5542,7 +5585,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a4e
+				// Method begins at RVA 0x4ac2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5568,7 +5611,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4040
+			// Method begins at RVA 0x40ac
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -5643,7 +5686,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a60
+				// Method begins at RVA 0x4ad4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5667,7 +5710,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x40d8
+			// Method begins at RVA 0x4144
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -5741,7 +5784,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a69
+				// Method begins at RVA 0x4add
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5766,7 +5809,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x415d
+			// Method begins at RVA 0x41c9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5794,7 +5837,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a96
+					// Method begins at RVA 0x4b0a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5818,7 +5861,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x46d7
+				// Method begins at RVA 0x474c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -5844,7 +5887,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a9f
+					// Method begins at RVA 0x4b13
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5868,7 +5911,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x46e6
+				// Method begins at RVA 0x475b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -5898,7 +5941,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4acc
+						// Method begins at RVA 0x4b40
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -5922,7 +5965,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x478d
+					// Method begins at RVA 0x4801
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -5956,7 +5999,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ac3
+					// Method begins at RVA 0x4b37
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5981,7 +6024,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x46f8
+				// Method begins at RVA 0x476c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -6074,7 +6117,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a7b
+					// Method begins at RVA 0x4aef
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6094,7 +6137,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a84
+					// Method begins at RVA 0x4af8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6114,7 +6157,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a8d
+					// Method begins at RVA 0x4b01
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6138,7 +6181,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4ab1
+						// Method begins at RVA 0x4b25
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6158,7 +6201,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4aba
+						// Method begins at RVA 0x4b2e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -6176,7 +6219,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4aa8
+					// Method begins at RVA 0x4b1c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6196,7 +6239,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ad5
+					// Method begins at RVA 0x4b49
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6216,7 +6259,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4ade
+					// Method begins at RVA 0x4b52
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -6238,7 +6281,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a72
+				// Method begins at RVA 0x4ae6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6265,7 +6308,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4168
+			// Method begins at RVA 0x41d4
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -6790,7 +6833,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ae7
+				// Method begins at RVA 0x4b5b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6818,41 +6861,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 75 00 00 02
 			)
-			// Method begins at RVA 0x4684
+			// Method begins at RVA 0x46f0
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -6880,7 +6928,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4a1d
+			// Method begins at RVA 0x4a91
 			// Header size: 1
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -6910,9 +6958,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2710
+		// Method begins at RVA 0x2740
 		// Header size: 12
-		// Code size: 386 (0x182)
+		// Code size: 398 (0x18e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibA/Scope,
@@ -6920,7 +6968,8 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object
+			[5] object,
+			[6] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/Scope::.ctor()
@@ -7014,67 +7063,69 @@
 		IL_00da: ldloc.s 5
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldc.i4.1
-		IL_00ec: newarr [System.Runtime]System.Object
-		IL_00f1: dup
-		IL_00f2: ldc.i4.0
-		IL_00f3: ldloc.0
-		IL_00f4: stelem.ref
-		IL_00f5: ldc.i4.0
-		IL_00f6: ldelem.ref
-		IL_00f7: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_00fc: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0107: ldc.i4.0
-		IL_0108: conv.r8
-		IL_0109: ldstr ""
-		IL_010e: ldc.i4.0
-		IL_010f: ldc.i4.1
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0115: stloc.s 5
-		IL_0117: ldloc.0
-		IL_0118: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_011d: ldnull
-		IL_011e: ldstr "alpha"
-		IL_0123: ldloc.s 5
-		IL_0125: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object, object)
-		IL_012a: pop
-		IL_012b: ldc.i4.1
-		IL_012c: newarr [System.Runtime]System.Object
-		IL_0131: dup
-		IL_0132: ldc.i4.0
-		IL_0133: ldloc.0
-		IL_0134: stelem.ref
-		IL_0135: ldc.i4.0
-		IL_0136: ldelem.ref
-		IL_0137: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_013c: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0147: ldc.i4.0
-		IL_0148: conv.r8
-		IL_0149: ldstr ""
-		IL_014e: ldc.i4.0
-		IL_014f: ldc.i4.1
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0155: stloc.s 5
-		IL_0157: ldloc.0
-		IL_0158: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_015d: ldnull
-		IL_015e: ldstr "beta"
-		IL_0163: ldloc.s 5
-		IL_0165: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object, object)
-		IL_016a: pop
-		IL_016b: ldloc.0
-		IL_016c: ldstr "a"
-		IL_0171: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::alpha
-		IL_0176: ldloc.0
-		IL_0177: ldstr "b"
-		IL_017c: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::beta
-		IL_0181: ret
+		IL_00df: ldfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00f4: stloc.s 6
+		IL_00f6: ldc.i4.1
+		IL_00f7: newarr [System.Runtime]System.Object
+		IL_00fc: dup
+		IL_00fd: ldc.i4.0
+		IL_00fe: ldloc.0
+		IL_00ff: stelem.ref
+		IL_0100: ldc.i4.0
+		IL_0101: ldelem.ref
+		IL_0102: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+		IL_0107: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+		IL_010d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0112: ldc.i4.0
+		IL_0113: conv.r8
+		IL_0114: ldstr ""
+		IL_0119: ldc.i4.0
+		IL_011a: ldc.i4.1
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0120: stloc.s 5
+		IL_0122: ldloc.s 4
+		IL_0124: ldloc.s 6
+		IL_0126: ldstr "alpha"
+		IL_012b: ldloc.s 5
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0132: pop
+		IL_0133: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0138: stloc.s 6
+		IL_013a: ldc.i4.1
+		IL_013b: newarr [System.Runtime]System.Object
+		IL_0140: dup
+		IL_0141: ldc.i4.0
+		IL_0142: ldloc.0
+		IL_0143: stelem.ref
+		IL_0144: ldc.i4.0
+		IL_0145: ldelem.ref
+		IL_0146: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
+		IL_014b: ldftn object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+		IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0156: ldc.i4.0
+		IL_0157: conv.r8
+		IL_0158: ldstr ""
+		IL_015d: ldc.i4.0
+		IL_015e: ldc.i4.1
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0164: stloc.s 5
+		IL_0166: ldloc.s 4
+		IL_0168: ldloc.s 6
+		IL_016a: ldstr "beta"
+		IL_016f: ldloc.s 5
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0176: pop
+		IL_0177: ldloc.0
+		IL_0178: ldstr "a"
+		IL_017d: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::alpha
+		IL_0182: ldloc.0
+		IL_0183: ldstr "b"
+		IL_0188: stfld object Modules.Import_ExportStarFromMultiHop_LibA/Scope::beta
+		IL_018d: ret
 	} // end of method Import_ExportStarFromMultiHop_LibA::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop_LibA
@@ -7086,7 +7137,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4af0
+		// Method begins at RVA 0x4b64
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x376c
+					// Method begins at RVA 0x37c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3763
+				// Method begins at RVA 0x37b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x27fc
+			// Method begins at RVA 0x2840
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3775
+				// Method begins at RVA 0x37c9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2894
+			// Method begins at RVA 0x28d8
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x377e
+				// Method begins at RVA 0x37d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2919
+			// Method begins at RVA 0x295d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37ab
+					// Method begins at RVA 0x37ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e93
+				// Method begins at RVA 0x2ee0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37b4
+					// Method begins at RVA 0x3808
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ea2
+				// Method begins at RVA 0x2eef
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37e1
+						// Method begins at RVA 0x3835
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f49
+					// Method begins at RVA 0x2f95
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37d8
+					// Method begins at RVA 0x382c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2eb4
+				// Method begins at RVA 0x2f00
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3790
+					// Method begins at RVA 0x37e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3799
+					// Method begins at RVA 0x37ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37a2
+					// Method begins at RVA 0x37f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37c6
+						// Method begins at RVA 0x381a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x37cf
+						// Method begins at RVA 0x3823
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37bd
+					// Method begins at RVA 0x3811
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37ea
+					// Method begins at RVA 0x383e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37f3
+					// Method begins at RVA 0x3847
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3787
+				// Method begins at RVA 0x37db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2924
+			// Method begins at RVA 0x2968
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37fc
+				// Method begins at RVA 0x3850
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1a 00 00 02
 			)
-			// Method begins at RVA 0x2e40
+			// Method begins at RVA 0x2e84
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ImportMeta_Url/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ImportMeta_Url/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ImportMeta_Url/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x375a
+			// Method begins at RVA 0x37ae
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1174 (0x496)
+		// Code size: 1223 (0x4c7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url/Scope,
@@ -1513,306 +1518,321 @@
 		IL_00da: ldloc.s 11
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_ImportMeta_Url_Lib.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 11
-		IL_00f8: ldloc.s 11
-		IL_00fa: stloc.s 5
-		IL_00fc: ldarg.1
-		IL_00fd: ldstr "node:url"
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0107: stloc.s 11
-		IL_0109: ldloc.s 11
-		IL_010b: stloc.s 6
-		IL_010d: ldloc.s 6
-		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0114: stloc.s 11
-		IL_0116: ldarg.3
-		IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_011c: stloc.s 12
-		IL_011e: ldloc.s 12
-		IL_0120: ldstr "url"
-		IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012a: stloc.s 12
-		IL_012c: ldloc.s 11
-		IL_012e: ldstr "fileURLToPath"
-		IL_0133: ldloc.s 12
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_013a: stloc.s 12
-		IL_013c: ldloc.s 12
-		IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0143: stloc.s 12
-		IL_0145: ldloc.s 12
-		IL_0147: ldstr "split"
-		IL_014c: ldstr "\\"
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0156: stloc.s 12
-		IL_0158: ldloc.s 12
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015f: stloc.s 12
-		IL_0161: ldloc.s 12
-		IL_0163: ldstr "join"
-		IL_0168: ldstr "/"
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0172: stloc.s 12
-		IL_0174: ldloc.s 12
-		IL_0176: stloc.s 7
-		IL_0178: ldloc.s 6
-		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017f: stloc.s 12
-		IL_0181: ldloc.s 6
-		IL_0183: ldstr "URL"
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018d: stloc.s 11
-		IL_018f: ldarg.3
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_0195: stloc.s 13
-		IL_0197: ldloc.s 13
-		IL_0199: ldstr "url"
-		IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a3: stloc.s 13
-		IL_01a5: ldc.i4.2
-		IL_01a6: newarr [System.Runtime]System.Object
-		IL_01ab: dup
-		IL_01ac: ldc.i4.0
-		IL_01ad: ldstr "./fixtures/main.txt"
-		IL_01b2: stelem.ref
-		IL_01b3: dup
-		IL_01b4: ldc.i4.1
-		IL_01b5: ldloc.s 13
-		IL_01b7: stelem.ref
-		IL_01b8: stloc.s 14
-		IL_01ba: ldloc.s 11
-		IL_01bc: ldloc.s 14
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_01c3: stloc.s 11
-		IL_01c5: ldloc.s 12
-		IL_01c7: ldstr "fileURLToPath"
-		IL_01cc: ldloc.s 11
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01d3: stloc.s 11
-		IL_01d5: ldloc.s 11
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01dc: stloc.s 11
-		IL_01de: ldloc.s 11
-		IL_01e0: ldstr "split"
-		IL_01e5: ldstr "\\"
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01ef: stloc.s 11
-		IL_01f1: ldloc.s 11
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f8: stloc.s 11
-		IL_01fa: ldloc.s 11
-		IL_01fc: ldstr "join"
-		IL_0201: ldstr "/"
-		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_020b: stloc.s 11
-		IL_020d: ldloc.s 11
-		IL_020f: stloc.s 8
-		IL_0211: ldloc.s 6
-		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0218: stloc.s 11
-		IL_021a: ldnull
-		IL_021b: ldloc.s 5
-		IL_021d: ldstr "importedUrl"
-		IL_0222: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0227: stloc.s 12
-		IL_0229: ldloc.s 11
-		IL_022b: ldstr "fileURLToPath"
-		IL_0230: ldloc.s 12
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0237: stloc.s 12
-		IL_0239: ldloc.s 12
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0240: stloc.s 12
-		IL_0242: ldloc.s 12
-		IL_0244: ldstr "split"
-		IL_0249: ldstr "\\"
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0253: stloc.s 12
-		IL_0255: ldloc.s 12
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_025c: stloc.s 12
-		IL_025e: ldloc.s 12
-		IL_0260: ldstr "join"
-		IL_0265: ldstr "/"
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_026f: stloc.s 12
-		IL_0271: ldloc.s 12
-		IL_0273: stloc.s 9
-		IL_0275: ldloc.s 6
-		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00df: ldfld object Modules.Import_ImportMeta_Url/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_ImportMeta_Url_Lib.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 11
+		IL_00fc: ldloc.s 11
+		IL_00fe: stloc.s 5
+		IL_0100: ldarg.1
+		IL_0101: ldstr "node:url"
+		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_010b: stloc.s 11
+		IL_010d: ldloc.s 11
+		IL_010f: stloc.s 6
+		IL_0111: ldloc.s 6
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0118: stloc.s 11
+		IL_011a: ldarg.3
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0120: stloc.s 12
+		IL_0122: ldloc.s 12
+		IL_0124: ldstr "url"
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_012e: stloc.s 12
+		IL_0130: ldloc.s 11
+		IL_0132: ldstr "fileURLToPath"
+		IL_0137: ldloc.s 12
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_013e: stloc.s 12
+		IL_0140: ldloc.s 12
+		IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0147: stloc.s 12
+		IL_0149: ldloc.s 12
+		IL_014b: ldstr "split"
+		IL_0150: ldstr "\\"
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_015a: stloc.s 12
+		IL_015c: ldloc.s 12
+		IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0163: stloc.s 12
+		IL_0165: ldloc.s 12
+		IL_0167: ldstr "join"
+		IL_016c: ldstr "/"
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0176: stloc.s 12
+		IL_0178: ldloc.s 12
+		IL_017a: stloc.s 7
+		IL_017c: ldloc.s 6
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0183: stloc.s 12
+		IL_0185: ldloc.s 6
+		IL_0187: ldstr "URL"
+		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0191: stloc.s 11
+		IL_0193: ldarg.3
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0199: stloc.s 13
+		IL_019b: ldloc.s 13
+		IL_019d: ldstr "url"
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a7: stloc.s 13
+		IL_01a9: ldc.i4.2
+		IL_01aa: newarr [System.Runtime]System.Object
+		IL_01af: dup
+		IL_01b0: ldc.i4.0
+		IL_01b1: ldstr "./fixtures/main.txt"
+		IL_01b6: stelem.ref
+		IL_01b7: dup
+		IL_01b8: ldc.i4.1
+		IL_01b9: ldloc.s 13
+		IL_01bb: stelem.ref
+		IL_01bc: stloc.s 14
+		IL_01be: ldloc.s 11
+		IL_01c0: ldloc.s 14
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_01c7: stloc.s 11
+		IL_01c9: ldloc.s 12
+		IL_01cb: ldstr "fileURLToPath"
+		IL_01d0: ldloc.s 11
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01d7: stloc.s 11
+		IL_01d9: ldloc.s 11
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e0: stloc.s 11
+		IL_01e2: ldloc.s 11
+		IL_01e4: ldstr "split"
+		IL_01e9: ldstr "\\"
+		IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01f3: stloc.s 11
+		IL_01f5: ldloc.s 11
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01fc: stloc.s 11
+		IL_01fe: ldloc.s 11
+		IL_0200: ldstr "join"
+		IL_0205: ldstr "/"
+		IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_020f: stloc.s 11
+		IL_0211: ldloc.s 11
+		IL_0213: stloc.s 8
+		IL_0215: ldloc.s 6
+		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021c: stloc.s 11
+		IL_021e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0223: stloc.s 14
+		IL_0225: ldloc.2
+		IL_0226: ldloc.s 14
+		IL_0228: ldloc.s 5
+		IL_022a: ldstr "importedUrl"
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0234: stloc.s 12
+		IL_0236: ldloc.s 11
+		IL_0238: ldstr "fileURLToPath"
+		IL_023d: ldloc.s 12
+		IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0244: stloc.s 12
+		IL_0246: ldloc.s 12
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024d: stloc.s 12
+		IL_024f: ldloc.s 12
+		IL_0251: ldstr "split"
+		IL_0256: ldstr "\\"
+		IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0260: stloc.s 12
+		IL_0262: ldloc.s 12
+		IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0269: stloc.s 12
+		IL_026b: ldloc.s 12
+		IL_026d: ldstr "join"
+		IL_0272: ldstr "/"
+		IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_027c: stloc.s 12
-		IL_027e: ldloc.s 6
-		IL_0280: ldstr "URL"
-		IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028a: stloc.s 11
-		IL_028c: ldnull
-		IL_028d: ldloc.s 5
-		IL_028f: ldstr "importedUrl"
-		IL_0294: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0299: stloc.s 13
-		IL_029b: ldc.i4.2
-		IL_029c: newarr [System.Runtime]System.Object
-		IL_02a1: dup
-		IL_02a2: ldc.i4.0
-		IL_02a3: ldstr "./fixtures/lib.txt"
-		IL_02a8: stelem.ref
-		IL_02a9: dup
-		IL_02aa: ldc.i4.1
-		IL_02ab: ldloc.s 13
-		IL_02ad: stelem.ref
-		IL_02ae: stloc.s 14
-		IL_02b0: ldloc.s 11
-		IL_02b2: ldloc.s 14
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-		IL_02b9: stloc.s 11
-		IL_02bb: ldloc.s 12
-		IL_02bd: ldstr "fileURLToPath"
-		IL_02c2: ldloc.s 11
-		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02c9: stloc.s 11
-		IL_02cb: ldloc.s 11
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d2: stloc.s 11
-		IL_02d4: ldloc.s 11
-		IL_02d6: ldstr "split"
-		IL_02db: ldstr "\\"
-		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02e5: stloc.s 11
-		IL_02e7: ldloc.s 11
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ee: stloc.s 11
-		IL_02f0: ldloc.s 11
-		IL_02f2: ldstr "join"
-		IL_02f7: ldstr "/"
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0301: stloc.s 11
-		IL_0303: ldloc.s 11
-		IL_0305: stloc.s 10
-		IL_0307: ldarg.3
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_030d: stloc.s 11
-		IL_030f: ldloc.s 11
-		IL_0311: ldstr "url"
-		IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031b: stloc.s 11
-		IL_031d: ldloc.s 11
-		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0324: stloc.s 11
-		IL_0326: ldloc.s 11
-		IL_0328: ldstr "startsWith"
-		IL_032d: ldstr "file://"
-		IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0337: stloc.s 11
-		IL_0339: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_033e: ldstr "main has file url:"
-		IL_0343: ldloc.s 11
-		IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_034a: pop
-		IL_034b: ldarg.3
-		IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0351: stloc.s 11
-		IL_0353: ldloc.s 11
-		IL_0355: ldstr "split"
-		IL_035a: ldstr "\\"
-		IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0364: stloc.s 11
-		IL_0366: ldloc.s 11
-		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_036d: stloc.s 11
-		IL_036f: ldloc.s 11
-		IL_0371: ldstr "join"
-		IL_0376: ldstr "/"
-		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0380: stloc.s 11
-		IL_0382: ldloc.s 7
-		IL_0384: ldloc.s 11
-		IL_0386: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_038b: stloc.s 15
-		IL_038d: ldloc.s 15
-		IL_038f: box [System.Runtime]System.Boolean
-		IL_0394: stloc.s 16
-		IL_0396: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_039b: ldstr "main path matches filename:"
-		IL_03a0: ldloc.s 16
-		IL_03a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03a7: pop
-		IL_03a8: ldloc.s 8
-		IL_03aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03af: stloc.s 11
-		IL_03b1: ldloc.s 11
-		IL_03b3: ldstr "endsWith"
-		IL_03b8: ldstr "/fixtures/main.txt"
-		IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03c2: stloc.s 11
-		IL_03c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c9: ldstr "main asset path:"
-		IL_03ce: ldloc.s 11
-		IL_03d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03d5: pop
-		IL_03d6: ldnull
-		IL_03d7: ldloc.s 5
-		IL_03d9: ldstr "importedUrlHasFileScheme"
-		IL_03de: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_03e3: stloc.s 11
-		IL_03e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03ea: ldstr "lib has file url:"
-		IL_03ef: ldloc.s 11
-		IL_03f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03f6: pop
-		IL_03f7: ldloc.s 9
-		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03fe: stloc.s 11
-		IL_0400: ldloc.s 11
-		IL_0402: ldstr "endsWith"
-		IL_0407: ldstr "/Import_ImportMeta_Url_Lib"
-		IL_040c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0411: stloc.s 11
-		IL_0413: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0418: ldstr "lib path:"
-		IL_041d: ldloc.s 11
-		IL_041f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0424: pop
-		IL_0425: ldloc.s 10
-		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_042c: stloc.s 11
-		IL_042e: ldloc.s 11
-		IL_0430: ldstr "endsWith"
-		IL_0435: ldstr "/fixtures/lib.txt"
-		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_043f: stloc.s 11
-		IL_0441: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0446: ldstr "lib asset path:"
-		IL_044b: ldloc.s 11
-		IL_044d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0452: pop
-		IL_0453: ldnull
-		IL_0454: ldloc.s 5
-		IL_0456: ldstr "importedModuleFilenameMatches"
-		IL_045b: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0460: stloc.s 11
-		IL_0462: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0467: ldstr "lib module.filename:"
-		IL_046c: ldloc.s 11
-		IL_046e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0473: pop
-		IL_0474: ldnull
-		IL_0475: ldloc.s 5
-		IL_0477: ldstr "importedModulePathMatches"
-		IL_047c: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0481: stloc.s 11
-		IL_0483: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0488: ldstr "lib module.path:"
-		IL_048d: ldloc.s 11
-		IL_048f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0494: pop
-		IL_0495: ret
+		IL_027e: ldloc.s 12
+		IL_0280: stloc.s 9
+		IL_0282: ldloc.s 6
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0289: stloc.s 12
+		IL_028b: ldloc.s 6
+		IL_028d: ldstr "URL"
+		IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0297: stloc.s 11
+		IL_0299: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_029e: stloc.s 14
+		IL_02a0: ldloc.2
+		IL_02a1: ldloc.s 14
+		IL_02a3: ldloc.s 5
+		IL_02a5: ldstr "importedUrl"
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02af: stloc.s 13
+		IL_02b1: ldc.i4.2
+		IL_02b2: newarr [System.Runtime]System.Object
+		IL_02b7: dup
+		IL_02b8: ldc.i4.0
+		IL_02b9: ldstr "./fixtures/lib.txt"
+		IL_02be: stelem.ref
+		IL_02bf: dup
+		IL_02c0: ldc.i4.1
+		IL_02c1: ldloc.s 13
+		IL_02c3: stelem.ref
+		IL_02c4: stloc.s 14
+		IL_02c6: ldloc.s 11
+		IL_02c8: ldloc.s 14
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+		IL_02cf: stloc.s 11
+		IL_02d1: ldloc.s 12
+		IL_02d3: ldstr "fileURLToPath"
+		IL_02d8: ldloc.s 11
+		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02df: stloc.s 11
+		IL_02e1: ldloc.s 11
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02e8: stloc.s 11
+		IL_02ea: ldloc.s 11
+		IL_02ec: ldstr "split"
+		IL_02f1: ldstr "\\"
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02fb: stloc.s 11
+		IL_02fd: ldloc.s 11
+		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0304: stloc.s 11
+		IL_0306: ldloc.s 11
+		IL_0308: ldstr "join"
+		IL_030d: ldstr "/"
+		IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0317: stloc.s 11
+		IL_0319: ldloc.s 11
+		IL_031b: stloc.s 10
+		IL_031d: ldarg.3
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0323: stloc.s 11
+		IL_0325: ldloc.s 11
+		IL_0327: ldstr "url"
+		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0331: stloc.s 11
+		IL_0333: ldloc.s 11
+		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_033a: stloc.s 11
+		IL_033c: ldloc.s 11
+		IL_033e: ldstr "startsWith"
+		IL_0343: ldstr "file://"
+		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_034d: stloc.s 11
+		IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0354: ldstr "main has file url:"
+		IL_0359: ldloc.s 11
+		IL_035b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0360: pop
+		IL_0361: ldarg.3
+		IL_0362: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0367: stloc.s 11
+		IL_0369: ldloc.s 11
+		IL_036b: ldstr "split"
+		IL_0370: ldstr "\\"
+		IL_0375: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_037a: stloc.s 11
+		IL_037c: ldloc.s 11
+		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0383: stloc.s 11
+		IL_0385: ldloc.s 11
+		IL_0387: ldstr "join"
+		IL_038c: ldstr "/"
+		IL_0391: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0396: stloc.s 11
+		IL_0398: ldloc.s 7
+		IL_039a: ldloc.s 11
+		IL_039c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_03a1: stloc.s 15
+		IL_03a3: ldloc.s 15
+		IL_03a5: box [System.Runtime]System.Boolean
+		IL_03aa: stloc.s 16
+		IL_03ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03b1: ldstr "main path matches filename:"
+		IL_03b6: ldloc.s 16
+		IL_03b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03bd: pop
+		IL_03be: ldloc.s 8
+		IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03c5: stloc.s 11
+		IL_03c7: ldloc.s 11
+		IL_03c9: ldstr "endsWith"
+		IL_03ce: ldstr "/fixtures/main.txt"
+		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03d8: stloc.s 11
+		IL_03da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03df: ldstr "main asset path:"
+		IL_03e4: ldloc.s 11
+		IL_03e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03eb: pop
+		IL_03ec: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03f1: stloc.s 14
+		IL_03f3: ldloc.2
+		IL_03f4: ldloc.s 14
+		IL_03f6: ldloc.s 5
+		IL_03f8: ldstr "importedUrlHasFileScheme"
+		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0402: stloc.s 11
+		IL_0404: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0409: ldstr "lib has file url:"
+		IL_040e: ldloc.s 11
+		IL_0410: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0415: pop
+		IL_0416: ldloc.s 9
+		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_041d: stloc.s 11
+		IL_041f: ldloc.s 11
+		IL_0421: ldstr "endsWith"
+		IL_0426: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0430: stloc.s 11
+		IL_0432: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0437: ldstr "lib path:"
+		IL_043c: ldloc.s 11
+		IL_043e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0443: pop
+		IL_0444: ldloc.s 10
+		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_044b: stloc.s 11
+		IL_044d: ldloc.s 11
+		IL_044f: ldstr "endsWith"
+		IL_0454: ldstr "/fixtures/lib.txt"
+		IL_0459: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_045e: stloc.s 11
+		IL_0460: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0465: ldstr "lib asset path:"
+		IL_046a: ldloc.s 11
+		IL_046c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0471: pop
+		IL_0472: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0477: stloc.s 14
+		IL_0479: ldloc.2
+		IL_047a: ldloc.s 14
+		IL_047c: ldloc.s 5
+		IL_047e: ldstr "importedModuleFilenameMatches"
+		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0488: stloc.s 11
+		IL_048a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_048f: ldstr "lib module.filename:"
+		IL_0494: ldloc.s 11
+		IL_0496: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_049b: pop
+		IL_049c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04a1: stloc.s 14
+		IL_04a3: ldloc.2
+		IL_04a4: ldloc.s 14
+		IL_04a6: ldloc.s 5
+		IL_04a8: ldstr "importedModulePathMatches"
+		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04b2: stloc.s 11
+		IL_04b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04b9: ldstr "lib module.path:"
+		IL_04be: ldloc.s 11
+		IL_04c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_04c5: pop
+		IL_04c6: ret
 	} // end of method Import_ImportMeta_Url::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url
@@ -1832,7 +1852,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x383a
+				// Method begins at RVA 0x388e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1858,7 +1878,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2f6c
+			// Method begins at RVA 0x2fb8
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1888,7 +1908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3843
+				// Method begins at RVA 0x3897
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1914,7 +1934,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2f8c
+			// Method begins at RVA 0x2fd8
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1944,7 +1964,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x384c
+				// Method begins at RVA 0x38a0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1970,7 +1990,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2fac
+			// Method begins at RVA 0x2ff8
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2000,7 +2020,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3855
+				// Method begins at RVA 0x38a9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2026,7 +2046,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2fcc
+			// Method begins at RVA 0x3018
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -2060,7 +2080,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3867
+					// Method begins at RVA 0x38bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2078,7 +2098,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x385e
+				// Method begins at RVA 0x38b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2104,7 +2124,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x2fec
+			// Method begins at RVA 0x3038
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -2179,7 +2199,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3870
+				// Method begins at RVA 0x38c4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2203,7 +2223,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3084
+			// Method begins at RVA 0x30d0
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -2277,7 +2297,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3879
+				// Method begins at RVA 0x38cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2302,7 +2322,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3109
+			// Method begins at RVA 0x3155
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2330,7 +2350,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38a6
+					// Method begins at RVA 0x38fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2354,7 +2374,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3683
+				// Method begins at RVA 0x36d8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2380,7 +2400,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38af
+					// Method begins at RVA 0x3903
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2404,7 +2424,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3692
+				// Method begins at RVA 0x36e7
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2434,7 +2454,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x38dc
+						// Method begins at RVA 0x3930
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2458,7 +2478,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3739
+					// Method begins at RVA 0x378d
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2492,7 +2512,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38d3
+					// Method begins at RVA 0x3927
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2517,7 +2537,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36a4
+				// Method begins at RVA 0x36f8
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2610,7 +2630,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x388b
+					// Method begins at RVA 0x38df
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2630,7 +2650,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3894
+					// Method begins at RVA 0x38e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2650,7 +2670,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x389d
+					// Method begins at RVA 0x38f1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2674,7 +2694,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x38c1
+						// Method begins at RVA 0x3915
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2694,7 +2714,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x38ca
+						// Method begins at RVA 0x391e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2712,7 +2732,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38b8
+					// Method begins at RVA 0x390c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2732,7 +2752,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38e5
+					// Method begins at RVA 0x3939
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2752,7 +2772,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x38ee
+					// Method begins at RVA 0x3942
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2774,7 +2794,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3882
+				// Method begins at RVA 0x38d6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2801,7 +2821,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3114
+			// Method begins at RVA 0x3160
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3326,7 +3346,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x38f7
+				// Method begins at RVA 0x394b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3354,41 +3374,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2d 00 00 02
 			)
-			// Method begins at RVA 0x3630
+			// Method begins at RVA 0x367c
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3429,7 +3454,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3805
+			// Method begins at RVA 0x3859
 			// Header size: 1
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -3465,9 +3490,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x24f4
+		// Method begins at RVA 0x2524
 		// Header size: 12
-		// Code size: 761 (0x2f9)
+		// Code size: 781 (0x30d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url_Lib/Scope,
@@ -3476,9 +3501,10 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] bool,
-			[7] object,
-			[8] object
+			[6] object[],
+			[7] bool,
+			[8] object,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_ImportMeta_Url_Lib/Scope::.ctor()
@@ -3572,193 +3598,197 @@
 		IL_00da: ldloc.s 5
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldc.i4.1
-		IL_00ec: newarr [System.Runtime]System.Object
-		IL_00f1: dup
-		IL_00f2: ldc.i4.0
-		IL_00f3: ldloc.0
-		IL_00f4: stelem.ref
-		IL_00f5: ldc.i4.0
-		IL_00f6: ldelem.ref
-		IL_00f7: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_00fc: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0102: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0107: ldc.i4.0
-		IL_0108: conv.r8
-		IL_0109: ldstr ""
-		IL_010e: ldc.i4.0
-		IL_010f: ldc.i4.1
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0115: stloc.s 5
-		IL_0117: ldloc.0
-		IL_0118: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_011d: ldnull
-		IL_011e: ldstr "importedUrl"
-		IL_0123: ldloc.s 5
-		IL_0125: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_012a: pop
-		IL_012b: ldc.i4.1
-		IL_012c: newarr [System.Runtime]System.Object
-		IL_0131: dup
-		IL_0132: ldc.i4.0
-		IL_0133: ldloc.0
-		IL_0134: stelem.ref
-		IL_0135: ldc.i4.0
-		IL_0136: ldelem.ref
-		IL_0137: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_013c: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0147: ldc.i4.0
-		IL_0148: conv.r8
-		IL_0149: ldstr ""
-		IL_014e: ldc.i4.0
-		IL_014f: ldc.i4.1
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0155: stloc.s 5
-		IL_0157: ldloc.0
-		IL_0158: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_015d: ldnull
-		IL_015e: ldstr "importedUrlHasFileScheme"
-		IL_0163: ldloc.s 5
-		IL_0165: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_016a: pop
-		IL_016b: ldc.i4.1
-		IL_016c: newarr [System.Runtime]System.Object
-		IL_0171: dup
-		IL_0172: ldc.i4.0
-		IL_0173: ldloc.0
-		IL_0174: stelem.ref
-		IL_0175: ldc.i4.0
-		IL_0176: ldelem.ref
-		IL_0177: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_017c: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0182: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0187: ldc.i4.0
-		IL_0188: conv.r8
-		IL_0189: ldstr ""
-		IL_018e: ldc.i4.0
-		IL_018f: ldc.i4.1
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0195: stloc.s 5
-		IL_0197: ldloc.0
-		IL_0198: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_019d: ldnull
-		IL_019e: ldstr "importedModuleFilenameMatches"
-		IL_01a3: ldloc.s 5
-		IL_01a5: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_01aa: pop
-		IL_01ab: ldc.i4.1
-		IL_01ac: newarr [System.Runtime]System.Object
-		IL_01b1: dup
-		IL_01b2: ldc.i4.0
-		IL_01b3: ldloc.0
-		IL_01b4: stelem.ref
-		IL_01b5: ldc.i4.0
-		IL_01b6: ldelem.ref
-		IL_01b7: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_01bc: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_01c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01c7: ldc.i4.0
-		IL_01c8: conv.r8
-		IL_01c9: ldstr ""
-		IL_01ce: ldc.i4.0
-		IL_01cf: ldc.i4.1
-		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01d5: stloc.s 5
-		IL_01d7: ldloc.0
-		IL_01d8: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_01dd: ldnull
-		IL_01de: ldstr "importedModulePathMatches"
-		IL_01e3: ldloc.s 5
-		IL_01e5: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object, object)
-		IL_01ea: pop
-		IL_01eb: ldarg.3
-		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_01f1: stloc.s 5
-		IL_01f3: ldloc.s 5
-		IL_01f5: ldstr "url"
-		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01ff: stloc.s 5
-		IL_0201: ldloc.0
-		IL_0202: ldloc.s 5
-		IL_0204: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
-		IL_0209: ldloc.0
-		IL_020a: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
-		IL_020f: ldstr "Cannot access 'importedUrl' before initialization"
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0219: stloc.s 5
-		IL_021b: ldloc.s 5
-		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0222: stloc.s 5
-		IL_0224: ldloc.s 5
-		IL_0226: ldstr "startsWith"
-		IL_022b: ldstr "file://"
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0235: stloc.s 5
-		IL_0237: ldloc.0
+		IL_00df: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00f4: stloc.s 6
+		IL_00f6: ldc.i4.1
+		IL_00f7: newarr [System.Runtime]System.Object
+		IL_00fc: dup
+		IL_00fd: ldc.i4.0
+		IL_00fe: ldloc.0
+		IL_00ff: stelem.ref
+		IL_0100: ldc.i4.0
+		IL_0101: ldelem.ref
+		IL_0102: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_0107: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_010d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0112: ldc.i4.0
+		IL_0113: conv.r8
+		IL_0114: ldstr ""
+		IL_0119: ldc.i4.0
+		IL_011a: ldc.i4.1
+		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0120: stloc.s 5
+		IL_0122: ldloc.s 4
+		IL_0124: ldloc.s 6
+		IL_0126: ldstr "importedUrl"
+		IL_012b: ldloc.s 5
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0132: pop
+		IL_0133: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0138: stloc.s 6
+		IL_013a: ldc.i4.1
+		IL_013b: newarr [System.Runtime]System.Object
+		IL_0140: dup
+		IL_0141: ldc.i4.0
+		IL_0142: ldloc.0
+		IL_0143: stelem.ref
+		IL_0144: ldc.i4.0
+		IL_0145: ldelem.ref
+		IL_0146: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_014b: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_0151: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0156: ldc.i4.0
+		IL_0157: conv.r8
+		IL_0158: ldstr ""
+		IL_015d: ldc.i4.0
+		IL_015e: ldc.i4.1
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0164: stloc.s 5
+		IL_0166: ldloc.s 4
+		IL_0168: ldloc.s 6
+		IL_016a: ldstr "importedUrlHasFileScheme"
+		IL_016f: ldloc.s 5
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0176: pop
+		IL_0177: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017c: stloc.s 6
+		IL_017e: ldc.i4.1
+		IL_017f: newarr [System.Runtime]System.Object
+		IL_0184: dup
+		IL_0185: ldc.i4.0
+		IL_0186: ldloc.0
+		IL_0187: stelem.ref
+		IL_0188: ldc.i4.0
+		IL_0189: ldelem.ref
+		IL_018a: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_018f: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_019a: ldc.i4.0
+		IL_019b: conv.r8
+		IL_019c: ldstr ""
+		IL_01a1: ldc.i4.0
+		IL_01a2: ldc.i4.1
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01a8: stloc.s 5
+		IL_01aa: ldloc.s 4
+		IL_01ac: ldloc.s 6
+		IL_01ae: ldstr "importedModuleFilenameMatches"
+		IL_01b3: ldloc.s 5
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01ba: pop
+		IL_01bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01c0: stloc.s 6
+		IL_01c2: ldc.i4.1
+		IL_01c3: newarr [System.Runtime]System.Object
+		IL_01c8: dup
+		IL_01c9: ldc.i4.0
+		IL_01ca: ldloc.0
+		IL_01cb: stelem.ref
+		IL_01cc: ldc.i4.0
+		IL_01cd: ldelem.ref
+		IL_01ce: castclass Modules.Import_ImportMeta_Url_Lib/Scope
+		IL_01d3: ldftn object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+		IL_01d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01de: ldc.i4.0
+		IL_01df: conv.r8
+		IL_01e0: ldstr ""
+		IL_01e5: ldc.i4.0
+		IL_01e6: ldc.i4.1
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01ec: stloc.s 5
+		IL_01ee: ldloc.s 4
+		IL_01f0: ldloc.s 6
+		IL_01f2: ldstr "importedModulePathMatches"
+		IL_01f7: ldloc.s 5
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01fe: pop
+		IL_01ff: ldarg.3
+		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0205: stloc.s 5
+		IL_0207: ldloc.s 5
+		IL_0209: ldstr "url"
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0213: stloc.s 5
+		IL_0215: ldloc.0
+		IL_0216: ldloc.s 5
+		IL_0218: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
+		IL_021d: ldloc.0
+		IL_021e: ldfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrl
+		IL_0223: ldstr "Cannot access 'importedUrl' before initialization"
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_022d: stloc.s 5
+		IL_022f: ldloc.s 5
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0236: stloc.s 5
 		IL_0238: ldloc.s 5
-		IL_023a: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrlHasFileScheme
-		IL_023f: ldarg.2
-		IL_0240: ldstr "filename"
-		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_024a: ldarg.3
-		IL_024b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0250: stloc.s 6
-		IL_0252: ldloc.s 6
-		IL_0254: box [System.Runtime]System.Boolean
-		IL_0259: stloc.s 7
-		IL_025b: ldloc.0
-		IL_025c: ldloc.s 7
-		IL_025e: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModuleFilenameMatches
-		IL_0263: ldarg.2
-		IL_0264: ldstr "path"
-		IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0273: stloc.s 5
-		IL_0275: ldloc.s 5
-		IL_0277: ldstr "split"
-		IL_027c: ldstr "\\"
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0286: stloc.s 5
-		IL_0288: ldloc.s 5
-		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_028f: stloc.s 5
-		IL_0291: ldloc.s 5
-		IL_0293: ldstr "join"
-		IL_0298: ldstr "/"
-		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02a2: stloc.s 5
-		IL_02a4: ldarg.s __dirname
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02ab: stloc.s 8
-		IL_02ad: ldloc.s 8
-		IL_02af: ldstr "split"
-		IL_02b4: ldstr "\\"
-		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02be: stloc.s 8
-		IL_02c0: ldloc.s 8
-		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02c7: stloc.s 8
-		IL_02c9: ldloc.s 8
-		IL_02cb: ldstr "join"
-		IL_02d0: ldstr "/"
-		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02da: stloc.s 8
-		IL_02dc: ldloc.s 5
-		IL_02de: ldloc.s 8
-		IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02e5: stloc.s 6
-		IL_02e7: ldloc.s 6
-		IL_02e9: box [System.Runtime]System.Boolean
-		IL_02ee: stloc.s 7
-		IL_02f0: ldloc.0
-		IL_02f1: ldloc.s 7
-		IL_02f3: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModulePathMatches
-		IL_02f8: ret
+		IL_023a: ldstr "startsWith"
+		IL_023f: ldstr "file://"
+		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0249: stloc.s 5
+		IL_024b: ldloc.0
+		IL_024c: ldloc.s 5
+		IL_024e: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedUrlHasFileScheme
+		IL_0253: ldarg.2
+		IL_0254: ldstr "filename"
+		IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_025e: ldarg.3
+		IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0264: stloc.s 7
+		IL_0266: ldloc.s 7
+		IL_0268: box [System.Runtime]System.Boolean
+		IL_026d: stloc.s 8
+		IL_026f: ldloc.0
+		IL_0270: ldloc.s 8
+		IL_0272: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModuleFilenameMatches
+		IL_0277: ldarg.2
+		IL_0278: ldstr "path"
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0287: stloc.s 5
+		IL_0289: ldloc.s 5
+		IL_028b: ldstr "split"
+		IL_0290: ldstr "\\"
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_029a: stloc.s 5
+		IL_029c: ldloc.s 5
+		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02a3: stloc.s 5
+		IL_02a5: ldloc.s 5
+		IL_02a7: ldstr "join"
+		IL_02ac: ldstr "/"
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02b6: stloc.s 5
+		IL_02b8: ldarg.s __dirname
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02bf: stloc.s 9
+		IL_02c1: ldloc.s 9
+		IL_02c3: ldstr "split"
+		IL_02c8: ldstr "\\"
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02d2: stloc.s 9
+		IL_02d4: ldloc.s 9
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02db: stloc.s 9
+		IL_02dd: ldloc.s 9
+		IL_02df: ldstr "join"
+		IL_02e4: ldstr "/"
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_02ee: stloc.s 9
+		IL_02f0: ldloc.s 5
+		IL_02f2: ldloc.s 9
+		IL_02f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02f9: stloc.s 7
+		IL_02fb: ldloc.s 7
+		IL_02fd: box [System.Runtime]System.Boolean
+		IL_0302: stloc.s 8
+		IL_0304: ldloc.0
+		IL_0305: ldloc.s 8
+		IL_0307: stfld object Modules.Import_ImportMeta_Url_Lib/Scope::importedModulePathMatches
+		IL_030c: ret
 	} // end of method Import_ImportMeta_Url_Lib::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url_Lib
@@ -3770,7 +3800,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3900
+		// Method begins at RVA 0x3954
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f50
+					// Method begins at RVA 0x3fdc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f47
+				// Method begins at RVA 0x3fd3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x27c0
+			// Method begins at RVA 0x2834
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f59
+				// Method begins at RVA 0x3fe5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2858
+			// Method begins at RVA 0x28cc
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f62
+				// Method begins at RVA 0x3fee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x28dd
+			// Method begins at RVA 0x2951
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f8f
+					// Method begins at RVA 0x401b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e57
+				// Method begins at RVA 0x2ed4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f98
+					// Method begins at RVA 0x4024
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e66
+				// Method begins at RVA 0x2ee3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3fc5
+						// Method begins at RVA 0x4051
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f0d
+					// Method begins at RVA 0x2f89
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fbc
+					// Method begins at RVA 0x4048
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2e78
+				// Method begins at RVA 0x2ef4
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f74
+					// Method begins at RVA 0x4000
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f7d
+					// Method begins at RVA 0x4009
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3f86
+					// Method begins at RVA 0x4012
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3faa
+						// Method begins at RVA 0x4036
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3fb3
+						// Method begins at RVA 0x403f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fa1
+					// Method begins at RVA 0x402d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fce
+					// Method begins at RVA 0x405a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3fd7
+					// Method begins at RVA 0x4063
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3f6b
+				// Method begins at RVA 0x3ff7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x28e8
+			// Method begins at RVA 0x295c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3fe0
+				// Method begins at RVA 0x406c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
-			// Method begins at RVA 0x2e04
+			// Method begins at RVA 0x2e78
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_LiveBindings_Cycle/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Cycle/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3f3e
+			// Method begins at RVA 0x3fca
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 706 (0x2c2)
+		// Code size: 800 (0x320)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle/Scope,
@@ -1505,161 +1510,191 @@
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_LiveBindings_Cycle_A.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 7
-		IL_00f8: ldloc.s 7
-		IL_00fa: stloc.s 5
-		IL_00fc: ldarg.1
-		IL_00fd: ldstr "./Import_LiveBindings_Cycle_B.mjs"
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0107: stloc.s 7
-		IL_0109: ldloc.s 7
-		IL_010b: stloc.s 6
-		IL_010d: ldnull
-		IL_010e: ldloc.s 5
-		IL_0110: ldstr "a"
-		IL_0115: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_011a: stloc.s 7
-		IL_011c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0121: ldstr "a0:"
-		IL_0126: ldloc.s 7
-		IL_0128: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_012d: pop
-		IL_012e: ldnull
-		IL_012f: ldloc.s 6
-		IL_0131: ldstr "b"
-		IL_0136: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_013b: stloc.s 7
-		IL_013d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0142: ldstr "b0:"
-		IL_0147: ldloc.s 7
-		IL_0149: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_014e: pop
-		IL_014f: ldnull
-		IL_0150: ldloc.s 5
-		IL_0152: ldstr "getBFromA"
-		IL_0157: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_015c: stloc.s 7
-		IL_015e: ldc.i4.0
-		IL_015f: newarr [System.Runtime]System.Object
-		IL_0164: stloc.s 8
-		IL_0166: ldloc.s 7
-		IL_0168: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00df: ldfld object Modules.Import_LiveBindings_Cycle/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_LiveBindings_Cycle_A.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 7
+		IL_00fc: ldloc.s 7
+		IL_00fe: stloc.s 5
+		IL_0100: ldarg.1
+		IL_0101: ldstr "./Import_LiveBindings_Cycle_B.mjs"
+		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_010b: stloc.s 7
+		IL_010d: ldloc.s 7
+		IL_010f: stloc.s 6
+		IL_0111: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0116: stloc.s 8
+		IL_0118: ldloc.2
+		IL_0119: ldloc.s 8
+		IL_011b: ldloc.s 5
+		IL_011d: ldstr "a"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0127: stloc.s 7
+		IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012e: ldstr "a0:"
+		IL_0133: ldloc.s 7
+		IL_0135: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_013a: pop
+		IL_013b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0140: stloc.s 8
+		IL_0142: ldloc.2
+		IL_0143: ldloc.s 8
+		IL_0145: ldloc.s 6
+		IL_0147: ldstr "b"
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0151: stloc.s 7
+		IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0158: ldstr "b0:"
+		IL_015d: ldloc.s 7
+		IL_015f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0164: pop
+		IL_0165: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_016a: stloc.s 8
+		IL_016c: ldloc.2
 		IL_016d: ldloc.s 8
-		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0174: stloc.s 7
-		IL_0176: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017b: ldstr "a->b:"
-		IL_0180: ldloc.s 7
-		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0187: pop
-		IL_0188: ldnull
-		IL_0189: ldloc.s 6
-		IL_018b: ldstr "getAFromB"
-		IL_0190: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0195: stloc.s 7
-		IL_0197: ldc.i4.0
-		IL_0198: newarr [System.Runtime]System.Object
-		IL_019d: stloc.s 8
+		IL_016f: ldloc.s 5
+		IL_0171: ldstr "getBFromA"
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_017b: stloc.s 7
+		IL_017d: ldc.i4.0
+		IL_017e: newarr [System.Runtime]System.Object
+		IL_0183: stloc.s 8
+		IL_0185: ldloc.s 7
+		IL_0187: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_018c: ldloc.s 8
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0193: stloc.s 7
+		IL_0195: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019a: ldstr "a->b:"
 		IL_019f: ldloc.s 7
-		IL_01a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01a6: ldloc.s 8
-		IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_01ad: stloc.s 7
-		IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01b4: ldstr "b->a:"
-		IL_01b9: ldloc.s 7
-		IL_01bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01c0: pop
-		IL_01c1: ldnull
-		IL_01c2: ldloc.s 5
-		IL_01c4: ldstr "incA"
-		IL_01c9: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01ce: stloc.s 7
-		IL_01d0: ldc.i4.0
-		IL_01d1: newarr [System.Runtime]System.Object
-		IL_01d6: stloc.s 8
-		IL_01d8: ldloc.s 7
-		IL_01da: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01df: ldloc.s 8
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_01e6: pop
-		IL_01e7: ldnull
-		IL_01e8: ldloc.s 6
-		IL_01ea: ldstr "incB"
-		IL_01ef: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01f4: stloc.s 7
-		IL_01f6: ldc.i4.0
-		IL_01f7: newarr [System.Runtime]System.Object
-		IL_01fc: stloc.s 8
-		IL_01fe: ldloc.s 7
-		IL_0200: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0205: ldloc.s 8
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_020c: pop
-		IL_020d: ldnull
-		IL_020e: ldloc.s 5
-		IL_0210: ldstr "a"
-		IL_0215: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_021a: stloc.s 7
-		IL_021c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0221: ldstr "a1:"
-		IL_0226: ldloc.s 7
-		IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_022d: pop
-		IL_022e: ldnull
-		IL_022f: ldloc.s 6
-		IL_0231: ldstr "b"
-		IL_0236: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_023b: stloc.s 7
-		IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0242: ldstr "b1:"
-		IL_0247: ldloc.s 7
-		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_024e: pop
-		IL_024f: ldnull
-		IL_0250: ldloc.s 5
-		IL_0252: ldstr "getBFromA"
-		IL_0257: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_025c: stloc.s 7
-		IL_025e: ldc.i4.0
-		IL_025f: newarr [System.Runtime]System.Object
-		IL_0264: stloc.s 8
-		IL_0266: ldloc.s 7
-		IL_0268: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_026d: ldloc.s 8
-		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0274: stloc.s 7
-		IL_0276: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027b: ldstr "a->b1:"
-		IL_0280: ldloc.s 7
-		IL_0282: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0287: pop
-		IL_0288: ldnull
-		IL_0289: ldloc.s 6
-		IL_028b: ldstr "getAFromB"
-		IL_0290: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0295: stloc.s 7
-		IL_0297: ldc.i4.0
-		IL_0298: newarr [System.Runtime]System.Object
-		IL_029d: stloc.s 8
-		IL_029f: ldloc.s 7
-		IL_02a1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02a6: ldloc.s 8
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_02ad: stloc.s 7
-		IL_02af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b4: ldstr "b->a1:"
-		IL_02b9: ldloc.s 7
-		IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02c0: pop
-		IL_02c1: ret
+		IL_01a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01a6: pop
+		IL_01a7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01ac: stloc.s 8
+		IL_01ae: ldloc.2
+		IL_01af: ldloc.s 8
+		IL_01b1: ldloc.s 6
+		IL_01b3: ldstr "getAFromB"
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01bd: stloc.s 7
+		IL_01bf: ldc.i4.0
+		IL_01c0: newarr [System.Runtime]System.Object
+		IL_01c5: stloc.s 8
+		IL_01c7: ldloc.s 7
+		IL_01c9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01ce: ldloc.s 8
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_01d5: stloc.s 7
+		IL_01d7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01dc: ldstr "b->a:"
+		IL_01e1: ldloc.s 7
+		IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01e8: pop
+		IL_01e9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01ee: stloc.s 8
+		IL_01f0: ldloc.2
+		IL_01f1: ldloc.s 8
+		IL_01f3: ldloc.s 5
+		IL_01f5: ldstr "incA"
+		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01ff: stloc.s 7
+		IL_0201: ldc.i4.0
+		IL_0202: newarr [System.Runtime]System.Object
+		IL_0207: stloc.s 8
+		IL_0209: ldloc.s 7
+		IL_020b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0210: ldloc.s 8
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0217: pop
+		IL_0218: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_021d: stloc.s 8
+		IL_021f: ldloc.2
+		IL_0220: ldloc.s 8
+		IL_0222: ldloc.s 6
+		IL_0224: ldstr "incB"
+		IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_022e: stloc.s 7
+		IL_0230: ldc.i4.0
+		IL_0231: newarr [System.Runtime]System.Object
+		IL_0236: stloc.s 8
+		IL_0238: ldloc.s 7
+		IL_023a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_023f: ldloc.s 8
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0246: pop
+		IL_0247: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_024c: stloc.s 8
+		IL_024e: ldloc.2
+		IL_024f: ldloc.s 8
+		IL_0251: ldloc.s 5
+		IL_0253: ldstr "a"
+		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_025d: stloc.s 7
+		IL_025f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0264: ldstr "a1:"
+		IL_0269: ldloc.s 7
+		IL_026b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0270: pop
+		IL_0271: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0276: stloc.s 8
+		IL_0278: ldloc.2
+		IL_0279: ldloc.s 8
+		IL_027b: ldloc.s 6
+		IL_027d: ldstr "b"
+		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0287: stloc.s 7
+		IL_0289: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_028e: ldstr "b1:"
+		IL_0293: ldloc.s 7
+		IL_0295: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_029a: pop
+		IL_029b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02a0: stloc.s 8
+		IL_02a2: ldloc.2
+		IL_02a3: ldloc.s 8
+		IL_02a5: ldloc.s 5
+		IL_02a7: ldstr "getBFromA"
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02b1: stloc.s 7
+		IL_02b3: ldc.i4.0
+		IL_02b4: newarr [System.Runtime]System.Object
+		IL_02b9: stloc.s 8
+		IL_02bb: ldloc.s 7
+		IL_02bd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02c2: ldloc.s 8
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_02c9: stloc.s 7
+		IL_02cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d0: ldstr "a->b1:"
+		IL_02d5: ldloc.s 7
+		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02dc: pop
+		IL_02dd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02e2: stloc.s 8
+		IL_02e4: ldloc.2
+		IL_02e5: ldloc.s 8
+		IL_02e7: ldloc.s 6
+		IL_02e9: ldstr "getAFromB"
+		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02f3: stloc.s 7
+		IL_02f5: ldc.i4.0
+		IL_02f6: newarr [System.Runtime]System.Object
+		IL_02fb: stloc.s 8
+		IL_02fd: ldloc.s 7
+		IL_02ff: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0304: ldloc.s 8
+		IL_0306: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_030b: stloc.s 7
+		IL_030d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0312: ldstr "b->a1:"
+		IL_0317: ldloc.s 7
+		IL_0319: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_031e: pop
+		IL_031f: ret
 	} // end of method Import_LiveBindings_Cycle::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Cycle
@@ -1679,7 +1714,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ffd
+				// Method begins at RVA 0x4089
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1705,7 +1740,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x2f30
+			// Method begins at RVA 0x2fac
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1735,7 +1770,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4006
+				// Method begins at RVA 0x4092
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1761,7 +1796,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x2f4f
+			// Method begins at RVA 0x2fcb
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1784,7 +1819,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x400f
+				// Method begins at RVA 0x409b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1810,7 +1845,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x2f57
+			// Method begins at RVA 0x2fd3
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1833,7 +1868,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4018
+				// Method begins at RVA 0x40a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1859,7 +1894,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x2f60
+			// Method begins at RVA 0x2fdc
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1897,7 +1932,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4021
+				// Method begins at RVA 0x40ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1923,7 +1958,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x2f98
+			// Method begins at RVA 0x3014
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -1970,7 +2005,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4033
+					// Method begins at RVA 0x40bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1988,7 +2023,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x402a
+				// Method begins at RVA 0x40b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2014,7 +2049,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x2fc8
+			// Method begins at RVA 0x3044
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -2089,7 +2124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x403c
+				// Method begins at RVA 0x40c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2113,7 +2148,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3060
+			// Method begins at RVA 0x30dc
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -2187,7 +2222,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4045
+				// Method begins at RVA 0x40d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2212,7 +2247,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x30e5
+			// Method begins at RVA 0x3161
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2240,7 +2275,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4072
+					// Method begins at RVA 0x40fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2264,7 +2299,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x365f
+				// Method begins at RVA 0x36e4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2290,7 +2325,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x407b
+					// Method begins at RVA 0x4107
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2314,7 +2349,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x366e
+				// Method begins at RVA 0x36f3
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2344,7 +2379,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x40a8
+						// Method begins at RVA 0x4134
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2368,7 +2403,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3715
+					// Method begins at RVA 0x3799
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2402,7 +2437,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x409f
+					// Method begins at RVA 0x412b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2427,7 +2462,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3680
+				// Method begins at RVA 0x3704
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2520,7 +2555,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4057
+					// Method begins at RVA 0x40e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2540,7 +2575,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4060
+					// Method begins at RVA 0x40ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2560,7 +2595,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4069
+					// Method begins at RVA 0x40f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2584,7 +2619,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x408d
+						// Method begins at RVA 0x4119
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2604,7 +2639,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4096
+						// Method begins at RVA 0x4122
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2622,7 +2657,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4084
+					// Method begins at RVA 0x4110
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2642,7 +2677,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40b1
+					// Method begins at RVA 0x413d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2662,7 +2697,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x40ba
+					// Method begins at RVA 0x4146
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2684,7 +2719,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x404e
+				// Method begins at RVA 0x40da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2711,7 +2746,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x30f0
+			// Method begins at RVA 0x316c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3236,7 +3271,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40c3
+				// Method begins at RVA 0x414f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3264,41 +3299,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 3d 00 00 02
 			)
-			// Method begins at RVA 0x360c
+			// Method begins at RVA 0x3688
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3329,7 +3369,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3fe9
+			// Method begins at RVA 0x4075
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3356,16 +3396,17 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2320
+		// Method begins at RVA 0x237c
 		// Header size: 12
-		// Code size: 577 (0x241)
+		// Code size: 590 (0x24e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_A/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_A/Scope::.ctor()
@@ -3502,97 +3543,100 @@
 		IL_0147: ldloc.s 4
 		IL_0149: stloc.3
 		IL_014a: ldloc.0
-		IL_014b: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0150: ldnull
-		IL_0151: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0156: pop
-		IL_0157: ldc.i4.1
-		IL_0158: newarr [System.Runtime]System.Object
-		IL_015d: dup
-		IL_015e: ldc.i4.0
-		IL_015f: ldloc.0
-		IL_0160: stelem.ref
-		IL_0161: ldc.i4.0
-		IL_0162: ldelem.ref
-		IL_0163: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0168: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0173: ldc.i4.0
-		IL_0174: conv.r8
-		IL_0175: ldstr ""
-		IL_017a: ldc.i4.0
-		IL_017b: ldc.i4.1
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0181: stloc.s 4
-		IL_0183: ldloc.0
-		IL_0184: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0189: ldnull
-		IL_018a: ldstr "a"
-		IL_018f: ldloc.s 4
-		IL_0191: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
-		IL_0196: pop
-		IL_0197: ldc.i4.1
-		IL_0198: newarr [System.Runtime]System.Object
-		IL_019d: dup
-		IL_019e: ldc.i4.0
-		IL_019f: ldloc.0
-		IL_01a0: stelem.ref
-		IL_01a1: ldc.i4.0
-		IL_01a2: ldelem.ref
-		IL_01a3: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01a8: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_01ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01b3: ldc.i4.0
-		IL_01b4: conv.r8
-		IL_01b5: ldstr ""
-		IL_01ba: ldc.i4.0
-		IL_01bb: ldc.i4.1
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01c1: stloc.s 4
-		IL_01c3: ldloc.0
-		IL_01c4: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01c9: ldnull
-		IL_01ca: ldstr "incA"
-		IL_01cf: ldloc.s 4
-		IL_01d1: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
-		IL_01d6: pop
-		IL_01d7: ldc.i4.1
-		IL_01d8: newarr [System.Runtime]System.Object
-		IL_01dd: dup
-		IL_01de: ldc.i4.0
-		IL_01df: ldloc.0
-		IL_01e0: stelem.ref
-		IL_01e1: ldc.i4.0
-		IL_01e2: ldelem.ref
-		IL_01e3: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01e8: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01f3: ldc.i4.0
-		IL_01f4: conv.r8
-		IL_01f5: ldstr ""
-		IL_01fa: ldc.i4.0
-		IL_01fb: ldc.i4.1
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0201: stloc.s 4
-		IL_0203: ldloc.0
-		IL_0204: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0209: ldnull
-		IL_020a: ldstr "getBFromA"
-		IL_020f: ldloc.s 4
-		IL_0211: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object, object)
-		IL_0216: pop
-		IL_0217: ldarg.1
-		IL_0218: ldstr "./Import_LiveBindings_Cycle_B.mjs"
-		IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0222: stloc.s 4
-		IL_0224: ldloc.0
-		IL_0225: ldloc.s 4
-		IL_0227: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mod_0
-		IL_022c: ldloc.0
-		IL_022d: ldc.r8 1
-		IL_0236: box [System.Runtime]System.Double
-		IL_023b: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::a
-		IL_0240: ret
+		IL_014b: ldfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mark
+		IL_0150: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_015a: pop
+		IL_015b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0160: stloc.s 5
+		IL_0162: ldc.i4.1
+		IL_0163: newarr [System.Runtime]System.Object
+		IL_0168: dup
+		IL_0169: ldc.i4.0
+		IL_016a: ldloc.0
+		IL_016b: stelem.ref
+		IL_016c: ldc.i4.0
+		IL_016d: ldelem.ref
+		IL_016e: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_0173: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+		IL_0179: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_017e: ldc.i4.0
+		IL_017f: conv.r8
+		IL_0180: ldstr ""
+		IL_0185: ldc.i4.0
+		IL_0186: ldc.i4.1
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_018c: stloc.s 4
+		IL_018e: ldloc.3
+		IL_018f: ldloc.s 5
+		IL_0191: ldstr "a"
+		IL_0196: ldloc.s 4
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_019d: pop
+		IL_019e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a3: stloc.s 5
+		IL_01a5: ldc.i4.1
+		IL_01a6: newarr [System.Runtime]System.Object
+		IL_01ab: dup
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldloc.0
+		IL_01ae: stelem.ref
+		IL_01af: ldc.i4.0
+		IL_01b0: ldelem.ref
+		IL_01b1: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_01b6: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+		IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01c1: ldc.i4.0
+		IL_01c2: conv.r8
+		IL_01c3: ldstr ""
+		IL_01c8: ldc.i4.0
+		IL_01c9: ldc.i4.1
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01cf: stloc.s 4
+		IL_01d1: ldloc.3
+		IL_01d2: ldloc.s 5
+		IL_01d4: ldstr "incA"
+		IL_01d9: ldloc.s 4
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01e0: pop
+		IL_01e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01e6: stloc.s 5
+		IL_01e8: ldc.i4.1
+		IL_01e9: newarr [System.Runtime]System.Object
+		IL_01ee: dup
+		IL_01ef: ldc.i4.0
+		IL_01f0: ldloc.0
+		IL_01f1: stelem.ref
+		IL_01f2: ldc.i4.0
+		IL_01f3: ldelem.ref
+		IL_01f4: castclass Modules.Import_LiveBindings_Cycle_A/Scope
+		IL_01f9: ldftn object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+		IL_01ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0204: ldc.i4.0
+		IL_0205: conv.r8
+		IL_0206: ldstr ""
+		IL_020b: ldc.i4.0
+		IL_020c: ldc.i4.1
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0212: stloc.s 4
+		IL_0214: ldloc.3
+		IL_0215: ldloc.s 5
+		IL_0217: ldstr "getBFromA"
+		IL_021c: ldloc.s 4
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0223: pop
+		IL_0224: ldarg.1
+		IL_0225: ldstr "./Import_LiveBindings_Cycle_B.mjs"
+		IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_022f: stloc.s 4
+		IL_0231: ldloc.0
+		IL_0232: ldloc.s 4
+		IL_0234: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::__jroc_esm_mod_0
+		IL_0239: ldloc.0
+		IL_023a: ldc.r8 1
+		IL_0243: box [System.Runtime]System.Double
+		IL_0248: stfld object Modules.Import_LiveBindings_Cycle_A/Scope::a
+		IL_024d: ret
 	} // end of method Import_LiveBindings_Cycle_A::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Cycle_A
@@ -3612,7 +3656,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40e0
+				// Method begins at RVA 0x416c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3638,7 +3682,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3738
+			// Method begins at RVA 0x37bc
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3668,7 +3712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40e9
+				// Method begins at RVA 0x4175
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3694,7 +3738,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3757
+			// Method begins at RVA 0x37db
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3717,7 +3761,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40f2
+				// Method begins at RVA 0x417e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3743,7 +3787,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x375f
+			// Method begins at RVA 0x37e3
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3766,7 +3810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x40fb
+				// Method begins at RVA 0x4187
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3792,7 +3836,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3768
+			// Method begins at RVA 0x37ec
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -3830,7 +3874,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4104
+				// Method begins at RVA 0x4190
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3856,7 +3900,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x37a0
+			// Method begins at RVA 0x3824
 			// Header size: 12
 			// Code size: 35 (0x23)
 			.maxstack 8
@@ -3903,7 +3947,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4116
+					// Method begins at RVA 0x41a2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3921,7 +3965,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x410d
+				// Method begins at RVA 0x4199
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3947,7 +3991,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x37d0
+			// Method begins at RVA 0x3854
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -4022,7 +4066,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x411f
+				// Method begins at RVA 0x41ab
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4046,7 +4090,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3868
+			// Method begins at RVA 0x38ec
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -4120,7 +4164,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4128
+				// Method begins at RVA 0x41b4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4145,7 +4189,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x38ed
+			// Method begins at RVA 0x3971
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4173,7 +4217,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4155
+					// Method begins at RVA 0x41e1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4197,7 +4241,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e67
+				// Method begins at RVA 0x3ef4
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -4223,7 +4267,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x415e
+					// Method begins at RVA 0x41ea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4247,7 +4291,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e76
+				// Method begins at RVA 0x3f03
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -4277,7 +4321,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x418b
+						// Method begins at RVA 0x4217
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4301,7 +4345,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3f1d
+					// Method begins at RVA 0x3fa9
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -4335,7 +4379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4182
+					// Method begins at RVA 0x420e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4360,7 +4404,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3e88
+				// Method begins at RVA 0x3f14
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4453,7 +4497,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x413a
+					// Method begins at RVA 0x41c6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4473,7 +4517,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4143
+					// Method begins at RVA 0x41cf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4493,7 +4537,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x414c
+					// Method begins at RVA 0x41d8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4517,7 +4561,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4170
+						// Method begins at RVA 0x41fc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4537,7 +4581,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4179
+						// Method begins at RVA 0x4205
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4555,7 +4599,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4167
+					// Method begins at RVA 0x41f3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4575,7 +4619,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4194
+					// Method begins at RVA 0x4220
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4595,7 +4639,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x419d
+					// Method begins at RVA 0x4229
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4617,7 +4661,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4131
+				// Method begins at RVA 0x41bd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4644,7 +4688,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x38f8
+			// Method begins at RVA 0x397c
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -5169,7 +5213,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x41a6
+				// Method begins at RVA 0x4232
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5197,41 +5241,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 55 00 00 02
 			)
-			// Method begins at RVA 0x3e14
+			// Method begins at RVA 0x3e98
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -5262,7 +5311,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x40cc
+			// Method begins at RVA 0x4158
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -5289,16 +5338,17 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2570
+		// Method begins at RVA 0x25d8
 		// Header size: 12
-		// Code size: 577 (0x241)
+		// Code size: 590 (0x24e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_B/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object,
+			[5] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_B/Scope::.ctor()
@@ -5435,97 +5485,100 @@
 		IL_0147: ldloc.s 4
 		IL_0149: stloc.3
 		IL_014a: ldloc.0
-		IL_014b: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0150: ldnull
-		IL_0151: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0156: pop
-		IL_0157: ldc.i4.1
-		IL_0158: newarr [System.Runtime]System.Object
-		IL_015d: dup
-		IL_015e: ldc.i4.0
-		IL_015f: ldloc.0
-		IL_0160: stelem.ref
-		IL_0161: ldc.i4.0
-		IL_0162: ldelem.ref
-		IL_0163: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0168: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0173: ldc.i4.0
-		IL_0174: conv.r8
-		IL_0175: ldstr ""
-		IL_017a: ldc.i4.0
-		IL_017b: ldc.i4.1
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0181: stloc.s 4
-		IL_0183: ldloc.0
-		IL_0184: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0189: ldnull
-		IL_018a: ldstr "b"
-		IL_018f: ldloc.s 4
-		IL_0191: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
-		IL_0196: pop
-		IL_0197: ldc.i4.1
-		IL_0198: newarr [System.Runtime]System.Object
-		IL_019d: dup
-		IL_019e: ldc.i4.0
-		IL_019f: ldloc.0
-		IL_01a0: stelem.ref
-		IL_01a1: ldc.i4.0
-		IL_01a2: ldelem.ref
-		IL_01a3: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01a8: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_01ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01b3: ldc.i4.0
-		IL_01b4: conv.r8
-		IL_01b5: ldstr ""
-		IL_01ba: ldc.i4.0
-		IL_01bb: ldc.i4.1
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01c1: stloc.s 4
-		IL_01c3: ldloc.0
-		IL_01c4: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01c9: ldnull
-		IL_01ca: ldstr "incB"
-		IL_01cf: ldloc.s 4
-		IL_01d1: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
-		IL_01d6: pop
-		IL_01d7: ldc.i4.1
-		IL_01d8: newarr [System.Runtime]System.Object
-		IL_01dd: dup
-		IL_01de: ldc.i4.0
-		IL_01df: ldloc.0
-		IL_01e0: stelem.ref
-		IL_01e1: ldc.i4.0
-		IL_01e2: ldelem.ref
-		IL_01e3: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01e8: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01f3: ldc.i4.0
-		IL_01f4: conv.r8
-		IL_01f5: ldstr ""
-		IL_01fa: ldc.i4.0
-		IL_01fb: ldc.i4.1
-		IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0201: stloc.s 4
-		IL_0203: ldloc.0
-		IL_0204: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0209: ldnull
-		IL_020a: ldstr "getAFromB"
-		IL_020f: ldloc.s 4
-		IL_0211: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object, object)
-		IL_0216: pop
-		IL_0217: ldarg.1
-		IL_0218: ldstr "./Import_LiveBindings_Cycle_A.mjs"
-		IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0222: stloc.s 4
-		IL_0224: ldloc.0
-		IL_0225: ldloc.s 4
-		IL_0227: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mod_0
-		IL_022c: ldloc.0
-		IL_022d: ldc.r8 10
-		IL_0236: box [System.Runtime]System.Double
-		IL_023b: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::b
-		IL_0240: ret
+		IL_014b: ldfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mark
+		IL_0150: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_015a: pop
+		IL_015b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0160: stloc.s 5
+		IL_0162: ldc.i4.1
+		IL_0163: newarr [System.Runtime]System.Object
+		IL_0168: dup
+		IL_0169: ldc.i4.0
+		IL_016a: ldloc.0
+		IL_016b: stelem.ref
+		IL_016c: ldc.i4.0
+		IL_016d: ldelem.ref
+		IL_016e: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_0173: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+		IL_0179: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_017e: ldc.i4.0
+		IL_017f: conv.r8
+		IL_0180: ldstr ""
+		IL_0185: ldc.i4.0
+		IL_0186: ldc.i4.1
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_018c: stloc.s 4
+		IL_018e: ldloc.3
+		IL_018f: ldloc.s 5
+		IL_0191: ldstr "b"
+		IL_0196: ldloc.s 4
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_019d: pop
+		IL_019e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a3: stloc.s 5
+		IL_01a5: ldc.i4.1
+		IL_01a6: newarr [System.Runtime]System.Object
+		IL_01ab: dup
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldloc.0
+		IL_01ae: stelem.ref
+		IL_01af: ldc.i4.0
+		IL_01b0: ldelem.ref
+		IL_01b1: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_01b6: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+		IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01c1: ldc.i4.0
+		IL_01c2: conv.r8
+		IL_01c3: ldstr ""
+		IL_01c8: ldc.i4.0
+		IL_01c9: ldc.i4.1
+		IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01cf: stloc.s 4
+		IL_01d1: ldloc.3
+		IL_01d2: ldloc.s 5
+		IL_01d4: ldstr "incB"
+		IL_01d9: ldloc.s 4
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01e0: pop
+		IL_01e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01e6: stloc.s 5
+		IL_01e8: ldc.i4.1
+		IL_01e9: newarr [System.Runtime]System.Object
+		IL_01ee: dup
+		IL_01ef: ldc.i4.0
+		IL_01f0: ldloc.0
+		IL_01f1: stelem.ref
+		IL_01f2: ldc.i4.0
+		IL_01f3: ldelem.ref
+		IL_01f4: castclass Modules.Import_LiveBindings_Cycle_B/Scope
+		IL_01f9: ldftn object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+		IL_01ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0204: ldc.i4.0
+		IL_0205: conv.r8
+		IL_0206: ldstr ""
+		IL_020b: ldc.i4.0
+		IL_020c: ldc.i4.1
+		IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0212: stloc.s 4
+		IL_0214: ldloc.3
+		IL_0215: ldloc.s 5
+		IL_0217: ldstr "getAFromB"
+		IL_021c: ldloc.s 4
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0223: pop
+		IL_0224: ldarg.1
+		IL_0225: ldstr "./Import_LiveBindings_Cycle_A.mjs"
+		IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_022f: stloc.s 4
+		IL_0231: ldloc.0
+		IL_0232: ldloc.s 4
+		IL_0234: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::__jroc_esm_mod_0
+		IL_0239: ldloc.0
+		IL_023a: ldc.r8 10
+		IL_0243: box [System.Runtime]System.Double
+		IL_0248: stfld object Modules.Import_LiveBindings_Cycle_B/Scope::b
+		IL_024d: ret
 	} // end of method Import_LiveBindings_Cycle_B::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Cycle_B
@@ -5537,7 +5590,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x41af
+		// Method begins at RVA 0x423b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32d4
+					// Method begins at RVA 0x330c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32cb
+				// Method begins at RVA 0x3303
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x2384
+			// Method begins at RVA 0x23ac
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32dd
+				// Method begins at RVA 0x3315
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x241c
+			// Method begins at RVA 0x2444
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32e6
+				// Method begins at RVA 0x331e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24a1
+			// Method begins at RVA 0x24c9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3313
+					// Method begins at RVA 0x334b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a1b
+				// Method begins at RVA 0x2a4c
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x331c
+					// Method begins at RVA 0x3354
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a2a
+				// Method begins at RVA 0x2a5b
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3349
+						// Method begins at RVA 0x3381
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2ad1
+					// Method begins at RVA 0x2b01
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3340
+					// Method begins at RVA 0x3378
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a3c
+				// Method begins at RVA 0x2a6c
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x32f8
+					// Method begins at RVA 0x3330
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3301
+					// Method begins at RVA 0x3339
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x330a
+					// Method begins at RVA 0x3342
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x332e
+						// Method begins at RVA 0x3366
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3337
+						// Method begins at RVA 0x336f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3325
+					// Method begins at RVA 0x335d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3352
+					// Method begins at RVA 0x338a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x335b
+					// Method begins at RVA 0x3393
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x32ef
+				// Method begins at RVA 0x3327
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x24ac
+			// Method begins at RVA 0x24d4
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3364
+				// Method begins at RVA 0x339c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 19 00 00 02
 			)
-			// Method begins at RVA 0x29c8
+			// Method begins at RVA 0x29f0
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_LiveBindings_Named/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_LiveBindings_Named/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Named/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x32c2
+			// Method begins at RVA 0x32fa
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 357 (0x165)
+		// Code size: 388 (0x184)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named/Scope,
@@ -1504,50 +1509,59 @@
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_LiveBindings_Named_Lib.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 6
-		IL_00f8: ldloc.s 6
-		IL_00fa: stloc.s 5
-		IL_00fc: ldnull
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldstr "x"
-		IL_0104: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0109: stloc.s 6
-		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0110: ldstr "x0:"
-		IL_0115: ldloc.s 6
-		IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_011c: pop
-		IL_011d: ldnull
-		IL_011e: ldloc.s 5
-		IL_0120: ldstr "inc"
-		IL_0125: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
-		IL_012a: stloc.s 6
-		IL_012c: ldc.i4.0
-		IL_012d: newarr [System.Runtime]System.Object
-		IL_0132: stloc.s 7
-		IL_0134: ldloc.s 6
-		IL_0136: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_013b: ldloc.s 7
-		IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0142: pop
-		IL_0143: ldnull
-		IL_0144: ldloc.s 5
-		IL_0146: ldstr "x"
-		IL_014b: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0150: stloc.s 6
-		IL_0152: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0157: ldstr "x1:"
-		IL_015c: ldloc.s 6
-		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0163: pop
-		IL_0164: ret
+		IL_00df: ldfld object Modules.Import_LiveBindings_Named/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_LiveBindings_Named_Lib.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 6
+		IL_00fc: ldloc.s 6
+		IL_00fe: stloc.s 5
+		IL_0100: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0105: stloc.s 7
+		IL_0107: ldloc.2
+		IL_0108: ldloc.s 7
+		IL_010a: ldloc.s 5
+		IL_010c: ldstr "x"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0116: stloc.s 6
+		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011d: ldstr "x0:"
+		IL_0122: ldloc.s 6
+		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0129: pop
+		IL_012a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_012f: stloc.s 7
+		IL_0131: ldloc.2
+		IL_0132: ldloc.s 7
+		IL_0134: ldloc.s 5
+		IL_0136: ldstr "inc"
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0140: stloc.s 6
+		IL_0142: ldc.i4.0
+		IL_0143: newarr [System.Runtime]System.Object
+		IL_0148: stloc.s 7
+		IL_014a: ldloc.s 6
+		IL_014c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0151: ldloc.s 7
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0158: pop
+		IL_0159: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_015e: stloc.s 7
+		IL_0160: ldloc.2
+		IL_0161: ldloc.s 7
+		IL_0163: ldloc.s 5
+		IL_0165: ldstr "x"
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_016f: stloc.s 6
+		IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0176: ldstr "x1:"
+		IL_017b: ldloc.s 6
+		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0182: pop
+		IL_0183: ret
 	} // end of method Import_LiveBindings_Named::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Named
@@ -1567,7 +1581,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3381
+				// Method begins at RVA 0x33b9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1593,7 +1607,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2af4
+			// Method begins at RVA 0x2b24
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1623,7 +1637,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x338a
+				// Method begins at RVA 0x33c2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1649,7 +1663,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b13
+			// Method begins at RVA 0x2b43
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1672,7 +1686,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3393
+				// Method begins at RVA 0x33cb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1698,7 +1712,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b1c
+			// Method begins at RVA 0x2b4c
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1740,7 +1754,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33a5
+					// Method begins at RVA 0x33dd
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1758,7 +1772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x339c
+				// Method begins at RVA 0x33d4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1784,7 +1798,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2b54
+			// Method begins at RVA 0x2b84
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1859,7 +1873,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33ae
+				// Method begins at RVA 0x33e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1883,7 +1897,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bec
+			// Method begins at RVA 0x2c1c
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1957,7 +1971,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33b7
+				// Method begins at RVA 0x33ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1982,7 +1996,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2c71
+			// Method begins at RVA 0x2ca1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2010,7 +2024,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33e4
+					// Method begins at RVA 0x341c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2034,7 +2048,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x31eb
+				// Method begins at RVA 0x3224
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2060,7 +2074,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33ed
+					// Method begins at RVA 0x3425
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2084,7 +2098,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x31fa
+				// Method begins at RVA 0x3233
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2114,7 +2128,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x341a
+						// Method begins at RVA 0x3452
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2138,7 +2152,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x32a1
+					// Method begins at RVA 0x32d9
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2172,7 +2186,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3411
+					// Method begins at RVA 0x3449
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2197,7 +2211,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x320c
+				// Method begins at RVA 0x3244
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2290,7 +2304,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33c9
+					// Method begins at RVA 0x3401
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2310,7 +2324,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33d2
+					// Method begins at RVA 0x340a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2330,7 +2344,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33db
+					// Method begins at RVA 0x3413
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2354,7 +2368,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x33ff
+						// Method begins at RVA 0x3437
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2374,7 +2388,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3408
+						// Method begins at RVA 0x3440
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2392,7 +2406,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x33f6
+					// Method begins at RVA 0x342e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2412,7 +2426,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3423
+					// Method begins at RVA 0x345b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2432,7 +2446,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x342c
+					// Method begins at RVA 0x3464
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2454,7 +2468,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x33c0
+				// Method begins at RVA 0x33f8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2481,7 +2495,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x2c7c
+			// Method begins at RVA 0x2cac
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3006,7 +3020,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3435
+				// Method begins at RVA 0x346d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3034,41 +3048,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2c 00 00 02
 			)
-			// Method begins at RVA 0x3198
+			// Method begins at RVA 0x31c8
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3095,7 +3114,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x336d
+			// Method begins at RVA 0x33a5
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3122,9 +3141,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x21c4
+		// Method begins at RVA 0x21e0
 		// Header size: 12
-		// Code size: 436 (0x1b4)
+		// Code size: 448 (0x1c0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named_Lib/Scope,
@@ -3132,7 +3151,8 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object
+			[5] object,
+			[6] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Named_Lib/Scope::.ctor()
@@ -3247,65 +3267,67 @@
 		IL_010e: ldloc.s 5
 		IL_0110: stloc.s 4
 		IL_0112: ldloc.0
-		IL_0113: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0118: ldnull
-		IL_0119: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_011e: pop
-		IL_011f: ldc.i4.1
-		IL_0120: newarr [System.Runtime]System.Object
-		IL_0125: dup
-		IL_0126: ldc.i4.0
-		IL_0127: ldloc.0
-		IL_0128: stelem.ref
-		IL_0129: ldc.i4.0
-		IL_012a: ldelem.ref
-		IL_012b: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0130: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_0136: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_013b: ldc.i4.0
-		IL_013c: conv.r8
-		IL_013d: ldstr ""
-		IL_0142: ldc.i4.0
-		IL_0143: ldc.i4.1
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0149: stloc.s 5
-		IL_014b: ldloc.0
-		IL_014c: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0151: ldnull
-		IL_0152: ldstr "x"
-		IL_0157: ldloc.s 5
-		IL_0159: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object, object)
-		IL_015e: pop
-		IL_015f: ldc.i4.1
-		IL_0160: newarr [System.Runtime]System.Object
-		IL_0165: dup
-		IL_0166: ldc.i4.0
-		IL_0167: ldloc.0
-		IL_0168: stelem.ref
-		IL_0169: ldc.i4.0
-		IL_016a: ldelem.ref
-		IL_016b: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0170: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_0176: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_017b: ldc.i4.0
-		IL_017c: conv.r8
-		IL_017d: ldstr ""
-		IL_0182: ldc.i4.0
-		IL_0183: ldc.i4.1
-		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0189: stloc.s 5
-		IL_018b: ldloc.0
-		IL_018c: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0191: ldnull
-		IL_0192: ldstr "inc"
-		IL_0197: ldloc.s 5
-		IL_0199: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object, object)
-		IL_019e: pop
-		IL_019f: ldloc.0
-		IL_01a0: ldc.r8 1
-		IL_01a9: box [System.Runtime]System.Double
-		IL_01ae: stfld object Modules.Import_LiveBindings_Named_Lib/Scope::x
-		IL_01b3: ret
+		IL_0113: ldfld object Modules.Import_LiveBindings_Named_Lib/Scope::__jroc_esm_mark
+		IL_0118: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0122: pop
+		IL_0123: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0128: stloc.s 6
+		IL_012a: ldc.i4.1
+		IL_012b: newarr [System.Runtime]System.Object
+		IL_0130: dup
+		IL_0131: ldc.i4.0
+		IL_0132: ldloc.0
+		IL_0133: stelem.ref
+		IL_0134: ldc.i4.0
+		IL_0135: ldelem.ref
+		IL_0136: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+		IL_013b: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+		IL_0141: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0146: ldc.i4.0
+		IL_0147: conv.r8
+		IL_0148: ldstr ""
+		IL_014d: ldc.i4.0
+		IL_014e: ldc.i4.1
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0154: stloc.s 5
+		IL_0156: ldloc.s 4
+		IL_0158: ldloc.s 6
+		IL_015a: ldstr "x"
+		IL_015f: ldloc.s 5
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0166: pop
+		IL_0167: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_016c: stloc.s 6
+		IL_016e: ldc.i4.1
+		IL_016f: newarr [System.Runtime]System.Object
+		IL_0174: dup
+		IL_0175: ldc.i4.0
+		IL_0176: ldloc.0
+		IL_0177: stelem.ref
+		IL_0178: ldc.i4.0
+		IL_0179: ldelem.ref
+		IL_017a: castclass Modules.Import_LiveBindings_Named_Lib/Scope
+		IL_017f: ldftn object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+		IL_0185: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_018a: ldc.i4.0
+		IL_018b: conv.r8
+		IL_018c: ldstr ""
+		IL_0191: ldc.i4.0
+		IL_0192: ldc.i4.1
+		IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0198: stloc.s 5
+		IL_019a: ldloc.s 4
+		IL_019c: ldloc.s 6
+		IL_019e: ldstr "inc"
+		IL_01a3: ldloc.s 5
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01aa: pop
+		IL_01ab: ldloc.0
+		IL_01ac: ldc.r8 1
+		IL_01b5: box [System.Runtime]System.Double
+		IL_01ba: stfld object Modules.Import_LiveBindings_Named_Lib/Scope::x
+		IL_01bf: ret
 	} // end of method Import_LiveBindings_Named_Lib::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Named_Lib
@@ -3317,7 +3339,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x343e
+		// Method begins at RVA 0x3476
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x34dc
+					// Method begins at RVA 0x3500
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34d3
+				// Method begins at RVA 0x34f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2564
+			// Method begins at RVA 0x2578
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34e5
+				// Method begins at RVA 0x3509
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x25fc
+			// Method begins at RVA 0x2610
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34ee
+				// Method begins at RVA 0x3512
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2681
+			// Method begins at RVA 0x2695
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x351b
+					// Method begins at RVA 0x353f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bfb
+				// Method begins at RVA 0x2c18
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3524
+					// Method begins at RVA 0x3548
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c0a
+				// Method begins at RVA 0x2c27
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3551
+						// Method begins at RVA 0x3575
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2cb1
+					// Method begins at RVA 0x2ccd
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3548
+					// Method begins at RVA 0x356c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c1c
+				// Method begins at RVA 0x2c38
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3500
+					// Method begins at RVA 0x3524
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3509
+					// Method begins at RVA 0x352d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3512
+					// Method begins at RVA 0x3536
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3536
+						// Method begins at RVA 0x355a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x353f
+						// Method begins at RVA 0x3563
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x352d
+					// Method begins at RVA 0x3551
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x355a
+					// Method begins at RVA 0x357e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3563
+					// Method begins at RVA 0x3587
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x34f7
+				// Method begins at RVA 0x351b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x26a0
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x356c
+				// Method begins at RVA 0x3590
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
-			// Method begins at RVA 0x2ba8
+			// Method begins at RVA 0x2bbc
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_Namespace_Esm_Basic/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x34ca
+			// Method begins at RVA 0x34ee
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 724 (0x2d4)
+		// Code size: 727 (0x2d7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic/Scope,
@@ -1504,147 +1509,146 @@
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_Namespace_Esm_Basic_Lib.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 7
-		IL_00f8: ldloc.s 7
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.0
-		IL_00fd: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_0102: ldnull
-		IL_0103: ldloc.s 5
-		IL_0105: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
-		IL_010a: stloc.s 7
-		IL_010c: ldloc.s 7
-		IL_010e: stloc.s 6
-		IL_0110: ldloc.s 6
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0117: stloc.s 7
-		IL_0119: ldloc.s 7
-		IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0120: stloc.s 7
-		IL_0122: ldloc.s 7
-		IL_0124: ldstr "sort"
-		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_012e: stloc.s 7
-		IL_0130: ldloc.s 7
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0137: stloc.s 7
-		IL_0139: ldloc.s 7
-		IL_013b: ldstr "join"
-		IL_0140: ldstr ","
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014a: stloc.s 7
-		IL_014c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0151: ldstr "keys:"
-		IL_0156: ldloc.s 7
-		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_015d: pop
-		IL_015e: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0163: ldstr "prototype"
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_016d: ldstr "propertyIsEnumerable"
-		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017c: stloc.s 7
-		IL_017e: ldloc.s 7
-		IL_0180: ldstr "call"
-		IL_0185: ldloc.s 6
-		IL_0187: ldstr "default"
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0191: stloc.s 7
-		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0198: ldstr "enum.default:"
-		IL_019d: ldloc.s 7
-		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01a4: pop
-		IL_01a5: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_01aa: ldstr "prototype"
-		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b4: ldstr "propertyIsEnumerable"
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c3: stloc.s 7
-		IL_01c5: ldloc.s 7
-		IL_01c7: ldstr "call"
-		IL_01cc: ldloc.s 6
-		IL_01ce: ldstr "inc"
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_01d8: stloc.s 7
-		IL_01da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01df: ldstr "enum.inc:"
-		IL_01e4: ldloc.s 7
-		IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01eb: pop
-		IL_01ec: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_01f1: ldstr "prototype"
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01fb: ldstr "propertyIsEnumerable"
-		IL_0200: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020a: stloc.s 7
-		IL_020c: ldloc.s 7
-		IL_020e: ldstr "call"
-		IL_0213: ldloc.s 6
-		IL_0215: ldstr "x"
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_021f: stloc.s 7
-		IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0226: ldstr "enum.x:"
-		IL_022b: ldloc.s 7
-		IL_022d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0232: pop
-		IL_0233: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0238: ldstr "x0:"
-		IL_023d: ldloc.s 6
-		IL_023f: ldstr "x"
-		IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0249: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_024e: pop
-		IL_024f: ldloc.s 6
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0256: stloc.s 7
-		IL_0258: ldloc.s 7
-		IL_025a: ldstr "default"
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0264: stloc.s 7
-		IL_0266: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_026b: ldstr "def0:"
-		IL_0270: ldloc.s 7
-		IL_0272: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0277: pop
-		IL_0278: ldloc.s 6
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_027f: stloc.s 7
-		IL_0281: ldloc.s 7
-		IL_0283: ldstr "inc"
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_028d: pop
-		IL_028e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0293: ldstr "x1:"
-		IL_0298: ldloc.s 6
-		IL_029a: ldstr "x"
-		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02a9: pop
-		IL_02aa: ldloc.s 6
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02b1: stloc.s 7
-		IL_02b3: ldloc.s 7
-		IL_02b5: ldstr "default"
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_02bf: stloc.s 7
-		IL_02c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02c6: ldstr "def1:"
-		IL_02cb: ldloc.s 7
-		IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02d2: pop
-		IL_02d3: ret
+		IL_00df: ldfld object Modules.Import_Namespace_Esm_Basic/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_Namespace_Esm_Basic_Lib.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 7
+		IL_00fc: ldloc.s 7
+		IL_00fe: stloc.s 5
+		IL_0100: ldloc.3
+		IL_0101: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0106: ldloc.s 5
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_010d: stloc.s 7
+		IL_010f: ldloc.s 7
+		IL_0111: stloc.s 6
+		IL_0113: ldloc.s 6
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_011a: stloc.s 7
+		IL_011c: ldloc.s 7
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0123: stloc.s 7
+		IL_0125: ldloc.s 7
+		IL_0127: ldstr "sort"
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0131: stloc.s 7
+		IL_0133: ldloc.s 7
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013a: stloc.s 7
+		IL_013c: ldloc.s 7
+		IL_013e: ldstr "join"
+		IL_0143: ldstr ","
+		IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_014d: stloc.s 7
+		IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0154: ldstr "keys:"
+		IL_0159: ldloc.s 7
+		IL_015b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0160: pop
+		IL_0161: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_0166: ldstr "prototype"
+		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0170: ldstr "propertyIsEnumerable"
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017f: stloc.s 7
+		IL_0181: ldloc.s 7
+		IL_0183: ldstr "call"
+		IL_0188: ldloc.s 6
+		IL_018a: ldstr "default"
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0194: stloc.s 7
+		IL_0196: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019b: ldstr "enum.default:"
+		IL_01a0: ldloc.s 7
+		IL_01a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01a7: pop
+		IL_01a8: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_01ad: ldstr "prototype"
+		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b7: ldstr "propertyIsEnumerable"
+		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01c6: stloc.s 7
+		IL_01c8: ldloc.s 7
+		IL_01ca: ldstr "call"
+		IL_01cf: ldloc.s 6
+		IL_01d1: ldstr "inc"
+		IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_01db: stloc.s 7
+		IL_01dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e2: ldstr "enum.inc:"
+		IL_01e7: ldloc.s 7
+		IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01ee: pop
+		IL_01ef: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_01f4: ldstr "prototype"
+		IL_01f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01fe: ldstr "propertyIsEnumerable"
+		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020d: stloc.s 7
+		IL_020f: ldloc.s 7
+		IL_0211: ldstr "call"
+		IL_0216: ldloc.s 6
+		IL_0218: ldstr "x"
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_0222: stloc.s 7
+		IL_0224: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0229: ldstr "enum.x:"
+		IL_022e: ldloc.s 7
+		IL_0230: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0235: pop
+		IL_0236: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_023b: ldstr "x0:"
+		IL_0240: ldloc.s 6
+		IL_0242: ldstr "x"
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_024c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0251: pop
+		IL_0252: ldloc.s 6
+		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0259: stloc.s 7
+		IL_025b: ldloc.s 7
+		IL_025d: ldstr "default"
+		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0267: stloc.s 7
+		IL_0269: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_026e: ldstr "def0:"
+		IL_0273: ldloc.s 7
+		IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_027a: pop
+		IL_027b: ldloc.s 6
+		IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0282: stloc.s 7
+		IL_0284: ldloc.s 7
+		IL_0286: ldstr "inc"
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0290: pop
+		IL_0291: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0296: ldstr "x1:"
+		IL_029b: ldloc.s 6
+		IL_029d: ldstr "x"
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02ac: pop
+		IL_02ad: ldloc.s 6
+		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02b4: stloc.s 7
+		IL_02b6: ldloc.s 7
+		IL_02b8: ldstr "default"
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_02c2: stloc.s 7
+		IL_02c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02c9: ldstr "def1:"
+		IL_02ce: ldloc.s 7
+		IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02d5: pop
+		IL_02d6: ret
 	} // end of method Import_Namespace_Esm_Basic::__js_module_init__
 
 } // end of class Modules.Import_Namespace_Esm_Basic
@@ -1664,7 +1668,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3589
+				// Method begins at RVA 0x35ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1690,7 +1694,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2cd4
+			// Method begins at RVA 0x2cf0
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1720,7 +1724,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3592
+				// Method begins at RVA 0x35b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1746,7 +1750,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2cf3
+			// Method begins at RVA 0x2d0f
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1769,7 +1773,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x359b
+				// Method begins at RVA 0x35bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1795,7 +1799,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2cfb
+			// Method begins at RVA 0x2d17
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1818,7 +1822,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35a4
+				// Method begins at RVA 0x35c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1844,7 +1848,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2d04
+			// Method begins at RVA 0x2d20
 			// Header size: 12
 			// Code size: 42 (0x2a)
 			.maxstack 8
@@ -1882,7 +1886,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35ad
+				// Method begins at RVA 0x35d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1908,7 +1912,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2d3c
+			// Method begins at RVA 0x2d58
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1942,7 +1946,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35bf
+					// Method begins at RVA 0x35e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1960,7 +1964,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35b6
+				// Method begins at RVA 0x35da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1986,7 +1990,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2d5c
+			// Method begins at RVA 0x2d78
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -2061,7 +2065,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35c8
+				// Method begins at RVA 0x35ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2085,7 +2089,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2df4
+			// Method begins at RVA 0x2e10
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -2159,7 +2163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35d1
+				// Method begins at RVA 0x35f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2184,7 +2188,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e79
+			// Method begins at RVA 0x2e95
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2212,7 +2216,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35fe
+					// Method begins at RVA 0x3622
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2236,7 +2240,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x33f3
+				// Method begins at RVA 0x3418
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2262,7 +2266,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3607
+					// Method begins at RVA 0x362b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2286,7 +2290,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3402
+				// Method begins at RVA 0x3427
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2316,7 +2320,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3634
+						// Method begins at RVA 0x3658
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2340,7 +2344,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x34a9
+					// Method begins at RVA 0x34cd
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2374,7 +2378,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x362b
+					// Method begins at RVA 0x364f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2399,7 +2403,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3414
+				// Method begins at RVA 0x3438
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2492,7 +2496,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35e3
+					// Method begins at RVA 0x3607
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2512,7 +2516,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35ec
+					// Method begins at RVA 0x3610
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2532,7 +2536,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35f5
+					// Method begins at RVA 0x3619
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2556,7 +2560,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3619
+						// Method begins at RVA 0x363d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2576,7 +2580,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3622
+						// Method begins at RVA 0x3646
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2594,7 +2598,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3610
+					// Method begins at RVA 0x3634
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2614,7 +2618,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x363d
+					// Method begins at RVA 0x3661
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2634,7 +2638,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3646
+					// Method begins at RVA 0x366a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2656,7 +2660,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35da
+				// Method begins at RVA 0x35fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2683,7 +2687,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x2e84
+			// Method begins at RVA 0x2ea0
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -3208,7 +3212,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x364f
+				// Method begins at RVA 0x3673
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3236,41 +3240,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 2e 00 00 02
 			)
-			// Method begins at RVA 0x33a0
+			// Method begins at RVA 0x33bc
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3299,7 +3308,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3575
+			// Method begins at RVA 0x3599
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -3326,9 +3335,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2330
+		// Method begins at RVA 0x2334
 		// Header size: 12
-		// Code size: 552 (0x228)
+		// Code size: 568 (0x238)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic_Lib/Scope,
@@ -3336,7 +3345,8 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object
+			[5] object,
+			[6] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/Scope::.ctor()
@@ -3472,90 +3482,93 @@
 		IL_0142: ldloc.s 5
 		IL_0144: stloc.s 4
 		IL_0146: ldloc.0
-		IL_0147: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_014c: ldnull
-		IL_014d: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0152: pop
-		IL_0153: ldc.i4.1
-		IL_0154: newarr [System.Runtime]System.Object
-		IL_0159: dup
-		IL_015a: ldc.i4.0
-		IL_015b: ldloc.0
-		IL_015c: stelem.ref
-		IL_015d: ldc.i4.0
-		IL_015e: ldelem.ref
-		IL_015f: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0164: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_016a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_016f: ldc.i4.0
-		IL_0170: conv.r8
-		IL_0171: ldstr ""
-		IL_0176: ldc.i4.0
-		IL_0177: ldc.i4.1
-		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_017d: stloc.s 5
-		IL_017f: ldloc.0
-		IL_0180: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0185: ldnull
-		IL_0186: ldstr "x"
-		IL_018b: ldloc.s 5
-		IL_018d: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
-		IL_0192: pop
-		IL_0193: ldc.i4.1
-		IL_0194: newarr [System.Runtime]System.Object
-		IL_0199: dup
-		IL_019a: ldc.i4.0
-		IL_019b: ldloc.0
-		IL_019c: stelem.ref
-		IL_019d: ldc.i4.0
-		IL_019e: ldelem.ref
-		IL_019f: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01a4: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_01aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01af: ldc.i4.0
-		IL_01b0: conv.r8
-		IL_01b1: ldstr ""
-		IL_01b6: ldc.i4.0
-		IL_01b7: ldc.i4.1
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01bd: stloc.s 5
-		IL_01bf: ldloc.0
-		IL_01c0: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01c5: ldnull
-		IL_01c6: ldstr "inc"
-		IL_01cb: ldloc.s 5
-		IL_01cd: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
-		IL_01d2: pop
-		IL_01d3: ldc.i4.1
-		IL_01d4: newarr [System.Runtime]System.Object
-		IL_01d9: dup
-		IL_01da: ldc.i4.0
-		IL_01db: ldloc.0
-		IL_01dc: stelem.ref
-		IL_01dd: ldc.i4.0
-		IL_01de: ldelem.ref
-		IL_01df: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01e4: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_01ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01ef: ldc.i4.0
-		IL_01f0: conv.r8
-		IL_01f1: ldstr ""
-		IL_01f6: ldc.i4.0
-		IL_01f7: ldc.i4.1
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01fd: stloc.s 5
-		IL_01ff: ldloc.0
-		IL_0200: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0205: ldnull
-		IL_0206: ldstr "default"
-		IL_020b: ldloc.s 5
-		IL_020d: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object, object)
-		IL_0212: pop
-		IL_0213: ldloc.0
-		IL_0214: ldc.r8 1
-		IL_021d: box [System.Runtime]System.Double
-		IL_0222: stfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::x
-		IL_0227: ret
+		IL_0147: ldfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::__jroc_esm_mark
+		IL_014c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0156: pop
+		IL_0157: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_015c: stloc.s 6
+		IL_015e: ldc.i4.1
+		IL_015f: newarr [System.Runtime]System.Object
+		IL_0164: dup
+		IL_0165: ldc.i4.0
+		IL_0166: ldloc.0
+		IL_0167: stelem.ref
+		IL_0168: ldc.i4.0
+		IL_0169: ldelem.ref
+		IL_016a: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_016f: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+		IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_017a: ldc.i4.0
+		IL_017b: conv.r8
+		IL_017c: ldstr ""
+		IL_0181: ldc.i4.0
+		IL_0182: ldc.i4.1
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0188: stloc.s 5
+		IL_018a: ldloc.s 4
+		IL_018c: ldloc.s 6
+		IL_018e: ldstr "x"
+		IL_0193: ldloc.s 5
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_019a: pop
+		IL_019b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a0: stloc.s 6
+		IL_01a2: ldc.i4.1
+		IL_01a3: newarr [System.Runtime]System.Object
+		IL_01a8: dup
+		IL_01a9: ldc.i4.0
+		IL_01aa: ldloc.0
+		IL_01ab: stelem.ref
+		IL_01ac: ldc.i4.0
+		IL_01ad: ldelem.ref
+		IL_01ae: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_01b3: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+		IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01be: ldc.i4.0
+		IL_01bf: conv.r8
+		IL_01c0: ldstr ""
+		IL_01c5: ldc.i4.0
+		IL_01c6: ldc.i4.1
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01cc: stloc.s 5
+		IL_01ce: ldloc.s 4
+		IL_01d0: ldloc.s 6
+		IL_01d2: ldstr "inc"
+		IL_01d7: ldloc.s 5
+		IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01de: pop
+		IL_01df: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01e4: stloc.s 6
+		IL_01e6: ldc.i4.1
+		IL_01e7: newarr [System.Runtime]System.Object
+		IL_01ec: dup
+		IL_01ed: ldc.i4.0
+		IL_01ee: ldloc.0
+		IL_01ef: stelem.ref
+		IL_01f0: ldc.i4.0
+		IL_01f1: ldelem.ref
+		IL_01f2: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
+		IL_01f7: ldftn object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+		IL_01fd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0202: ldc.i4.0
+		IL_0203: conv.r8
+		IL_0204: ldstr ""
+		IL_0209: ldc.i4.0
+		IL_020a: ldc.i4.1
+		IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0210: stloc.s 5
+		IL_0212: ldloc.s 4
+		IL_0214: ldloc.s 6
+		IL_0216: ldstr "default"
+		IL_021b: ldloc.s 5
+		IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0222: pop
+		IL_0223: ldloc.0
+		IL_0224: ldc.r8 1
+		IL_022d: box [System.Runtime]System.Double
+		IL_0232: stfld object Modules.Import_Namespace_Esm_Basic_Lib/Scope::x
+		IL_0237: ret
 	} // end of method Import_Namespace_Esm_Basic_Lib::__js_module_init__
 
 } // end of class Modules.Import_Namespace_Esm_Basic_Lib
@@ -3567,7 +3580,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3658
+		// Method begins at RVA 0x367c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ce0
+					// Method begins at RVA 0x3d4c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cd7
+				// Method begins at RVA 0x3d43
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x262c
+			// Method begins at RVA 0x2680
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ce9
+				// Method begins at RVA 0x3d55
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26c4
+			// Method begins at RVA 0x2718
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cf2
+				// Method begins at RVA 0x3d5e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2749
+			// Method begins at RVA 0x279d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d1f
+					// Method begins at RVA 0x3d8b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cc3
+				// Method begins at RVA 0x2d20
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d28
+					// Method begins at RVA 0x3d94
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2cd2
+				// Method begins at RVA 0x2d2f
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3d55
+						// Method begins at RVA 0x3dc1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2d79
+					// Method begins at RVA 0x2dd5
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d4c
+					// Method begins at RVA 0x3db8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ce4
+				// Method begins at RVA 0x2d40
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d04
+					// Method begins at RVA 0x3d70
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d0d
+					// Method begins at RVA 0x3d79
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d16
+					// Method begins at RVA 0x3d82
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3d3a
+						// Method begins at RVA 0x3da6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3d43
+						// Method begins at RVA 0x3daf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d31
+					// Method begins at RVA 0x3d9d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d5e
+					// Method begins at RVA 0x3dca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d67
+					// Method begins at RVA 0x3dd3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cfb
+				// Method begins at RVA 0x3d67
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2754
+			// Method begins at RVA 0x27a8
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d70
+				// Method begins at RVA 0x3ddc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c70
+			// Method begins at RVA 0x2cc4
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3cce
+			// Method begins at RVA 0x3d3a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 658 (0x292)
+		// Code size: 734 (0x2de)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable/Scope,
@@ -1411,9 +1416,10 @@
 			[5] object,
 			[6] object,
 			[7] object,
-			[8] object,
-			[9] bool,
-			[10] object
+			[8] object[],
+			[9] object,
+			[10] bool,
+			[11] object
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable/Scope::.ctor()
@@ -1507,143 +1513,167 @@
 		IL_00da: ldloc.s 7
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_Namespace_FromCjs_Stable_A.mjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 7
-		IL_00f8: ldloc.s 7
-		IL_00fa: stloc.s 5
-		IL_00fc: ldarg.1
-		IL_00fd: ldstr "./Import_Namespace_FromCjs_Stable_B.mjs"
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0107: stloc.s 7
-		IL_0109: ldloc.s 7
-		IL_010b: stloc.s 6
-		IL_010d: ldnull
-		IL_010e: ldloc.s 5
-		IL_0110: ldstr "ns"
-		IL_0115: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_011a: stloc.s 7
-		IL_011c: ldnull
-		IL_011d: ldloc.s 6
-		IL_011f: ldstr "ns"
-		IL_0124: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0129: stloc.s 8
-		IL_012b: ldloc.s 7
-		IL_012d: ldloc.s 8
-		IL_012f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0134: stloc.s 9
-		IL_0136: ldloc.s 9
-		IL_0138: box [System.Runtime]System.Boolean
-		IL_013d: stloc.s 10
-		IL_013f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0144: ldstr "same:"
-		IL_0149: ldloc.s 10
-		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0150: pop
-		IL_0151: ldnull
-		IL_0152: ldloc.s 5
-		IL_0154: ldstr "ns"
-		IL_0159: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_015e: stloc.s 8
-		IL_0160: ldloc.s 8
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0167: stloc.s 8
-		IL_0169: ldloc.s 8
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0170: stloc.s 8
-		IL_0172: ldloc.s 8
-		IL_0174: ldstr "sort"
-		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_017e: stloc.s 8
-		IL_0180: ldloc.s 8
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0187: stloc.s 8
-		IL_0189: ldloc.s 8
-		IL_018b: ldstr "join"
-		IL_0190: ldstr ","
-		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_019a: stloc.s 8
-		IL_019c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a1: ldstr "keys:"
-		IL_01a6: ldloc.s 8
-		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01ad: pop
-		IL_01ae: ldnull
-		IL_01af: ldloc.s 5
-		IL_01b1: ldstr "ns"
-		IL_01b6: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01bb: stloc.s 8
-		IL_01bd: ldloc.s 8
-		IL_01bf: ldstr "default"
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c9: stloc.s 8
-		IL_01cb: ldnull
-		IL_01cc: ldloc.s 5
-		IL_01ce: ldstr "ns"
-		IL_01d3: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_01d8: stloc.s 7
-		IL_01da: ldloc.s 7
-		IL_01dc: ldstr "module.exports"
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01e6: stloc.s 7
-		IL_01e8: ldloc.s 8
-		IL_01ea: ldloc.s 7
-		IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00df: ldfld object Modules.Import_Namespace_FromCjs_Stable/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_Namespace_FromCjs_Stable_A.mjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 7
+		IL_00fc: ldloc.s 7
+		IL_00fe: stloc.s 5
+		IL_0100: ldarg.1
+		IL_0101: ldstr "./Import_Namespace_FromCjs_Stable_B.mjs"
+		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_010b: stloc.s 7
+		IL_010d: ldloc.s 7
+		IL_010f: stloc.s 6
+		IL_0111: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0116: stloc.s 8
+		IL_0118: ldloc.2
+		IL_0119: ldloc.s 8
+		IL_011b: ldloc.s 5
+		IL_011d: ldstr "ns"
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0127: stloc.s 7
+		IL_0129: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_012e: stloc.s 8
+		IL_0130: ldloc.2
+		IL_0131: ldloc.s 8
+		IL_0133: ldloc.s 6
+		IL_0135: ldstr "ns"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_013f: stloc.s 9
+		IL_0141: ldloc.s 7
+		IL_0143: ldloc.s 9
+		IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_014a: stloc.s 10
+		IL_014c: ldloc.s 10
+		IL_014e: box [System.Runtime]System.Boolean
+		IL_0153: stloc.s 11
+		IL_0155: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_015a: ldstr "same:"
+		IL_015f: ldloc.s 11
+		IL_0161: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0166: pop
+		IL_0167: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_016c: stloc.s 8
+		IL_016e: ldloc.2
+		IL_016f: ldloc.s 8
+		IL_0171: ldloc.s 5
+		IL_0173: ldstr "ns"
+		IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_017d: stloc.s 9
+		IL_017f: ldloc.s 9
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_0186: stloc.s 9
+		IL_0188: ldloc.s 9
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018f: stloc.s 9
+		IL_0191: ldloc.s 9
+		IL_0193: ldstr "sort"
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_019d: stloc.s 9
+		IL_019f: ldloc.s 9
+		IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a6: stloc.s 9
+		IL_01a8: ldloc.s 9
+		IL_01aa: ldstr "join"
+		IL_01af: ldstr ","
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01b9: stloc.s 9
+		IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c0: ldstr "keys:"
+		IL_01c5: ldloc.s 9
+		IL_01c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01cc: pop
+		IL_01cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01d2: stloc.s 8
+		IL_01d4: ldloc.2
+		IL_01d5: ldloc.s 8
+		IL_01d7: ldloc.s 5
+		IL_01d9: ldstr "ns"
+		IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01e3: stloc.s 9
+		IL_01e5: ldloc.s 9
+		IL_01e7: ldstr "default"
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_01f1: stloc.s 9
-		IL_01f3: ldloc.s 9
-		IL_01f5: box [System.Runtime]System.Boolean
-		IL_01fa: stloc.s 10
-		IL_01fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0201: ldstr "defaultIsModuleExports:"
-		IL_0206: ldloc.s 10
-		IL_0208: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_020d: pop
-		IL_020e: ldnull
-		IL_020f: ldloc.s 5
-		IL_0211: ldstr "ns"
-		IL_0216: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_021b: stloc.s 7
-		IL_021d: ldloc.s 7
-		IL_021f: ldstr "x"
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0229: stloc.s 7
-		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0230: ldstr "x0:"
-		IL_0235: ldloc.s 7
-		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_023c: pop
-		IL_023d: ldnull
-		IL_023e: ldloc.s 5
-		IL_0240: ldstr "ns"
-		IL_0245: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_024a: stloc.s 7
-		IL_024c: ldloc.s 7
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0253: stloc.s 7
-		IL_0255: ldloc.s 7
-		IL_0257: ldstr "inc"
-		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0261: pop
-		IL_0262: ldnull
-		IL_0263: ldloc.s 6
-		IL_0265: ldstr "ns"
-		IL_026a: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, object)
-		IL_026f: stloc.s 7
-		IL_0271: ldloc.s 7
-		IL_0273: ldstr "x"
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_027d: stloc.s 7
-		IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0284: ldstr "x1:"
-		IL_0289: ldloc.s 7
-		IL_028b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0290: pop
-		IL_0291: ret
+		IL_01f3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f8: stloc.s 8
+		IL_01fa: ldloc.2
+		IL_01fb: ldloc.s 8
+		IL_01fd: ldloc.s 5
+		IL_01ff: ldstr "ns"
+		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0209: stloc.s 7
+		IL_020b: ldloc.s 7
+		IL_020d: ldstr "module.exports"
+		IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0217: stloc.s 7
+		IL_0219: ldloc.s 9
+		IL_021b: ldloc.s 7
+		IL_021d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0222: stloc.s 10
+		IL_0224: ldloc.s 10
+		IL_0226: box [System.Runtime]System.Boolean
+		IL_022b: stloc.s 11
+		IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0232: ldstr "defaultIsModuleExports:"
+		IL_0237: ldloc.s 11
+		IL_0239: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_023e: pop
+		IL_023f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0244: stloc.s 8
+		IL_0246: ldloc.2
+		IL_0247: ldloc.s 8
+		IL_0249: ldloc.s 5
+		IL_024b: ldstr "ns"
+		IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0255: stloc.s 7
+		IL_0257: ldloc.s 7
+		IL_0259: ldstr "x"
+		IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0263: stloc.s 7
+		IL_0265: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_026a: ldstr "x0:"
+		IL_026f: ldloc.s 7
+		IL_0271: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0276: pop
+		IL_0277: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_027c: stloc.s 8
+		IL_027e: ldloc.2
+		IL_027f: ldloc.s 8
+		IL_0281: ldloc.s 5
+		IL_0283: ldstr "ns"
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_028d: stloc.s 7
+		IL_028f: ldloc.s 7
+		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0296: stloc.s 7
+		IL_0298: ldloc.s 7
+		IL_029a: ldstr "inc"
+		IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_02a4: pop
+		IL_02a5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02aa: stloc.s 8
+		IL_02ac: ldloc.2
+		IL_02ad: ldloc.s 8
+		IL_02af: ldloc.s 6
+		IL_02b1: ldstr "ns"
+		IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02bb: stloc.s 7
+		IL_02bd: ldloc.s 7
+		IL_02bf: ldstr "x"
+		IL_02c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c9: stloc.s 7
+		IL_02cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d0: ldstr "x1:"
+		IL_02d5: ldloc.s 7
+		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02dc: pop
+		IL_02dd: ret
 	} // end of method Import_Namespace_FromCjs_Stable::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable
@@ -1663,7 +1693,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d82
+				// Method begins at RVA 0x3dee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1689,7 +1719,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2d9a
+			// Method begins at RVA 0x2df6
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -1716,7 +1746,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d94
+					// Method begins at RVA 0x3e00
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1734,7 +1764,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d8b
+				// Method begins at RVA 0x3df7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1760,7 +1790,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2da4
+			// Method begins at RVA 0x2e00
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -1835,7 +1865,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d9d
+				// Method begins at RVA 0x3e09
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1859,7 +1889,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e3c
+			// Method begins at RVA 0x2e98
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -1933,7 +1963,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3da6
+				// Method begins at RVA 0x3e12
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1958,7 +1988,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ec1
+			// Method begins at RVA 0x2f1d
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1986,7 +2016,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dd3
+					// Method begins at RVA 0x3e3f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2010,7 +2040,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x343b
+				// Method begins at RVA 0x34a0
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2036,7 +2066,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ddc
+					// Method begins at RVA 0x3e48
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2060,7 +2090,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x344a
+				// Method begins at RVA 0x34af
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -2090,7 +2120,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3e09
+						// Method begins at RVA 0x3e75
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2114,7 +2144,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x34f1
+					// Method begins at RVA 0x3555
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -2148,7 +2178,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e00
+					// Method begins at RVA 0x3e6c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2173,7 +2203,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x345c
+				// Method begins at RVA 0x34c0
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -2266,7 +2296,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3db8
+					// Method begins at RVA 0x3e24
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2286,7 +2316,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dc1
+					// Method begins at RVA 0x3e2d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2306,7 +2336,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3dca
+					// Method begins at RVA 0x3e36
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2330,7 +2360,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3dee
+						// Method begins at RVA 0x3e5a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2350,7 +2380,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3df7
+						// Method begins at RVA 0x3e63
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2368,7 +2398,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3de5
+					// Method begins at RVA 0x3e51
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2388,7 +2418,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e12
+					// Method begins at RVA 0x3e7e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2408,7 +2438,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e1b
+					// Method begins at RVA 0x3e87
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2430,7 +2460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3daf
+				// Method begins at RVA 0x3e1b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2457,7 +2487,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x2ecc
+			// Method begins at RVA 0x2f28
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -2982,7 +3012,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e24
+				// Method begins at RVA 0x3e90
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3010,41 +3040,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 37 00 00 02
 			)
-			// Method begins at RVA 0x33e8
+			// Method begins at RVA 0x3444
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -3070,7 +3105,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3d79
+			// Method begins at RVA 0x3de5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3094,9 +3129,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x22f0
+		// Method begins at RVA 0x233c
 		// Header size: 12
-		// Code size: 341 (0x155)
+		// Code size: 348 (0x15c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_A/Scope,
@@ -3105,7 +3140,8 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object
+			[6] object,
+			[7] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/Scope::.ctor()
@@ -3199,51 +3235,51 @@
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 6
-		IL_00f8: ldloc.s 6
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.0
-		IL_00fd: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0102: ldnull
-		IL_0103: ldloc.s 5
-		IL_0105: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
-		IL_010a: stloc.s 6
-		IL_010c: ldloc.0
-		IL_010d: ldloc.s 6
-		IL_010f: stfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::ns
-		IL_0114: ldc.i4.1
-		IL_0115: newarr [System.Runtime]System.Object
-		IL_011a: dup
-		IL_011b: ldc.i4.0
-		IL_011c: ldloc.0
-		IL_011d: stelem.ref
-		IL_011e: ldc.i4.0
-		IL_011f: ldelem.ref
-		IL_0120: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0125: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0130: ldc.i4.0
-		IL_0131: conv.r8
-		IL_0132: ldstr ""
-		IL_0137: ldc.i4.0
-		IL_0138: ldc.i4.1
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_013e: stloc.s 6
-		IL_0140: ldloc.0
-		IL_0141: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0146: ldnull
-		IL_0147: ldstr "ns"
-		IL_014c: ldloc.s 6
-		IL_014e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object, object)
-		IL_0153: pop
-		IL_0154: ret
+		IL_00df: ldfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 6
+		IL_00fc: ldloc.s 6
+		IL_00fe: stloc.s 5
+		IL_0100: ldloc.3
+		IL_0101: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0106: ldloc.s 5
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_010d: stloc.s 6
+		IL_010f: ldloc.0
+		IL_0110: ldloc.s 6
+		IL_0112: stfld object Modules.Import_Namespace_FromCjs_Stable_A/Scope::ns
+		IL_0117: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_011c: stloc.s 7
+		IL_011e: ldc.i4.1
+		IL_011f: newarr [System.Runtime]System.Object
+		IL_0124: dup
+		IL_0125: ldc.i4.0
+		IL_0126: ldloc.0
+		IL_0127: stelem.ref
+		IL_0128: ldc.i4.0
+		IL_0129: ldelem.ref
+		IL_012a: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
+		IL_012f: ldftn object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+		IL_0135: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_013a: ldc.i4.0
+		IL_013b: conv.r8
+		IL_013c: ldstr ""
+		IL_0141: ldc.i4.0
+		IL_0142: ldc.i4.1
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0148: stloc.s 6
+		IL_014a: ldloc.s 4
+		IL_014c: ldloc.s 7
+		IL_014e: ldstr "ns"
+		IL_0153: ldloc.s 6
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_015a: pop
+		IL_015b: ret
 	} // end of method Import_Namespace_FromCjs_Stable_A::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable_A
@@ -3263,7 +3299,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e36
+				// Method begins at RVA 0x3ea2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3289,7 +3325,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4b 00 00 02
 			)
-			// Method begins at RVA 0x3514
+			// Method begins at RVA 0x3578
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -3334,7 +3370,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3e2d
+			// Method begins at RVA 0x3e99
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3358,7 +3394,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x2454
+		// Method begins at RVA 0x24a4
 		// Header size: 12
 		// Code size: 103 (0x67)
 		.maxstack 8
@@ -3424,7 +3460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e48
+				// Method begins at RVA 0x3eb4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3450,7 +3486,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3556
+			// Method begins at RVA 0x35ba
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -3477,7 +3513,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e5a
+					// Method begins at RVA 0x3ec6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3495,7 +3531,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e51
+				// Method begins at RVA 0x3ebd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3521,7 +3557,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3560
+			// Method begins at RVA 0x35c4
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -3596,7 +3632,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e63
+				// Method begins at RVA 0x3ecf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3620,7 +3656,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x35f8
+			// Method begins at RVA 0x365c
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -3694,7 +3730,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e6c
+				// Method begins at RVA 0x3ed8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3719,7 +3755,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x367d
+			// Method begins at RVA 0x36e1
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3747,7 +3783,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e99
+					// Method begins at RVA 0x3f05
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3771,7 +3807,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3bf7
+				// Method begins at RVA 0x3c64
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3797,7 +3833,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ea2
+					// Method begins at RVA 0x3f0e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3821,7 +3857,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c06
+				// Method begins at RVA 0x3c73
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -3851,7 +3887,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3ecf
+						// Method begins at RVA 0x3f3b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3875,7 +3911,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x3cad
+					// Method begins at RVA 0x3d19
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -3909,7 +3945,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ec6
+					// Method begins at RVA 0x3f32
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3934,7 +3970,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3c18
+				// Method begins at RVA 0x3c84
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -4027,7 +4063,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e7e
+					// Method begins at RVA 0x3eea
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4047,7 +4083,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e87
+					// Method begins at RVA 0x3ef3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4067,7 +4103,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3e90
+					// Method begins at RVA 0x3efc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4091,7 +4127,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3eb4
+						// Method begins at RVA 0x3f20
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4111,7 +4147,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3ebd
+						// Method begins at RVA 0x3f29
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -4129,7 +4165,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3eab
+					// Method begins at RVA 0x3f17
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4149,7 +4185,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ed8
+					// Method begins at RVA 0x3f44
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4169,7 +4205,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ee1
+					// Method begins at RVA 0x3f4d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4191,7 +4227,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3e75
+				// Method begins at RVA 0x3ee1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4218,7 +4254,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3688
+			// Method begins at RVA 0x36ec
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -4743,7 +4779,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3eea
+				// Method begins at RVA 0x3f56
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4771,41 +4807,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 4d 00 00 02
 			)
-			// Method begins at RVA 0x3ba4
+			// Method begins at RVA 0x3c08
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -4831,7 +4872,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3e3f
+			// Method begins at RVA 0x3eab
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -4855,9 +4896,9 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x24c8
+		// Method begins at RVA 0x2518
 		// Header size: 12
-		// Code size: 341 (0x155)
+		// Code size: 348 (0x15c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_B/Scope,
@@ -4866,7 +4907,8 @@
 			[3] object,
 			[4] object,
 			[5] object,
-			[6] object
+			[6] object,
+			[7] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/Scope::.ctor()
@@ -4960,51 +5002,51 @@
 		IL_00da: ldloc.s 6
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 6
-		IL_00f8: ldloc.s 6
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.0
-		IL_00fd: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0102: ldnull
-		IL_0103: ldloc.s 5
-		IL_0105: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
-		IL_010a: stloc.s 6
-		IL_010c: ldloc.0
-		IL_010d: ldloc.s 6
-		IL_010f: stfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::ns
-		IL_0114: ldc.i4.1
-		IL_0115: newarr [System.Runtime]System.Object
-		IL_011a: dup
-		IL_011b: ldc.i4.0
-		IL_011c: ldloc.0
-		IL_011d: stelem.ref
-		IL_011e: ldc.i4.0
-		IL_011f: ldelem.ref
-		IL_0120: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0125: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0130: ldc.i4.0
-		IL_0131: conv.r8
-		IL_0132: ldstr ""
-		IL_0137: ldc.i4.0
-		IL_0138: ldc.i4.1
-		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_013e: stloc.s 6
-		IL_0140: ldloc.0
-		IL_0141: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0146: ldnull
-		IL_0147: ldstr "ns"
-		IL_014c: ldloc.s 6
-		IL_014e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object, object)
-		IL_0153: pop
-		IL_0154: ret
+		IL_00df: ldfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_Namespace_FromCjs_Stable_Lib.cjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 6
+		IL_00fc: ldloc.s 6
+		IL_00fe: stloc.s 5
+		IL_0100: ldloc.3
+		IL_0101: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0106: ldloc.s 5
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_010d: stloc.s 6
+		IL_010f: ldloc.0
+		IL_0110: ldloc.s 6
+		IL_0112: stfld object Modules.Import_Namespace_FromCjs_Stable_B/Scope::ns
+		IL_0117: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_011c: stloc.s 7
+		IL_011e: ldc.i4.1
+		IL_011f: newarr [System.Runtime]System.Object
+		IL_0124: dup
+		IL_0125: ldc.i4.0
+		IL_0126: ldloc.0
+		IL_0127: stelem.ref
+		IL_0128: ldc.i4.0
+		IL_0129: ldelem.ref
+		IL_012a: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
+		IL_012f: ldftn object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+		IL_0135: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_013a: ldc.i4.0
+		IL_013b: conv.r8
+		IL_013c: ldstr ""
+		IL_0141: ldc.i4.0
+		IL_0142: ldc.i4.1
+		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0148: stloc.s 6
+		IL_014a: ldloc.s 4
+		IL_014c: ldloc.s 7
+		IL_014e: ldstr "ns"
+		IL_0153: ldloc.s 6
+		IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_015a: pop
+		IL_015b: ret
 	} // end of method Import_Namespace_FromCjs_Stable_B::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable_B
@@ -5016,7 +5058,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3ef3
+		// Method begins at RVA 0x3f5f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -14,7 +14,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a9a
+			// Method begins at RVA 0x2ab2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,7 +106,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ab7
+				// Method begins at RVA 0x2acf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -132,7 +132,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x22e4
+			// Method begins at RVA 0x22f4
 			// Header size: 12
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -162,7 +162,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac0
+				// Method begins at RVA 0x2ad8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -188,7 +188,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2303
+			// Method begins at RVA 0x2313
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -211,7 +211,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ac9
+				// Method begins at RVA 0x2ae1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -236,7 +236,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x230c
+			// Method begins at RVA 0x231c
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -265,7 +265,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2ad2
+				// Method begins at RVA 0x2aea
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -291,7 +291,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2322
+			// Method begins at RVA 0x2332
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -318,7 +318,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2ae4
+					// Method begins at RVA 0x2afc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -336,7 +336,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2adb
+				// Method begins at RVA 0x2af3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -362,7 +362,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x232c
+			// Method begins at RVA 0x233c
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -437,7 +437,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aed
+				// Method begins at RVA 0x2b05
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -461,7 +461,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c4
+			// Method begins at RVA 0x23d4
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -535,7 +535,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2af6
+				// Method begins at RVA 0x2b0e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -560,7 +560,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2449
+			// Method begins at RVA 0x2459
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -588,7 +588,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b23
+					// Method begins at RVA 0x2b3b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29c3
+				// Method begins at RVA 0x29dc
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -638,7 +638,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b2c
+					// Method begins at RVA 0x2b44
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -662,7 +662,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29d2
+				// Method begins at RVA 0x29eb
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -692,7 +692,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b59
+						// Method begins at RVA 0x2b71
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -716,7 +716,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2a79
+					// Method begins at RVA 0x2a91
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -750,7 +750,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b50
+					// Method begins at RVA 0x2b68
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -775,7 +775,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x29e4
+				// Method begins at RVA 0x29fc
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -868,7 +868,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b08
+					// Method begins at RVA 0x2b20
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -888,7 +888,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b11
+					// Method begins at RVA 0x2b29
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -908,7 +908,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b1a
+					// Method begins at RVA 0x2b32
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -932,7 +932,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b3e
+						// Method begins at RVA 0x2b56
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -952,7 +952,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2b47
+						// Method begins at RVA 0x2b5f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -970,7 +970,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b35
+					// Method begins at RVA 0x2b4d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -990,7 +990,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b62
+					// Method begins at RVA 0x2b7a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1010,7 +1010,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2b6b
+					// Method begins at RVA 0x2b83
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1032,7 +1032,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2aff
+				// Method begins at RVA 0x2b17
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1059,7 +1059,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2454
+			// Method begins at RVA 0x2464
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1584,7 +1584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2b74
+				// Method begins at RVA 0x2b8c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1612,41 +1612,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2970
+			// Method begins at RVA 0x2980
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_RequireEsmModule_Lib/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1675,7 +1680,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2aa3
+			// Method begins at RVA 0x2abb
 			// Header size: 1
 			// Code size: 19 (0x13)
 			.maxstack 8
@@ -1704,7 +1709,7 @@
 	{
 		// Method begins at RVA 0x20e8
 		// Header size: 12
-		// Code size: 495 (0x1ef)
+		// Code size: 511 (0x1ff)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_RequireEsmModule_Lib/Scope,
@@ -1712,7 +1717,8 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object
+			[5] object,
+			[6] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_RequireEsmModule_Lib/Scope::.ctor()
@@ -1819,93 +1825,96 @@
 		IL_00fe: ldloc.s 5
 		IL_0100: stloc.s 4
 		IL_0102: ldloc.0
-		IL_0103: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0108: ldnull
-		IL_0109: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_010e: pop
-		IL_010f: ldc.i4.1
-		IL_0110: newarr [System.Runtime]System.Object
-		IL_0115: dup
-		IL_0116: ldc.i4.0
-		IL_0117: ldloc.0
-		IL_0118: stelem.ref
-		IL_0119: ldc.i4.0
-		IL_011a: ldelem.ref
-		IL_011b: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0120: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0126: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_012b: ldc.i4.0
-		IL_012c: conv.r8
-		IL_012d: ldstr ""
-		IL_0132: ldc.i4.0
-		IL_0133: ldc.i4.1
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0139: stloc.s 5
-		IL_013b: ldloc.0
-		IL_013c: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0141: ldnull
-		IL_0142: ldstr "named"
-		IL_0147: ldloc.s 5
-		IL_0149: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
-		IL_014e: pop
-		IL_014f: ldc.i4.1
-		IL_0150: newarr [System.Runtime]System.Object
-		IL_0155: dup
-		IL_0156: ldc.i4.0
-		IL_0157: ldloc.0
-		IL_0158: stelem.ref
-		IL_0159: ldc.i4.0
-		IL_015a: ldelem.ref
-		IL_015b: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0160: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0166: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_016b: ldc.i4.0
-		IL_016c: conv.r8
-		IL_016d: ldstr ""
-		IL_0172: ldc.i4.0
-		IL_0173: ldc.i4.1
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0179: stloc.s 5
-		IL_017b: ldloc.0
-		IL_017c: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0181: ldnull
-		IL_0182: ldstr "sum"
-		IL_0187: ldloc.s 5
-		IL_0189: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
-		IL_018e: pop
-		IL_018f: ldloc.0
-		IL_0190: ldc.r8 7
-		IL_0199: box [System.Runtime]System.Double
-		IL_019e: stfld object Modules.Import_RequireEsmModule_Lib/Scope::named
-		IL_01a3: ldloc.0
-		IL_01a4: ldstr "esm-default"
-		IL_01a9: stfld string Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_default_0
-		IL_01ae: ldc.i4.1
-		IL_01af: newarr [System.Runtime]System.Object
-		IL_01b4: dup
-		IL_01b5: ldc.i4.0
-		IL_01b6: ldloc.0
-		IL_01b7: stelem.ref
-		IL_01b8: ldc.i4.0
-		IL_01b9: ldelem.ref
-		IL_01ba: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_01bf: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_01c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01ca: ldc.i4.0
-		IL_01cb: conv.r8
-		IL_01cc: ldstr ""
-		IL_01d1: ldc.i4.0
-		IL_01d2: ldc.i4.1
-		IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01d8: stloc.s 5
-		IL_01da: ldloc.0
-		IL_01db: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_01e0: ldnull
-		IL_01e1: ldstr "default"
-		IL_01e6: ldloc.s 5
-		IL_01e8: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, object)
-		IL_01ed: pop
-		IL_01ee: ret
+		IL_0103: ldfld object Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_mark
+		IL_0108: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0112: pop
+		IL_0113: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0118: stloc.s 6
+		IL_011a: ldc.i4.1
+		IL_011b: newarr [System.Runtime]System.Object
+		IL_0120: dup
+		IL_0121: ldc.i4.0
+		IL_0122: ldloc.0
+		IL_0123: stelem.ref
+		IL_0124: ldc.i4.0
+		IL_0125: ldelem.ref
+		IL_0126: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_012b: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+		IL_0131: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0136: ldc.i4.0
+		IL_0137: conv.r8
+		IL_0138: ldstr ""
+		IL_013d: ldc.i4.0
+		IL_013e: ldc.i4.1
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0144: stloc.s 5
+		IL_0146: ldloc.s 4
+		IL_0148: ldloc.s 6
+		IL_014a: ldstr "named"
+		IL_014f: ldloc.s 5
+		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0156: pop
+		IL_0157: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_015c: stloc.s 6
+		IL_015e: ldc.i4.1
+		IL_015f: newarr [System.Runtime]System.Object
+		IL_0164: dup
+		IL_0165: ldc.i4.0
+		IL_0166: ldloc.0
+		IL_0167: stelem.ref
+		IL_0168: ldc.i4.0
+		IL_0169: ldelem.ref
+		IL_016a: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_016f: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+		IL_0175: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_017a: ldc.i4.0
+		IL_017b: conv.r8
+		IL_017c: ldstr ""
+		IL_0181: ldc.i4.0
+		IL_0182: ldc.i4.1
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0188: stloc.s 5
+		IL_018a: ldloc.s 4
+		IL_018c: ldloc.s 6
+		IL_018e: ldstr "sum"
+		IL_0193: ldloc.s 5
+		IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_019a: pop
+		IL_019b: ldloc.0
+		IL_019c: ldc.r8 7
+		IL_01a5: box [System.Runtime]System.Double
+		IL_01aa: stfld object Modules.Import_RequireEsmModule_Lib/Scope::named
+		IL_01af: ldloc.0
+		IL_01b0: ldstr "esm-default"
+		IL_01b5: stfld string Modules.Import_RequireEsmModule_Lib/Scope::__jroc_esm_default_0
+		IL_01ba: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01bf: stloc.s 6
+		IL_01c1: ldc.i4.1
+		IL_01c2: newarr [System.Runtime]System.Object
+		IL_01c7: dup
+		IL_01c8: ldc.i4.0
+		IL_01c9: ldloc.0
+		IL_01ca: stelem.ref
+		IL_01cb: ldc.i4.0
+		IL_01cc: ldelem.ref
+		IL_01cd: castclass Modules.Import_RequireEsmModule_Lib/Scope
+		IL_01d2: ldftn object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+		IL_01d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01dd: ldc.i4.0
+		IL_01de: conv.r8
+		IL_01df: ldstr ""
+		IL_01e4: ldc.i4.0
+		IL_01e5: ldc.i4.1
+		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01eb: stloc.s 5
+		IL_01ed: ldloc.s 4
+		IL_01ef: ldloc.s 6
+		IL_01f1: ldstr "default"
+		IL_01f6: ldloc.s 5
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01fd: pop
+		IL_01fe: ret
 	} // end of method Import_RequireEsmModule_Lib::__js_module_init__
 
 } // end of class Modules.Import_RequireEsmModule_Lib
@@ -1917,7 +1926,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2b7d
+		// Method begins at RVA 0x2b95
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29c8
+					// Method begins at RVA 0x29e0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29bf
+				// Method begins at RVA 0x29d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -66,7 +66,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2248
+			// Method begins at RVA 0x2258
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -141,7 +141,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29d1
+				// Method begins at RVA 0x29e9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -165,7 +165,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e0
+			// Method begins at RVA 0x22f0
 			// Header size: 12
 			// Code size: 121 (0x79)
 			.maxstack 8
@@ -239,7 +239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29da
+				// Method begins at RVA 0x29f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -264,7 +264,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2365
+			// Method begins at RVA 0x2375
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -292,7 +292,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a07
+					// Method begins at RVA 0x2a1f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -316,7 +316,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28df
+				// Method begins at RVA 0x28f8
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -342,7 +342,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a10
+					// Method begins at RVA 0x2a28
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -366,7 +366,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x28ee
+				// Method begins at RVA 0x2907
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -396,7 +396,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a3d
+						// Method begins at RVA 0x2a55
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -420,7 +420,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2995
+					// Method begins at RVA 0x29ad
 					// Header size: 1
 					// Code size: 32 (0x20)
 					.maxstack 8
@@ -454,7 +454,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a34
+					// Method begins at RVA 0x2a4c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -479,7 +479,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2900
+				// Method begins at RVA 0x2918
 				// Header size: 12
 				// Code size: 137 (0x89)
 				.maxstack 8
@@ -572,7 +572,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29ec
+					// Method begins at RVA 0x2a04
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -592,7 +592,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29f5
+					// Method begins at RVA 0x2a0d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -612,7 +612,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29fe
+					// Method begins at RVA 0x2a16
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -636,7 +636,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a22
+						// Method begins at RVA 0x2a3a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -656,7 +656,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2a2b
+						// Method begins at RVA 0x2a43
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a19
+					// Method begins at RVA 0x2a31
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -694,7 +694,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a46
+					// Method begins at RVA 0x2a5e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -714,7 +714,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2a4f
+					// Method begins at RVA 0x2a67
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29e3
+				// Method begins at RVA 0x29fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,7 +763,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2370
+			// Method begins at RVA 0x2380
 			// Header size: 12
 			// Code size: 1279 (0x4ff)
 			.maxstack 8
@@ -1288,7 +1288,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a58
+				// Method begins at RVA 0x2a70
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1316,41 +1316,46 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x288c
+			// Method begins at RVA 0x289c
 			// Header size: 12
-			// Code size: 71 (0x47)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] object
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Import_StaticImport_FromCjs/Scope
-			IL_0006: ldnull
-			IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
-			IL_000c: pop
-			IL_000d: ldarg.0
-			IL_000e: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
-			IL_0013: stloc.0
-			IL_0014: ldloc.0
-			IL_0015: ldarg.2
-			IL_0016: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_001b: dup
-			IL_001c: ldstr "enumerable"
-			IL_0021: ldc.i4.1
-			IL_0022: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0027: dup
-			IL_0028: ldstr "configurable"
-			IL_002d: ldc.i4.1
-			IL_002e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0033: dup
-			IL_0034: ldstr "get"
-			IL_0039: ldarg.3
-			IL_003a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-			IL_0044: pop
-			IL_0045: ldnull
-			IL_0046: ret
+			IL_0001: ldfld object Modules.Import_StaticImport_FromCjs/Scope::__jroc_esm_mark
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0015: pop
+			IL_0016: ldarg.0
+			IL_0017: ldfld object Modules.Import_StaticImport_FromCjs/Scope::exports
+			IL_001c: stloc.0
+			IL_001d: ldloc.0
+			IL_001e: ldarg.2
+			IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0024: dup
+			IL_0025: ldstr "enumerable"
+			IL_002a: ldc.i4.1
+			IL_002b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0030: dup
+			IL_0031: ldstr "configurable"
+			IL_0036: ldc.i4.1
+			IL_0037: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_003c: dup
+			IL_003d: ldstr "get"
+			IL_0042: ldarg.3
+			IL_0043: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method __jroc_esm_export::__js_call__
 
 	} // end of class __jroc_esm_export
@@ -1374,7 +1379,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29b6
+			// Method begins at RVA 0x29ce
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1400,7 +1405,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 431 (0x1af)
+		// Code size: 448 (0x1c0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_StaticImport_FromCjs/Scope,
@@ -1411,7 +1416,8 @@
 			[5] object,
 			[6] object,
 			[7] object,
-			[8] object
+			[8] object,
+			[9] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Import_StaticImport_FromCjs/Scope::.ctor()
@@ -1505,70 +1511,73 @@
 		IL_00da: ldloc.s 8
 		IL_00dc: stloc.s 4
 		IL_00de: ldloc.0
-		IL_00df: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_00e4: ldnull
-		IL_00e5: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
-		IL_00ea: pop
-		IL_00eb: ldarg.1
-		IL_00ec: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
-		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_00f6: stloc.s 8
-		IL_00f8: ldloc.s 8
-		IL_00fa: stloc.s 5
-		IL_00fc: ldarg.1
-		IL_00fd: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0107: stloc.s 8
-		IL_0109: ldloc.s 8
-		IL_010b: stloc.s 6
-		IL_010d: ldloc.0
-		IL_010e: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_0113: ldnull
-		IL_0114: ldloc.s 6
-		IL_0116: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
-		IL_011b: stloc.s 8
-		IL_011d: ldloc.s 8
-		IL_011f: stloc.s 7
-		IL_0121: ldnull
-		IL_0122: ldloc.s 5
-		IL_0124: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
-		IL_0129: stloc.s 8
-		IL_012b: ldloc.s 8
-		IL_012d: ldstr "value"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0137: stloc.s 8
-		IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013e: ldstr "default.value:"
-		IL_0143: ldloc.s 8
-		IL_0145: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_014a: pop
-		IL_014b: ldnull
-		IL_014c: ldloc.s 5
-		IL_014e: ldstr "value"
-		IL_0153: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0158: stloc.s 8
-		IL_015a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_015f: ldstr "named:"
-		IL_0164: ldloc.s 8
-		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_016b: pop
-		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0171: ldstr "namespace.default.value:"
-		IL_0176: ldloc.s 7
-		IL_0178: ldstr "default"
-		IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0182: ldstr "value"
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0191: pop
-		IL_0192: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0197: ldstr "namespace.value:"
-		IL_019c: ldloc.s 7
-		IL_019e: ldstr "value"
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01ad: pop
-		IL_01ae: ret
+		IL_00df: ldfld object Modules.Import_StaticImport_FromCjs/Scope::__jroc_esm_mark
+		IL_00e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00ee: pop
+		IL_00ef: ldarg.1
+		IL_00f0: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
+		IL_00f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_00fa: stloc.s 8
+		IL_00fc: ldloc.s 8
+		IL_00fe: stloc.s 5
+		IL_0100: ldarg.1
+		IL_0101: ldstr "./Import_StaticImport_FromCjs_Lib.cjs"
+		IL_0106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_010b: stloc.s 8
+		IL_010d: ldloc.s 8
+		IL_010f: stloc.s 6
+		IL_0111: ldloc.3
+		IL_0112: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0117: ldloc.s 6
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_011e: stloc.s 8
+		IL_0120: ldloc.s 8
+		IL_0122: stloc.s 7
+		IL_0124: ldloc.1
+		IL_0125: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_012a: ldloc.s 5
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0131: stloc.s 8
+		IL_0133: ldloc.s 8
+		IL_0135: ldstr "value"
+		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_013f: stloc.s 8
+		IL_0141: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0146: ldstr "default.value:"
+		IL_014b: ldloc.s 8
+		IL_014d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0152: pop
+		IL_0153: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0158: stloc.s 9
+		IL_015a: ldloc.2
+		IL_015b: ldloc.s 9
+		IL_015d: ldloc.s 5
+		IL_015f: ldstr "value"
+		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0169: stloc.s 8
+		IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0170: ldstr "named:"
+		IL_0175: ldloc.s 8
+		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_017c: pop
+		IL_017d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0182: ldstr "namespace.default.value:"
+		IL_0187: ldloc.s 7
+		IL_0189: ldstr "default"
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0193: ldstr "value"
+		IL_0198: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_019d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01a2: pop
+		IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a8: ldstr "namespace.value:"
+		IL_01ad: ldloc.s 7
+		IL_01af: ldstr "value"
+		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01be: pop
+		IL_01bf: ret
 	} // end of method Import_StaticImport_FromCjs::__js_module_init__
 
 } // end of class Modules.Import_StaticImport_FromCjs
@@ -1584,7 +1593,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2a61
+			// Method begins at RVA 0x2a79
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1608,7 +1617,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x220c
+		// Method begins at RVA 0x221c
 		// Header size: 12
 		// Code size: 47 (0x2f)
 		.maxstack 8
@@ -1643,7 +1652,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a6a
+		// Method begins at RVA 0x2a82
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x274e
+				// Method begins at RVA 0x27ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23bd
+			// Method begins at RVA 0x241b
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2757
+				// Method begins at RVA 0x27b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c0
+			// Method begins at RVA 0x241e
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2769
+					// Method begins at RVA 0x27c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2760
+				// Method begins at RVA 0x27c0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23c4
+			// Method begins at RVA 0x2424
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x277b
+					// Method begins at RVA 0x27db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2772
+				// Method begins at RVA 0x27d2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x23f0
+			// Method begins at RVA 0x2450
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2784
+				// Method begins at RVA 0x27e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2796
+					// Method begins at RVA 0x27f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -317,7 +317,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x278d
+				// Method begins at RVA 0x27ed
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -343,7 +343,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x241c
+			// Method begins at RVA 0x247c
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -401,7 +401,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x279f
+				// Method begins at RVA 0x27ff
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -421,7 +421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a8
+				// Method begins at RVA 0x2808
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -447,7 +447,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2484
+			// Method begins at RVA 0x24e4
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -505,7 +505,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b1
+				// Method begins at RVA 0x2811
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -525,7 +525,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ba
+				// Method begins at RVA 0x281a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -551,7 +551,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x24ec
+			// Method begins at RVA 0x254c
 			// Header size: 12
 			// Code size: 77 (0x4d)
 			.maxstack 8
@@ -608,7 +608,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27c3
+				// Method begins at RVA 0x2823
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -628,7 +628,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27cc
+				// Method begins at RVA 0x282c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -654,7 +654,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2548
+			// Method begins at RVA 0x25a8
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -715,7 +715,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d5
+				// Method begins at RVA 0x2835
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -735,7 +735,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27de
+				// Method begins at RVA 0x283e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -761,7 +761,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x25c0
+			// Method begins at RVA 0x2620
 			// Header size: 12
 			// Code size: 71 (0x47)
 			.maxstack 8
@@ -817,7 +817,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27e7
+				// Method begins at RVA 0x2847
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -837,7 +837,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f0
+				// Method begins at RVA 0x2850
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -863,7 +863,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2614
+			// Method begins at RVA 0x2674
 			// Header size: 12
 			// Code size: 99 (0x63)
 			.maxstack 8
@@ -922,7 +922,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27f9
+				// Method begins at RVA 0x2859
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -942,7 +942,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2802
+				// Method begins at RVA 0x2862
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -968,7 +968,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x2684
+			// Method begins at RVA 0x26e4
 			// Header size: 12
 			// Code size: 87 (0x57)
 			.maxstack 8
@@ -1027,7 +1027,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x280b
+				// Method begins at RVA 0x286b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1047,7 +1047,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2814
+				// Method begins at RVA 0x2874
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1073,7 +1073,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
-			// Method begins at RVA 0x26e8
+			// Method begins at RVA 0x2748
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1145,7 +1145,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2745
+			// Method begins at RVA 0x27a5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1171,7 +1171,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 865 (0x361)
+		// Code size: 959 (0x3bf)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope,
@@ -1180,7 +1180,8 @@
 			[3] object,
 			[4] object,
 			[5] float64,
-			[6] object
+			[6] object,
+			[7] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::.ctor()
@@ -1233,283 +1234,311 @@
 		IL_007d: stloc.s 6
 		IL_007f: ldloc.s 6
 		IL_0081: stloc.s 4
-		IL_0083: ldnull
-		IL_0084: ldstr "dromaeo-object-array"
-		IL_0089: ldstr "bde4f5f4"
-		IL_008e: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
-		IL_0093: pop
-		IL_0094: ldloc.0
-		IL_0095: ldc.i4.0
-		IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_009b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
-		IL_00a0: ldloc.0
-		IL_00a1: ldnull
-		IL_00a2: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
-		IL_00a7: ldc.r8 500
-		IL_00b0: stloc.s 5
-		IL_00b2: ldloc.0
-		IL_00b3: ldc.r8 1024
-		IL_00bc: stfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
-		IL_00c1: ldc.i4.1
-		IL_00c2: newarr [System.Runtime]System.Object
-		IL_00c7: dup
-		IL_00c8: ldc.i4.0
-		IL_00c9: ldloc.0
-		IL_00ca: stelem.ref
-		IL_00cb: ldc.i4.0
-		IL_00cc: ldelem.ref
-		IL_00cd: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_00d2: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_00d8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00dd: ldc.i4.1
-		IL_00de: newarr [System.Runtime]System.Object
-		IL_00e3: dup
-		IL_00e4: ldc.i4.0
-		IL_00e5: ldloc.0
-		IL_00e6: stelem.ref
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00f1: ldc.i4.0
-		IL_00f2: conv.r8
-		IL_00f3: ldstr ""
-		IL_00f8: ldc.i4.0
-		IL_00f9: ldc.i4.1
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0104: stloc.s 6
-		IL_0106: ldnull
-		IL_0107: ldstr "Array Construction, []"
-		IL_010c: ldloc.s 6
-		IL_010e: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0113: pop
-		IL_0114: ldc.i4.1
-		IL_0115: newarr [System.Runtime]System.Object
-		IL_011a: dup
-		IL_011b: ldc.i4.0
-		IL_011c: ldloc.0
-		IL_011d: stelem.ref
-		IL_011e: ldc.i4.0
-		IL_011f: ldelem.ref
-		IL_0120: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0125: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_012b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0130: ldc.i4.1
-		IL_0131: newarr [System.Runtime]System.Object
-		IL_0136: dup
-		IL_0137: ldc.i4.0
-		IL_0138: ldloc.0
-		IL_0139: stelem.ref
-		IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0144: ldc.i4.0
-		IL_0145: conv.r8
-		IL_0146: ldstr ""
-		IL_014b: ldc.i4.0
-		IL_014c: ldc.i4.1
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0157: stloc.s 6
-		IL_0159: ldnull
-		IL_015a: ldstr "Array Construction, new Array()"
-		IL_015f: ldloc.s 6
-		IL_0161: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0166: pop
-		IL_0167: ldc.i4.1
-		IL_0168: newarr [System.Runtime]System.Object
-		IL_016d: dup
-		IL_016e: ldc.i4.0
-		IL_016f: ldloc.0
-		IL_0170: stelem.ref
-		IL_0171: ldc.i4.0
-		IL_0172: ldelem.ref
-		IL_0173: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0178: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_017e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0183: ldc.i4.1
-		IL_0184: newarr [System.Runtime]System.Object
-		IL_0189: dup
-		IL_018a: ldc.i4.0
-		IL_018b: ldloc.0
-		IL_018c: stelem.ref
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0197: ldc.i4.0
-		IL_0198: conv.r8
-		IL_0199: ldstr ""
-		IL_019e: ldc.i4.0
-		IL_019f: ldc.i4.1
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01aa: stloc.s 6
-		IL_01ac: ldnull
-		IL_01ad: ldstr "Array Construction, unshift"
-		IL_01b2: ldloc.s 6
-		IL_01b4: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_01b9: pop
-		IL_01ba: ldc.i4.1
-		IL_01bb: newarr [System.Runtime]System.Object
-		IL_01c0: dup
-		IL_01c1: ldc.i4.0
-		IL_01c2: ldloc.0
-		IL_01c3: stelem.ref
-		IL_01c4: ldc.i4.0
-		IL_01c5: ldelem.ref
-		IL_01c6: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_01cb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_01d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01d6: ldc.i4.1
-		IL_01d7: newarr [System.Runtime]System.Object
-		IL_01dc: dup
-		IL_01dd: ldc.i4.0
-		IL_01de: ldloc.0
-		IL_01df: stelem.ref
-		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01ea: ldc.i4.0
-		IL_01eb: conv.r8
-		IL_01ec: ldstr ""
-		IL_01f1: ldc.i4.0
-		IL_01f2: ldc.i4.1
-		IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01fd: stloc.s 6
-		IL_01ff: ldnull
-		IL_0200: ldstr "Array Construction, splice"
-		IL_0205: ldloc.s 6
-		IL_0207: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_020c: pop
-		IL_020d: ldc.i4.1
-		IL_020e: newarr [System.Runtime]System.Object
-		IL_0213: dup
-		IL_0214: ldc.i4.0
-		IL_0215: ldloc.0
-		IL_0216: stelem.ref
-		IL_0217: ldc.i4.0
-		IL_0218: ldelem.ref
-		IL_0219: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_021e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0224: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0229: ldc.i4.1
-		IL_022a: newarr [System.Runtime]System.Object
-		IL_022f: dup
-		IL_0230: ldc.i4.0
-		IL_0231: ldloc.0
-		IL_0232: stelem.ref
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_023d: ldc.i4.0
-		IL_023e: conv.r8
-		IL_023f: ldstr ""
-		IL_0244: ldc.i4.0
+		IL_0083: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0088: stloc.s 7
+		IL_008a: ldloc.1
+		IL_008b: ldloc.s 7
+		IL_008d: ldstr "dromaeo-object-array"
+		IL_0092: ldstr "bde4f5f4"
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_009c: pop
+		IL_009d: ldloc.0
+		IL_009e: ldc.i4.0
+		IL_009f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00a4: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::'ret'
+		IL_00a9: ldloc.0
+		IL_00aa: ldnull
+		IL_00ab: stfld object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::tmp
+		IL_00b0: ldc.r8 500
+		IL_00b9: stloc.s 5
+		IL_00bb: ldloc.0
+		IL_00bc: ldc.r8 1024
+		IL_00c5: stfld float64 Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope::i
+		IL_00ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00cf: stloc.s 7
+		IL_00d1: ldc.i4.1
+		IL_00d2: newarr [System.Runtime]System.Object
+		IL_00d7: dup
+		IL_00d8: ldc.i4.0
+		IL_00d9: ldloc.0
+		IL_00da: stelem.ref
+		IL_00db: ldc.i4.0
+		IL_00dc: ldelem.ref
+		IL_00dd: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_00e2: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L15C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_00e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ed: ldc.i4.1
+		IL_00ee: newarr [System.Runtime]System.Object
+		IL_00f3: dup
+		IL_00f4: ldc.i4.0
+		IL_00f5: ldloc.0
+		IL_00f6: stelem.ref
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0101: ldc.i4.0
+		IL_0102: conv.r8
+		IL_0103: ldstr ""
+		IL_0108: ldc.i4.0
+		IL_0109: ldc.i4.1
+		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0114: stloc.s 6
+		IL_0116: ldloc.s 4
+		IL_0118: ldloc.s 7
+		IL_011a: ldstr "Array Construction, []"
+		IL_011f: ldloc.s 6
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0126: pop
+		IL_0127: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_012c: stloc.s 7
+		IL_012e: ldc.i4.1
+		IL_012f: newarr [System.Runtime]System.Object
+		IL_0134: dup
+		IL_0135: ldc.i4.0
+		IL_0136: ldloc.0
+		IL_0137: stelem.ref
+		IL_0138: ldc.i4.0
+		IL_0139: ldelem.ref
+		IL_013a: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_013f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L22C41::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0145: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_014a: ldc.i4.1
+		IL_014b: newarr [System.Runtime]System.Object
+		IL_0150: dup
+		IL_0151: ldc.i4.0
+		IL_0152: ldloc.0
+		IL_0153: stelem.ref
+		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_015e: ldc.i4.0
+		IL_015f: conv.r8
+		IL_0160: ldstr ""
+		IL_0165: ldc.i4.0
+		IL_0166: ldc.i4.1
+		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0171: stloc.s 6
+		IL_0173: ldloc.s 4
+		IL_0175: ldloc.s 7
+		IL_0177: ldstr "Array Construction, new Array()"
+		IL_017c: ldloc.s 6
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0183: pop
+		IL_0184: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0189: stloc.s 7
+		IL_018b: ldc.i4.1
+		IL_018c: newarr [System.Runtime]System.Object
+		IL_0191: dup
+		IL_0192: ldc.i4.0
+		IL_0193: ldloc.0
+		IL_0194: stelem.ref
+		IL_0195: ldc.i4.0
+		IL_0196: ldelem.ref
+		IL_0197: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_019c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L27C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_01a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01a7: ldc.i4.1
+		IL_01a8: newarr [System.Runtime]System.Object
+		IL_01ad: dup
+		IL_01ae: ldc.i4.0
+		IL_01af: ldloc.0
+		IL_01b0: stelem.ref
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01bb: ldc.i4.0
+		IL_01bc: conv.r8
+		IL_01bd: ldstr ""
+		IL_01c2: ldc.i4.0
+		IL_01c3: ldc.i4.1
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_01ce: stloc.s 6
+		IL_01d0: ldloc.s 4
+		IL_01d2: ldloc.s 7
+		IL_01d4: ldstr "Array Construction, unshift"
+		IL_01d9: ldloc.s 6
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01e0: pop
+		IL_01e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01e6: stloc.s 7
+		IL_01e8: ldc.i4.1
+		IL_01e9: newarr [System.Runtime]System.Object
+		IL_01ee: dup
+		IL_01ef: ldc.i4.0
+		IL_01f0: ldloc.0
+		IL_01f1: stelem.ref
+		IL_01f2: ldc.i4.0
+		IL_01f3: ldelem.ref
+		IL_01f4: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_01f9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L33C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_01ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0204: ldc.i4.1
+		IL_0205: newarr [System.Runtime]System.Object
+		IL_020a: dup
+		IL_020b: ldc.i4.0
+		IL_020c: ldloc.0
+		IL_020d: stelem.ref
+		IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0218: ldc.i4.0
+		IL_0219: conv.r8
+		IL_021a: ldstr ""
+		IL_021f: ldc.i4.0
+		IL_0220: ldc.i4.1
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_022b: stloc.s 6
+		IL_022d: ldloc.s 4
+		IL_022f: ldloc.s 7
+		IL_0231: ldstr "Array Construction, splice"
+		IL_0236: ldloc.s 6
+		IL_0238: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_023d: pop
+		IL_023e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0243: stloc.s 7
 		IL_0245: ldc.i4.1
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_024b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0250: stloc.s 6
-		IL_0252: ldnull
-		IL_0253: ldstr "Array Deconstruction, shift"
-		IL_0258: ldloc.s 6
-		IL_025a: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_025f: pop
-		IL_0260: ldc.i4.1
-		IL_0261: newarr [System.Runtime]System.Object
-		IL_0266: dup
-		IL_0267: ldc.i4.0
-		IL_0268: ldloc.0
-		IL_0269: stelem.ref
-		IL_026a: ldc.i4.0
-		IL_026b: ldelem.ref
-		IL_026c: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0271: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_0277: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_027c: ldc.i4.1
-		IL_027d: newarr [System.Runtime]System.Object
-		IL_0282: dup
-		IL_0283: ldc.i4.0
-		IL_0284: ldloc.0
-		IL_0285: stelem.ref
-		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0290: ldc.i4.0
-		IL_0291: conv.r8
-		IL_0292: ldstr ""
-		IL_0297: ldc.i4.0
-		IL_0298: ldc.i4.1
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02a3: stloc.s 6
-		IL_02a5: ldnull
-		IL_02a6: ldstr "Array Deconstruction, splice"
-		IL_02ab: ldloc.s 6
-		IL_02ad: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_02b2: pop
-		IL_02b3: ldc.i4.1
-		IL_02b4: newarr [System.Runtime]System.Object
-		IL_02b9: dup
-		IL_02ba: ldc.i4.0
-		IL_02bb: ldloc.0
-		IL_02bc: stelem.ref
-		IL_02bd: ldc.i4.0
-		IL_02be: ldelem.ref
-		IL_02bf: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_02c4: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_02ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02cf: ldc.i4.1
-		IL_02d0: newarr [System.Runtime]System.Object
-		IL_02d5: dup
-		IL_02d6: ldc.i4.0
-		IL_02d7: ldloc.0
-		IL_02d8: stelem.ref
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02e3: ldc.i4.0
-		IL_02e4: conv.r8
-		IL_02e5: ldstr ""
-		IL_02ea: ldc.i4.0
-		IL_02eb: ldc.i4.1
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02f6: stloc.s 6
-		IL_02f8: ldnull
-		IL_02f9: ldstr "Array Construction, push"
-		IL_02fe: ldloc.s 6
-		IL_0300: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0305: pop
-		IL_0306: ldc.i4.1
-		IL_0307: newarr [System.Runtime]System.Object
-		IL_030c: dup
-		IL_030d: ldc.i4.0
-		IL_030e: ldloc.0
-		IL_030f: stelem.ref
-		IL_0310: ldc.i4.0
-		IL_0311: ldelem.ref
-		IL_0312: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
-		IL_0317: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
-		IL_031d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0322: ldc.i4.1
-		IL_0323: newarr [System.Runtime]System.Object
-		IL_0328: dup
-		IL_0329: ldc.i4.0
-		IL_032a: ldloc.0
-		IL_032b: stelem.ref
-		IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0246: newarr [System.Runtime]System.Object
+		IL_024b: dup
+		IL_024c: ldc.i4.0
+		IL_024d: ldloc.0
+		IL_024e: stelem.ref
+		IL_024f: ldc.i4.0
+		IL_0250: ldelem.ref
+		IL_0251: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0256: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L39C37::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_025c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0261: ldc.i4.1
+		IL_0262: newarr [System.Runtime]System.Object
+		IL_0267: dup
+		IL_0268: ldc.i4.0
+		IL_0269: ldloc.0
+		IL_026a: stelem.ref
+		IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0275: ldc.i4.0
+		IL_0276: conv.r8
+		IL_0277: ldstr ""
+		IL_027c: ldc.i4.0
+		IL_027d: ldc.i4.1
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0288: stloc.s 6
+		IL_028a: ldloc.s 4
+		IL_028c: ldloc.s 7
+		IL_028e: ldstr "Array Deconstruction, shift"
+		IL_0293: ldloc.s 6
+		IL_0295: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_029a: pop
+		IL_029b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02a0: stloc.s 7
+		IL_02a2: ldc.i4.1
+		IL_02a3: newarr [System.Runtime]System.Object
+		IL_02a8: dup
+		IL_02a9: ldc.i4.0
+		IL_02aa: ldloc.0
+		IL_02ab: stelem.ref
+		IL_02ac: ldc.i4.0
+		IL_02ad: ldelem.ref
+		IL_02ae: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_02b3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L45C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_02b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02be: ldc.i4.1
+		IL_02bf: newarr [System.Runtime]System.Object
+		IL_02c4: dup
+		IL_02c5: ldc.i4.0
+		IL_02c6: ldloc.0
+		IL_02c7: stelem.ref
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02d2: ldc.i4.0
+		IL_02d3: conv.r8
+		IL_02d4: ldstr ""
+		IL_02d9: ldc.i4.0
+		IL_02da: ldc.i4.1
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_02e5: stloc.s 6
+		IL_02e7: ldloc.s 4
+		IL_02e9: ldloc.s 7
+		IL_02eb: ldstr "Array Deconstruction, splice"
+		IL_02f0: ldloc.s 6
+		IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02f7: pop
+		IL_02f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02fd: stloc.s 7
+		IL_02ff: ldc.i4.1
+		IL_0300: newarr [System.Runtime]System.Object
+		IL_0305: dup
+		IL_0306: ldc.i4.0
+		IL_0307: ldloc.0
+		IL_0308: stelem.ref
+		IL_0309: ldc.i4.0
+		IL_030a: ldelem.ref
+		IL_030b: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_0310: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L51C34::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0316: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_031b: ldc.i4.1
+		IL_031c: newarr [System.Runtime]System.Object
+		IL_0321: dup
+		IL_0322: ldc.i4.0
+		IL_0323: ldloc.0
+		IL_0324: stelem.ref
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_032f: ldc.i4.0
+		IL_0330: conv.r8
+		IL_0331: ldstr ""
 		IL_0336: ldc.i4.0
-		IL_0337: conv.r8
-		IL_0338: ldstr ""
-		IL_033d: ldc.i4.0
-		IL_033e: ldc.i4.1
-		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0344: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0349: stloc.s 6
-		IL_034b: ldnull
-		IL_034c: ldstr "Array Deconstruction, pop"
-		IL_0351: ldloc.s 6
-		IL_0353: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, object, object)
-		IL_0358: pop
-		IL_0359: ldnull
-		IL_035a: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
-		IL_035f: pop
-		IL_0360: ret
+		IL_0337: ldc.i4.1
+		IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0342: stloc.s 6
+		IL_0344: ldloc.s 4
+		IL_0346: ldloc.s 7
+		IL_0348: ldstr "Array Construction, push"
+		IL_034d: ldloc.s 6
+		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0354: pop
+		IL_0355: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_035a: stloc.s 7
+		IL_035c: ldc.i4.1
+		IL_035d: newarr [System.Runtime]System.Object
+		IL_0362: dup
+		IL_0363: ldc.i4.0
+		IL_0364: ldloc.0
+		IL_0365: stelem.ref
+		IL_0366: ldc.i4.0
+		IL_0367: ldelem.ref
+		IL_0368: castclass Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope
+		IL_036d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/ArrowFunction_L57C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope, object)
+		IL_0373: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0378: ldc.i4.1
+		IL_0379: newarr [System.Runtime]System.Object
+		IL_037e: dup
+		IL_037f: ldc.i4.0
+		IL_0380: ldloc.0
+		IL_0381: stelem.ref
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_038c: ldc.i4.0
+		IL_038d: conv.r8
+		IL_038e: ldstr ""
+		IL_0393: ldc.i4.0
+		IL_0394: ldc.i4.1
+		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_039f: stloc.s 6
+		IL_03a1: ldloc.s 4
+		IL_03a3: ldloc.s 7
+		IL_03a5: ldstr "Array Deconstruction, pop"
+		IL_03aa: ldloc.s 6
+		IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_03b1: pop
+		IL_03b2: ldloc.2
+		IL_03b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_03bd: pop
+		IL_03be: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Array_Modern::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Array_Modern
@@ -1521,7 +1550,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x281d
+		// Method begins at RVA 0x287d
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a22
+				// Method begins at RVA 0x502e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3102
+			// Method begins at RVA 0x33a0
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a2b
+				// Method begins at RVA 0x5037
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3105
+			// Method begins at RVA 0x33a3
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a3d
+					// Method begins at RVA 0x5049
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a34
+				// Method begins at RVA 0x5040
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3108
+			// Method begins at RVA 0x33a8
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a4f
+					// Method begins at RVA 0x505b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a46
+				// Method begins at RVA 0x5052
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3134
+			// Method begins at RVA 0x33d4
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -275,7 +275,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a58
+				// Method begins at RVA 0x5064
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -298,7 +298,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3160
+			// Method begins at RVA 0x3400
 			// Header size: 12
 			// Code size: 46 (0x2e)
 			.maxstack 8
@@ -349,7 +349,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4a73
+						// Method begins at RVA 0x507f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -369,7 +369,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4a7c
+						// Method begins at RVA 0x5088
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -387,7 +387,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4a6a
+					// Method begins at RVA 0x5076
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -405,7 +405,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a61
+				// Method begins at RVA 0x506d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -432,9 +432,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x319c
+			// Method begins at RVA 0x343c
 			// Header size: 12
-			// Code size: 460 (0x1cc)
+			// Code size: 520 (0x208)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -445,10 +445,11 @@
 				[5] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L32C39,
 				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L37C48,
 				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[8] string,
+				[8] object,
 				[9] object,
 				[10] float64,
-				[11] object
+				[11] object,
+				[12] string
 			)
 
 			IL_0000: ldnull
@@ -487,142 +488,170 @@
 				IL_0050: ldloc.2
 				IL_0051: ldarg.2
 				IL_0052: clt
-				IL_0054: brfalse IL_01c5
+				IL_0054: brfalse IL_0201
 
 				IL_0059: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53::.ctor()
 				IL_005e: stloc.3
-				IL_005f: ldnull
-				IL_0060: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
-				IL_0065: stloc.s 8
-				IL_0067: ldloc.s 8
-				IL_0069: ldarg.0
-				IL_006a: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0074: stloc.s 9
-				IL_0076: ldnull
-				IL_0077: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
-				IL_007c: stloc.s 8
-				IL_007e: ldloc.s 9
-				IL_0080: ldloc.s 8
-				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0087: stloc.s 9
-				IL_0089: ldloc.s 9
-				IL_008b: stloc.0
-				IL_008c: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
-				IL_0091: stloc.s 10
-				IL_0093: ldc.r8 4
-				IL_009c: ldloc.s 10
-				IL_009e: mul
-				IL_009f: stloc.s 10
-				IL_00a1: ldloc.s 10
-				IL_00a3: box [System.Runtime]System.Double
-				IL_00a8: stloc.s 11
-				IL_00aa: ldloc.s 11
-				IL_00ac: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-				IL_00b1: stloc.s 10
-				IL_00b3: ldloc.s 10
-				IL_00b5: box [System.Runtime]System.Double
-				IL_00ba: stloc.s 11
-				IL_00bc: ldloc.s 11
-				IL_00be: stloc.1
-				IL_00bf: ldc.r8 0.0
-				IL_00c8: stloc.s 4
-				// loop start (head: IL_00ca)
-					IL_00ca: ldloc.1
-					IL_00cb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_00d0: stloc.s 10
-					IL_00d2: ldloc.s 4
-					IL_00d4: ldloc.s 10
-					IL_00d6: clt
-					IL_00d8: brfalse IL_011f
+				IL_005f: ldarg.0
+				IL_0060: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+				IL_0065: ldc.i4.1
+				IL_0066: newarr [System.Runtime]System.Object
+				IL_006b: dup
+				IL_006c: ldc.i4.0
+				IL_006d: ldarg.0
+				IL_006e: stelem.ref
+				IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0074: stloc.s 8
+				IL_0076: ldloc.s 8
+				IL_0078: ldarg.0
+				IL_0079: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0083: stloc.s 9
+				IL_0085: ldarg.0
+				IL_0086: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+				IL_008b: ldc.i4.1
+				IL_008c: newarr [System.Runtime]System.Object
+				IL_0091: dup
+				IL_0092: ldc.i4.0
+				IL_0093: ldarg.0
+				IL_0094: stelem.ref
+				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_009a: stloc.s 8
+				IL_009c: ldloc.s 9
+				IL_009e: ldloc.s 8
+				IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_00a5: stloc.s 9
+				IL_00a7: ldloc.s 9
+				IL_00a9: stloc.0
+				IL_00aa: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+				IL_00af: stloc.s 10
+				IL_00b1: ldc.r8 4
+				IL_00ba: ldloc.s 10
+				IL_00bc: mul
+				IL_00bd: stloc.s 10
+				IL_00bf: ldloc.s 10
+				IL_00c1: box [System.Runtime]System.Double
+				IL_00c6: stloc.s 11
+				IL_00c8: ldloc.s 11
+				IL_00ca: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+				IL_00cf: stloc.s 10
+				IL_00d1: ldloc.s 10
+				IL_00d3: box [System.Runtime]System.Double
+				IL_00d8: stloc.s 11
+				IL_00da: ldloc.s 11
+				IL_00dc: stloc.1
+				IL_00dd: ldc.r8 0.0
+				IL_00e6: stloc.s 4
+				// loop start (head: IL_00e8)
+					IL_00e8: ldloc.1
+					IL_00e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_00ee: stloc.s 10
+					IL_00f0: ldloc.s 4
+					IL_00f2: ldloc.s 10
+					IL_00f4: clt
+					IL_00f6: brfalse IL_015b
 
-					IL_00dd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L32C39::.ctor()
-					IL_00e2: stloc.s 5
-					IL_00e4: ldnull
-					IL_00e5: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
-					IL_00ea: stloc.s 8
-					IL_00ec: ldloc.s 8
-					IL_00ee: ldloc.0
-					IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_00f4: stloc.s 9
-					IL_00f6: ldnull
-					IL_00f7: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
-					IL_00fc: stloc.s 8
-					IL_00fe: ldloc.s 9
-					IL_0100: ldloc.s 8
-					IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0107: stloc.s 9
-					IL_0109: ldloc.s 9
-					IL_010b: stloc.0
-					IL_010c: ldloc.s 4
-					IL_010e: ldc.r8 1
-					IL_0117: add
-					IL_0118: stloc.s 4
-					IL_011a: br IL_00ca
-				// end loop
-
-				IL_011f: ldc.r8 0.0
-				IL_0128: stloc.s 4
-				// loop start (head: IL_012a)
-					IL_012a: ldloc.s 4
-					IL_012c: ldloc.0
-					IL_012d: castclass [System.Runtime]System.String
-					IL_0132: callvirt instance int32 [System.Runtime]System.String::get_Length()
-					IL_0137: conv.r8
-					IL_0138: clt
-					IL_013a: brfalse IL_01a0
-
-					IL_013f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L37C48::.ctor()
-					IL_0144: stloc.s 6
-					IL_0146: ldarg.0
-					IL_0147: ldloc.0
+					IL_00fb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L32C39::.ctor()
+					IL_0100: stloc.s 5
+					IL_0102: ldarg.0
+					IL_0103: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+					IL_0108: ldc.i4.1
+					IL_0109: newarr [System.Runtime]System.Object
+					IL_010e: dup
+					IL_010f: ldc.i4.0
+					IL_0110: ldarg.0
+					IL_0111: stelem.ref
+					IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_0117: stloc.s 8
+					IL_0119: ldloc.s 8
+					IL_011b: ldloc.0
+					IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0121: stloc.s 9
+					IL_0123: ldarg.0
+					IL_0124: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+					IL_0129: ldc.i4.1
+					IL_012a: newarr [System.Runtime]System.Object
+					IL_012f: dup
+					IL_0130: ldc.i4.0
+					IL_0131: ldarg.0
+					IL_0132: stelem.ref
+					IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+					IL_0138: stloc.s 8
+					IL_013a: ldloc.s 9
+					IL_013c: ldloc.s 8
+					IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0143: stloc.s 9
+					IL_0145: ldloc.s 9
+					IL_0147: stloc.0
 					IL_0148: ldloc.s 4
-					IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-					IL_014f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_0154: ldloc.0
-					IL_0155: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_015a: stloc.s 8
-					IL_015c: ldloc.s 4
-					IL_015e: box [System.Runtime]System.Double
-					IL_0163: stloc.s 11
-					IL_0165: ldloc.s 8
-					IL_0167: ldloc.s 11
-					IL_0169: ldloc.s 4
-					IL_016b: ldc.r8 100
-					IL_0174: add
-					IL_0175: box [System.Runtime]System.Double
-					IL_017a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-					IL_017f: stloc.s 8
-					IL_0181: ldarg.0
-					IL_0182: ldloc.s 8
-					IL_0184: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_0189: ldloc.s 4
-					IL_018b: ldc.r8 100
-					IL_0194: add
-					IL_0195: stloc.s 10
-					IL_0197: ldloc.s 10
-					IL_0199: stloc.s 4
-					IL_019b: br IL_012a
+					IL_014a: ldc.r8 1
+					IL_0153: add
+					IL_0154: stloc.s 4
+					IL_0156: br IL_00e8
 				// end loop
 
-				IL_01a0: ldarg.0
-				IL_01a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-				IL_01a6: ldloc.2
-				IL_01a7: box [System.Runtime]System.Double
-				IL_01ac: ldloc.0
-				IL_01ad: ldc.i4.1
-				IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_01b3: pop
-				IL_01b4: ldloc.2
-				IL_01b5: ldc.r8 1
-				IL_01be: add
-				IL_01bf: stloc.2
-				IL_01c0: br IL_0050
+				IL_015b: ldc.r8 0.0
+				IL_0164: stloc.s 4
+				// loop start (head: IL_0166)
+					IL_0166: ldloc.s 4
+					IL_0168: ldloc.0
+					IL_0169: castclass [System.Runtime]System.String
+					IL_016e: callvirt instance int32 [System.Runtime]System.String::get_Length()
+					IL_0173: conv.r8
+					IL_0174: clt
+					IL_0176: brfalse IL_01dc
+
+					IL_017b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/Scope/Block_L28C53/Block_L37C48::.ctor()
+					IL_0180: stloc.s 6
+					IL_0182: ldarg.0
+					IL_0183: ldloc.0
+					IL_0184: ldloc.s 4
+					IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+					IL_018b: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_0190: ldloc.0
+					IL_0191: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0196: stloc.s 12
+					IL_0198: ldloc.s 4
+					IL_019a: box [System.Runtime]System.Double
+					IL_019f: stloc.s 11
+					IL_01a1: ldloc.s 12
+					IL_01a3: ldloc.s 11
+					IL_01a5: ldloc.s 4
+					IL_01a7: ldc.r8 100
+					IL_01b0: add
+					IL_01b1: box [System.Runtime]System.Double
+					IL_01b6: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+					IL_01bb: stloc.s 12
+					IL_01bd: ldarg.0
+					IL_01be: ldloc.s 12
+					IL_01c0: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_01c5: ldloc.s 4
+					IL_01c7: ldc.r8 100
+					IL_01d0: add
+					IL_01d1: stloc.s 10
+					IL_01d3: ldloc.s 10
+					IL_01d5: stloc.s 4
+					IL_01d7: br IL_0166
+				// end loop
+
+				IL_01dc: ldarg.0
+				IL_01dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+				IL_01e2: ldloc.2
+				IL_01e3: box [System.Runtime]System.Double
+				IL_01e8: ldloc.0
+				IL_01e9: ldc.i4.1
+				IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_01ef: pop
+				IL_01f0: ldloc.2
+				IL_01f1: ldc.r8 1
+				IL_01fa: add
+				IL_01fb: stloc.2
+				IL_01fc: br IL_0050
 			// end loop
 
-			IL_01c5: ldarg.0
-			IL_01c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_01cb: ret
+			IL_0201: ldarg.0
+			IL_0202: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0207: ret
 		} // end of method generateTestStrings::__js_call__
 
 	} // end of class generateTestStrings
@@ -638,7 +667,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a85
+				// Method begins at RVA 0x5091
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -664,13 +693,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3374
+			// Method begins at RVA 0x3650
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr "(?:)"
@@ -681,16 +711,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 30
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 30
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L48C5::__js_call__
 
 	} // end of class FunctionExpression_L48C5
@@ -706,7 +747,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a8e
+				// Method begins at RVA 0x509a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -732,7 +773,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x33b8
+			// Method begins at RVA 0x36ac
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -789,7 +830,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4a97
+				// Method begins at RVA 0x50a3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -815,13 +856,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3424
+			// Method begins at RVA 0x3718
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr "a"
@@ -832,16 +874,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 30
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 30
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L61C5::__js_call__
 
 	} // end of class FunctionExpression_L61C5
@@ -857,7 +910,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4aa0
+				// Method begins at RVA 0x50ac
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -883,7 +936,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3468
+			// Method begins at RVA 0x3774
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -940,7 +993,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4aa9
+				// Method begins at RVA 0x50b5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -966,13 +1019,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x34d4
+			// Method begins at RVA 0x37e0
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr ".*"
@@ -983,16 +1037,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 100
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L71C5::__js_call__
 
 	} // end of class FunctionExpression_L71C5
@@ -1008,7 +1073,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ab2
+				// Method begins at RVA 0x50be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1034,7 +1099,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3518
+			// Method begins at RVA 0x383c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1091,7 +1156,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4abb
+				// Method begins at RVA 0x50c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1117,13 +1182,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3584
+			// Method begins at RVA 0x38a8
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -1134,16 +1200,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 100
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L83C5::__js_call__
 
 	} // end of class FunctionExpression_L83C5
@@ -1159,7 +1236,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ac4
+				// Method begins at RVA 0x50d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1185,7 +1262,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x35c8
+			// Method begins at RVA 0x3904
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1242,7 +1319,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4acd
+				// Method begins at RVA 0x50d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1268,25 +1345,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3634
+			// Method begins at RVA 0x3970
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L93C5::__js_call__
 
 	} // end of class FunctionExpression_L93C5
@@ -1302,7 +1391,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ad6
+				// Method begins at RVA 0x50e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1328,7 +1417,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3660
+			// Method begins at RVA 0x39b4
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1385,7 +1474,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4adf
+				// Method begins at RVA 0x50eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1411,25 +1500,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x36cc
+			// Method begins at RVA 0x3a20
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L102C5::__js_call__
 
 	} // end of class FunctionExpression_L102C5
@@ -1445,7 +1546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ae8
+				// Method begins at RVA 0x50f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1471,7 +1572,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x36f8
+			// Method begins at RVA 0x3a64
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1532,7 +1633,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4af1
+				// Method begins at RVA 0x50fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1558,25 +1659,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x376c
+			// Method begins at RVA 0x3ad8
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L111C5::__js_call__
 
 	} // end of class FunctionExpression_L111C5
@@ -1592,7 +1705,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4afa
+				// Method begins at RVA 0x5106
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1618,7 +1731,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3798
+			// Method begins at RVA 0x3b1c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -1679,7 +1792,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b03
+				// Method begins at RVA 0x510f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1705,13 +1818,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x380c
+			// Method begins at RVA 0x3b90
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -1722,16 +1836,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 100
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L120C5::__js_call__
 
 	} // end of class FunctionExpression_L120C5
@@ -1747,7 +1872,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b0c
+				// Method begins at RVA 0x5118
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1773,7 +1898,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3850
+			// Method begins at RVA 0x3bec
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1830,7 +1955,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b15
+				// Method begins at RVA 0x5121
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1856,25 +1981,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x38bc
+			// Method begins at RVA 0x3c58
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L130C5::__js_call__
 
 	} // end of class FunctionExpression_L130C5
@@ -1890,7 +2027,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b1e
+				// Method begins at RVA 0x512a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1916,7 +2053,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x38e8
+			// Method begins at RVA 0x3c9c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -1973,7 +2110,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b27
+				// Method begins at RVA 0x5133
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1999,25 +2136,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3954
+			// Method begins at RVA 0x3d08
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L139C5::__js_call__
 
 	} // end of class FunctionExpression_L139C5
@@ -2033,7 +2182,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b30
+				// Method begins at RVA 0x513c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2059,7 +2208,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3980
+			// Method begins at RVA 0x3d4c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2120,7 +2269,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b39
+				// Method begins at RVA 0x5145
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2146,25 +2295,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x39f4
+			// Method begins at RVA 0x3dc0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L148C5::__js_call__
 
 	} // end of class FunctionExpression_L148C5
@@ -2180,7 +2341,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b42
+				// Method begins at RVA 0x514e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2206,7 +2367,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a20
+			// Method begins at RVA 0x3e04
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2267,7 +2428,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b4b
+				// Method begins at RVA 0x5157
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2293,25 +2454,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3a94
+			// Method begins at RVA 0x3e78
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L157C5::__js_call__
 
 	} // end of class FunctionExpression_L157C5
@@ -2331,7 +2504,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4b5d
+					// Method begins at RVA 0x5169
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2355,7 +2528,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x49c2
+				// Method begins at RVA 0x4fce
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -2373,7 +2546,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b54
+				// Method begins at RVA 0x5160
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2399,7 +2572,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ac0
+			// Method begins at RVA 0x3ebc
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -2474,7 +2647,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b66
+				// Method begins at RVA 0x5172
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2500,13 +2673,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b54
+			// Method begins at RVA 0x3f50
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr "a.*a"
@@ -2517,16 +2691,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 100
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L170C5::__js_call__
 
 	} // end of class FunctionExpression_L170C5
@@ -2542,7 +2727,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b6f
+				// Method begins at RVA 0x517b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2568,7 +2753,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3b98
+			// Method begins at RVA 0x3fac
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -2625,7 +2810,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b78
+				// Method begins at RVA 0x5184
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2651,25 +2836,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c04
+			// Method begins at RVA 0x4018
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L180C5::__js_call__
 
 	} // end of class FunctionExpression_L180C5
@@ -2685,7 +2882,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b81
+				// Method begins at RVA 0x518d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2711,7 +2908,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c30
+			// Method begins at RVA 0x405c
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -2768,7 +2965,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b8a
+				// Method begins at RVA 0x5196
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2794,25 +2991,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3c9c
+			// Method begins at RVA 0x40c8
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L189C5::__js_call__
 
 	} // end of class FunctionExpression_L189C5
@@ -2828,7 +3037,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b93
+				// Method begins at RVA 0x519f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2854,7 +3063,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3cc8
+			// Method begins at RVA 0x410c
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -2915,7 +3124,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4b9c
+				// Method begins at RVA 0x51a8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2941,25 +3150,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d3c
+			// Method begins at RVA 0x4180
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L198C5::__js_call__
 
 	} // end of class FunctionExpression_L198C5
@@ -2975,7 +3196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ba5
+				// Method begins at RVA 0x51b1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3001,7 +3222,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3d68
+			// Method begins at RVA 0x41c4
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3062,7 +3283,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bae
+				// Method begins at RVA 0x51ba
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3088,13 +3309,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ddc
+			// Method begins at RVA 0x4238
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr "aaaaaaaaaa"
@@ -3105,16 +3327,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 100
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L207C5::__js_call__
 
 	} // end of class FunctionExpression_L207C5
@@ -3130,7 +3363,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bb7
+				// Method begins at RVA 0x51c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3156,7 +3389,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e20
+			// Method begins at RVA 0x4294
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -3213,7 +3446,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bc0
+				// Method begins at RVA 0x51cc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3239,25 +3472,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3e8c
+			// Method begins at RVA 0x4300
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L217C5::__js_call__
 
 	} // end of class FunctionExpression_L217C5
@@ -3273,7 +3518,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bc9
+				// Method begins at RVA 0x51d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3299,7 +3544,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3eb8
+			// Method begins at RVA 0x4344
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -3356,7 +3601,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bd2
+				// Method begins at RVA 0x51de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3382,25 +3627,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f24
+			// Method begins at RVA 0x43b0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L226C5::__js_call__
 
 	} // end of class FunctionExpression_L226C5
@@ -3416,7 +3673,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bdb
+				// Method begins at RVA 0x51e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3442,7 +3699,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3f50
+			// Method begins at RVA 0x43f4
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3503,7 +3760,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4be4
+				// Method begins at RVA 0x51f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3529,25 +3786,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3fc4
+			// Method begins at RVA 0x4468
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L235C5::__js_call__
 
 	} // end of class FunctionExpression_L235C5
@@ -3563,7 +3832,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bed
+				// Method begins at RVA 0x51f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3589,7 +3858,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x3ff0
+			// Method begins at RVA 0x44ac
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -3650,7 +3919,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bf6
+				// Method begins at RVA 0x5202
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3676,25 +3945,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4064
+			// Method begins at RVA 0x4520
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L244C5::__js_call__
 
 	} // end of class FunctionExpression_L244C5
@@ -3714,7 +3995,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c08
+					// Method begins at RVA 0x5214
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3738,7 +4019,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x49c9
+				// Method begins at RVA 0x4fd5
 				// Header size: 1
 				// Code size: 6 (0x6)
 				.maxstack 8
@@ -3756,7 +4037,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4bff
+				// Method begins at RVA 0x520b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3782,7 +4063,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4090
+			// Method begins at RVA 0x4564
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -3857,7 +4138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c11
+				// Method begins at RVA 0x521d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3883,13 +4164,14 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4124
+			// Method begins at RVA 0x45f8
 			// Header size: 12
-			// Code size: 54 (0x36)
+			// Code size: 77 (0x4d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldstr "aa(b)aa"
@@ -3900,16 +4182,27 @@
 			IL_0011: ldloc.0
 			IL_0012: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
 			IL_0017: ldarg.0
-			IL_0018: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_001d: ldnull
-			IL_001e: ldc.r8 100
-			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_002c: stloc.1
-			IL_002d: ldarg.0
-			IL_002e: ldloc.1
-			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_0034: ldnull
-			IL_0035: ret
+			IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_001d: stloc.1
+			IL_001e: ldc.i4.1
+			IL_001f: newarr [System.Runtime]System.Object
+			IL_0024: dup
+			IL_0025: ldc.i4.0
+			IL_0026: ldarg.0
+			IL_0027: stelem.ref
+			IL_0028: stloc.2
+			IL_0029: ldloc.1
+			IL_002a: ldloc.2
+			IL_002b: ldc.r8 100
+			IL_0034: box [System.Runtime]System.Double
+			IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_003e: stloc.1
+			IL_003f: ldarg.0
+			IL_0040: ldloc.1
+			IL_0041: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0046: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_004b: ldnull
+			IL_004c: ret
 		} // end of method FunctionExpression_L257C5::__js_call__
 
 	} // end of class FunctionExpression_L257C5
@@ -3925,7 +4218,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c1a
+				// Method begins at RVA 0x5226
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3951,7 +4244,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4168
+			// Method begins at RVA 0x4654
 			// Header size: 12
 			// Code size: 94 (0x5e)
 			.maxstack 8
@@ -4008,7 +4301,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c23
+				// Method begins at RVA 0x522f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4034,25 +4327,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x41d4
+			// Method begins at RVA 0x46c0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L267C5::__js_call__
 
 	} // end of class FunctionExpression_L267C5
@@ -4068,7 +4373,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c2c
+				// Method begins at RVA 0x5238
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4094,7 +4399,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4200
+			// Method begins at RVA 0x4704
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -4155,7 +4460,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c35
+				// Method begins at RVA 0x5241
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4181,25 +4486,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4274
+			// Method begins at RVA 0x4778
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L276C5::__js_call__
 
 	} // end of class FunctionExpression_L276C5
@@ -4215,7 +4532,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c3e
+				// Method begins at RVA 0x524a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4241,7 +4558,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x42a0
+			// Method begins at RVA 0x47bc
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -4302,7 +4619,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c47
+				// Method begins at RVA 0x5253
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4328,25 +4645,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4314
+			// Method begins at RVA 0x4830
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L285C5::__js_call__
 
 	} // end of class FunctionExpression_L285C5
@@ -4366,7 +4695,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c59
+					// Method begins at RVA 0x5265
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4391,7 +4720,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x49d0
+				// Method begins at RVA 0x4fdc
 				// Header size: 12
 				// Code size: 26 (0x1a)
 				.maxstack 8
@@ -4420,7 +4749,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c50
+				// Method begins at RVA 0x525c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4446,7 +4775,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4340
+			// Method begins at RVA 0x4874
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -4521,7 +4850,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c62
+				// Method begins at RVA 0x526e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4547,25 +4876,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x43d4
+			// Method begins at RVA 0x4908
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L296C5::__js_call__
 
 	} // end of class FunctionExpression_L296C5
@@ -4585,7 +4926,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4c74
+					// Method begins at RVA 0x5280
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4610,7 +4951,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x49f8
+				// Method begins at RVA 0x5004
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -4638,7 +4979,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c6b
+				// Method begins at RVA 0x5277
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4664,7 +5005,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4400
+			// Method begins at RVA 0x494c
 			// Header size: 12
 			// Code size: 134 (0x86)
 			.maxstack 8
@@ -4739,7 +5080,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c7d
+				// Method begins at RVA 0x5289
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4765,25 +5106,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4494
+			// Method begins at RVA 0x49e0
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L309C5::__js_call__
 
 	} // end of class FunctionExpression_L309C5
@@ -4799,7 +5152,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c86
+				// Method begins at RVA 0x5292
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4825,7 +5178,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x44c0
+			// Method begins at RVA 0x4a24
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -4886,7 +5239,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c8f
+				// Method begins at RVA 0x529b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4912,25 +5265,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4538
+			// Method begins at RVA 0x4a9c
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L318C5::__js_call__
 
 	} // end of class FunctionExpression_L318C5
@@ -4946,7 +5311,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4c98
+				// Method begins at RVA 0x52a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4972,7 +5337,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4564
+			// Method begins at RVA 0x4ae0
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5033,7 +5398,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ca1
+				// Method begins at RVA 0x52ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5059,25 +5424,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x45dc
+			// Method begins at RVA 0x4b58
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L327C5::__js_call__
 
 	} // end of class FunctionExpression_L327C5
@@ -5093,7 +5470,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4caa
+				// Method begins at RVA 0x52b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5119,7 +5496,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4608
+			// Method begins at RVA 0x4b9c
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5181,7 +5558,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cb3
+				// Method begins at RVA 0x52bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5207,25 +5584,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4684
+			// Method begins at RVA 0x4c18
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L336C5::__js_call__
 
 	} // end of class FunctionExpression_L336C5
@@ -5241,7 +5630,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cbc
+				// Method begins at RVA 0x52c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5267,7 +5656,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x46b0
+			// Method begins at RVA 0x4c5c
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5329,7 +5718,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cc5
+				// Method begins at RVA 0x52d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5355,25 +5744,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x472c
+			// Method begins at RVA 0x4cd8
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L345C5::__js_call__
 
 	} // end of class FunctionExpression_L345C5
@@ -5389,7 +5790,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cce
+				// Method begins at RVA 0x52da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5415,7 +5816,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4758
+			// Method begins at RVA 0x4d1c
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5476,7 +5877,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cd7
+				// Method begins at RVA 0x52e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5502,25 +5903,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x47d0
+			// Method begins at RVA 0x4d94
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 100
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 100
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L354C5::__js_call__
 
 	} // end of class FunctionExpression_L354C5
@@ -5536,7 +5949,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ce0
+				// Method begins at RVA 0x52ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5562,7 +5975,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x47fc
+			// Method begins at RVA 0x4dd8
 			// Header size: 12
 			// Code size: 105 (0x69)
 			.maxstack 8
@@ -5623,7 +6036,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4ce9
+				// Method begins at RVA 0x52f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5649,25 +6062,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4874
+			// Method begins at RVA 0x4e50
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L363C5::__js_call__
 
 	} // end of class FunctionExpression_L363C5
@@ -5683,7 +6108,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cf2
+				// Method begins at RVA 0x52fe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5709,7 +6134,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x48a0
+			// Method begins at RVA 0x4e94
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5771,7 +6196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4cfb
+				// Method begins at RVA 0x5307
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5797,25 +6222,37 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x491c
+			// Method begins at RVA 0x4f10
 			// Header size: 12
-			// Code size: 31 (0x1f)
+			// Code size: 54 (0x36)
 			.maxstack 8
 			.locals init (
-				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[0] object,
+				[1] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 50
-			IL_0010: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-			IL_0015: stloc.0
-			IL_0016: ldarg.0
-			IL_0017: ldloc.0
-			IL_0018: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-			IL_001d: ldnull
-			IL_001e: ret
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: ldloc.1
+			IL_0014: ldc.r8 50
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: stloc.0
+			IL_0028: ldarg.0
+			IL_0029: ldloc.0
+			IL_002a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_002f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+			IL_0034: ldnull
+			IL_0035: ret
 		} // end of method FunctionExpression_L372C5::__js_call__
 
 	} // end of class FunctionExpression_L372C5
@@ -5831,7 +6268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4d04
+				// Method begins at RVA 0x5310
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5857,7 +6294,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
-			// Method begins at RVA 0x4948
+			// Method begins at RVA 0x4f54
 			// Header size: 12
 			// Code size: 110 (0x6e)
 			.maxstack 8
@@ -5938,7 +6375,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x4a19
+			// Method begins at RVA 0x5025
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5964,7 +6401,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 4262 (0x10a6)
+		// Code size: 4932 (0x1344)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope,
@@ -5974,8 +6411,9 @@
 			[4] object,
 			[5] float64,
 			[6] object,
-			[7] string,
-			[8] object
+			[7] object[],
+			[8] object,
+			[9] object
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::.ctor()
@@ -6062,336 +6500,325 @@
 		IL_00d3: ldloc.0
 		IL_00d4: ldloc.s 6
 		IL_00d6: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::generateTestStrings
-		IL_00db: ldnull
-		IL_00dc: ldstr "dromaeo-object-regexp"
-		IL_00e1: ldstr "812dde38"
-		IL_00e6: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
-		IL_00eb: pop
-		IL_00ec: ldloc.0
-		IL_00ed: ldc.i4.0
-		IL_00ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00f3: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_00f8: ldloc.0
-		IL_00f9: ldnull
-		IL_00fa: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_00ff: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
-		IL_0104: ldloc.0
-		IL_0105: ldnull
-		IL_0106: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-		IL_010b: ldloc.0
-		IL_010c: ldnull
-		IL_010d: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
-		IL_0112: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
-		IL_0117: ldloc.0
-		IL_0118: ldc.i4.0
-		IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_011e: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-		IL_0123: ldc.r8 65536
-		IL_012c: stloc.s 5
-		IL_012e: ldc.r8 0.0
-		IL_0137: stloc.s 5
-		// loop start (head: IL_0139)
-			IL_0139: ldloc.s 5
-			IL_013b: ldc.r8 16384
-			IL_0144: clt
-			IL_0146: brfalse IL_0182
+		IL_00db: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e0: stloc.s 7
+		IL_00e2: ldloc.1
+		IL_00e3: ldloc.s 7
+		IL_00e5: ldstr "dromaeo-object-regexp"
+		IL_00ea: ldstr "812dde38"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00f4: pop
+		IL_00f5: ldloc.0
+		IL_00f6: ldc.i4.0
+		IL_00f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00fc: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0101: ldloc.0
+		IL_0102: ldnull
+		IL_0103: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0108: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::tmp
+		IL_010d: ldloc.0
+		IL_010e: ldnull
+		IL_010f: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+		IL_0114: ldloc.0
+		IL_0115: ldnull
+		IL_0116: castclass [JavaScriptRuntime]JavaScriptRuntime.RegExp
+		IL_011b: stfld class [JavaScriptRuntime]JavaScriptRuntime.RegExp Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::re
+		IL_0120: ldloc.0
+		IL_0121: ldc.i4.0
+		IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0127: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+		IL_012c: ldc.r8 65536
+		IL_0135: stloc.s 5
+		IL_0137: ldc.r8 0.0
+		IL_0140: stloc.s 5
+		// loop start (head: IL_0142)
+			IL_0142: ldloc.s 5
+			IL_0144: ldc.r8 16384
+			IL_014d: clt
+			IL_014f: brfalse IL_0195
 
-			IL_014b: ldloc.0
-			IL_014c: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0156: stloc.s 6
-			IL_0158: ldnull
-			IL_0159: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
-			IL_015e: stloc.s 7
-			IL_0160: ldloc.s 6
-			IL_0162: ldstr "push"
-			IL_0167: ldloc.s 7
-			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_016e: pop
-			IL_016f: ldloc.s 5
-			IL_0171: ldc.r8 1
-			IL_017a: add
-			IL_017b: stloc.s 5
-			IL_017d: br IL_0139
+			IL_0154: ldloc.0
+			IL_0155: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_015f: stloc.s 6
+			IL_0161: ldloc.0
+			IL_0162: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
+			IL_0167: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0171: stloc.s 8
+			IL_0173: ldloc.s 6
+			IL_0175: ldstr "push"
+			IL_017a: ldloc.s 8
+			IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0181: pop
+			IL_0182: ldloc.s 5
+			IL_0184: ldc.r8 1
+			IL_018d: add
+			IL_018e: stloc.s 5
+			IL_0190: br IL_0142
 		// end loop
 
-		IL_0182: ldloc.0
-		IL_0183: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018d: stloc.s 6
-		IL_018f: ldloc.s 6
-		IL_0191: ldstr "join"
-		IL_0196: ldstr ""
-		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01a0: stloc.s 6
-		IL_01a2: ldloc.0
-		IL_01a3: ldloc.s 6
-		IL_01a5: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01aa: ldloc.0
-		IL_01ab: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01b0: ldloc.0
-		IL_01b1: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01bb: stloc.s 8
+		IL_0195: ldloc.0
+		IL_0196: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a0: stloc.s 8
+		IL_01a2: ldloc.s 8
+		IL_01a4: ldstr "join"
+		IL_01a9: ldstr ""
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01b3: stloc.s 8
+		IL_01b5: ldloc.0
+		IL_01b6: ldloc.s 8
+		IL_01b8: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
 		IL_01bd: ldloc.0
-		IL_01be: ldloc.s 8
-		IL_01c0: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01c5: ldloc.0
-		IL_01c6: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01cb: ldloc.0
-		IL_01cc: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01d6: stloc.s 8
+		IL_01be: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01c3: ldloc.0
+		IL_01c4: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01ce: stloc.s 9
+		IL_01d0: ldloc.0
+		IL_01d1: ldloc.s 9
+		IL_01d3: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
 		IL_01d8: ldloc.0
-		IL_01d9: ldloc.s 8
-		IL_01db: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01e0: ldc.i4.1
-		IL_01e1: newarr [System.Runtime]System.Object
-		IL_01e6: dup
-		IL_01e7: ldc.i4.0
-		IL_01e8: ldloc.0
-		IL_01e9: stelem.ref
-		IL_01ea: ldc.i4.0
-		IL_01eb: ldelem.ref
-		IL_01ec: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_01f1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_01f7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01fc: ldc.i4.0
-		IL_01fd: conv.r8
-		IL_01fe: ldstr ""
-		IL_0203: ldc.i4.0
-		IL_0204: ldc.i4.1
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_020a: stloc.s 6
-		IL_020c: ldnull
-		IL_020d: ldloc.s 6
-		IL_020f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0214: pop
-		IL_0215: ldc.i4.1
-		IL_0216: newarr [System.Runtime]System.Object
-		IL_021b: dup
-		IL_021c: ldc.i4.0
-		IL_021d: ldloc.0
-		IL_021e: stelem.ref
-		IL_021f: ldc.i4.0
-		IL_0220: ldelem.ref
-		IL_0221: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0226: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_022c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0231: ldc.i4.0
-		IL_0232: conv.r8
-		IL_0233: ldstr ""
-		IL_0238: ldc.i4.0
-		IL_0239: ldc.i4.1
-		IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_023f: stloc.s 6
-		IL_0241: ldnull
-		IL_0242: ldstr "Compiled Object Empty Split"
-		IL_0247: ldloc.s 6
-		IL_0249: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_024e: pop
-		IL_024f: ldc.i4.1
-		IL_0250: newarr [System.Runtime]System.Object
-		IL_0255: dup
-		IL_0256: ldc.i4.0
-		IL_0257: ldloc.0
-		IL_0258: stelem.ref
-		IL_0259: ldc.i4.0
-		IL_025a: ldelem.ref
-		IL_025b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0260: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0266: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_026b: ldc.i4.0
-		IL_026c: conv.r8
-		IL_026d: ldstr ""
-		IL_0272: ldc.i4.0
-		IL_0273: ldc.i4.1
-		IL_0274: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0279: stloc.s 6
-		IL_027b: ldnull
-		IL_027c: ldloc.s 6
-		IL_027e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0283: pop
-		IL_0284: ldc.i4.1
-		IL_0285: newarr [System.Runtime]System.Object
-		IL_028a: dup
-		IL_028b: ldc.i4.0
-		IL_028c: ldloc.0
-		IL_028d: stelem.ref
-		IL_028e: ldc.i4.0
-		IL_028f: ldelem.ref
-		IL_0290: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0295: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_029b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02a0: ldc.i4.0
-		IL_02a1: conv.r8
-		IL_02a2: ldstr ""
-		IL_02a7: ldc.i4.0
-		IL_02a8: ldc.i4.1
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02ae: stloc.s 6
-		IL_02b0: ldnull
-		IL_02b1: ldstr "Compiled Object Char Split"
-		IL_02b6: ldloc.s 6
-		IL_02b8: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_02bd: pop
-		IL_02be: ldc.i4.1
-		IL_02bf: newarr [System.Runtime]System.Object
-		IL_02c4: dup
-		IL_02c5: ldc.i4.0
-		IL_02c6: ldloc.0
-		IL_02c7: stelem.ref
-		IL_02c8: ldc.i4.0
-		IL_02c9: ldelem.ref
-		IL_02ca: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02cf: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_02d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02da: ldc.i4.0
-		IL_02db: conv.r8
-		IL_02dc: ldstr ""
-		IL_02e1: ldc.i4.0
-		IL_02e2: ldc.i4.1
-		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02e8: stloc.s 6
-		IL_02ea: ldnull
-		IL_02eb: ldloc.s 6
-		IL_02ed: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_02f2: pop
-		IL_02f3: ldc.i4.1
-		IL_02f4: newarr [System.Runtime]System.Object
-		IL_02f9: dup
-		IL_02fa: ldc.i4.0
-		IL_02fb: ldloc.0
-		IL_02fc: stelem.ref
-		IL_02fd: ldc.i4.0
-		IL_02fe: ldelem.ref
-		IL_02ff: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0304: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_030a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_030f: ldc.i4.0
-		IL_0310: conv.r8
-		IL_0311: ldstr ""
-		IL_0316: ldc.i4.0
-		IL_0317: ldc.i4.1
-		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_031d: stloc.s 6
-		IL_031f: ldnull
-		IL_0320: ldstr "Compiled Object Variable Split"
-		IL_0325: ldloc.s 6
-		IL_0327: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_032c: pop
-		IL_032d: ldc.i4.1
-		IL_032e: newarr [System.Runtime]System.Object
-		IL_0333: dup
-		IL_0334: ldc.i4.0
-		IL_0335: ldloc.0
-		IL_0336: stelem.ref
-		IL_0337: ldc.i4.0
-		IL_0338: ldelem.ref
-		IL_0339: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_033e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0344: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0349: ldc.i4.0
-		IL_034a: conv.r8
-		IL_034b: ldstr ""
-		IL_0350: ldc.i4.0
-		IL_0351: ldc.i4.1
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0357: stloc.s 6
-		IL_0359: ldnull
-		IL_035a: ldloc.s 6
-		IL_035c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0361: pop
-		IL_0362: ldc.i4.1
-		IL_0363: newarr [System.Runtime]System.Object
-		IL_0368: dup
-		IL_0369: ldc.i4.0
-		IL_036a: ldloc.0
-		IL_036b: stelem.ref
-		IL_036c: ldc.i4.0
-		IL_036d: ldelem.ref
-		IL_036e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0373: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0379: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_037e: ldc.i4.0
-		IL_037f: conv.r8
-		IL_0380: ldstr ""
-		IL_0385: ldc.i4.0
-		IL_0386: ldc.i4.1
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_038c: stloc.s 6
-		IL_038e: ldnull
-		IL_038f: ldstr "Compiled Match"
-		IL_0394: ldloc.s 6
-		IL_0396: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_039b: pop
-		IL_039c: ldc.i4.1
-		IL_039d: newarr [System.Runtime]System.Object
-		IL_03a2: dup
+		IL_01d9: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01de: ldloc.0
+		IL_01df: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_01e9: stloc.s 9
+		IL_01eb: ldloc.0
+		IL_01ec: ldloc.s 9
+		IL_01ee: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_01f3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f8: stloc.s 7
+		IL_01fa: ldc.i4.1
+		IL_01fb: newarr [System.Runtime]System.Object
+		IL_0200: dup
+		IL_0201: ldc.i4.0
+		IL_0202: ldloc.0
+		IL_0203: stelem.ref
+		IL_0204: ldc.i4.0
+		IL_0205: ldelem.ref
+		IL_0206: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_020b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0211: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0216: ldc.i4.0
+		IL_0217: conv.r8
+		IL_0218: ldstr ""
+		IL_021d: ldc.i4.0
+		IL_021e: ldc.i4.1
+		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0224: stloc.s 8
+		IL_0226: ldloc.3
+		IL_0227: ldloc.s 7
+		IL_0229: ldloc.s 8
+		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0230: pop
+		IL_0231: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0236: stloc.s 7
+		IL_0238: ldc.i4.1
+		IL_0239: newarr [System.Runtime]System.Object
+		IL_023e: dup
+		IL_023f: ldc.i4.0
+		IL_0240: ldloc.0
+		IL_0241: stelem.ref
+		IL_0242: ldc.i4.0
+		IL_0243: ldelem.ref
+		IL_0244: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0249: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_024f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0254: ldc.i4.0
+		IL_0255: conv.r8
+		IL_0256: ldstr ""
+		IL_025b: ldc.i4.0
+		IL_025c: ldc.i4.1
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0262: stloc.s 8
+		IL_0264: ldloc.s 4
+		IL_0266: ldloc.s 7
+		IL_0268: ldstr "Compiled Object Empty Split"
+		IL_026d: ldloc.s 8
+		IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0274: pop
+		IL_0275: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_027a: stloc.s 7
+		IL_027c: ldc.i4.1
+		IL_027d: newarr [System.Runtime]System.Object
+		IL_0282: dup
+		IL_0283: ldc.i4.0
+		IL_0284: ldloc.0
+		IL_0285: stelem.ref
+		IL_0286: ldc.i4.0
+		IL_0287: ldelem.ref
+		IL_0288: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_028d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0293: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0298: ldc.i4.0
+		IL_0299: conv.r8
+		IL_029a: ldstr ""
+		IL_029f: ldc.i4.0
+		IL_02a0: ldc.i4.1
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02a6: stloc.s 8
+		IL_02a8: ldloc.3
+		IL_02a9: ldloc.s 7
+		IL_02ab: ldloc.s 8
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_02b2: pop
+		IL_02b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02b8: stloc.s 7
+		IL_02ba: ldc.i4.1
+		IL_02bb: newarr [System.Runtime]System.Object
+		IL_02c0: dup
+		IL_02c1: ldc.i4.0
+		IL_02c2: ldloc.0
+		IL_02c3: stelem.ref
+		IL_02c4: ldc.i4.0
+		IL_02c5: ldelem.ref
+		IL_02c6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_02cb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_02d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02d6: ldc.i4.0
+		IL_02d7: conv.r8
+		IL_02d8: ldstr ""
+		IL_02dd: ldc.i4.0
+		IL_02de: ldc.i4.1
+		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02e4: stloc.s 8
+		IL_02e6: ldloc.s 4
+		IL_02e8: ldloc.s 7
+		IL_02ea: ldstr "Compiled Object Char Split"
+		IL_02ef: ldloc.s 8
+		IL_02f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02f6: pop
+		IL_02f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02fc: stloc.s 7
+		IL_02fe: ldc.i4.1
+		IL_02ff: newarr [System.Runtime]System.Object
+		IL_0304: dup
+		IL_0305: ldc.i4.0
+		IL_0306: ldloc.0
+		IL_0307: stelem.ref
+		IL_0308: ldc.i4.0
+		IL_0309: ldelem.ref
+		IL_030a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_030f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0315: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_031a: ldc.i4.0
+		IL_031b: conv.r8
+		IL_031c: ldstr ""
+		IL_0321: ldc.i4.0
+		IL_0322: ldc.i4.1
+		IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0328: stloc.s 8
+		IL_032a: ldloc.3
+		IL_032b: ldloc.s 7
+		IL_032d: ldloc.s 8
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0334: pop
+		IL_0335: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_033a: stloc.s 7
+		IL_033c: ldc.i4.1
+		IL_033d: newarr [System.Runtime]System.Object
+		IL_0342: dup
+		IL_0343: ldc.i4.0
+		IL_0344: ldloc.0
+		IL_0345: stelem.ref
+		IL_0346: ldc.i4.0
+		IL_0347: ldelem.ref
+		IL_0348: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_034d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0353: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0358: ldc.i4.0
+		IL_0359: conv.r8
+		IL_035a: ldstr ""
+		IL_035f: ldc.i4.0
+		IL_0360: ldc.i4.1
+		IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0366: stloc.s 8
+		IL_0368: ldloc.s 4
+		IL_036a: ldloc.s 7
+		IL_036c: ldstr "Compiled Object Variable Split"
+		IL_0371: ldloc.s 8
+		IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0378: pop
+		IL_0379: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_037e: stloc.s 7
+		IL_0380: ldc.i4.1
+		IL_0381: newarr [System.Runtime]System.Object
+		IL_0386: dup
+		IL_0387: ldc.i4.0
+		IL_0388: ldloc.0
+		IL_0389: stelem.ref
+		IL_038a: ldc.i4.0
+		IL_038b: ldelem.ref
+		IL_038c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0391: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0397: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_039c: ldc.i4.0
+		IL_039d: conv.r8
+		IL_039e: ldstr ""
 		IL_03a3: ldc.i4.0
-		IL_03a4: ldloc.0
-		IL_03a5: stelem.ref
-		IL_03a6: ldc.i4.0
-		IL_03a7: ldelem.ref
-		IL_03a8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03ad: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_03b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_03b8: ldc.i4.0
-		IL_03b9: conv.r8
-		IL_03ba: ldstr ""
-		IL_03bf: ldc.i4.0
-		IL_03c0: ldc.i4.1
-		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03c6: stloc.s 6
-		IL_03c8: ldnull
-		IL_03c9: ldloc.s 6
-		IL_03cb: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_03d0: pop
-		IL_03d1: ldc.i4.1
-		IL_03d2: newarr [System.Runtime]System.Object
-		IL_03d7: dup
-		IL_03d8: ldc.i4.0
-		IL_03d9: ldloc.0
-		IL_03da: stelem.ref
-		IL_03db: ldc.i4.0
-		IL_03dc: ldelem.ref
-		IL_03dd: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03e2: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_03e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_03ed: ldc.i4.0
-		IL_03ee: conv.r8
-		IL_03ef: ldstr ""
-		IL_03f4: ldc.i4.0
-		IL_03f5: ldc.i4.1
-		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03fb: stloc.s 6
-		IL_03fd: ldnull
-		IL_03fe: ldstr "Compiled Test"
-		IL_0403: ldloc.s 6
-		IL_0405: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_040a: pop
-		IL_040b: ldc.i4.1
-		IL_040c: newarr [System.Runtime]System.Object
-		IL_0411: dup
-		IL_0412: ldc.i4.0
-		IL_0413: ldloc.0
-		IL_0414: stelem.ref
-		IL_0415: ldc.i4.0
-		IL_0416: ldelem.ref
-		IL_0417: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_041c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0422: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0427: ldc.i4.0
-		IL_0428: conv.r8
-		IL_0429: ldstr ""
-		IL_042e: ldc.i4.0
-		IL_042f: ldc.i4.1
-		IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0435: stloc.s 6
-		IL_0437: ldnull
-		IL_0438: ldloc.s 6
-		IL_043a: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_043f: pop
+		IL_03a4: ldc.i4.1
+		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03aa: stloc.s 8
+		IL_03ac: ldloc.3
+		IL_03ad: ldloc.s 7
+		IL_03af: ldloc.s 8
+		IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03b6: pop
+		IL_03b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03bc: stloc.s 7
+		IL_03be: ldc.i4.1
+		IL_03bf: newarr [System.Runtime]System.Object
+		IL_03c4: dup
+		IL_03c5: ldc.i4.0
+		IL_03c6: ldloc.0
+		IL_03c7: stelem.ref
+		IL_03c8: ldc.i4.0
+		IL_03c9: ldelem.ref
+		IL_03ca: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_03cf: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_03d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_03da: ldc.i4.0
+		IL_03db: conv.r8
+		IL_03dc: ldstr ""
+		IL_03e1: ldc.i4.0
+		IL_03e2: ldc.i4.1
+		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03e8: stloc.s 8
+		IL_03ea: ldloc.s 4
+		IL_03ec: ldloc.s 7
+		IL_03ee: ldstr "Compiled Match"
+		IL_03f3: ldloc.s 8
+		IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_03fa: pop
+		IL_03fb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0400: stloc.s 7
+		IL_0402: ldc.i4.1
+		IL_0403: newarr [System.Runtime]System.Object
+		IL_0408: dup
+		IL_0409: ldc.i4.0
+		IL_040a: ldloc.0
+		IL_040b: stelem.ref
+		IL_040c: ldc.i4.0
+		IL_040d: ldelem.ref
+		IL_040e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0413: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0419: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_041e: ldc.i4.0
+		IL_041f: conv.r8
+		IL_0420: ldstr ""
+		IL_0425: ldc.i4.0
+		IL_0426: ldc.i4.1
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_042c: stloc.s 8
+		IL_042e: ldloc.3
+		IL_042f: ldloc.s 7
+		IL_0431: ldloc.s 8
+		IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0438: pop
+		IL_0439: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_043e: stloc.s 7
 		IL_0440: ldc.i4.1
 		IL_0441: newarr [System.Runtime]System.Object
 		IL_0446: dup
@@ -6401,7 +6828,7 @@
 		IL_044a: ldc.i4.0
 		IL_044b: ldelem.ref
 		IL_044c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0451: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0451: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 		IL_0457: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_045c: ldc.i4.0
 		IL_045d: conv.r8
@@ -6409,912 +6836,882 @@
 		IL_0463: ldc.i4.0
 		IL_0464: ldc.i4.1
 		IL_0465: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_046a: stloc.s 6
-		IL_046c: ldnull
-		IL_046d: ldstr "Compiled Empty Replace"
-		IL_0472: ldloc.s 6
-		IL_0474: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0479: pop
-		IL_047a: ldc.i4.1
-		IL_047b: newarr [System.Runtime]System.Object
-		IL_0480: dup
-		IL_0481: ldc.i4.0
-		IL_0482: ldloc.0
-		IL_0483: stelem.ref
-		IL_0484: ldc.i4.0
-		IL_0485: ldelem.ref
-		IL_0486: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_048b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0491: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0496: ldc.i4.0
-		IL_0497: conv.r8
-		IL_0498: ldstr ""
-		IL_049d: ldc.i4.0
-		IL_049e: ldc.i4.1
-		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04a4: stloc.s 6
-		IL_04a6: ldnull
-		IL_04a7: ldloc.s 6
-		IL_04a9: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_04ae: pop
-		IL_04af: ldc.i4.1
-		IL_04b0: newarr [System.Runtime]System.Object
-		IL_04b5: dup
-		IL_04b6: ldc.i4.0
-		IL_04b7: ldloc.0
-		IL_04b8: stelem.ref
-		IL_04b9: ldc.i4.0
-		IL_04ba: ldelem.ref
-		IL_04bb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04c0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_04c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_04cb: ldc.i4.0
-		IL_04cc: conv.r8
-		IL_04cd: ldstr ""
-		IL_04d2: ldc.i4.0
-		IL_04d3: ldc.i4.1
-		IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04d9: stloc.s 6
-		IL_04db: ldnull
-		IL_04dc: ldstr "Compiled 12 Char Replace"
-		IL_04e1: ldloc.s 6
-		IL_04e3: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_04e8: pop
-		IL_04e9: ldc.i4.1
-		IL_04ea: newarr [System.Runtime]System.Object
-		IL_04ef: dup
-		IL_04f0: ldc.i4.0
-		IL_04f1: ldloc.0
-		IL_04f2: stelem.ref
-		IL_04f3: ldc.i4.0
-		IL_04f4: ldelem.ref
-		IL_04f5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04fa: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0500: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0505: ldc.i4.0
-		IL_0506: conv.r8
-		IL_0507: ldstr ""
-		IL_050c: ldc.i4.0
-		IL_050d: ldc.i4.1
-		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0513: stloc.s 6
-		IL_0515: ldnull
-		IL_0516: ldloc.s 6
-		IL_0518: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_051d: pop
-		IL_051e: ldc.i4.1
-		IL_051f: newarr [System.Runtime]System.Object
-		IL_0524: dup
-		IL_0525: ldc.i4.0
-		IL_0526: ldloc.0
-		IL_0527: stelem.ref
-		IL_0528: ldc.i4.0
-		IL_0529: ldelem.ref
-		IL_052a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_052f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0535: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_053a: ldc.i4.0
-		IL_053b: conv.r8
-		IL_053c: ldstr ""
-		IL_0541: ldc.i4.0
-		IL_0542: ldc.i4.1
-		IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0548: stloc.s 6
-		IL_054a: ldnull
-		IL_054b: ldstr "Compiled Object Match"
-		IL_0550: ldloc.s 6
-		IL_0552: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0557: pop
-		IL_0558: ldc.i4.1
-		IL_0559: newarr [System.Runtime]System.Object
-		IL_055e: dup
-		IL_055f: ldc.i4.0
-		IL_0560: ldloc.0
-		IL_0561: stelem.ref
-		IL_0562: ldc.i4.0
-		IL_0563: ldelem.ref
-		IL_0564: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0569: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_056f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0574: ldc.i4.0
-		IL_0575: conv.r8
-		IL_0576: ldstr ""
-		IL_057b: ldc.i4.0
-		IL_057c: ldc.i4.1
-		IL_057d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0582: stloc.s 6
-		IL_0584: ldnull
-		IL_0585: ldloc.s 6
-		IL_0587: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_058c: pop
-		IL_058d: ldc.i4.1
-		IL_058e: newarr [System.Runtime]System.Object
-		IL_0593: dup
-		IL_0594: ldc.i4.0
-		IL_0595: ldloc.0
-		IL_0596: stelem.ref
-		IL_0597: ldc.i4.0
-		IL_0598: ldelem.ref
-		IL_0599: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_059e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_05a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_05a9: ldc.i4.0
-		IL_05aa: conv.r8
-		IL_05ab: ldstr ""
-		IL_05b0: ldc.i4.0
-		IL_05b1: ldc.i4.1
-		IL_05b2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05b7: stloc.s 6
-		IL_05b9: ldnull
-		IL_05ba: ldstr "Compiled Object Test"
-		IL_05bf: ldloc.s 6
-		IL_05c1: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_05c6: pop
-		IL_05c7: ldc.i4.1
-		IL_05c8: newarr [System.Runtime]System.Object
-		IL_05cd: dup
-		IL_05ce: ldc.i4.0
-		IL_05cf: ldloc.0
-		IL_05d0: stelem.ref
-		IL_05d1: ldc.i4.0
-		IL_05d2: ldelem.ref
-		IL_05d3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05d8: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_05de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_05e3: ldc.i4.0
-		IL_05e4: conv.r8
-		IL_05e5: ldstr ""
-		IL_05ea: ldc.i4.0
-		IL_05eb: ldc.i4.1
-		IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05f1: stloc.s 6
-		IL_05f3: ldnull
-		IL_05f4: ldloc.s 6
-		IL_05f6: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_05fb: pop
-		IL_05fc: ldc.i4.1
-		IL_05fd: newarr [System.Runtime]System.Object
-		IL_0602: dup
-		IL_0603: ldc.i4.0
-		IL_0604: ldloc.0
-		IL_0605: stelem.ref
-		IL_0606: ldc.i4.0
-		IL_0607: ldelem.ref
-		IL_0608: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_060d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0613: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0618: ldc.i4.0
-		IL_0619: conv.r8
-		IL_061a: ldstr ""
-		IL_061f: ldc.i4.0
-		IL_0620: ldc.i4.1
-		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0626: stloc.s 6
-		IL_0628: ldnull
-		IL_0629: ldstr "Compiled Object Empty Replace"
-		IL_062e: ldloc.s 6
-		IL_0630: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0635: pop
-		IL_0636: ldc.i4.1
-		IL_0637: newarr [System.Runtime]System.Object
-		IL_063c: dup
-		IL_063d: ldc.i4.0
-		IL_063e: ldloc.0
-		IL_063f: stelem.ref
-		IL_0640: ldc.i4.0
-		IL_0641: ldelem.ref
-		IL_0642: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0647: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_064d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_046a: stloc.s 8
+		IL_046c: ldloc.s 4
+		IL_046e: ldloc.s 7
+		IL_0470: ldstr "Compiled Test"
+		IL_0475: ldloc.s 8
+		IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_047c: pop
+		IL_047d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0482: stloc.s 7
+		IL_0484: ldc.i4.1
+		IL_0485: newarr [System.Runtime]System.Object
+		IL_048a: dup
+		IL_048b: ldc.i4.0
+		IL_048c: ldloc.0
+		IL_048d: stelem.ref
+		IL_048e: ldc.i4.0
+		IL_048f: ldelem.ref
+		IL_0490: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0495: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_049b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_04a0: ldc.i4.0
+		IL_04a1: conv.r8
+		IL_04a2: ldstr ""
+		IL_04a7: ldc.i4.0
+		IL_04a8: ldc.i4.1
+		IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04ae: stloc.s 8
+		IL_04b0: ldloc.3
+		IL_04b1: ldloc.s 7
+		IL_04b3: ldloc.s 8
+		IL_04b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_04ba: pop
+		IL_04bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04c0: stloc.s 7
+		IL_04c2: ldc.i4.1
+		IL_04c3: newarr [System.Runtime]System.Object
+		IL_04c8: dup
+		IL_04c9: ldc.i4.0
+		IL_04ca: ldloc.0
+		IL_04cb: stelem.ref
+		IL_04cc: ldc.i4.0
+		IL_04cd: ldelem.ref
+		IL_04ce: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_04d3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_04d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_04de: ldc.i4.0
+		IL_04df: conv.r8
+		IL_04e0: ldstr ""
+		IL_04e5: ldc.i4.0
+		IL_04e6: ldc.i4.1
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04ec: stloc.s 8
+		IL_04ee: ldloc.s 4
+		IL_04f0: ldloc.s 7
+		IL_04f2: ldstr "Compiled Empty Replace"
+		IL_04f7: ldloc.s 8
+		IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04fe: pop
+		IL_04ff: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0504: stloc.s 7
+		IL_0506: ldc.i4.1
+		IL_0507: newarr [System.Runtime]System.Object
+		IL_050c: dup
+		IL_050d: ldc.i4.0
+		IL_050e: ldloc.0
+		IL_050f: stelem.ref
+		IL_0510: ldc.i4.0
+		IL_0511: ldelem.ref
+		IL_0512: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0517: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_051d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0522: ldc.i4.0
+		IL_0523: conv.r8
+		IL_0524: ldstr ""
+		IL_0529: ldc.i4.0
+		IL_052a: ldc.i4.1
+		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0530: stloc.s 8
+		IL_0532: ldloc.3
+		IL_0533: ldloc.s 7
+		IL_0535: ldloc.s 8
+		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_053c: pop
+		IL_053d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0542: stloc.s 7
+		IL_0544: ldc.i4.1
+		IL_0545: newarr [System.Runtime]System.Object
+		IL_054a: dup
+		IL_054b: ldc.i4.0
+		IL_054c: ldloc.0
+		IL_054d: stelem.ref
+		IL_054e: ldc.i4.0
+		IL_054f: ldelem.ref
+		IL_0550: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0555: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_055b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0560: ldc.i4.0
+		IL_0561: conv.r8
+		IL_0562: ldstr ""
+		IL_0567: ldc.i4.0
+		IL_0568: ldc.i4.1
+		IL_0569: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_056e: stloc.s 8
+		IL_0570: ldloc.s 4
+		IL_0572: ldloc.s 7
+		IL_0574: ldstr "Compiled 12 Char Replace"
+		IL_0579: ldloc.s 8
+		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0580: pop
+		IL_0581: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0586: stloc.s 7
+		IL_0588: ldc.i4.1
+		IL_0589: newarr [System.Runtime]System.Object
+		IL_058e: dup
+		IL_058f: ldc.i4.0
+		IL_0590: ldloc.0
+		IL_0591: stelem.ref
+		IL_0592: ldc.i4.0
+		IL_0593: ldelem.ref
+		IL_0594: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0599: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_059f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_05a4: ldc.i4.0
+		IL_05a5: conv.r8
+		IL_05a6: ldstr ""
+		IL_05ab: ldc.i4.0
+		IL_05ac: ldc.i4.1
+		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_05b2: stloc.s 8
+		IL_05b4: ldloc.3
+		IL_05b5: ldloc.s 7
+		IL_05b7: ldloc.s 8
+		IL_05b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_05be: pop
+		IL_05bf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05c4: stloc.s 7
+		IL_05c6: ldc.i4.1
+		IL_05c7: newarr [System.Runtime]System.Object
+		IL_05cc: dup
+		IL_05cd: ldc.i4.0
+		IL_05ce: ldloc.0
+		IL_05cf: stelem.ref
+		IL_05d0: ldc.i4.0
+		IL_05d1: ldelem.ref
+		IL_05d2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_05d7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_05dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_05e2: ldc.i4.0
+		IL_05e3: conv.r8
+		IL_05e4: ldstr ""
+		IL_05e9: ldc.i4.0
+		IL_05ea: ldc.i4.1
+		IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_05f0: stloc.s 8
+		IL_05f2: ldloc.s 4
+		IL_05f4: ldloc.s 7
+		IL_05f6: ldstr "Compiled Object Match"
+		IL_05fb: ldloc.s 8
+		IL_05fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0602: pop
+		IL_0603: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0608: stloc.s 7
+		IL_060a: ldc.i4.1
+		IL_060b: newarr [System.Runtime]System.Object
+		IL_0610: dup
+		IL_0611: ldc.i4.0
+		IL_0612: ldloc.0
+		IL_0613: stelem.ref
+		IL_0614: ldc.i4.0
+		IL_0615: ldelem.ref
+		IL_0616: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_061b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0621: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0626: ldc.i4.0
+		IL_0627: conv.r8
+		IL_0628: ldstr ""
+		IL_062d: ldc.i4.0
+		IL_062e: ldc.i4.1
+		IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0634: stloc.s 8
+		IL_0636: ldloc.3
+		IL_0637: ldloc.s 7
+		IL_0639: ldloc.s 8
+		IL_063b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0640: pop
+		IL_0641: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0646: stloc.s 7
+		IL_0648: ldc.i4.1
+		IL_0649: newarr [System.Runtime]System.Object
+		IL_064e: dup
+		IL_064f: ldc.i4.0
+		IL_0650: ldloc.0
+		IL_0651: stelem.ref
 		IL_0652: ldc.i4.0
-		IL_0653: conv.r8
-		IL_0654: ldstr ""
-		IL_0659: ldc.i4.0
-		IL_065a: ldc.i4.1
-		IL_065b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0660: stloc.s 6
-		IL_0662: ldnull
-		IL_0663: ldloc.s 6
-		IL_0665: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_066a: pop
-		IL_066b: ldc.i4.1
-		IL_066c: newarr [System.Runtime]System.Object
-		IL_0671: dup
-		IL_0672: ldc.i4.0
-		IL_0673: ldloc.0
-		IL_0674: stelem.ref
-		IL_0675: ldc.i4.0
-		IL_0676: ldelem.ref
-		IL_0677: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_067c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0682: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0687: ldc.i4.0
-		IL_0688: conv.r8
-		IL_0689: ldstr ""
-		IL_068e: ldc.i4.0
-		IL_068f: ldc.i4.1
-		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0695: stloc.s 6
-		IL_0697: ldnull
-		IL_0698: ldstr "Compiled Object 12 Char Replace"
-		IL_069d: ldloc.s 6
-		IL_069f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_06a4: pop
-		IL_06a5: ldc.i4.1
-		IL_06a6: newarr [System.Runtime]System.Object
-		IL_06ab: dup
-		IL_06ac: ldc.i4.0
-		IL_06ad: ldloc.0
-		IL_06ae: stelem.ref
+		IL_0653: ldelem.ref
+		IL_0654: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0659: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_065f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0664: ldc.i4.0
+		IL_0665: conv.r8
+		IL_0666: ldstr ""
+		IL_066b: ldc.i4.0
+		IL_066c: ldc.i4.1
+		IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0672: stloc.s 8
+		IL_0674: ldloc.s 4
+		IL_0676: ldloc.s 7
+		IL_0678: ldstr "Compiled Object Test"
+		IL_067d: ldloc.s 8
+		IL_067f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0684: pop
+		IL_0685: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_068a: stloc.s 7
+		IL_068c: ldc.i4.1
+		IL_068d: newarr [System.Runtime]System.Object
+		IL_0692: dup
+		IL_0693: ldc.i4.0
+		IL_0694: ldloc.0
+		IL_0695: stelem.ref
+		IL_0696: ldc.i4.0
+		IL_0697: ldelem.ref
+		IL_0698: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_069d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_06a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_06a8: ldc.i4.0
+		IL_06a9: conv.r8
+		IL_06aa: ldstr ""
 		IL_06af: ldc.i4.0
-		IL_06b0: ldelem.ref
-		IL_06b1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06b6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_06bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_06c1: ldc.i4.0
-		IL_06c2: conv.r8
-		IL_06c3: ldstr ""
-		IL_06c8: ldc.i4.0
-		IL_06c9: ldc.i4.1
-		IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_06cf: stloc.s 6
-		IL_06d1: ldnull
-		IL_06d2: ldloc.s 6
-		IL_06d4: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_06d9: pop
-		IL_06da: ldc.i4.1
-		IL_06db: newarr [System.Runtime]System.Object
-		IL_06e0: dup
-		IL_06e1: ldc.i4.0
-		IL_06e2: ldloc.0
-		IL_06e3: stelem.ref
-		IL_06e4: ldc.i4.0
-		IL_06e5: ldelem.ref
-		IL_06e6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06eb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_06f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_06f6: ldc.i4.0
-		IL_06f7: conv.r8
-		IL_06f8: ldstr ""
-		IL_06fd: ldc.i4.0
-		IL_06fe: ldc.i4.1
-		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0704: stloc.s 6
-		IL_0706: ldnull
-		IL_0707: ldstr "Compiled Object 12 Char Replace Function"
-		IL_070c: ldloc.s 6
-		IL_070e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0713: pop
-		IL_0714: ldc.i4.1
-		IL_0715: newarr [System.Runtime]System.Object
-		IL_071a: dup
-		IL_071b: ldc.i4.0
-		IL_071c: ldloc.0
-		IL_071d: stelem.ref
-		IL_071e: ldc.i4.0
-		IL_071f: ldelem.ref
-		IL_0720: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0725: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_072b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0730: ldc.i4.0
-		IL_0731: conv.r8
-		IL_0732: ldstr ""
-		IL_0737: ldc.i4.0
-		IL_0738: ldc.i4.1
-		IL_0739: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_073e: stloc.s 6
-		IL_0740: ldnull
-		IL_0741: ldloc.s 6
-		IL_0743: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0748: pop
-		IL_0749: ldc.i4.1
-		IL_074a: newarr [System.Runtime]System.Object
-		IL_074f: dup
-		IL_0750: ldc.i4.0
-		IL_0751: ldloc.0
-		IL_0752: stelem.ref
+		IL_06b0: ldc.i4.1
+		IL_06b1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_06b6: stloc.s 8
+		IL_06b8: ldloc.3
+		IL_06b9: ldloc.s 7
+		IL_06bb: ldloc.s 8
+		IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_06c2: pop
+		IL_06c3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06c8: stloc.s 7
+		IL_06ca: ldc.i4.1
+		IL_06cb: newarr [System.Runtime]System.Object
+		IL_06d0: dup
+		IL_06d1: ldc.i4.0
+		IL_06d2: ldloc.0
+		IL_06d3: stelem.ref
+		IL_06d4: ldc.i4.0
+		IL_06d5: ldelem.ref
+		IL_06d6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_06db: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_06e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_06e6: ldc.i4.0
+		IL_06e7: conv.r8
+		IL_06e8: ldstr ""
+		IL_06ed: ldc.i4.0
+		IL_06ee: ldc.i4.1
+		IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_06f4: stloc.s 8
+		IL_06f6: ldloc.s 4
+		IL_06f8: ldloc.s 7
+		IL_06fa: ldstr "Compiled Object Empty Replace"
+		IL_06ff: ldloc.s 8
+		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0706: pop
+		IL_0707: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_070c: stloc.s 7
+		IL_070e: ldc.i4.1
+		IL_070f: newarr [System.Runtime]System.Object
+		IL_0714: dup
+		IL_0715: ldc.i4.0
+		IL_0716: ldloc.0
+		IL_0717: stelem.ref
+		IL_0718: ldc.i4.0
+		IL_0719: ldelem.ref
+		IL_071a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_071f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0725: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_072a: ldc.i4.0
+		IL_072b: conv.r8
+		IL_072c: ldstr ""
+		IL_0731: ldc.i4.0
+		IL_0732: ldc.i4.1
+		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0738: stloc.s 8
+		IL_073a: ldloc.3
+		IL_073b: ldloc.s 7
+		IL_073d: ldloc.s 8
+		IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0744: pop
+		IL_0745: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_074a: stloc.s 7
+		IL_074c: ldc.i4.1
+		IL_074d: newarr [System.Runtime]System.Object
+		IL_0752: dup
 		IL_0753: ldc.i4.0
-		IL_0754: ldelem.ref
-		IL_0755: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_075a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0760: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0765: ldc.i4.0
-		IL_0766: conv.r8
-		IL_0767: ldstr ""
-		IL_076c: ldc.i4.0
-		IL_076d: ldc.i4.1
-		IL_076e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0773: stloc.s 6
-		IL_0775: ldnull
-		IL_0776: ldstr "Compiled Variable Match"
-		IL_077b: ldloc.s 6
-		IL_077d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0782: pop
-		IL_0783: ldc.i4.1
-		IL_0784: newarr [System.Runtime]System.Object
-		IL_0789: dup
-		IL_078a: ldc.i4.0
-		IL_078b: ldloc.0
-		IL_078c: stelem.ref
-		IL_078d: ldc.i4.0
-		IL_078e: ldelem.ref
-		IL_078f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0794: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_079a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_079f: ldc.i4.0
-		IL_07a0: conv.r8
-		IL_07a1: ldstr ""
-		IL_07a6: ldc.i4.0
-		IL_07a7: ldc.i4.1
-		IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_07ad: stloc.s 6
-		IL_07af: ldnull
-		IL_07b0: ldloc.s 6
-		IL_07b2: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_07b7: pop
-		IL_07b8: ldc.i4.1
-		IL_07b9: newarr [System.Runtime]System.Object
-		IL_07be: dup
-		IL_07bf: ldc.i4.0
-		IL_07c0: ldloc.0
-		IL_07c1: stelem.ref
-		IL_07c2: ldc.i4.0
-		IL_07c3: ldelem.ref
-		IL_07c4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_07c9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_07cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_07d4: ldc.i4.0
-		IL_07d5: conv.r8
-		IL_07d6: ldstr ""
-		IL_07db: ldc.i4.0
-		IL_07dc: ldc.i4.1
-		IL_07dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_07e2: stloc.s 6
-		IL_07e4: ldnull
-		IL_07e5: ldstr "Compiled Variable Test"
-		IL_07ea: ldloc.s 6
-		IL_07ec: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_07f1: pop
+		IL_0754: ldloc.0
+		IL_0755: stelem.ref
+		IL_0756: ldc.i4.0
+		IL_0757: ldelem.ref
+		IL_0758: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_075d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0763: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0768: ldc.i4.0
+		IL_0769: conv.r8
+		IL_076a: ldstr ""
+		IL_076f: ldc.i4.0
+		IL_0770: ldc.i4.1
+		IL_0771: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0776: stloc.s 8
+		IL_0778: ldloc.s 4
+		IL_077a: ldloc.s 7
+		IL_077c: ldstr "Compiled Object 12 Char Replace"
+		IL_0781: ldloc.s 8
+		IL_0783: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0788: pop
+		IL_0789: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_078e: stloc.s 7
+		IL_0790: ldc.i4.1
+		IL_0791: newarr [System.Runtime]System.Object
+		IL_0796: dup
+		IL_0797: ldc.i4.0
+		IL_0798: ldloc.0
+		IL_0799: stelem.ref
+		IL_079a: ldc.i4.0
+		IL_079b: ldelem.ref
+		IL_079c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_07a1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_07a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_07ac: ldc.i4.0
+		IL_07ad: conv.r8
+		IL_07ae: ldstr ""
+		IL_07b3: ldc.i4.0
+		IL_07b4: ldc.i4.1
+		IL_07b5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_07ba: stloc.s 8
+		IL_07bc: ldloc.3
+		IL_07bd: ldloc.s 7
+		IL_07bf: ldloc.s 8
+		IL_07c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_07c6: pop
+		IL_07c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_07cc: stloc.s 7
+		IL_07ce: ldc.i4.1
+		IL_07cf: newarr [System.Runtime]System.Object
+		IL_07d4: dup
+		IL_07d5: ldc.i4.0
+		IL_07d6: ldloc.0
+		IL_07d7: stelem.ref
+		IL_07d8: ldc.i4.0
+		IL_07d9: ldelem.ref
+		IL_07da: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_07df: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_07e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_07ea: ldc.i4.0
+		IL_07eb: conv.r8
+		IL_07ec: ldstr ""
+		IL_07f1: ldc.i4.0
 		IL_07f2: ldc.i4.1
-		IL_07f3: newarr [System.Runtime]System.Object
-		IL_07f8: dup
-		IL_07f9: ldc.i4.0
-		IL_07fa: ldloc.0
-		IL_07fb: stelem.ref
-		IL_07fc: ldc.i4.0
-		IL_07fd: ldelem.ref
-		IL_07fe: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0803: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0809: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_080e: ldc.i4.0
-		IL_080f: conv.r8
-		IL_0810: ldstr ""
-		IL_0815: ldc.i4.0
-		IL_0816: ldc.i4.1
-		IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_081c: stloc.s 6
-		IL_081e: ldnull
-		IL_081f: ldloc.s 6
-		IL_0821: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0826: pop
-		IL_0827: ldc.i4.1
-		IL_0828: newarr [System.Runtime]System.Object
-		IL_082d: dup
+		IL_07f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_07f8: stloc.s 8
+		IL_07fa: ldloc.s 4
+		IL_07fc: ldloc.s 7
+		IL_07fe: ldstr "Compiled Object 12 Char Replace Function"
+		IL_0803: ldloc.s 8
+		IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_080a: pop
+		IL_080b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0810: stloc.s 7
+		IL_0812: ldc.i4.1
+		IL_0813: newarr [System.Runtime]System.Object
+		IL_0818: dup
+		IL_0819: ldc.i4.0
+		IL_081a: ldloc.0
+		IL_081b: stelem.ref
+		IL_081c: ldc.i4.0
+		IL_081d: ldelem.ref
+		IL_081e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0823: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0829: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_082e: ldc.i4.0
-		IL_082f: ldloc.0
-		IL_0830: stelem.ref
-		IL_0831: ldc.i4.0
-		IL_0832: ldelem.ref
-		IL_0833: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0838: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_083e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0843: ldc.i4.0
-		IL_0844: conv.r8
-		IL_0845: ldstr ""
-		IL_084a: ldc.i4.0
-		IL_084b: ldc.i4.1
-		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0851: stloc.s 6
-		IL_0853: ldnull
-		IL_0854: ldstr "Compiled Variable Empty Replace"
-		IL_0859: ldloc.s 6
-		IL_085b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0860: pop
-		IL_0861: ldc.i4.1
-		IL_0862: newarr [System.Runtime]System.Object
-		IL_0867: dup
-		IL_0868: ldc.i4.0
-		IL_0869: ldloc.0
-		IL_086a: stelem.ref
-		IL_086b: ldc.i4.0
-		IL_086c: ldelem.ref
-		IL_086d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0872: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0878: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_087d: ldc.i4.0
-		IL_087e: conv.r8
-		IL_087f: ldstr ""
-		IL_0884: ldc.i4.0
-		IL_0885: ldc.i4.1
-		IL_0886: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_088b: stloc.s 6
-		IL_088d: ldnull
-		IL_088e: ldloc.s 6
-		IL_0890: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0895: pop
-		IL_0896: ldc.i4.1
-		IL_0897: newarr [System.Runtime]System.Object
-		IL_089c: dup
-		IL_089d: ldc.i4.0
-		IL_089e: ldloc.0
-		IL_089f: stelem.ref
-		IL_08a0: ldc.i4.0
-		IL_08a1: ldelem.ref
-		IL_08a2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08a7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_08ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_08b2: ldc.i4.0
-		IL_08b3: conv.r8
-		IL_08b4: ldstr ""
-		IL_08b9: ldc.i4.0
-		IL_08ba: ldc.i4.1
-		IL_08bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_08c0: stloc.s 6
-		IL_08c2: ldnull
-		IL_08c3: ldstr "Compiled Variable 12 Char Replace"
-		IL_08c8: ldloc.s 6
-		IL_08ca: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_08cf: pop
-		IL_08d0: ldc.i4.1
-		IL_08d1: newarr [System.Runtime]System.Object
-		IL_08d6: dup
-		IL_08d7: ldc.i4.0
-		IL_08d8: ldloc.0
-		IL_08d9: stelem.ref
-		IL_08da: ldc.i4.0
-		IL_08db: ldelem.ref
-		IL_08dc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08e1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_08e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_08ec: ldc.i4.0
-		IL_08ed: conv.r8
-		IL_08ee: ldstr ""
-		IL_08f3: ldc.i4.0
-		IL_08f4: ldc.i4.1
-		IL_08f5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_08fa: stloc.s 6
-		IL_08fc: ldnull
-		IL_08fd: ldloc.s 6
-		IL_08ff: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0904: pop
-		IL_0905: ldc.i4.1
-		IL_0906: newarr [System.Runtime]System.Object
-		IL_090b: dup
-		IL_090c: ldc.i4.0
-		IL_090d: ldloc.0
-		IL_090e: stelem.ref
-		IL_090f: ldc.i4.0
-		IL_0910: ldelem.ref
-		IL_0911: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0916: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_091c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0921: ldc.i4.0
-		IL_0922: conv.r8
-		IL_0923: ldstr ""
-		IL_0928: ldc.i4.0
-		IL_0929: ldc.i4.1
-		IL_092a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_092f: stloc.s 6
-		IL_0931: ldnull
-		IL_0932: ldstr "Compiled Variable Object Match"
-		IL_0937: ldloc.s 6
-		IL_0939: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_093e: pop
-		IL_093f: ldc.i4.1
-		IL_0940: newarr [System.Runtime]System.Object
-		IL_0945: dup
-		IL_0946: ldc.i4.0
-		IL_0947: ldloc.0
-		IL_0948: stelem.ref
-		IL_0949: ldc.i4.0
-		IL_094a: ldelem.ref
-		IL_094b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0950: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0956: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_082f: conv.r8
+		IL_0830: ldstr ""
+		IL_0835: ldc.i4.0
+		IL_0836: ldc.i4.1
+		IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_083c: stloc.s 8
+		IL_083e: ldloc.3
+		IL_083f: ldloc.s 7
+		IL_0841: ldloc.s 8
+		IL_0843: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0848: pop
+		IL_0849: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_084e: stloc.s 7
+		IL_0850: ldc.i4.1
+		IL_0851: newarr [System.Runtime]System.Object
+		IL_0856: dup
+		IL_0857: ldc.i4.0
+		IL_0858: ldloc.0
+		IL_0859: stelem.ref
+		IL_085a: ldc.i4.0
+		IL_085b: ldelem.ref
+		IL_085c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0861: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0867: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_086c: ldc.i4.0
+		IL_086d: conv.r8
+		IL_086e: ldstr ""
+		IL_0873: ldc.i4.0
+		IL_0874: ldc.i4.1
+		IL_0875: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_087a: stloc.s 8
+		IL_087c: ldloc.s 4
+		IL_087e: ldloc.s 7
+		IL_0880: ldstr "Compiled Variable Match"
+		IL_0885: ldloc.s 8
+		IL_0887: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_088c: pop
+		IL_088d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0892: stloc.s 7
+		IL_0894: ldc.i4.1
+		IL_0895: newarr [System.Runtime]System.Object
+		IL_089a: dup
+		IL_089b: ldc.i4.0
+		IL_089c: ldloc.0
+		IL_089d: stelem.ref
+		IL_089e: ldc.i4.0
+		IL_089f: ldelem.ref
+		IL_08a0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_08a5: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_08ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_08b0: ldc.i4.0
+		IL_08b1: conv.r8
+		IL_08b2: ldstr ""
+		IL_08b7: ldc.i4.0
+		IL_08b8: ldc.i4.1
+		IL_08b9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_08be: stloc.s 8
+		IL_08c0: ldloc.3
+		IL_08c1: ldloc.s 7
+		IL_08c3: ldloc.s 8
+		IL_08c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_08ca: pop
+		IL_08cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08d0: stloc.s 7
+		IL_08d2: ldc.i4.1
+		IL_08d3: newarr [System.Runtime]System.Object
+		IL_08d8: dup
+		IL_08d9: ldc.i4.0
+		IL_08da: ldloc.0
+		IL_08db: stelem.ref
+		IL_08dc: ldc.i4.0
+		IL_08dd: ldelem.ref
+		IL_08de: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_08e3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_08e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_08ee: ldc.i4.0
+		IL_08ef: conv.r8
+		IL_08f0: ldstr ""
+		IL_08f5: ldc.i4.0
+		IL_08f6: ldc.i4.1
+		IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_08fc: stloc.s 8
+		IL_08fe: ldloc.s 4
+		IL_0900: ldloc.s 7
+		IL_0902: ldstr "Compiled Variable Test"
+		IL_0907: ldloc.s 8
+		IL_0909: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_090e: pop
+		IL_090f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0914: stloc.s 7
+		IL_0916: ldc.i4.1
+		IL_0917: newarr [System.Runtime]System.Object
+		IL_091c: dup
+		IL_091d: ldc.i4.0
+		IL_091e: ldloc.0
+		IL_091f: stelem.ref
+		IL_0920: ldc.i4.0
+		IL_0921: ldelem.ref
+		IL_0922: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0927: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_092d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0932: ldc.i4.0
+		IL_0933: conv.r8
+		IL_0934: ldstr ""
+		IL_0939: ldc.i4.0
+		IL_093a: ldc.i4.1
+		IL_093b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0940: stloc.s 8
+		IL_0942: ldloc.3
+		IL_0943: ldloc.s 7
+		IL_0945: ldloc.s 8
+		IL_0947: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_094c: pop
+		IL_094d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0952: stloc.s 7
+		IL_0954: ldc.i4.1
+		IL_0955: newarr [System.Runtime]System.Object
+		IL_095a: dup
 		IL_095b: ldc.i4.0
-		IL_095c: conv.r8
-		IL_095d: ldstr ""
-		IL_0962: ldc.i4.0
-		IL_0963: ldc.i4.1
-		IL_0964: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0969: stloc.s 6
-		IL_096b: ldnull
-		IL_096c: ldloc.s 6
-		IL_096e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0973: pop
-		IL_0974: ldc.i4.1
-		IL_0975: newarr [System.Runtime]System.Object
-		IL_097a: dup
-		IL_097b: ldc.i4.0
-		IL_097c: ldloc.0
-		IL_097d: stelem.ref
-		IL_097e: ldc.i4.0
-		IL_097f: ldelem.ref
-		IL_0980: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0985: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_098b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0990: ldc.i4.0
-		IL_0991: conv.r8
-		IL_0992: ldstr ""
-		IL_0997: ldc.i4.0
+		IL_095c: ldloc.0
+		IL_095d: stelem.ref
+		IL_095e: ldc.i4.0
+		IL_095f: ldelem.ref
+		IL_0960: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0965: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_096b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0970: ldc.i4.0
+		IL_0971: conv.r8
+		IL_0972: ldstr ""
+		IL_0977: ldc.i4.0
+		IL_0978: ldc.i4.1
+		IL_0979: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_097e: stloc.s 8
+		IL_0980: ldloc.s 4
+		IL_0982: ldloc.s 7
+		IL_0984: ldstr "Compiled Variable Empty Replace"
+		IL_0989: ldloc.s 8
+		IL_098b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0990: pop
+		IL_0991: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0996: stloc.s 7
 		IL_0998: ldc.i4.1
-		IL_0999: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_099e: stloc.s 6
-		IL_09a0: ldnull
-		IL_09a1: ldstr "Compiled Variable Object Test"
-		IL_09a6: ldloc.s 6
-		IL_09a8: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_09ad: pop
-		IL_09ae: ldc.i4.1
-		IL_09af: newarr [System.Runtime]System.Object
-		IL_09b4: dup
-		IL_09b5: ldc.i4.0
-		IL_09b6: ldloc.0
-		IL_09b7: stelem.ref
-		IL_09b8: ldc.i4.0
-		IL_09b9: ldelem.ref
-		IL_09ba: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09bf: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_09c5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_09ca: ldc.i4.0
-		IL_09cb: conv.r8
-		IL_09cc: ldstr ""
-		IL_09d1: ldc.i4.0
-		IL_09d2: ldc.i4.1
-		IL_09d3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_09d8: stloc.s 6
-		IL_09da: ldnull
-		IL_09db: ldloc.s 6
-		IL_09dd: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_09e2: pop
-		IL_09e3: ldc.i4.1
-		IL_09e4: newarr [System.Runtime]System.Object
-		IL_09e9: dup
-		IL_09ea: ldc.i4.0
-		IL_09eb: ldloc.0
-		IL_09ec: stelem.ref
-		IL_09ed: ldc.i4.0
-		IL_09ee: ldelem.ref
-		IL_09ef: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09f4: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_09fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_09ff: ldc.i4.0
-		IL_0a00: conv.r8
-		IL_0a01: ldstr ""
-		IL_0a06: ldc.i4.0
-		IL_0a07: ldc.i4.1
-		IL_0a08: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0a0d: stloc.s 6
-		IL_0a0f: ldnull
-		IL_0a10: ldstr "Compiled Variable Object Empty Replace"
-		IL_0a15: ldloc.s 6
-		IL_0a17: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0a1c: pop
-		IL_0a1d: ldc.i4.1
-		IL_0a1e: newarr [System.Runtime]System.Object
-		IL_0a23: dup
+		IL_0999: newarr [System.Runtime]System.Object
+		IL_099e: dup
+		IL_099f: ldc.i4.0
+		IL_09a0: ldloc.0
+		IL_09a1: stelem.ref
+		IL_09a2: ldc.i4.0
+		IL_09a3: ldelem.ref
+		IL_09a4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_09a9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_09af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_09b4: ldc.i4.0
+		IL_09b5: conv.r8
+		IL_09b6: ldstr ""
+		IL_09bb: ldc.i4.0
+		IL_09bc: ldc.i4.1
+		IL_09bd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_09c2: stloc.s 8
+		IL_09c4: ldloc.3
+		IL_09c5: ldloc.s 7
+		IL_09c7: ldloc.s 8
+		IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_09ce: pop
+		IL_09cf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_09d4: stloc.s 7
+		IL_09d6: ldc.i4.1
+		IL_09d7: newarr [System.Runtime]System.Object
+		IL_09dc: dup
+		IL_09dd: ldc.i4.0
+		IL_09de: ldloc.0
+		IL_09df: stelem.ref
+		IL_09e0: ldc.i4.0
+		IL_09e1: ldelem.ref
+		IL_09e2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_09e7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_09ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_09f2: ldc.i4.0
+		IL_09f3: conv.r8
+		IL_09f4: ldstr ""
+		IL_09f9: ldc.i4.0
+		IL_09fa: ldc.i4.1
+		IL_09fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0a00: stloc.s 8
+		IL_0a02: ldloc.s 4
+		IL_0a04: ldloc.s 7
+		IL_0a06: ldstr "Compiled Variable 12 Char Replace"
+		IL_0a0b: ldloc.s 8
+		IL_0a0d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0a12: pop
+		IL_0a13: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a18: stloc.s 7
+		IL_0a1a: ldc.i4.1
+		IL_0a1b: newarr [System.Runtime]System.Object
+		IL_0a20: dup
+		IL_0a21: ldc.i4.0
+		IL_0a22: ldloc.0
+		IL_0a23: stelem.ref
 		IL_0a24: ldc.i4.0
-		IL_0a25: ldloc.0
-		IL_0a26: stelem.ref
-		IL_0a27: ldc.i4.0
-		IL_0a28: ldelem.ref
-		IL_0a29: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a2e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0a34: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0a39: ldc.i4.0
-		IL_0a3a: conv.r8
-		IL_0a3b: ldstr ""
-		IL_0a40: ldc.i4.0
-		IL_0a41: ldc.i4.1
-		IL_0a42: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0a47: stloc.s 6
-		IL_0a49: ldnull
-		IL_0a4a: ldloc.s 6
-		IL_0a4c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0a51: pop
-		IL_0a52: ldc.i4.1
-		IL_0a53: newarr [System.Runtime]System.Object
-		IL_0a58: dup
-		IL_0a59: ldc.i4.0
-		IL_0a5a: ldloc.0
-		IL_0a5b: stelem.ref
-		IL_0a5c: ldc.i4.0
-		IL_0a5d: ldelem.ref
-		IL_0a5e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a63: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0a69: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0a6e: ldc.i4.0
-		IL_0a6f: conv.r8
-		IL_0a70: ldstr ""
-		IL_0a75: ldc.i4.0
-		IL_0a76: ldc.i4.1
-		IL_0a77: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0a7c: stloc.s 6
-		IL_0a7e: ldnull
-		IL_0a7f: ldstr "Compiled Variable Object 12 Char Replace"
-		IL_0a84: ldloc.s 6
-		IL_0a86: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0a8b: pop
-		IL_0a8c: ldc.i4.1
-		IL_0a8d: newarr [System.Runtime]System.Object
-		IL_0a92: dup
-		IL_0a93: ldc.i4.0
-		IL_0a94: ldloc.0
-		IL_0a95: stelem.ref
-		IL_0a96: ldc.i4.0
-		IL_0a97: ldelem.ref
-		IL_0a98: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a9d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0aa3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0aa8: ldc.i4.0
-		IL_0aa9: conv.r8
-		IL_0aaa: ldstr ""
-		IL_0aaf: ldc.i4.0
-		IL_0ab0: ldc.i4.1
-		IL_0ab1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ab6: stloc.s 6
-		IL_0ab8: ldnull
-		IL_0ab9: ldloc.s 6
-		IL_0abb: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0ac0: pop
-		IL_0ac1: ldc.i4.1
-		IL_0ac2: newarr [System.Runtime]System.Object
-		IL_0ac7: dup
-		IL_0ac8: ldc.i4.0
-		IL_0ac9: ldloc.0
-		IL_0aca: stelem.ref
-		IL_0acb: ldc.i4.0
-		IL_0acc: ldelem.ref
-		IL_0acd: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ad2: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0ad8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0add: ldc.i4.0
-		IL_0ade: conv.r8
-		IL_0adf: ldstr ""
+		IL_0a25: ldelem.ref
+		IL_0a26: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a2b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0a31: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0a36: ldc.i4.0
+		IL_0a37: conv.r8
+		IL_0a38: ldstr ""
+		IL_0a3d: ldc.i4.0
+		IL_0a3e: ldc.i4.1
+		IL_0a3f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0a44: stloc.s 8
+		IL_0a46: ldloc.3
+		IL_0a47: ldloc.s 7
+		IL_0a49: ldloc.s 8
+		IL_0a4b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0a50: pop
+		IL_0a51: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a56: stloc.s 7
+		IL_0a58: ldc.i4.1
+		IL_0a59: newarr [System.Runtime]System.Object
+		IL_0a5e: dup
+		IL_0a5f: ldc.i4.0
+		IL_0a60: ldloc.0
+		IL_0a61: stelem.ref
+		IL_0a62: ldc.i4.0
+		IL_0a63: ldelem.ref
+		IL_0a64: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a69: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0a6f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0a74: ldc.i4.0
+		IL_0a75: conv.r8
+		IL_0a76: ldstr ""
+		IL_0a7b: ldc.i4.0
+		IL_0a7c: ldc.i4.1
+		IL_0a7d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0a82: stloc.s 8
+		IL_0a84: ldloc.s 4
+		IL_0a86: ldloc.s 7
+		IL_0a88: ldstr "Compiled Variable Object Match"
+		IL_0a8d: ldloc.s 8
+		IL_0a8f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0a94: pop
+		IL_0a95: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a9a: stloc.s 7
+		IL_0a9c: ldc.i4.1
+		IL_0a9d: newarr [System.Runtime]System.Object
+		IL_0aa2: dup
+		IL_0aa3: ldc.i4.0
+		IL_0aa4: ldloc.0
+		IL_0aa5: stelem.ref
+		IL_0aa6: ldc.i4.0
+		IL_0aa7: ldelem.ref
+		IL_0aa8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0aad: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0ab3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0ab8: ldc.i4.0
+		IL_0ab9: conv.r8
+		IL_0aba: ldstr ""
+		IL_0abf: ldc.i4.0
+		IL_0ac0: ldc.i4.1
+		IL_0ac1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0ac6: stloc.s 8
+		IL_0ac8: ldloc.3
+		IL_0ac9: ldloc.s 7
+		IL_0acb: ldloc.s 8
+		IL_0acd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0ad2: pop
+		IL_0ad3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ad8: stloc.s 7
+		IL_0ada: ldc.i4.1
+		IL_0adb: newarr [System.Runtime]System.Object
+		IL_0ae0: dup
+		IL_0ae1: ldc.i4.0
+		IL_0ae2: ldloc.0
+		IL_0ae3: stelem.ref
 		IL_0ae4: ldc.i4.0
-		IL_0ae5: ldc.i4.1
-		IL_0ae6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0aeb: stloc.s 6
-		IL_0aed: ldnull
-		IL_0aee: ldstr "Compiled Variable Object 12 Char Replace Function"
-		IL_0af3: ldloc.s 6
-		IL_0af5: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0afa: pop
-		IL_0afb: ldc.i4.1
-		IL_0afc: newarr [System.Runtime]System.Object
-		IL_0b01: dup
-		IL_0b02: ldc.i4.0
-		IL_0b03: ldloc.0
-		IL_0b04: stelem.ref
-		IL_0b05: ldc.i4.0
-		IL_0b06: ldelem.ref
-		IL_0b07: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b0c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0b12: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0b17: ldc.i4.0
-		IL_0b18: conv.r8
-		IL_0b19: ldstr ""
-		IL_0b1e: ldc.i4.0
-		IL_0b1f: ldc.i4.1
-		IL_0b20: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0b25: stloc.s 6
-		IL_0b27: ldnull
-		IL_0b28: ldloc.s 6
-		IL_0b2a: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0b2f: pop
-		IL_0b30: ldc.i4.1
-		IL_0b31: newarr [System.Runtime]System.Object
-		IL_0b36: dup
-		IL_0b37: ldc.i4.0
-		IL_0b38: ldloc.0
-		IL_0b39: stelem.ref
+		IL_0ae5: ldelem.ref
+		IL_0ae6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0aeb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0af1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0af6: ldc.i4.0
+		IL_0af7: conv.r8
+		IL_0af8: ldstr ""
+		IL_0afd: ldc.i4.0
+		IL_0afe: ldc.i4.1
+		IL_0aff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0b04: stloc.s 8
+		IL_0b06: ldloc.s 4
+		IL_0b08: ldloc.s 7
+		IL_0b0a: ldstr "Compiled Variable Object Test"
+		IL_0b0f: ldloc.s 8
+		IL_0b11: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0b16: pop
+		IL_0b17: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b1c: stloc.s 7
+		IL_0b1e: ldc.i4.1
+		IL_0b1f: newarr [System.Runtime]System.Object
+		IL_0b24: dup
+		IL_0b25: ldc.i4.0
+		IL_0b26: ldloc.0
+		IL_0b27: stelem.ref
+		IL_0b28: ldc.i4.0
+		IL_0b29: ldelem.ref
+		IL_0b2a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b2f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0b35: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_0b3a: ldc.i4.0
-		IL_0b3b: ldelem.ref
-		IL_0b3c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b41: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0b47: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0b4c: ldc.i4.0
-		IL_0b4d: conv.r8
-		IL_0b4e: ldstr ""
-		IL_0b53: ldc.i4.0
-		IL_0b54: ldc.i4.1
-		IL_0b55: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0b5a: stloc.s 6
-		IL_0b5c: ldnull
-		IL_0b5d: ldstr "Compiled Capture Match"
-		IL_0b62: ldloc.s 6
-		IL_0b64: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0b69: pop
-		IL_0b6a: ldc.i4.1
-		IL_0b6b: newarr [System.Runtime]System.Object
-		IL_0b70: dup
-		IL_0b71: ldc.i4.0
-		IL_0b72: ldloc.0
-		IL_0b73: stelem.ref
-		IL_0b74: ldc.i4.0
-		IL_0b75: ldelem.ref
-		IL_0b76: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b7b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0b81: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0b86: ldc.i4.0
-		IL_0b87: conv.r8
-		IL_0b88: ldstr ""
-		IL_0b8d: ldc.i4.0
-		IL_0b8e: ldc.i4.1
-		IL_0b8f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0b94: stloc.s 6
-		IL_0b96: ldnull
-		IL_0b97: ldloc.s 6
-		IL_0b99: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0b9e: pop
-		IL_0b9f: ldc.i4.1
-		IL_0ba0: newarr [System.Runtime]System.Object
-		IL_0ba5: dup
-		IL_0ba6: ldc.i4.0
-		IL_0ba7: ldloc.0
-		IL_0ba8: stelem.ref
-		IL_0ba9: ldc.i4.0
-		IL_0baa: ldelem.ref
-		IL_0bab: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0bb0: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0bb6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0bbb: ldc.i4.0
-		IL_0bbc: conv.r8
-		IL_0bbd: ldstr ""
-		IL_0bc2: ldc.i4.0
-		IL_0bc3: ldc.i4.1
-		IL_0bc4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0bc9: stloc.s 6
-		IL_0bcb: ldnull
-		IL_0bcc: ldstr "Compiled Capture Replace"
-		IL_0bd1: ldloc.s 6
-		IL_0bd3: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0bd8: pop
-		IL_0bd9: ldc.i4.1
-		IL_0bda: newarr [System.Runtime]System.Object
-		IL_0bdf: dup
-		IL_0be0: ldc.i4.0
-		IL_0be1: ldloc.0
-		IL_0be2: stelem.ref
-		IL_0be3: ldc.i4.0
-		IL_0be4: ldelem.ref
-		IL_0be5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0bea: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0bf0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0bf5: ldc.i4.0
-		IL_0bf6: conv.r8
-		IL_0bf7: ldstr ""
-		IL_0bfc: ldc.i4.0
-		IL_0bfd: ldc.i4.1
-		IL_0bfe: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0c03: stloc.s 6
-		IL_0c05: ldnull
-		IL_0c06: ldloc.s 6
-		IL_0c08: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0c0d: pop
-		IL_0c0e: ldc.i4.1
-		IL_0c0f: newarr [System.Runtime]System.Object
-		IL_0c14: dup
-		IL_0c15: ldc.i4.0
-		IL_0c16: ldloc.0
-		IL_0c17: stelem.ref
-		IL_0c18: ldc.i4.0
-		IL_0c19: ldelem.ref
-		IL_0c1a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c1f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0c25: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0c2a: ldc.i4.0
-		IL_0c2b: conv.r8
-		IL_0c2c: ldstr ""
-		IL_0c31: ldc.i4.0
-		IL_0c32: ldc.i4.1
-		IL_0c33: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0c38: stloc.s 6
-		IL_0c3a: ldnull
-		IL_0c3b: ldstr "Compiled Capture Replace with Capture"
-		IL_0c40: ldloc.s 6
-		IL_0c42: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0c47: pop
-		IL_0c48: ldc.i4.1
-		IL_0c49: newarr [System.Runtime]System.Object
-		IL_0c4e: dup
-		IL_0c4f: ldc.i4.0
-		IL_0c50: ldloc.0
-		IL_0c51: stelem.ref
-		IL_0c52: ldc.i4.0
-		IL_0c53: ldelem.ref
-		IL_0c54: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c59: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0c5f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0c64: ldc.i4.0
-		IL_0c65: conv.r8
-		IL_0c66: ldstr ""
-		IL_0c6b: ldc.i4.0
-		IL_0c6c: ldc.i4.1
-		IL_0c6d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0c72: stloc.s 6
-		IL_0c74: ldnull
-		IL_0c75: ldloc.s 6
-		IL_0c77: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0c7c: pop
-		IL_0c7d: ldc.i4.1
-		IL_0c7e: newarr [System.Runtime]System.Object
-		IL_0c83: dup
-		IL_0c84: ldc.i4.0
-		IL_0c85: ldloc.0
-		IL_0c86: stelem.ref
-		IL_0c87: ldc.i4.0
-		IL_0c88: ldelem.ref
-		IL_0c89: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c8e: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0c94: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0c99: ldc.i4.0
-		IL_0c9a: conv.r8
-		IL_0c9b: ldstr ""
-		IL_0ca0: ldc.i4.0
-		IL_0ca1: ldc.i4.1
-		IL_0ca2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ca7: stloc.s 6
-		IL_0ca9: ldnull
-		IL_0caa: ldstr "Compiled Capture Replace with Capture Function"
-		IL_0caf: ldloc.s 6
-		IL_0cb1: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0cb6: pop
-		IL_0cb7: ldc.i4.1
-		IL_0cb8: newarr [System.Runtime]System.Object
-		IL_0cbd: dup
-		IL_0cbe: ldc.i4.0
-		IL_0cbf: ldloc.0
-		IL_0cc0: stelem.ref
-		IL_0cc1: ldc.i4.0
-		IL_0cc2: ldelem.ref
-		IL_0cc3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0cc8: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0cce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0cd3: ldc.i4.0
-		IL_0cd4: conv.r8
-		IL_0cd5: ldstr ""
-		IL_0cda: ldc.i4.0
-		IL_0cdb: ldc.i4.1
-		IL_0cdc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ce1: stloc.s 6
-		IL_0ce3: ldnull
-		IL_0ce4: ldloc.s 6
-		IL_0ce6: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0ceb: pop
-		IL_0cec: ldc.i4.1
-		IL_0ced: newarr [System.Runtime]System.Object
-		IL_0cf2: dup
-		IL_0cf3: ldc.i4.0
-		IL_0cf4: ldloc.0
-		IL_0cf5: stelem.ref
-		IL_0cf6: ldc.i4.0
-		IL_0cf7: ldelem.ref
-		IL_0cf8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0cfd: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0d03: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0d08: ldc.i4.0
-		IL_0d09: conv.r8
-		IL_0d0a: ldstr ""
-		IL_0d0f: ldc.i4.0
-		IL_0d10: ldc.i4.1
-		IL_0d11: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0d16: stloc.s 6
-		IL_0d18: ldnull
-		IL_0d19: ldstr "Compiled Capture Replace with Upperase Capture Function"
-		IL_0d1e: ldloc.s 6
-		IL_0d20: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0d25: pop
+		IL_0b3b: conv.r8
+		IL_0b3c: ldstr ""
+		IL_0b41: ldc.i4.0
+		IL_0b42: ldc.i4.1
+		IL_0b43: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0b48: stloc.s 8
+		IL_0b4a: ldloc.3
+		IL_0b4b: ldloc.s 7
+		IL_0b4d: ldloc.s 8
+		IL_0b4f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0b54: pop
+		IL_0b55: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b5a: stloc.s 7
+		IL_0b5c: ldc.i4.1
+		IL_0b5d: newarr [System.Runtime]System.Object
+		IL_0b62: dup
+		IL_0b63: ldc.i4.0
+		IL_0b64: ldloc.0
+		IL_0b65: stelem.ref
+		IL_0b66: ldc.i4.0
+		IL_0b67: ldelem.ref
+		IL_0b68: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b6d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0b73: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0b78: ldc.i4.0
+		IL_0b79: conv.r8
+		IL_0b7a: ldstr ""
+		IL_0b7f: ldc.i4.0
+		IL_0b80: ldc.i4.1
+		IL_0b81: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0b86: stloc.s 8
+		IL_0b88: ldloc.s 4
+		IL_0b8a: ldloc.s 7
+		IL_0b8c: ldstr "Compiled Variable Object Empty Replace"
+		IL_0b91: ldloc.s 8
+		IL_0b93: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0b98: pop
+		IL_0b99: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b9e: stloc.s 7
+		IL_0ba0: ldc.i4.1
+		IL_0ba1: newarr [System.Runtime]System.Object
+		IL_0ba6: dup
+		IL_0ba7: ldc.i4.0
+		IL_0ba8: ldloc.0
+		IL_0ba9: stelem.ref
+		IL_0baa: ldc.i4.0
+		IL_0bab: ldelem.ref
+		IL_0bac: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0bb1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0bb7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0bbc: ldc.i4.0
+		IL_0bbd: conv.r8
+		IL_0bbe: ldstr ""
+		IL_0bc3: ldc.i4.0
+		IL_0bc4: ldc.i4.1
+		IL_0bc5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0bca: stloc.s 8
+		IL_0bcc: ldloc.3
+		IL_0bcd: ldloc.s 7
+		IL_0bcf: ldloc.s 8
+		IL_0bd1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0bd6: pop
+		IL_0bd7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0bdc: stloc.s 7
+		IL_0bde: ldc.i4.1
+		IL_0bdf: newarr [System.Runtime]System.Object
+		IL_0be4: dup
+		IL_0be5: ldc.i4.0
+		IL_0be6: ldloc.0
+		IL_0be7: stelem.ref
+		IL_0be8: ldc.i4.0
+		IL_0be9: ldelem.ref
+		IL_0bea: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0bef: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0bf5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0bfa: ldc.i4.0
+		IL_0bfb: conv.r8
+		IL_0bfc: ldstr ""
+		IL_0c01: ldc.i4.0
+		IL_0c02: ldc.i4.1
+		IL_0c03: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0c08: stloc.s 8
+		IL_0c0a: ldloc.s 4
+		IL_0c0c: ldloc.s 7
+		IL_0c0e: ldstr "Compiled Variable Object 12 Char Replace"
+		IL_0c13: ldloc.s 8
+		IL_0c15: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0c1a: pop
+		IL_0c1b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c20: stloc.s 7
+		IL_0c22: ldc.i4.1
+		IL_0c23: newarr [System.Runtime]System.Object
+		IL_0c28: dup
+		IL_0c29: ldc.i4.0
+		IL_0c2a: ldloc.0
+		IL_0c2b: stelem.ref
+		IL_0c2c: ldc.i4.0
+		IL_0c2d: ldelem.ref
+		IL_0c2e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c33: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0c39: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0c3e: ldc.i4.0
+		IL_0c3f: conv.r8
+		IL_0c40: ldstr ""
+		IL_0c45: ldc.i4.0
+		IL_0c46: ldc.i4.1
+		IL_0c47: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0c4c: stloc.s 8
+		IL_0c4e: ldloc.3
+		IL_0c4f: ldloc.s 7
+		IL_0c51: ldloc.s 8
+		IL_0c53: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0c58: pop
+		IL_0c59: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c5e: stloc.s 7
+		IL_0c60: ldc.i4.1
+		IL_0c61: newarr [System.Runtime]System.Object
+		IL_0c66: dup
+		IL_0c67: ldc.i4.0
+		IL_0c68: ldloc.0
+		IL_0c69: stelem.ref
+		IL_0c6a: ldc.i4.0
+		IL_0c6b: ldelem.ref
+		IL_0c6c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c71: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0c77: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0c7c: ldc.i4.0
+		IL_0c7d: conv.r8
+		IL_0c7e: ldstr ""
+		IL_0c83: ldc.i4.0
+		IL_0c84: ldc.i4.1
+		IL_0c85: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0c8a: stloc.s 8
+		IL_0c8c: ldloc.s 4
+		IL_0c8e: ldloc.s 7
+		IL_0c90: ldstr "Compiled Variable Object 12 Char Replace Function"
+		IL_0c95: ldloc.s 8
+		IL_0c97: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0c9c: pop
+		IL_0c9d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ca2: stloc.s 7
+		IL_0ca4: ldc.i4.1
+		IL_0ca5: newarr [System.Runtime]System.Object
+		IL_0caa: dup
+		IL_0cab: ldc.i4.0
+		IL_0cac: ldloc.0
+		IL_0cad: stelem.ref
+		IL_0cae: ldc.i4.0
+		IL_0caf: ldelem.ref
+		IL_0cb0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0cb5: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0cbb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0cc0: ldc.i4.0
+		IL_0cc1: conv.r8
+		IL_0cc2: ldstr ""
+		IL_0cc7: ldc.i4.0
+		IL_0cc8: ldc.i4.1
+		IL_0cc9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0cce: stloc.s 8
+		IL_0cd0: ldloc.3
+		IL_0cd1: ldloc.s 7
+		IL_0cd3: ldloc.s 8
+		IL_0cd5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0cda: pop
+		IL_0cdb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ce0: stloc.s 7
+		IL_0ce2: ldc.i4.1
+		IL_0ce3: newarr [System.Runtime]System.Object
+		IL_0ce8: dup
+		IL_0ce9: ldc.i4.0
+		IL_0cea: ldloc.0
+		IL_0ceb: stelem.ref
+		IL_0cec: ldc.i4.0
+		IL_0ced: ldelem.ref
+		IL_0cee: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0cf3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0cf9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0cfe: ldc.i4.0
+		IL_0cff: conv.r8
+		IL_0d00: ldstr ""
+		IL_0d05: ldc.i4.0
+		IL_0d06: ldc.i4.1
+		IL_0d07: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0d0c: stloc.s 8
+		IL_0d0e: ldloc.s 4
+		IL_0d10: ldloc.s 7
+		IL_0d12: ldstr "Compiled Capture Match"
+		IL_0d17: ldloc.s 8
+		IL_0d19: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0d1e: pop
+		IL_0d1f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0d24: stloc.s 7
 		IL_0d26: ldc.i4.1
 		IL_0d27: newarr [System.Runtime]System.Object
 		IL_0d2c: dup
@@ -7324,7 +7721,7 @@
 		IL_0d30: ldc.i4.0
 		IL_0d31: ldelem.ref
 		IL_0d32: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d37: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0d37: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 		IL_0d3d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_0d42: ldc.i4.0
 		IL_0d43: conv.r8
@@ -7332,353 +7729,604 @@
 		IL_0d49: ldc.i4.0
 		IL_0d4a: ldc.i4.1
 		IL_0d4b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0d50: stloc.s 6
-		IL_0d52: ldnull
-		IL_0d53: ldloc.s 6
-		IL_0d55: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0d5a: pop
-		IL_0d5b: ldc.i4.1
-		IL_0d5c: newarr [System.Runtime]System.Object
-		IL_0d61: dup
-		IL_0d62: ldc.i4.0
-		IL_0d63: ldloc.0
-		IL_0d64: stelem.ref
-		IL_0d65: ldc.i4.0
-		IL_0d66: ldelem.ref
-		IL_0d67: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d6c: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0d72: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0d77: ldc.i4.0
-		IL_0d78: conv.r8
-		IL_0d79: ldstr ""
-		IL_0d7e: ldc.i4.0
-		IL_0d7f: ldc.i4.1
-		IL_0d80: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0d85: stloc.s 6
-		IL_0d87: ldnull
-		IL_0d88: ldstr "Uncompiled Match"
-		IL_0d8d: ldloc.s 6
-		IL_0d8f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0d94: pop
-		IL_0d95: ldc.i4.1
-		IL_0d96: newarr [System.Runtime]System.Object
-		IL_0d9b: dup
-		IL_0d9c: ldc.i4.0
-		IL_0d9d: ldloc.0
-		IL_0d9e: stelem.ref
-		IL_0d9f: ldc.i4.0
-		IL_0da0: ldelem.ref
-		IL_0da1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0da6: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0dac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0db1: ldc.i4.0
-		IL_0db2: conv.r8
-		IL_0db3: ldstr ""
-		IL_0db8: ldc.i4.0
-		IL_0db9: ldc.i4.1
-		IL_0dba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0dbf: stloc.s 6
-		IL_0dc1: ldnull
-		IL_0dc2: ldloc.s 6
-		IL_0dc4: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0dc9: pop
-		IL_0dca: ldc.i4.1
-		IL_0dcb: newarr [System.Runtime]System.Object
-		IL_0dd0: dup
-		IL_0dd1: ldc.i4.0
-		IL_0dd2: ldloc.0
-		IL_0dd3: stelem.ref
-		IL_0dd4: ldc.i4.0
-		IL_0dd5: ldelem.ref
-		IL_0dd6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ddb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0de1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0de6: ldc.i4.0
-		IL_0de7: conv.r8
-		IL_0de8: ldstr ""
+		IL_0d50: stloc.s 8
+		IL_0d52: ldloc.3
+		IL_0d53: ldloc.s 7
+		IL_0d55: ldloc.s 8
+		IL_0d57: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0d5c: pop
+		IL_0d5d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0d62: stloc.s 7
+		IL_0d64: ldc.i4.1
+		IL_0d65: newarr [System.Runtime]System.Object
+		IL_0d6a: dup
+		IL_0d6b: ldc.i4.0
+		IL_0d6c: ldloc.0
+		IL_0d6d: stelem.ref
+		IL_0d6e: ldc.i4.0
+		IL_0d6f: ldelem.ref
+		IL_0d70: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d75: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0d7b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0d80: ldc.i4.0
+		IL_0d81: conv.r8
+		IL_0d82: ldstr ""
+		IL_0d87: ldc.i4.0
+		IL_0d88: ldc.i4.1
+		IL_0d89: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0d8e: stloc.s 8
+		IL_0d90: ldloc.s 4
+		IL_0d92: ldloc.s 7
+		IL_0d94: ldstr "Compiled Capture Replace"
+		IL_0d99: ldloc.s 8
+		IL_0d9b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0da0: pop
+		IL_0da1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0da6: stloc.s 7
+		IL_0da8: ldc.i4.1
+		IL_0da9: newarr [System.Runtime]System.Object
+		IL_0dae: dup
+		IL_0daf: ldc.i4.0
+		IL_0db0: ldloc.0
+		IL_0db1: stelem.ref
+		IL_0db2: ldc.i4.0
+		IL_0db3: ldelem.ref
+		IL_0db4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0db9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0dbf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0dc4: ldc.i4.0
+		IL_0dc5: conv.r8
+		IL_0dc6: ldstr ""
+		IL_0dcb: ldc.i4.0
+		IL_0dcc: ldc.i4.1
+		IL_0dcd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0dd2: stloc.s 8
+		IL_0dd4: ldloc.3
+		IL_0dd5: ldloc.s 7
+		IL_0dd7: ldloc.s 8
+		IL_0dd9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0dde: pop
+		IL_0ddf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0de4: stloc.s 7
+		IL_0de6: ldc.i4.1
+		IL_0de7: newarr [System.Runtime]System.Object
+		IL_0dec: dup
 		IL_0ded: ldc.i4.0
-		IL_0dee: ldc.i4.1
-		IL_0def: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0df4: stloc.s 6
-		IL_0df6: ldnull
-		IL_0df7: ldstr "Uncompiled Test"
-		IL_0dfc: ldloc.s 6
-		IL_0dfe: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0e03: pop
-		IL_0e04: ldc.i4.1
-		IL_0e05: newarr [System.Runtime]System.Object
-		IL_0e0a: dup
-		IL_0e0b: ldc.i4.0
-		IL_0e0c: ldloc.0
-		IL_0e0d: stelem.ref
-		IL_0e0e: ldc.i4.0
-		IL_0e0f: ldelem.ref
-		IL_0e10: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e15: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0e1b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0e20: ldc.i4.0
-		IL_0e21: conv.r8
-		IL_0e22: ldstr ""
-		IL_0e27: ldc.i4.0
-		IL_0e28: ldc.i4.1
-		IL_0e29: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0e2e: stloc.s 6
-		IL_0e30: ldnull
-		IL_0e31: ldloc.s 6
-		IL_0e33: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0e38: pop
-		IL_0e39: ldc.i4.1
-		IL_0e3a: newarr [System.Runtime]System.Object
-		IL_0e3f: dup
-		IL_0e40: ldc.i4.0
-		IL_0e41: ldloc.0
-		IL_0e42: stelem.ref
-		IL_0e43: ldc.i4.0
-		IL_0e44: ldelem.ref
-		IL_0e45: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e4a: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0e50: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0e55: ldc.i4.0
-		IL_0e56: conv.r8
-		IL_0e57: ldstr ""
-		IL_0e5c: ldc.i4.0
-		IL_0e5d: ldc.i4.1
-		IL_0e5e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0e63: stloc.s 6
-		IL_0e65: ldnull
-		IL_0e66: ldstr "Uncompiled Empty Replace"
-		IL_0e6b: ldloc.s 6
-		IL_0e6d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0e72: pop
-		IL_0e73: ldc.i4.1
-		IL_0e74: newarr [System.Runtime]System.Object
-		IL_0e79: dup
-		IL_0e7a: ldc.i4.0
-		IL_0e7b: ldloc.0
-		IL_0e7c: stelem.ref
-		IL_0e7d: ldc.i4.0
-		IL_0e7e: ldelem.ref
-		IL_0e7f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e84: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0e8a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0e8f: ldc.i4.0
-		IL_0e90: conv.r8
-		IL_0e91: ldstr ""
-		IL_0e96: ldc.i4.0
-		IL_0e97: ldc.i4.1
-		IL_0e98: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0e9d: stloc.s 6
-		IL_0e9f: ldnull
-		IL_0ea0: ldloc.s 6
-		IL_0ea2: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0ea7: pop
-		IL_0ea8: ldc.i4.1
-		IL_0ea9: newarr [System.Runtime]System.Object
-		IL_0eae: dup
-		IL_0eaf: ldc.i4.0
-		IL_0eb0: ldloc.0
-		IL_0eb1: stelem.ref
-		IL_0eb2: ldc.i4.0
-		IL_0eb3: ldelem.ref
-		IL_0eb4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0eb9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0ebf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0ec4: ldc.i4.0
-		IL_0ec5: conv.r8
-		IL_0ec6: ldstr ""
-		IL_0ecb: ldc.i4.0
-		IL_0ecc: ldc.i4.1
-		IL_0ecd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0ed2: stloc.s 6
-		IL_0ed4: ldnull
-		IL_0ed5: ldstr "Uncompiled 12 Char Replace"
-		IL_0eda: ldloc.s 6
-		IL_0edc: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0ee1: pop
-		IL_0ee2: ldc.i4.1
-		IL_0ee3: newarr [System.Runtime]System.Object
-		IL_0ee8: dup
-		IL_0ee9: ldc.i4.0
-		IL_0eea: ldloc.0
-		IL_0eeb: stelem.ref
-		IL_0eec: ldc.i4.0
-		IL_0eed: ldelem.ref
-		IL_0eee: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ef3: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0ef9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0efe: ldc.i4.0
-		IL_0eff: conv.r8
-		IL_0f00: ldstr ""
-		IL_0f05: ldc.i4.0
-		IL_0f06: ldc.i4.1
-		IL_0f07: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0f0c: stloc.s 6
-		IL_0f0e: ldnull
-		IL_0f0f: ldloc.s 6
-		IL_0f11: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0f16: pop
-		IL_0f17: ldc.i4.1
-		IL_0f18: newarr [System.Runtime]System.Object
-		IL_0f1d: dup
-		IL_0f1e: ldc.i4.0
-		IL_0f1f: ldloc.0
-		IL_0f20: stelem.ref
-		IL_0f21: ldc.i4.0
-		IL_0f22: ldelem.ref
-		IL_0f23: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f28: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0f2e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0f33: ldc.i4.0
-		IL_0f34: conv.r8
-		IL_0f35: ldstr ""
-		IL_0f3a: ldc.i4.0
-		IL_0f3b: ldc.i4.1
-		IL_0f3c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0f41: stloc.s 6
-		IL_0f43: ldnull
-		IL_0f44: ldstr "Uncompiled Object Match"
-		IL_0f49: ldloc.s 6
-		IL_0f4b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0f50: pop
-		IL_0f51: ldc.i4.1
-		IL_0f52: newarr [System.Runtime]System.Object
-		IL_0f57: dup
-		IL_0f58: ldc.i4.0
-		IL_0f59: ldloc.0
-		IL_0f5a: stelem.ref
-		IL_0f5b: ldc.i4.0
-		IL_0f5c: ldelem.ref
-		IL_0f5d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f62: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0f68: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0f6d: ldc.i4.0
-		IL_0f6e: conv.r8
-		IL_0f6f: ldstr ""
-		IL_0f74: ldc.i4.0
-		IL_0f75: ldc.i4.1
-		IL_0f76: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0f7b: stloc.s 6
-		IL_0f7d: ldnull
-		IL_0f7e: ldloc.s 6
-		IL_0f80: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0f85: pop
-		IL_0f86: ldc.i4.1
-		IL_0f87: newarr [System.Runtime]System.Object
-		IL_0f8c: dup
-		IL_0f8d: ldc.i4.0
-		IL_0f8e: ldloc.0
-		IL_0f8f: stelem.ref
-		IL_0f90: ldc.i4.0
-		IL_0f91: ldelem.ref
-		IL_0f92: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f97: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0f9d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0fa2: ldc.i4.0
-		IL_0fa3: conv.r8
-		IL_0fa4: ldstr ""
-		IL_0fa9: ldc.i4.0
-		IL_0faa: ldc.i4.1
-		IL_0fab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0fb0: stloc.s 6
-		IL_0fb2: ldnull
-		IL_0fb3: ldstr "Uncompiled Object Test"
-		IL_0fb8: ldloc.s 6
-		IL_0fba: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_0fbf: pop
-		IL_0fc0: ldc.i4.1
-		IL_0fc1: newarr [System.Runtime]System.Object
-		IL_0fc6: dup
-		IL_0fc7: ldc.i4.0
-		IL_0fc8: ldloc.0
-		IL_0fc9: stelem.ref
-		IL_0fca: ldc.i4.0
-		IL_0fcb: ldelem.ref
-		IL_0fcc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0fd1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0fd7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0fdc: ldc.i4.0
-		IL_0fdd: conv.r8
-		IL_0fde: ldstr ""
-		IL_0fe3: ldc.i4.0
-		IL_0fe4: ldc.i4.1
-		IL_0fe5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0fea: stloc.s 6
-		IL_0fec: ldnull
-		IL_0fed: ldloc.s 6
-		IL_0fef: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0ff4: pop
-		IL_0ff5: ldc.i4.1
-		IL_0ff6: newarr [System.Runtime]System.Object
-		IL_0ffb: dup
-		IL_0ffc: ldc.i4.0
-		IL_0ffd: ldloc.0
-		IL_0ffe: stelem.ref
-		IL_0fff: ldc.i4.0
-		IL_1000: ldelem.ref
-		IL_1001: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1006: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_100c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0dee: ldloc.0
+		IL_0def: stelem.ref
+		IL_0df0: ldc.i4.0
+		IL_0df1: ldelem.ref
+		IL_0df2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0df7: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0dfd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0e02: ldc.i4.0
+		IL_0e03: conv.r8
+		IL_0e04: ldstr ""
+		IL_0e09: ldc.i4.0
+		IL_0e0a: ldc.i4.1
+		IL_0e0b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0e10: stloc.s 8
+		IL_0e12: ldloc.s 4
+		IL_0e14: ldloc.s 7
+		IL_0e16: ldstr "Compiled Capture Replace with Capture"
+		IL_0e1b: ldloc.s 8
+		IL_0e1d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0e22: pop
+		IL_0e23: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e28: stloc.s 7
+		IL_0e2a: ldc.i4.1
+		IL_0e2b: newarr [System.Runtime]System.Object
+		IL_0e30: dup
+		IL_0e31: ldc.i4.0
+		IL_0e32: ldloc.0
+		IL_0e33: stelem.ref
+		IL_0e34: ldc.i4.0
+		IL_0e35: ldelem.ref
+		IL_0e36: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e3b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0e41: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0e46: ldc.i4.0
+		IL_0e47: conv.r8
+		IL_0e48: ldstr ""
+		IL_0e4d: ldc.i4.0
+		IL_0e4e: ldc.i4.1
+		IL_0e4f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0e54: stloc.s 8
+		IL_0e56: ldloc.3
+		IL_0e57: ldloc.s 7
+		IL_0e59: ldloc.s 8
+		IL_0e5b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0e60: pop
+		IL_0e61: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e66: stloc.s 7
+		IL_0e68: ldc.i4.1
+		IL_0e69: newarr [System.Runtime]System.Object
+		IL_0e6e: dup
+		IL_0e6f: ldc.i4.0
+		IL_0e70: ldloc.0
+		IL_0e71: stelem.ref
+		IL_0e72: ldc.i4.0
+		IL_0e73: ldelem.ref
+		IL_0e74: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e79: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0e7f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0e84: ldc.i4.0
+		IL_0e85: conv.r8
+		IL_0e86: ldstr ""
+		IL_0e8b: ldc.i4.0
+		IL_0e8c: ldc.i4.1
+		IL_0e8d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0e92: stloc.s 8
+		IL_0e94: ldloc.s 4
+		IL_0e96: ldloc.s 7
+		IL_0e98: ldstr "Compiled Capture Replace with Capture Function"
+		IL_0e9d: ldloc.s 8
+		IL_0e9f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0ea4: pop
+		IL_0ea5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0eaa: stloc.s 7
+		IL_0eac: ldc.i4.1
+		IL_0ead: newarr [System.Runtime]System.Object
+		IL_0eb2: dup
+		IL_0eb3: ldc.i4.0
+		IL_0eb4: ldloc.0
+		IL_0eb5: stelem.ref
+		IL_0eb6: ldc.i4.0
+		IL_0eb7: ldelem.ref
+		IL_0eb8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ebd: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0ec3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0ec8: ldc.i4.0
+		IL_0ec9: conv.r8
+		IL_0eca: ldstr ""
+		IL_0ecf: ldc.i4.0
+		IL_0ed0: ldc.i4.1
+		IL_0ed1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0ed6: stloc.s 8
+		IL_0ed8: ldloc.3
+		IL_0ed9: ldloc.s 7
+		IL_0edb: ldloc.s 8
+		IL_0edd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0ee2: pop
+		IL_0ee3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ee8: stloc.s 7
+		IL_0eea: ldc.i4.1
+		IL_0eeb: newarr [System.Runtime]System.Object
+		IL_0ef0: dup
+		IL_0ef1: ldc.i4.0
+		IL_0ef2: ldloc.0
+		IL_0ef3: stelem.ref
+		IL_0ef4: ldc.i4.0
+		IL_0ef5: ldelem.ref
+		IL_0ef6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0efb: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0f01: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0f06: ldc.i4.0
+		IL_0f07: conv.r8
+		IL_0f08: ldstr ""
+		IL_0f0d: ldc.i4.0
+		IL_0f0e: ldc.i4.1
+		IL_0f0f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0f14: stloc.s 8
+		IL_0f16: ldloc.s 4
+		IL_0f18: ldloc.s 7
+		IL_0f1a: ldstr "Compiled Capture Replace with Upperase Capture Function"
+		IL_0f1f: ldloc.s 8
+		IL_0f21: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0f26: pop
+		IL_0f27: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f2c: stloc.s 7
+		IL_0f2e: ldc.i4.1
+		IL_0f2f: newarr [System.Runtime]System.Object
+		IL_0f34: dup
+		IL_0f35: ldc.i4.0
+		IL_0f36: ldloc.0
+		IL_0f37: stelem.ref
+		IL_0f38: ldc.i4.0
+		IL_0f39: ldelem.ref
+		IL_0f3a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f3f: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0f45: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0f4a: ldc.i4.0
+		IL_0f4b: conv.r8
+		IL_0f4c: ldstr ""
+		IL_0f51: ldc.i4.0
+		IL_0f52: ldc.i4.1
+		IL_0f53: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0f58: stloc.s 8
+		IL_0f5a: ldloc.3
+		IL_0f5b: ldloc.s 7
+		IL_0f5d: ldloc.s 8
+		IL_0f5f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0f64: pop
+		IL_0f65: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f6a: stloc.s 7
+		IL_0f6c: ldc.i4.1
+		IL_0f6d: newarr [System.Runtime]System.Object
+		IL_0f72: dup
+		IL_0f73: ldc.i4.0
+		IL_0f74: ldloc.0
+		IL_0f75: stelem.ref
+		IL_0f76: ldc.i4.0
+		IL_0f77: ldelem.ref
+		IL_0f78: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f7d: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0f83: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0f88: ldc.i4.0
+		IL_0f89: conv.r8
+		IL_0f8a: ldstr ""
+		IL_0f8f: ldc.i4.0
+		IL_0f90: ldc.i4.1
+		IL_0f91: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0f96: stloc.s 8
+		IL_0f98: ldloc.s 4
+		IL_0f9a: ldloc.s 7
+		IL_0f9c: ldstr "Uncompiled Match"
+		IL_0fa1: ldloc.s 8
+		IL_0fa3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0fa8: pop
+		IL_0fa9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0fae: stloc.s 7
+		IL_0fb0: ldc.i4.1
+		IL_0fb1: newarr [System.Runtime]System.Object
+		IL_0fb6: dup
+		IL_0fb7: ldc.i4.0
+		IL_0fb8: ldloc.0
+		IL_0fb9: stelem.ref
+		IL_0fba: ldc.i4.0
+		IL_0fbb: ldelem.ref
+		IL_0fbc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0fc1: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_0fc7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0fcc: ldc.i4.0
+		IL_0fcd: conv.r8
+		IL_0fce: ldstr ""
+		IL_0fd3: ldc.i4.0
+		IL_0fd4: ldc.i4.1
+		IL_0fd5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0fda: stloc.s 8
+		IL_0fdc: ldloc.3
+		IL_0fdd: ldloc.s 7
+		IL_0fdf: ldloc.s 8
+		IL_0fe1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0fe6: pop
+		IL_0fe7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0fec: stloc.s 7
+		IL_0fee: ldc.i4.1
+		IL_0fef: newarr [System.Runtime]System.Object
+		IL_0ff4: dup
+		IL_0ff5: ldc.i4.0
+		IL_0ff6: ldloc.0
+		IL_0ff7: stelem.ref
+		IL_0ff8: ldc.i4.0
+		IL_0ff9: ldelem.ref
+		IL_0ffa: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0fff: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_1005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_100a: ldc.i4.0
+		IL_100b: conv.r8
+		IL_100c: ldstr ""
 		IL_1011: ldc.i4.0
-		IL_1012: conv.r8
-		IL_1013: ldstr ""
-		IL_1018: ldc.i4.0
-		IL_1019: ldc.i4.1
-		IL_101a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_101f: stloc.s 6
-		IL_1021: ldnull
-		IL_1022: ldstr "Uncompiled Object Empty Replace"
-		IL_1027: ldloc.s 6
-		IL_1029: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_102e: pop
-		IL_102f: ldc.i4.1
-		IL_1030: newarr [System.Runtime]System.Object
-		IL_1035: dup
-		IL_1036: ldc.i4.0
-		IL_1037: ldloc.0
-		IL_1038: stelem.ref
+		IL_1012: ldc.i4.1
+		IL_1013: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_1018: stloc.s 8
+		IL_101a: ldloc.s 4
+		IL_101c: ldloc.s 7
+		IL_101e: ldstr "Uncompiled Test"
+		IL_1023: ldloc.s 8
+		IL_1025: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_102a: pop
+		IL_102b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1030: stloc.s 7
+		IL_1032: ldc.i4.1
+		IL_1033: newarr [System.Runtime]System.Object
+		IL_1038: dup
 		IL_1039: ldc.i4.0
-		IL_103a: ldelem.ref
-		IL_103b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1040: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_1046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_104b: ldc.i4.0
-		IL_104c: conv.r8
-		IL_104d: ldstr ""
-		IL_1052: ldc.i4.0
-		IL_1053: ldc.i4.1
-		IL_1054: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_1059: stloc.s 6
-		IL_105b: ldnull
-		IL_105c: ldloc.s 6
-		IL_105e: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_1063: pop
-		IL_1064: ldc.i4.1
-		IL_1065: newarr [System.Runtime]System.Object
-		IL_106a: dup
-		IL_106b: ldc.i4.0
-		IL_106c: ldloc.0
-		IL_106d: stelem.ref
-		IL_106e: ldc.i4.0
-		IL_106f: ldelem.ref
-		IL_1070: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1075: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_107b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_1080: ldc.i4.0
-		IL_1081: conv.r8
-		IL_1082: ldstr ""
-		IL_1087: ldc.i4.0
-		IL_1088: ldc.i4.1
-		IL_1089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_108e: stloc.s 6
-		IL_1090: ldnull
-		IL_1091: ldstr "Uncompiled Object 12 Char Replace"
-		IL_1096: ldloc.s 6
-		IL_1098: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, object, object)
-		IL_109d: pop
-		IL_109e: ldnull
-		IL_109f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
-		IL_10a4: pop
-		IL_10a5: ret
+		IL_103a: ldloc.0
+		IL_103b: stelem.ref
+		IL_103c: ldc.i4.0
+		IL_103d: ldelem.ref
+		IL_103e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1043: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_1049: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_104e: ldc.i4.0
+		IL_104f: conv.r8
+		IL_1050: ldstr ""
+		IL_1055: ldc.i4.0
+		IL_1056: ldc.i4.1
+		IL_1057: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_105c: stloc.s 8
+		IL_105e: ldloc.3
+		IL_105f: ldloc.s 7
+		IL_1061: ldloc.s 8
+		IL_1063: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1068: pop
+		IL_1069: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_106e: stloc.s 7
+		IL_1070: ldc.i4.1
+		IL_1071: newarr [System.Runtime]System.Object
+		IL_1076: dup
+		IL_1077: ldc.i4.0
+		IL_1078: ldloc.0
+		IL_1079: stelem.ref
+		IL_107a: ldc.i4.0
+		IL_107b: ldelem.ref
+		IL_107c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1081: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_1087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_108c: ldc.i4.0
+		IL_108d: conv.r8
+		IL_108e: ldstr ""
+		IL_1093: ldc.i4.0
+		IL_1094: ldc.i4.1
+		IL_1095: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_109a: stloc.s 8
+		IL_109c: ldloc.s 4
+		IL_109e: ldloc.s 7
+		IL_10a0: ldstr "Uncompiled Empty Replace"
+		IL_10a5: ldloc.s 8
+		IL_10a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_10ac: pop
+		IL_10ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_10b2: stloc.s 7
+		IL_10b4: ldc.i4.1
+		IL_10b5: newarr [System.Runtime]System.Object
+		IL_10ba: dup
+		IL_10bb: ldc.i4.0
+		IL_10bc: ldloc.0
+		IL_10bd: stelem.ref
+		IL_10be: ldc.i4.0
+		IL_10bf: ldelem.ref
+		IL_10c0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_10c5: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_10cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_10d0: ldc.i4.0
+		IL_10d1: conv.r8
+		IL_10d2: ldstr ""
+		IL_10d7: ldc.i4.0
+		IL_10d8: ldc.i4.1
+		IL_10d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_10de: stloc.s 8
+		IL_10e0: ldloc.3
+		IL_10e1: ldloc.s 7
+		IL_10e3: ldloc.s 8
+		IL_10e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_10ea: pop
+		IL_10eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_10f0: stloc.s 7
+		IL_10f2: ldc.i4.1
+		IL_10f3: newarr [System.Runtime]System.Object
+		IL_10f8: dup
+		IL_10f9: ldc.i4.0
+		IL_10fa: ldloc.0
+		IL_10fb: stelem.ref
+		IL_10fc: ldc.i4.0
+		IL_10fd: ldelem.ref
+		IL_10fe: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1103: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_1109: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_110e: ldc.i4.0
+		IL_110f: conv.r8
+		IL_1110: ldstr ""
+		IL_1115: ldc.i4.0
+		IL_1116: ldc.i4.1
+		IL_1117: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_111c: stloc.s 8
+		IL_111e: ldloc.s 4
+		IL_1120: ldloc.s 7
+		IL_1122: ldstr "Uncompiled 12 Char Replace"
+		IL_1127: ldloc.s 8
+		IL_1129: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_112e: pop
+		IL_112f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1134: stloc.s 7
+		IL_1136: ldc.i4.1
+		IL_1137: newarr [System.Runtime]System.Object
+		IL_113c: dup
+		IL_113d: ldc.i4.0
+		IL_113e: ldloc.0
+		IL_113f: stelem.ref
+		IL_1140: ldc.i4.0
+		IL_1141: ldelem.ref
+		IL_1142: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1147: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_114d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_1152: ldc.i4.0
+		IL_1153: conv.r8
+		IL_1154: ldstr ""
+		IL_1159: ldc.i4.0
+		IL_115a: ldc.i4.1
+		IL_115b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_1160: stloc.s 8
+		IL_1162: ldloc.3
+		IL_1163: ldloc.s 7
+		IL_1165: ldloc.s 8
+		IL_1167: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_116c: pop
+		IL_116d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1172: stloc.s 7
+		IL_1174: ldc.i4.1
+		IL_1175: newarr [System.Runtime]System.Object
+		IL_117a: dup
+		IL_117b: ldc.i4.0
+		IL_117c: ldloc.0
+		IL_117d: stelem.ref
+		IL_117e: ldc.i4.0
+		IL_117f: ldelem.ref
+		IL_1180: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1185: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_118b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_1190: ldc.i4.0
+		IL_1191: conv.r8
+		IL_1192: ldstr ""
+		IL_1197: ldc.i4.0
+		IL_1198: ldc.i4.1
+		IL_1199: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_119e: stloc.s 8
+		IL_11a0: ldloc.s 4
+		IL_11a2: ldloc.s 7
+		IL_11a4: ldstr "Uncompiled Object Match"
+		IL_11a9: ldloc.s 8
+		IL_11ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_11b0: pop
+		IL_11b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_11b6: stloc.s 7
+		IL_11b8: ldc.i4.1
+		IL_11b9: newarr [System.Runtime]System.Object
+		IL_11be: dup
+		IL_11bf: ldc.i4.0
+		IL_11c0: ldloc.0
+		IL_11c1: stelem.ref
+		IL_11c2: ldc.i4.0
+		IL_11c3: ldelem.ref
+		IL_11c4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_11c9: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_11cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_11d4: ldc.i4.0
+		IL_11d5: conv.r8
+		IL_11d6: ldstr ""
+		IL_11db: ldc.i4.0
+		IL_11dc: ldc.i4.1
+		IL_11dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_11e2: stloc.s 8
+		IL_11e4: ldloc.3
+		IL_11e5: ldloc.s 7
+		IL_11e7: ldloc.s 8
+		IL_11e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_11ee: pop
+		IL_11ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_11f4: stloc.s 7
+		IL_11f6: ldc.i4.1
+		IL_11f7: newarr [System.Runtime]System.Object
+		IL_11fc: dup
+		IL_11fd: ldc.i4.0
+		IL_11fe: ldloc.0
+		IL_11ff: stelem.ref
+		IL_1200: ldc.i4.0
+		IL_1201: ldelem.ref
+		IL_1202: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1207: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_120d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_1212: ldc.i4.0
+		IL_1213: conv.r8
+		IL_1214: ldstr ""
+		IL_1219: ldc.i4.0
+		IL_121a: ldc.i4.1
+		IL_121b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_1220: stloc.s 8
+		IL_1222: ldloc.s 4
+		IL_1224: ldloc.s 7
+		IL_1226: ldstr "Uncompiled Object Test"
+		IL_122b: ldloc.s 8
+		IL_122d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_1232: pop
+		IL_1233: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1238: stloc.s 7
+		IL_123a: ldc.i4.1
+		IL_123b: newarr [System.Runtime]System.Object
+		IL_1240: dup
+		IL_1241: ldc.i4.0
+		IL_1242: ldloc.0
+		IL_1243: stelem.ref
+		IL_1244: ldc.i4.0
+		IL_1245: ldelem.ref
+		IL_1246: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_124b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_1251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_1256: ldc.i4.0
+		IL_1257: conv.r8
+		IL_1258: ldstr ""
+		IL_125d: ldc.i4.0
+		IL_125e: ldc.i4.1
+		IL_125f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_1264: stloc.s 8
+		IL_1266: ldloc.3
+		IL_1267: ldloc.s 7
+		IL_1269: ldloc.s 8
+		IL_126b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1270: pop
+		IL_1271: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1276: stloc.s 7
+		IL_1278: ldc.i4.1
+		IL_1279: newarr [System.Runtime]System.Object
+		IL_127e: dup
+		IL_127f: ldc.i4.0
+		IL_1280: ldloc.0
+		IL_1281: stelem.ref
+		IL_1282: ldc.i4.0
+		IL_1283: ldelem.ref
+		IL_1284: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1289: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_128f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_1294: ldc.i4.0
+		IL_1295: conv.r8
+		IL_1296: ldstr ""
+		IL_129b: ldc.i4.0
+		IL_129c: ldc.i4.1
+		IL_129d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_12a2: stloc.s 8
+		IL_12a4: ldloc.s 4
+		IL_12a6: ldloc.s 7
+		IL_12a8: ldstr "Uncompiled Object Empty Replace"
+		IL_12ad: ldloc.s 8
+		IL_12af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_12b4: pop
+		IL_12b5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_12ba: stloc.s 7
+		IL_12bc: ldc.i4.1
+		IL_12bd: newarr [System.Runtime]System.Object
+		IL_12c2: dup
+		IL_12c3: ldc.i4.0
+		IL_12c4: ldloc.0
+		IL_12c5: stelem.ref
+		IL_12c6: ldc.i4.0
+		IL_12c7: ldelem.ref
+		IL_12c8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_12cd: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_12d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_12d8: ldc.i4.0
+		IL_12d9: conv.r8
+		IL_12da: ldstr ""
+		IL_12df: ldc.i4.0
+		IL_12e0: ldc.i4.1
+		IL_12e1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_12e6: stloc.s 8
+		IL_12e8: ldloc.3
+		IL_12e9: ldloc.s 7
+		IL_12eb: ldloc.s 8
+		IL_12ed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_12f2: pop
+		IL_12f3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_12f8: stloc.s 7
+		IL_12fa: ldc.i4.1
+		IL_12fb: newarr [System.Runtime]System.Object
+		IL_1300: dup
+		IL_1301: ldc.i4.0
+		IL_1302: ldloc.0
+		IL_1303: stelem.ref
+		IL_1304: ldc.i4.0
+		IL_1305: ldelem.ref
+		IL_1306: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_130b: ldftn object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+		IL_1311: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_1316: ldc.i4.0
+		IL_1317: conv.r8
+		IL_1318: ldstr ""
+		IL_131d: ldc.i4.0
+		IL_131e: ldc.i4.1
+		IL_131f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_1324: stloc.s 8
+		IL_1326: ldloc.s 4
+		IL_1328: ldloc.s 7
+		IL_132a: ldstr "Uncompiled Object 12 Char Replace"
+		IL_132f: ldloc.s 8
+		IL_1331: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_1336: pop
+		IL_1337: ldloc.2
+		IL_1338: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_133d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_1342: pop
+		IL_1343: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Regexp::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Regexp
@@ -7690,7 +8338,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x4d0d
+		// Method begins at RVA 0x5319
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d87
+				// Method begins at RVA 0x6011
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -43,7 +43,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24bd
+			// Method begins at RVA 0x24d5
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -65,7 +65,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d90
+				// Method begins at RVA 0x601a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24c0
+			// Method begins at RVA 0x24d8
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -114,7 +114,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5da2
+					// Method begins at RVA 0x602c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -132,7 +132,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5d99
+				// Method begins at RVA 0x6023
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -156,7 +156,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24c4
+			// Method begins at RVA 0x24dc
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -196,7 +196,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5db4
+					// Method begins at RVA 0x603e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -214,7 +214,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5dab
+				// Method begins at RVA 0x6035
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -239,7 +239,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24f0
+			// Method begins at RVA 0x2508
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -279,7 +279,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5dc6
+					// Method begins at RVA 0x6050
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -299,7 +299,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5dcf
+					// Method begins at RVA 0x6059
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -319,7 +319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5dd8
+					// Method begins at RVA 0x6062
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -339,7 +339,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5de1
+					// Method begins at RVA 0x606b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -359,7 +359,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5dea
+					// Method begins at RVA 0x6074
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -379,7 +379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5df3
+					// Method begins at RVA 0x607d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -403,7 +403,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e05
+						// Method begins at RVA 0x608f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -421,7 +421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5dfc
+					// Method begins at RVA 0x6086
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -439,7 +439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5dbd
+				// Method begins at RVA 0x6047
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -467,7 +467,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x251c
+			// Method begins at RVA 0x2534
 			// Header size: 12
 			// Code size: 1021 (0x3fd)
 			.maxstack 8
@@ -873,7 +873,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e0e
+				// Method begins at RVA 0x6098
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -898,7 +898,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2928
+			// Method begins at RVA 0x2940
 			// Header size: 12
 			// Code size: 369 (0x171)
 			.maxstack 8
@@ -1052,7 +1052,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e20
+					// Method begins at RVA 0x60aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1070,7 +1070,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e17
+				// Method begins at RVA 0x60a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1099,9 +1099,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2aa8
+			// Method begins at RVA 0x2ac0
 			// Header size: 12
-			// Code size: 514 (0x202)
+			// Code size: 479 (0x1df)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1112,8 +1112,7 @@
 				[5] object,
 				[6] object,
 				[7] float64,
-				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[9] float64
+				[8] float64
 			)
 
 			IL_0000: ldc.i4.0
@@ -1185,112 +1184,109 @@
 				IL_00aa: br IL_002a
 			// end loop
 
-			IL_00af: ldnull
-			IL_00b0: ldloc.0
-			IL_00b1: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_00b6: ldloc.1
-			IL_00b7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_00c1: stloc.s 8
-			IL_00c3: ldloc.s 8
-			IL_00c5: stloc.0
-			IL_00c6: ldloc.0
-			IL_00c7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00af: ldarg.0
+			IL_00b0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcCross
+			IL_00b5: ldc.i4.1
+			IL_00b6: newarr [System.Runtime]System.Object
+			IL_00bb: dup
+			IL_00bc: ldc.i4.0
+			IL_00bd: ldarg.0
+			IL_00be: stelem.ref
+			IL_00bf: ldloc.0
+			IL_00c0: ldloc.1
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_00c6: stloc.s 5
+			IL_00c8: ldloc.s 5
+			IL_00ca: stloc.0
+			IL_00cb: ldloc.0
 			IL_00cc: ldc.r8 0.0
-			IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
 			IL_00da: stloc.s 5
 			IL_00dc: ldloc.0
-			IL_00dd: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_00e2: ldc.r8 0.0
-			IL_00eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_00f0: stloc.s 6
-			IL_00f2: ldloc.s 5
-			IL_00f4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00f9: stloc.s 7
-			IL_00fb: ldloc.s 7
-			IL_00fd: ldloc.s 6
-			IL_00ff: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0104: mul
-			IL_0105: stloc.s 7
-			IL_0107: ldloc.0
-			IL_0108: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_010d: ldc.r8 1
-			IL_0116: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_011b: stloc.s 6
-			IL_011d: ldloc.0
-			IL_011e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0123: ldc.r8 1
-			IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0131: stloc.s 5
-			IL_0133: ldloc.s 6
-			IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_013a: stloc.s 9
-			IL_013c: ldloc.s 7
-			IL_013e: ldloc.s 9
-			IL_0140: ldloc.s 5
-			IL_0142: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0147: mul
-			IL_0148: add
-			IL_0149: stloc.s 7
-			IL_014b: ldloc.0
-			IL_014c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0151: ldc.r8 2
-			IL_015a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_015f: stloc.s 5
-			IL_0161: ldloc.0
-			IL_0162: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0167: ldc.r8 2
-			IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0175: stloc.s 6
-			IL_0177: ldloc.s 5
-			IL_0179: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_017e: stloc.s 9
-			IL_0180: ldloc.s 7
-			IL_0182: ldloc.s 9
-			IL_0184: ldloc.s 6
-			IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_018b: mul
-			IL_018c: add
-			IL_018d: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
-			IL_0192: stloc.s 7
-			IL_0194: ldloc.s 7
-			IL_0196: stloc.s 4
-			IL_0198: ldc.r8 0.0
-			IL_01a1: stloc.2
-			// loop start (head: IL_01a2)
-				IL_01a2: ldloc.2
-				IL_01a3: ldc.r8 3
-				IL_01ac: clt
-				IL_01ae: brfalse IL_01e1
+			IL_00dd: ldc.r8 0.0
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00eb: stloc.s 6
+			IL_00ed: ldloc.s 5
+			IL_00ef: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f4: stloc.s 7
+			IL_00f6: ldloc.s 7
+			IL_00f8: ldloc.s 6
+			IL_00fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ff: mul
+			IL_0100: stloc.s 7
+			IL_0102: ldloc.0
+			IL_0103: ldc.r8 1
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0111: stloc.s 6
+			IL_0113: ldloc.0
+			IL_0114: ldc.r8 1
+			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0122: stloc.s 5
+			IL_0124: ldloc.s 6
+			IL_0126: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_012b: stloc.s 8
+			IL_012d: ldloc.s 7
+			IL_012f: ldloc.s 8
+			IL_0131: ldloc.s 5
+			IL_0133: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0138: mul
+			IL_0139: add
+			IL_013a: stloc.s 7
+			IL_013c: ldloc.0
+			IL_013d: ldc.r8 2
+			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_014b: stloc.s 5
+			IL_014d: ldloc.0
+			IL_014e: ldc.r8 2
+			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_015c: stloc.s 6
+			IL_015e: ldloc.s 5
+			IL_0160: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0165: stloc.s 8
+			IL_0167: ldloc.s 7
+			IL_0169: ldloc.s 8
+			IL_016b: ldloc.s 6
+			IL_016d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0172: mul
+			IL_0173: add
+			IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::sqrt(float64)
+			IL_0179: stloc.s 7
+			IL_017b: ldloc.s 7
+			IL_017d: stloc.s 4
+			IL_017f: ldc.r8 0.0
+			IL_0188: stloc.2
+			// loop start (head: IL_0189)
+				IL_0189: ldloc.2
+				IL_018a: ldc.r8 3
+				IL_0193: clt
+				IL_0195: brfalse IL_01be
 
-				IL_01b3: ldloc.0
-				IL_01b4: ldloc.2
-				IL_01b5: ldloc.0
-				IL_01b6: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_01bb: ldloc.2
-				IL_01bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_01c1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_01c6: ldloc.s 4
-				IL_01c8: div
-				IL_01c9: ldc.i4.1
-				IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-				IL_01cf: pop
-				IL_01d0: ldloc.2
-				IL_01d1: ldc.r8 1
-				IL_01da: add
-				IL_01db: stloc.2
-				IL_01dc: br IL_01a2
+				IL_019a: ldloc.0
+				IL_019b: ldloc.2
+				IL_019c: ldloc.0
+				IL_019d: ldloc.2
+				IL_019e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, float64)
+				IL_01a3: ldloc.s 4
+				IL_01a5: div
+				IL_01a6: ldc.i4.1
+				IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+				IL_01ac: pop
+				IL_01ad: ldloc.2
+				IL_01ae: ldc.r8 1
+				IL_01b7: add
+				IL_01b8: stloc.2
+				IL_01b9: br IL_0189
 			// end loop
 
-			IL_01e1: ldloc.0
-			IL_01e2: ldc.r8 3
-			IL_01eb: ldc.r8 1
-			IL_01f4: ldc.i4.1
-			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
-			IL_01fa: pop
-			IL_01fb: ldloc.0
-			IL_01fc: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0201: ret
+			IL_01be: ldloc.0
+			IL_01bf: ldc.r8 3
+			IL_01c8: ldc.r8 1
+			IL_01d1: ldc.i4.1
+			IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, float64, bool)
+			IL_01d7: pop
+			IL_01d8: ldloc.0
+			IL_01d9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01de: ret
 		} // end of method CalcNormal::__js_call__
 
 	} // end of class CalcNormal
@@ -1306,7 +1302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e29
+				// Method begins at RVA 0x60b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1332,7 +1328,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2cb8
+			// Method begins at RVA 0x2cac
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -1383,7 +1379,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e3b
+					// Method begins at RVA 0x60c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1401,7 +1397,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e32
+				// Method begins at RVA 0x60bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1426,7 +1422,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2d08
+			// Method begins at RVA 0x2cfc
 			// Header size: 12
 			// Code size: 467 (0x1d3)
 			.maxstack 8
@@ -1614,7 +1610,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e44
+				// Method begins at RVA 0x60ce
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1639,7 +1635,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2ee8
+			// Method begins at RVA 0x2edc
 			// Header size: 12
 			// Code size: 309 (0x135)
 			.maxstack 8
@@ -1773,7 +1769,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e4d
+				// Method begins at RVA 0x60d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1798,7 +1794,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x302c
+			// Method begins at RVA 0x3020
 			// Header size: 12
 			// Code size: 249 (0xf9)
 			.maxstack 8
@@ -1916,7 +1912,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e5f
+					// Method begins at RVA 0x60e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1934,7 +1930,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e56
+				// Method begins at RVA 0x60e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1959,7 +1955,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3134
+			// Method begins at RVA 0x3128
 			// Header size: 12
 			// Code size: 236 (0xec)
 			.maxstack 8
@@ -2077,7 +2073,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e68
+				// Method begins at RVA 0x60f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2107,7 +2103,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x322c
+			// Method begins at RVA 0x3220
 			// Header size: 12
 			// Code size: 369 (0x171)
 			.maxstack 8
@@ -2236,7 +2232,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e71
+				// Method begins at RVA 0x60fb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2264,7 +2260,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x33ac
+			// Method begins at RVA 0x33a0
 			// Header size: 12
 			// Code size: 474 (0x1da)
 			.maxstack 8
@@ -2440,7 +2436,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e7a
+				// Method begins at RVA 0x6104
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2468,7 +2464,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3594
+			// Method begins at RVA 0x3588
 			// Header size: 12
 			// Code size: 474 (0x1da)
 			.maxstack 8
@@ -2644,7 +2640,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e83
+				// Method begins at RVA 0x610d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2672,7 +2668,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x377c
+			// Method begins at RVA 0x3770
 			// Header size: 12
 			// Code size: 474 (0x1da)
 			.maxstack 8
@@ -2856,7 +2852,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5e9e
+						// Method begins at RVA 0x6128
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2876,7 +2872,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5ea7
+						// Method begins at RVA 0x6131
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2896,7 +2892,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5eb0
+						// Method begins at RVA 0x613a
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2916,7 +2912,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5eb9
+						// Method begins at RVA 0x6143
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2934,7 +2930,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5e95
+					// Method begins at RVA 0x611f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2958,7 +2954,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5ecb
+						// Method begins at RVA 0x6155
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2978,7 +2974,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5ed4
+						// Method begins at RVA 0x615e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2998,7 +2994,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5edd
+						// Method begins at RVA 0x6167
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3018,7 +3014,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5ee6
+						// Method begins at RVA 0x6170
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3036,7 +3032,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5ec2
+					// Method begins at RVA 0x614c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3060,7 +3056,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5ef8
+						// Method begins at RVA 0x6182
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3080,7 +3076,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f01
+						// Method begins at RVA 0x618b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3100,7 +3096,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f0a
+						// Method begins at RVA 0x6194
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3120,7 +3116,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f13
+						// Method begins at RVA 0x619d
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3138,7 +3134,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5eef
+					// Method begins at RVA 0x6179
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3162,7 +3158,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f25
+						// Method begins at RVA 0x61af
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3182,7 +3178,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f2e
+						// Method begins at RVA 0x61b8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3202,7 +3198,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f37
+						// Method begins at RVA 0x61c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3222,7 +3218,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f40
+						// Method begins at RVA 0x61ca
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3240,7 +3236,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f1c
+					// Method begins at RVA 0x61a6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3264,7 +3260,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f52
+						// Method begins at RVA 0x61dc
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3284,7 +3280,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f5b
+						// Method begins at RVA 0x61e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3304,7 +3300,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f64
+						// Method begins at RVA 0x61ee
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3324,7 +3320,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f6d
+						// Method begins at RVA 0x61f7
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3342,7 +3338,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f49
+					// Method begins at RVA 0x61d3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3366,7 +3362,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f7f
+						// Method begins at RVA 0x6209
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3386,7 +3382,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f88
+						// Method begins at RVA 0x6212
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3406,7 +3402,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f91
+						// Method begins at RVA 0x621b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3426,7 +3422,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x5f9a
+						// Method begins at RVA 0x6224
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3444,7 +3440,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5f76
+					// Method begins at RVA 0x6200
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3462,7 +3458,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5e8c
+				// Method begins at RVA 0x6116
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3488,9 +3484,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x3964
+			// Method begins at RVA 0x3958
 			// Header size: 12
-			// Code size: 4486 (0x1186)
+			// Code size: 4817 (0x12d1)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3526,10 +3522,11 @@
 				[30] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L231C24,
 				[31] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L232C24,
 				[32] object,
-				[33] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[34] bool,
-				[35] object,
-				[36] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[33] object[],
+				[34] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[35] bool,
+				[36] object,
+				[37] class [JavaScriptRuntime]JavaScriptRuntime.Array
 			)
 
 			IL_0000: ldc.i4.0
@@ -3552,1234 +3549,1411 @@
 				IL_0036: ldc.r8 1
 				IL_003f: neg
 				IL_0040: cgt
-				IL_0042: brfalse IL_0094
+				IL_0042: brfalse IL_00a7
 
 				IL_0047: ldarg.0
-				IL_0048: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-				IL_004d: stloc.s 33
-				IL_004f: ldarg.0
-				IL_0050: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0055: ldstr "Normal"
-				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_005f: ldloc.1
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0065: stloc.s 32
-				IL_0067: ldnull
-				IL_0068: ldloc.s 33
-				IL_006a: ldloc.s 32
-				IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, object, object)
-				IL_0071: stloc.s 33
-				IL_0073: ldloc.0
-				IL_0074: ldloc.1
-				IL_0075: box [System.Runtime]System.Double
-				IL_007a: ldloc.s 33
-				IL_007c: ldc.i4.1
-				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0082: pop
-				IL_0083: ldloc.1
-				IL_0084: ldc.r8 1
-				IL_008d: sub
-				IL_008e: stloc.1
-				IL_008f: br IL_0035
+				IL_0048: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti2
+				IL_004d: stloc.s 32
+				IL_004f: ldc.i4.1
+				IL_0050: newarr [System.Runtime]System.Object
+				IL_0055: dup
+				IL_0056: ldc.i4.0
+				IL_0057: ldarg.0
+				IL_0058: stelem.ref
+				IL_0059: stloc.s 33
+				IL_005b: ldarg.0
+				IL_005c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+				IL_0061: stloc.s 34
+				IL_0063: ldloc.s 32
+				IL_0065: ldloc.s 33
+				IL_0067: ldloc.s 34
+				IL_0069: ldarg.0
+				IL_006a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_006f: ldstr "Normal"
+				IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0079: ldloc.1
+				IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0084: stloc.s 32
+				IL_0086: ldloc.0
+				IL_0087: ldloc.1
+				IL_0088: box [System.Runtime]System.Double
+				IL_008d: ldloc.s 32
+				IL_008f: ldc.i4.1
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0095: pop
+				IL_0096: ldloc.1
+				IL_0097: ldc.r8 1
+				IL_00a0: sub
+				IL_00a1: stloc.1
+				IL_00a2: br IL_0035
 			// end loop
 
-			IL_0094: ldloc.0
-			IL_0095: ldc.r8 0.0
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00a3: ldc.r8 2
-			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00b6: ldc.r8 0.0
-			IL_00bf: clt
-			IL_00c1: brfalse IL_0343
+			IL_00a7: ldloc.0
+			IL_00a8: ldc.r8 0.0
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00b6: ldc.r8 2
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00c4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00c9: ldc.r8 0.0
+			IL_00d2: clt
+			IL_00d4: brfalse IL_038a
 
-			IL_00c6: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24::.ctor()
-			IL_00cb: stloc.2
-			IL_00cc: ldarg.0
-			IL_00cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_00d2: ldstr "Line"
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00dc: ldc.r8 0.0
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00ef: ldc.i4.0
-			IL_00f0: ceq
-			IL_00f2: stloc.s 34
-			IL_00f4: ldloc.s 34
-			IL_00f6: brfalse IL_0169
+			IL_00d9: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24::.ctor()
+			IL_00de: stloc.2
+			IL_00df: ldarg.0
+			IL_00e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_00e5: ldstr "Line"
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ef: ldc.r8 0.0
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0102: ldc.i4.0
+			IL_0103: ceq
+			IL_0105: stloc.s 35
+			IL_0107: ldloc.s 35
+			IL_0109: brfalse IL_0189
 
-			IL_00fb: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L199C24::.ctor()
-			IL_0100: stloc.3
-			IL_0101: ldarg.0
-			IL_0102: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0107: ldc.r8 0.0
-			IL_0110: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0115: stloc.s 32
-			IL_0117: ldarg.0
-			IL_0118: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_011d: ldc.r8 1
-			IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_012b: stloc.s 35
-			IL_012d: ldarg.0
-			IL_012e: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0133: ldnull
-			IL_0134: ldloc.s 32
-			IL_0136: ldloc.s 35
-			IL_0138: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_013d: pop
-			IL_013e: ldarg.0
-			IL_013f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0144: ldstr "Line"
-			IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_014e: ldc.r8 0.0
-			IL_0157: box [System.Runtime]System.Double
-			IL_015c: ldc.i4.1
-			IL_015d: box [System.Runtime]System.Boolean
-			IL_0162: ldc.i4.1
-			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0168: pop
+			IL_010e: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L199C24::.ctor()
+			IL_0113: stloc.3
+			IL_0114: ldarg.0
+			IL_0115: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_011a: stloc.s 32
+			IL_011c: ldc.i4.1
+			IL_011d: newarr [System.Runtime]System.Object
+			IL_0122: dup
+			IL_0123: ldc.i4.0
+			IL_0124: ldarg.0
+			IL_0125: stelem.ref
+			IL_0126: stloc.s 33
+			IL_0128: ldarg.0
+			IL_0129: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_012e: ldc.r8 0.0
+			IL_0137: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_013c: stloc.s 36
+			IL_013e: ldloc.s 32
+			IL_0140: ldloc.s 33
+			IL_0142: ldloc.s 36
+			IL_0144: ldarg.0
+			IL_0145: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_014a: ldc.r8 1
+			IL_0153: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_015d: pop
+			IL_015e: ldarg.0
+			IL_015f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0164: ldstr "Line"
+			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_016e: ldc.r8 0.0
+			IL_0177: box [System.Runtime]System.Double
+			IL_017c: ldc.i4.1
+			IL_017d: box [System.Runtime]System.Boolean
+			IL_0182: ldc.i4.1
+			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0188: pop
 
-			IL_0169: ldarg.0
-			IL_016a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_016f: ldstr "Line"
-			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0179: ldc.r8 1
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_018c: ldc.i4.0
-			IL_018d: ceq
-			IL_018f: stloc.s 34
-			IL_0191: ldloc.s 34
-			IL_0193: brfalse IL_0207
+			IL_0189: ldarg.0
+			IL_018a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_018f: ldstr "Line"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0199: ldc.r8 1
+			IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01a7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01ac: ldc.i4.0
+			IL_01ad: ceq
+			IL_01af: stloc.s 35
+			IL_01b1: ldloc.s 35
+			IL_01b3: brfalse IL_0234
 
-			IL_0198: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L200C24::.ctor()
-			IL_019d: stloc.s 4
-			IL_019f: ldarg.0
-			IL_01a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01a5: ldc.r8 1
-			IL_01ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01b3: stloc.s 35
-			IL_01b5: ldarg.0
-			IL_01b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01bb: ldc.r8 2
-			IL_01c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01c9: stloc.s 32
-			IL_01cb: ldarg.0
-			IL_01cc: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_01d1: ldnull
-			IL_01d2: ldloc.s 35
-			IL_01d4: ldloc.s 32
-			IL_01d6: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_01db: pop
-			IL_01dc: ldarg.0
-			IL_01dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01e2: ldstr "Line"
-			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ec: ldc.r8 1
-			IL_01f5: box [System.Runtime]System.Double
-			IL_01fa: ldc.i4.1
-			IL_01fb: box [System.Runtime]System.Boolean
-			IL_0200: ldc.i4.1
-			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0206: pop
+			IL_01b8: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L200C24::.ctor()
+			IL_01bd: stloc.s 4
+			IL_01bf: ldarg.0
+			IL_01c0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_01c5: stloc.s 36
+			IL_01c7: ldc.i4.1
+			IL_01c8: newarr [System.Runtime]System.Object
+			IL_01cd: dup
+			IL_01ce: ldc.i4.0
+			IL_01cf: ldarg.0
+			IL_01d0: stelem.ref
+			IL_01d1: stloc.s 33
+			IL_01d3: ldarg.0
+			IL_01d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01d9: ldc.r8 1
+			IL_01e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01e7: stloc.s 32
+			IL_01e9: ldloc.s 36
+			IL_01eb: ldloc.s 33
+			IL_01ed: ldloc.s 32
+			IL_01ef: ldarg.0
+			IL_01f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_01f5: ldc.r8 2
+			IL_01fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0208: pop
+			IL_0209: ldarg.0
+			IL_020a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_020f: ldstr "Line"
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0219: ldc.r8 1
+			IL_0222: box [System.Runtime]System.Double
+			IL_0227: ldc.i4.1
+			IL_0228: box [System.Runtime]System.Boolean
+			IL_022d: ldc.i4.1
+			IL_022e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0233: pop
 
-			IL_0207: ldarg.0
-			IL_0208: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_020d: ldstr "Line"
-			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0217: ldc.r8 2
-			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0225: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_022a: ldc.i4.0
-			IL_022b: ceq
-			IL_022d: stloc.s 34
-			IL_022f: ldloc.s 34
-			IL_0231: brfalse IL_02a5
+			IL_0234: ldarg.0
+			IL_0235: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_023a: ldstr "Line"
+			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0244: ldc.r8 2
+			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0252: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0257: ldc.i4.0
+			IL_0258: ceq
+			IL_025a: stloc.s 35
+			IL_025c: ldloc.s 35
+			IL_025e: brfalse IL_02df
 
-			IL_0236: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L201C24::.ctor()
-			IL_023b: stloc.s 5
-			IL_023d: ldarg.0
-			IL_023e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0243: ldc.r8 2
-			IL_024c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0251: stloc.s 32
-			IL_0253: ldarg.0
-			IL_0254: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0259: ldc.r8 3
-			IL_0262: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0267: stloc.s 35
-			IL_0269: ldarg.0
-			IL_026a: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_026f: ldnull
-			IL_0270: ldloc.s 32
-			IL_0272: ldloc.s 35
-			IL_0274: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0279: pop
+			IL_0263: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L201C24::.ctor()
+			IL_0268: stloc.s 5
+			IL_026a: ldarg.0
+			IL_026b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0270: stloc.s 32
+			IL_0272: ldc.i4.1
+			IL_0273: newarr [System.Runtime]System.Object
+			IL_0278: dup
+			IL_0279: ldc.i4.0
 			IL_027a: ldarg.0
-			IL_027b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0280: ldstr "Line"
-			IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028a: ldc.r8 2
-			IL_0293: box [System.Runtime]System.Double
-			IL_0298: ldc.i4.1
-			IL_0299: box [System.Runtime]System.Boolean
-			IL_029e: ldc.i4.1
-			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_02a4: pop
+			IL_027b: stelem.ref
+			IL_027c: stloc.s 33
+			IL_027e: ldarg.0
+			IL_027f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0284: ldc.r8 2
+			IL_028d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0292: stloc.s 36
+			IL_0294: ldloc.s 32
+			IL_0296: ldloc.s 33
+			IL_0298: ldloc.s 36
+			IL_029a: ldarg.0
+			IL_029b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02a0: ldc.r8 3
+			IL_02a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02b3: pop
+			IL_02b4: ldarg.0
+			IL_02b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02ba: ldstr "Line"
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02c4: ldc.r8 2
+			IL_02cd: box [System.Runtime]System.Double
+			IL_02d2: ldc.i4.1
+			IL_02d3: box [System.Runtime]System.Boolean
+			IL_02d8: ldc.i4.1
+			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_02de: pop
 
-			IL_02a5: ldarg.0
-			IL_02a6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02ab: ldstr "Line"
-			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02b5: ldc.r8 3
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_02c3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02c8: ldc.i4.0
-			IL_02c9: ceq
-			IL_02cb: stloc.s 34
-			IL_02cd: ldloc.s 34
-			IL_02cf: brfalse IL_0343
+			IL_02df: ldarg.0
+			IL_02e0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02e5: ldstr "Line"
+			IL_02ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02ef: ldc.r8 3
+			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0302: ldc.i4.0
+			IL_0303: ceq
+			IL_0305: stloc.s 35
+			IL_0307: ldloc.s 35
+			IL_0309: brfalse IL_038a
 
-			IL_02d4: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L202C24::.ctor()
-			IL_02d9: stloc.s 6
-			IL_02db: ldarg.0
-			IL_02dc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02e1: ldc.r8 3
-			IL_02ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_02ef: stloc.s 35
-			IL_02f1: ldarg.0
-			IL_02f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_02f7: ldc.r8 0.0
-			IL_0300: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0305: stloc.s 32
-			IL_0307: ldarg.0
-			IL_0308: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_030d: ldnull
-			IL_030e: ldloc.s 35
-			IL_0310: ldloc.s 32
-			IL_0312: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0317: pop
-			IL_0318: ldarg.0
-			IL_0319: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_031e: ldstr "Line"
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0328: ldc.r8 3
-			IL_0331: box [System.Runtime]System.Double
-			IL_0336: ldc.i4.1
-			IL_0337: box [System.Runtime]System.Boolean
-			IL_033c: ldc.i4.1
-			IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0342: pop
+			IL_030e: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L198C24/Block_L202C24::.ctor()
+			IL_0313: stloc.s 6
+			IL_0315: ldarg.0
+			IL_0316: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_031b: stloc.s 36
+			IL_031d: ldc.i4.1
+			IL_031e: newarr [System.Runtime]System.Object
+			IL_0323: dup
+			IL_0324: ldc.i4.0
+			IL_0325: ldarg.0
+			IL_0326: stelem.ref
+			IL_0327: stloc.s 33
+			IL_0329: ldarg.0
+			IL_032a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_032f: ldc.r8 3
+			IL_0338: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_033d: stloc.s 32
+			IL_033f: ldloc.s 36
+			IL_0341: ldloc.s 33
+			IL_0343: ldloc.s 32
+			IL_0345: ldarg.0
+			IL_0346: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_034b: ldc.r8 0.0
+			IL_0354: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_035e: pop
+			IL_035f: ldarg.0
+			IL_0360: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0365: ldstr "Line"
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036f: ldc.r8 3
+			IL_0378: box [System.Runtime]System.Double
+			IL_037d: ldc.i4.1
+			IL_037e: box [System.Runtime]System.Boolean
+			IL_0383: ldc.i4.1
+			IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0389: pop
 
-			IL_0343: ldloc.0
-			IL_0344: ldc.r8 1
-			IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0352: ldc.r8 2
-			IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0360: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0365: ldc.r8 0.0
-			IL_036e: clt
-			IL_0370: brfalse IL_05f4
+			IL_038a: ldloc.0
+			IL_038b: ldc.r8 1
+			IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0399: ldc.r8 2
+			IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03a7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_03ac: ldc.r8 0.0
+			IL_03b5: clt
+			IL_03b7: brfalse IL_066f
 
-			IL_0375: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24::.ctor()
-			IL_037a: stloc.s 7
-			IL_037c: ldarg.0
-			IL_037d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0382: ldstr "Line"
-			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_038c: ldc.r8 2
-			IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_039f: ldc.i4.0
-			IL_03a0: ceq
-			IL_03a2: stloc.s 34
-			IL_03a4: ldloc.s 34
-			IL_03a6: brfalse IL_041a
+			IL_03bc: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24::.ctor()
+			IL_03c1: stloc.s 7
+			IL_03c3: ldarg.0
+			IL_03c4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_03c9: ldstr "Line"
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d3: ldc.r8 2
+			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_03e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_03e6: ldc.i4.0
+			IL_03e7: ceq
+			IL_03e9: stloc.s 35
+			IL_03eb: ldloc.s 35
+			IL_03ed: brfalse IL_046e
 
-			IL_03ab: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L205C24::.ctor()
-			IL_03b0: stloc.s 8
-			IL_03b2: ldarg.0
-			IL_03b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03b8: ldc.r8 3
-			IL_03c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_03c6: stloc.s 32
-			IL_03c8: ldarg.0
-			IL_03c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03ce: ldc.r8 2
-			IL_03d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_03dc: stloc.s 35
-			IL_03de: ldarg.0
-			IL_03df: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_03e4: ldnull
-			IL_03e5: ldloc.s 32
-			IL_03e7: ldloc.s 35
-			IL_03e9: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_03ee: pop
-			IL_03ef: ldarg.0
-			IL_03f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_03f5: ldstr "Line"
-			IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ff: ldc.r8 2
-			IL_0408: box [System.Runtime]System.Double
-			IL_040d: ldc.i4.1
-			IL_040e: box [System.Runtime]System.Boolean
-			IL_0413: ldc.i4.1
-			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0419: pop
+			IL_03f2: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L205C24::.ctor()
+			IL_03f7: stloc.s 8
+			IL_03f9: ldarg.0
+			IL_03fa: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_03ff: stloc.s 32
+			IL_0401: ldc.i4.1
+			IL_0402: newarr [System.Runtime]System.Object
+			IL_0407: dup
+			IL_0408: ldc.i4.0
+			IL_0409: ldarg.0
+			IL_040a: stelem.ref
+			IL_040b: stloc.s 33
+			IL_040d: ldarg.0
+			IL_040e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0413: ldc.r8 3
+			IL_041c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0421: stloc.s 36
+			IL_0423: ldloc.s 32
+			IL_0425: ldloc.s 33
+			IL_0427: ldloc.s 36
+			IL_0429: ldarg.0
+			IL_042a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_042f: ldc.r8 2
+			IL_0438: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0442: pop
+			IL_0443: ldarg.0
+			IL_0444: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0449: ldstr "Line"
+			IL_044e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0453: ldc.r8 2
+			IL_045c: box [System.Runtime]System.Double
+			IL_0461: ldc.i4.1
+			IL_0462: box [System.Runtime]System.Boolean
+			IL_0467: ldc.i4.1
+			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_046d: pop
 
-			IL_041a: ldarg.0
-			IL_041b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0420: ldstr "Line"
-			IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_042a: ldc.r8 9
-			IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0438: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_043d: ldc.i4.0
-			IL_043e: ceq
-			IL_0440: stloc.s 34
-			IL_0442: ldloc.s 34
-			IL_0444: brfalse IL_04b8
+			IL_046e: ldarg.0
+			IL_046f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0474: ldstr "Line"
+			IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_047e: ldc.r8 9
+			IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_048c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0491: ldc.i4.0
+			IL_0492: ceq
+			IL_0494: stloc.s 35
+			IL_0496: ldloc.s 35
+			IL_0498: brfalse IL_0519
 
-			IL_0449: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L206C24::.ctor()
-			IL_044e: stloc.s 9
-			IL_0450: ldarg.0
-			IL_0451: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0456: ldc.r8 2
-			IL_045f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0464: stloc.s 35
-			IL_0466: ldarg.0
-			IL_0467: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_046c: ldc.r8 6
-			IL_0475: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_047a: stloc.s 32
-			IL_047c: ldarg.0
-			IL_047d: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0482: ldnull
-			IL_0483: ldloc.s 35
-			IL_0485: ldloc.s 32
-			IL_0487: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_048c: pop
-			IL_048d: ldarg.0
-			IL_048e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0493: ldstr "Line"
-			IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_049d: ldc.r8 9
-			IL_04a6: box [System.Runtime]System.Double
-			IL_04ab: ldc.i4.1
-			IL_04ac: box [System.Runtime]System.Boolean
-			IL_04b1: ldc.i4.1
-			IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_04b7: pop
-
+			IL_049d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L206C24::.ctor()
+			IL_04a2: stloc.s 9
+			IL_04a4: ldarg.0
+			IL_04a5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_04aa: stloc.s 36
+			IL_04ac: ldc.i4.1
+			IL_04ad: newarr [System.Runtime]System.Object
+			IL_04b2: dup
+			IL_04b3: ldc.i4.0
+			IL_04b4: ldarg.0
+			IL_04b5: stelem.ref
+			IL_04b6: stloc.s 33
 			IL_04b8: ldarg.0
 			IL_04b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_04be: ldstr "Line"
-			IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04c8: ldc.r8 6
-			IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_04d6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04db: ldc.i4.0
-			IL_04dc: ceq
-			IL_04de: stloc.s 34
-			IL_04e0: ldloc.s 34
-			IL_04e2: brfalse IL_0556
-
-			IL_04e7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L207C24::.ctor()
-			IL_04ec: stloc.s 10
+			IL_04be: ldc.r8 2
+			IL_04c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_04cc: stloc.s 32
+			IL_04ce: ldloc.s 36
+			IL_04d0: ldloc.s 33
+			IL_04d2: ldloc.s 32
+			IL_04d4: ldarg.0
+			IL_04d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_04da: ldc.r8 6
+			IL_04e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04ed: pop
 			IL_04ee: ldarg.0
 			IL_04ef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_04f4: ldc.r8 6
-			IL_04fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0502: stloc.s 32
-			IL_0504: ldarg.0
-			IL_0505: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_050a: ldc.r8 7
-			IL_0513: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0518: stloc.s 35
-			IL_051a: ldarg.0
-			IL_051b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0520: ldnull
-			IL_0521: ldloc.s 32
-			IL_0523: ldloc.s 35
-			IL_0525: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_052a: pop
-			IL_052b: ldarg.0
-			IL_052c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0531: ldstr "Line"
-			IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_053b: ldc.r8 6
-			IL_0544: box [System.Runtime]System.Double
-			IL_0549: ldc.i4.1
-			IL_054a: box [System.Runtime]System.Boolean
-			IL_054f: ldc.i4.1
-			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0555: pop
+			IL_04f4: ldstr "Line"
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04fe: ldc.r8 9
+			IL_0507: box [System.Runtime]System.Double
+			IL_050c: ldc.i4.1
+			IL_050d: box [System.Runtime]System.Boolean
+			IL_0512: ldc.i4.1
+			IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0518: pop
 
-			IL_0556: ldarg.0
-			IL_0557: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_055c: ldstr "Line"
-			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0566: ldc.r8 10
-			IL_056f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0574: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0579: ldc.i4.0
-			IL_057a: ceq
-			IL_057c: stloc.s 34
-			IL_057e: ldloc.s 34
-			IL_0580: brfalse IL_05f4
+			IL_0519: ldarg.0
+			IL_051a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_051f: ldstr "Line"
+			IL_0524: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0529: ldc.r8 6
+			IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0537: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_053c: ldc.i4.0
+			IL_053d: ceq
+			IL_053f: stloc.s 35
+			IL_0541: ldloc.s 35
+			IL_0543: brfalse IL_05c4
 
-			IL_0585: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L208C25::.ctor()
-			IL_058a: stloc.s 11
-			IL_058c: ldarg.0
-			IL_058d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0592: ldc.r8 7
-			IL_059b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_05a0: stloc.s 35
-			IL_05a2: ldarg.0
-			IL_05a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05a8: ldc.r8 3
-			IL_05b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_05b6: stloc.s 32
-			IL_05b8: ldarg.0
-			IL_05b9: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_05be: ldnull
-			IL_05bf: ldloc.s 35
-			IL_05c1: ldloc.s 32
-			IL_05c3: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_05c8: pop
-			IL_05c9: ldarg.0
-			IL_05ca: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_05cf: ldstr "Line"
-			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d9: ldc.r8 10
-			IL_05e2: box [System.Runtime]System.Double
-			IL_05e7: ldc.i4.1
-			IL_05e8: box [System.Runtime]System.Boolean
-			IL_05ed: ldc.i4.1
-			IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_05f3: pop
+			IL_0548: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L207C24::.ctor()
+			IL_054d: stloc.s 10
+			IL_054f: ldarg.0
+			IL_0550: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0555: stloc.s 32
+			IL_0557: ldc.i4.1
+			IL_0558: newarr [System.Runtime]System.Object
+			IL_055d: dup
+			IL_055e: ldc.i4.0
+			IL_055f: ldarg.0
+			IL_0560: stelem.ref
+			IL_0561: stloc.s 33
+			IL_0563: ldarg.0
+			IL_0564: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0569: ldc.r8 6
+			IL_0572: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0577: stloc.s 36
+			IL_0579: ldloc.s 32
+			IL_057b: ldloc.s 33
+			IL_057d: ldloc.s 36
+			IL_057f: ldarg.0
+			IL_0580: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0585: ldc.r8 7
+			IL_058e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0598: pop
+			IL_0599: ldarg.0
+			IL_059a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_059f: ldstr "Line"
+			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05a9: ldc.r8 6
+			IL_05b2: box [System.Runtime]System.Double
+			IL_05b7: ldc.i4.1
+			IL_05b8: box [System.Runtime]System.Boolean
+			IL_05bd: ldc.i4.1
+			IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_05c3: pop
 
-			IL_05f4: ldloc.0
-			IL_05f5: ldc.r8 2
-			IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0603: ldc.r8 2
-			IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0611: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0616: ldc.r8 0.0
-			IL_061f: clt
-			IL_0621: brfalse IL_08a5
+			IL_05c4: ldarg.0
+			IL_05c5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_05ca: ldstr "Line"
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d4: ldc.r8 10
+			IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_05e2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05e7: ldc.i4.0
+			IL_05e8: ceq
+			IL_05ea: stloc.s 35
+			IL_05ec: ldloc.s 35
+			IL_05ee: brfalse IL_066f
 
-			IL_0626: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24::.ctor()
-			IL_062b: stloc.s 12
-			IL_062d: ldarg.0
-			IL_062e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0633: ldstr "Line"
-			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_063d: ldc.r8 4
-			IL_0646: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_064b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0650: ldc.i4.0
-			IL_0651: ceq
-			IL_0653: stloc.s 34
-			IL_0655: ldloc.s 34
-			IL_0657: brfalse IL_06cb
+			IL_05f3: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L204C24/Block_L208C25::.ctor()
+			IL_05f8: stloc.s 11
+			IL_05fa: ldarg.0
+			IL_05fb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0600: stloc.s 36
+			IL_0602: ldc.i4.1
+			IL_0603: newarr [System.Runtime]System.Object
+			IL_0608: dup
+			IL_0609: ldc.i4.0
+			IL_060a: ldarg.0
+			IL_060b: stelem.ref
+			IL_060c: stloc.s 33
+			IL_060e: ldarg.0
+			IL_060f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0614: ldc.r8 7
+			IL_061d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0622: stloc.s 32
+			IL_0624: ldloc.s 36
+			IL_0626: ldloc.s 33
+			IL_0628: ldloc.s 32
+			IL_062a: ldarg.0
+			IL_062b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0630: ldc.r8 3
+			IL_0639: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_063e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0643: pop
+			IL_0644: ldarg.0
+			IL_0645: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_064a: ldstr "Line"
+			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0654: ldc.r8 10
+			IL_065d: box [System.Runtime]System.Double
+			IL_0662: ldc.i4.1
+			IL_0663: box [System.Runtime]System.Boolean
+			IL_0668: ldc.i4.1
+			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_066e: pop
 
-			IL_065c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L211C24::.ctor()
-			IL_0661: stloc.s 13
-			IL_0663: ldarg.0
-			IL_0664: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0669: ldc.r8 4
-			IL_0672: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0677: stloc.s 32
-			IL_0679: ldarg.0
-			IL_067a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_067f: ldc.r8 5
-			IL_0688: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_068d: stloc.s 35
-			IL_068f: ldarg.0
-			IL_0690: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0695: ldnull
-			IL_0696: ldloc.s 32
-			IL_0698: ldloc.s 35
-			IL_069a: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_069f: pop
-			IL_06a0: ldarg.0
-			IL_06a1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06a6: ldstr "Line"
-			IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06b0: ldc.r8 4
-			IL_06b9: box [System.Runtime]System.Double
-			IL_06be: ldc.i4.1
-			IL_06bf: box [System.Runtime]System.Boolean
-			IL_06c4: ldc.i4.1
-			IL_06c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_06ca: pop
+			IL_066f: ldloc.0
+			IL_0670: ldc.r8 2
+			IL_0679: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_067e: ldc.r8 2
+			IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_068c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0691: ldc.r8 0.0
+			IL_069a: clt
+			IL_069c: brfalse IL_0954
 
-			IL_06cb: ldarg.0
-			IL_06cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_06d1: ldstr "Line"
-			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06db: ldc.r8 5
-			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_06e9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06ee: ldc.i4.0
-			IL_06ef: ceq
-			IL_06f1: stloc.s 34
-			IL_06f3: ldloc.s 34
-			IL_06f5: brfalse IL_0769
+			IL_06a1: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24::.ctor()
+			IL_06a6: stloc.s 12
+			IL_06a8: ldarg.0
+			IL_06a9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06ae: ldstr "Line"
+			IL_06b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b8: ldc.r8 4
+			IL_06c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_06c6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_06cb: ldc.i4.0
+			IL_06cc: ceq
+			IL_06ce: stloc.s 35
+			IL_06d0: ldloc.s 35
+			IL_06d2: brfalse IL_0753
 
-			IL_06fa: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L212C24::.ctor()
-			IL_06ff: stloc.s 14
-			IL_0701: ldarg.0
-			IL_0702: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0707: ldc.r8 5
-			IL_0710: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0715: stloc.s 35
-			IL_0717: ldarg.0
-			IL_0718: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_071d: ldc.r8 6
-			IL_0726: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_072b: stloc.s 32
-			IL_072d: ldarg.0
-			IL_072e: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0733: ldnull
-			IL_0734: ldloc.s 35
-			IL_0736: ldloc.s 32
-			IL_0738: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_073d: pop
-			IL_073e: ldarg.0
-			IL_073f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0744: ldstr "Line"
-			IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_074e: ldc.r8 5
-			IL_0757: box [System.Runtime]System.Double
-			IL_075c: ldc.i4.1
-			IL_075d: box [System.Runtime]System.Boolean
-			IL_0762: ldc.i4.1
-			IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0768: pop
+			IL_06d7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L211C24::.ctor()
+			IL_06dc: stloc.s 13
+			IL_06de: ldarg.0
+			IL_06df: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_06e4: stloc.s 32
+			IL_06e6: ldc.i4.1
+			IL_06e7: newarr [System.Runtime]System.Object
+			IL_06ec: dup
+			IL_06ed: ldc.i4.0
+			IL_06ee: ldarg.0
+			IL_06ef: stelem.ref
+			IL_06f0: stloc.s 33
+			IL_06f2: ldarg.0
+			IL_06f3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_06f8: ldc.r8 4
+			IL_0701: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0706: stloc.s 36
+			IL_0708: ldloc.s 32
+			IL_070a: ldloc.s 33
+			IL_070c: ldloc.s 36
+			IL_070e: ldarg.0
+			IL_070f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0714: ldc.r8 5
+			IL_071d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0727: pop
+			IL_0728: ldarg.0
+			IL_0729: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_072e: ldstr "Line"
+			IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0738: ldc.r8 4
+			IL_0741: box [System.Runtime]System.Double
+			IL_0746: ldc.i4.1
+			IL_0747: box [System.Runtime]System.Boolean
+			IL_074c: ldc.i4.1
+			IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0752: pop
 
-			IL_0769: ldarg.0
-			IL_076a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_076f: ldstr "Line"
-			IL_0774: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0779: ldc.r8 6
-			IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0787: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_078c: ldc.i4.0
-			IL_078d: ceq
-			IL_078f: stloc.s 34
-			IL_0791: ldloc.s 34
-			IL_0793: brfalse IL_0807
+			IL_0753: ldarg.0
+			IL_0754: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0759: ldstr "Line"
+			IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0763: ldc.r8 5
+			IL_076c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0771: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0776: ldc.i4.0
+			IL_0777: ceq
+			IL_0779: stloc.s 35
+			IL_077b: ldloc.s 35
+			IL_077d: brfalse IL_07fe
 
-			IL_0798: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L213C24::.ctor()
-			IL_079d: stloc.s 15
-			IL_079f: ldarg.0
-			IL_07a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07a5: ldc.r8 6
-			IL_07ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_07b3: stloc.s 32
-			IL_07b5: ldarg.0
-			IL_07b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07bb: ldc.r8 7
-			IL_07c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_07c9: stloc.s 35
-			IL_07cb: ldarg.0
-			IL_07cc: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_07d1: ldnull
-			IL_07d2: ldloc.s 32
-			IL_07d4: ldloc.s 35
-			IL_07d6: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_07db: pop
-			IL_07dc: ldarg.0
-			IL_07dd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_07e2: ldstr "Line"
-			IL_07e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07ec: ldc.r8 6
-			IL_07f5: box [System.Runtime]System.Double
-			IL_07fa: ldc.i4.1
-			IL_07fb: box [System.Runtime]System.Boolean
-			IL_0800: ldc.i4.1
-			IL_0801: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0806: pop
+			IL_0782: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L212C24::.ctor()
+			IL_0787: stloc.s 14
+			IL_0789: ldarg.0
+			IL_078a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_078f: stloc.s 36
+			IL_0791: ldc.i4.1
+			IL_0792: newarr [System.Runtime]System.Object
+			IL_0797: dup
+			IL_0798: ldc.i4.0
+			IL_0799: ldarg.0
+			IL_079a: stelem.ref
+			IL_079b: stloc.s 33
+			IL_079d: ldarg.0
+			IL_079e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07a3: ldc.r8 5
+			IL_07ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_07b1: stloc.s 32
+			IL_07b3: ldloc.s 36
+			IL_07b5: ldloc.s 33
+			IL_07b7: ldloc.s 32
+			IL_07b9: ldarg.0
+			IL_07ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07bf: ldc.r8 6
+			IL_07c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_07cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_07d2: pop
+			IL_07d3: ldarg.0
+			IL_07d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_07d9: ldstr "Line"
+			IL_07de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_07e3: ldc.r8 5
+			IL_07ec: box [System.Runtime]System.Double
+			IL_07f1: ldc.i4.1
+			IL_07f2: box [System.Runtime]System.Boolean
+			IL_07f7: ldc.i4.1
+			IL_07f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_07fd: pop
 
-			IL_0807: ldarg.0
-			IL_0808: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_080d: ldstr "Line"
-			IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0817: ldc.r8 7
-			IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0825: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_082a: ldc.i4.0
-			IL_082b: ceq
-			IL_082d: stloc.s 34
-			IL_082f: ldloc.s 34
-			IL_0831: brfalse IL_08a5
+			IL_07fe: ldarg.0
+			IL_07ff: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0804: ldstr "Line"
+			IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_080e: ldc.r8 6
+			IL_0817: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_081c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0821: ldc.i4.0
+			IL_0822: ceq
+			IL_0824: stloc.s 35
+			IL_0826: ldloc.s 35
+			IL_0828: brfalse IL_08a9
 
-			IL_0836: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L214C24::.ctor()
-			IL_083b: stloc.s 16
-			IL_083d: ldarg.0
-			IL_083e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0843: ldc.r8 7
-			IL_084c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0851: stloc.s 35
-			IL_0853: ldarg.0
-			IL_0854: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0859: ldc.r8 4
-			IL_0862: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0867: stloc.s 32
-			IL_0869: ldarg.0
-			IL_086a: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_086f: ldnull
-			IL_0870: ldloc.s 35
-			IL_0872: ldloc.s 32
-			IL_0874: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0879: pop
-			IL_087a: ldarg.0
-			IL_087b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0880: ldstr "Line"
-			IL_0885: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_088a: ldc.r8 7
-			IL_0893: box [System.Runtime]System.Double
-			IL_0898: ldc.i4.1
-			IL_0899: box [System.Runtime]System.Boolean
-			IL_089e: ldc.i4.1
-			IL_089f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_08a4: pop
+			IL_082d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L213C24::.ctor()
+			IL_0832: stloc.s 15
+			IL_0834: ldarg.0
+			IL_0835: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_083a: stloc.s 32
+			IL_083c: ldc.i4.1
+			IL_083d: newarr [System.Runtime]System.Object
+			IL_0842: dup
+			IL_0843: ldc.i4.0
+			IL_0844: ldarg.0
+			IL_0845: stelem.ref
+			IL_0846: stloc.s 33
+			IL_0848: ldarg.0
+			IL_0849: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_084e: ldc.r8 6
+			IL_0857: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_085c: stloc.s 36
+			IL_085e: ldloc.s 32
+			IL_0860: ldloc.s 33
+			IL_0862: ldloc.s 36
+			IL_0864: ldarg.0
+			IL_0865: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_086a: ldc.r8 7
+			IL_0873: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0878: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_087d: pop
+			IL_087e: ldarg.0
+			IL_087f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0884: ldstr "Line"
+			IL_0889: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_088e: ldc.r8 6
+			IL_0897: box [System.Runtime]System.Double
+			IL_089c: ldc.i4.1
+			IL_089d: box [System.Runtime]System.Boolean
+			IL_08a2: ldc.i4.1
+			IL_08a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_08a8: pop
 
-			IL_08a5: ldloc.0
-			IL_08a6: ldc.r8 3
-			IL_08af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_08b4: ldc.r8 2
-			IL_08bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_08c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_08c7: ldc.r8 0.0
-			IL_08d0: clt
-			IL_08d2: brfalse IL_0b56
+			IL_08a9: ldarg.0
+			IL_08aa: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08af: ldstr "Line"
+			IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08b9: ldc.r8 7
+			IL_08c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_08c7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08cc: ldc.i4.0
+			IL_08cd: ceq
+			IL_08cf: stloc.s 35
+			IL_08d1: ldloc.s 35
+			IL_08d3: brfalse IL_0954
 
-			IL_08d7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24::.ctor()
-			IL_08dc: stloc.s 17
-			IL_08de: ldarg.0
-			IL_08df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_08e4: ldstr "Line"
-			IL_08e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_08ee: ldc.r8 4
-			IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_08fc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0901: ldc.i4.0
-			IL_0902: ceq
-			IL_0904: stloc.s 34
-			IL_0906: ldloc.s 34
-			IL_0908: brfalse IL_097c
+			IL_08d8: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L210C24/Block_L214C24::.ctor()
+			IL_08dd: stloc.s 16
+			IL_08df: ldarg.0
+			IL_08e0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_08e5: stloc.s 36
+			IL_08e7: ldc.i4.1
+			IL_08e8: newarr [System.Runtime]System.Object
+			IL_08ed: dup
+			IL_08ee: ldc.i4.0
+			IL_08ef: ldarg.0
+			IL_08f0: stelem.ref
+			IL_08f1: stloc.s 33
+			IL_08f3: ldarg.0
+			IL_08f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_08f9: ldc.r8 7
+			IL_0902: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0907: stloc.s 32
+			IL_0909: ldloc.s 36
+			IL_090b: ldloc.s 33
+			IL_090d: ldloc.s 32
+			IL_090f: ldarg.0
+			IL_0910: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0915: ldc.r8 4
+			IL_091e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0928: pop
+			IL_0929: ldarg.0
+			IL_092a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_092f: ldstr "Line"
+			IL_0934: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0939: ldc.r8 7
+			IL_0942: box [System.Runtime]System.Double
+			IL_0947: ldc.i4.1
+			IL_0948: box [System.Runtime]System.Boolean
+			IL_094d: ldc.i4.1
+			IL_094e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0953: pop
 
-			IL_090d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L217C24::.ctor()
-			IL_0912: stloc.s 18
-			IL_0914: ldarg.0
-			IL_0915: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_091a: ldc.r8 4
-			IL_0923: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0928: stloc.s 32
-			IL_092a: ldarg.0
-			IL_092b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0930: ldc.r8 5
-			IL_0939: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_093e: stloc.s 35
-			IL_0940: ldarg.0
-			IL_0941: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0946: ldnull
-			IL_0947: ldloc.s 32
-			IL_0949: ldloc.s 35
-			IL_094b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0950: pop
-			IL_0951: ldarg.0
-			IL_0952: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0957: ldstr "Line"
-			IL_095c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0961: ldc.r8 4
-			IL_096a: box [System.Runtime]System.Double
-			IL_096f: ldc.i4.1
-			IL_0970: box [System.Runtime]System.Boolean
-			IL_0975: ldc.i4.1
-			IL_0976: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_097b: pop
+			IL_0954: ldloc.0
+			IL_0955: ldc.r8 3
+			IL_095e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0963: ldc.r8 2
+			IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0971: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0976: ldc.r8 0.0
+			IL_097f: clt
+			IL_0981: brfalse IL_0c39
 
-			IL_097c: ldarg.0
-			IL_097d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0982: ldstr "Line"
-			IL_0987: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_098c: ldc.r8 8
-			IL_0995: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_099a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_099f: ldc.i4.0
-			IL_09a0: ceq
-			IL_09a2: stloc.s 34
-			IL_09a4: ldloc.s 34
-			IL_09a6: brfalse IL_0a1a
+			IL_0986: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24::.ctor()
+			IL_098b: stloc.s 17
+			IL_098d: ldarg.0
+			IL_098e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0993: ldstr "Line"
+			IL_0998: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_099d: ldc.r8 4
+			IL_09a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_09ab: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09b0: ldc.i4.0
+			IL_09b1: ceq
+			IL_09b3: stloc.s 35
+			IL_09b5: ldloc.s 35
+			IL_09b7: brfalse IL_0a38
 
-			IL_09ab: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L218C24::.ctor()
-			IL_09b0: stloc.s 19
-			IL_09b2: ldarg.0
-			IL_09b3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_09b8: ldc.r8 5
-			IL_09c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_09c6: stloc.s 35
-			IL_09c8: ldarg.0
-			IL_09c9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_09ce: ldc.r8 1
-			IL_09d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_09dc: stloc.s 32
-			IL_09de: ldarg.0
-			IL_09df: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_09e4: ldnull
-			IL_09e5: ldloc.s 35
-			IL_09e7: ldloc.s 32
-			IL_09e9: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_09ee: pop
-			IL_09ef: ldarg.0
-			IL_09f0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_09f5: ldstr "Line"
-			IL_09fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ff: ldc.r8 8
-			IL_0a08: box [System.Runtime]System.Double
-			IL_0a0d: ldc.i4.1
-			IL_0a0e: box [System.Runtime]System.Boolean
-			IL_0a13: ldc.i4.1
-			IL_0a14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0a19: pop
+			IL_09bc: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L217C24::.ctor()
+			IL_09c1: stloc.s 18
+			IL_09c3: ldarg.0
+			IL_09c4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_09c9: stloc.s 32
+			IL_09cb: ldc.i4.1
+			IL_09cc: newarr [System.Runtime]System.Object
+			IL_09d1: dup
+			IL_09d2: ldc.i4.0
+			IL_09d3: ldarg.0
+			IL_09d4: stelem.ref
+			IL_09d5: stloc.s 33
+			IL_09d7: ldarg.0
+			IL_09d8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_09dd: ldc.r8 4
+			IL_09e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_09eb: stloc.s 36
+			IL_09ed: ldloc.s 32
+			IL_09ef: ldloc.s 33
+			IL_09f1: ldloc.s 36
+			IL_09f3: ldarg.0
+			IL_09f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_09f9: ldc.r8 5
+			IL_0a02: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0a07: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a0c: pop
+			IL_0a0d: ldarg.0
+			IL_0a0e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a13: ldstr "Line"
+			IL_0a18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a1d: ldc.r8 4
+			IL_0a26: box [System.Runtime]System.Double
+			IL_0a2b: ldc.i4.1
+			IL_0a2c: box [System.Runtime]System.Boolean
+			IL_0a31: ldc.i4.1
+			IL_0a32: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0a37: pop
 
-			IL_0a1a: ldarg.0
-			IL_0a1b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a20: ldstr "Line"
-			IL_0a25: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a2a: ldc.r8 0.0
-			IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0a38: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0a3d: ldc.i4.0
-			IL_0a3e: ceq
-			IL_0a40: stloc.s 34
-			IL_0a42: ldloc.s 34
-			IL_0a44: brfalse IL_0ab8
+			IL_0a38: ldarg.0
+			IL_0a39: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a3e: ldstr "Line"
+			IL_0a43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a48: ldc.r8 8
+			IL_0a51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0a56: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0a5b: ldc.i4.0
+			IL_0a5c: ceq
+			IL_0a5e: stloc.s 35
+			IL_0a60: ldloc.s 35
+			IL_0a62: brfalse IL_0ae3
 
-			IL_0a49: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L219C24::.ctor()
-			IL_0a4e: stloc.s 20
-			IL_0a50: ldarg.0
-			IL_0a51: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a56: ldc.r8 1
-			IL_0a5f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0a64: stloc.s 32
-			IL_0a66: ldarg.0
-			IL_0a67: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a6c: ldc.r8 0.0
-			IL_0a75: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0a7a: stloc.s 35
-			IL_0a7c: ldarg.0
-			IL_0a7d: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0a82: ldnull
-			IL_0a83: ldloc.s 32
-			IL_0a85: ldloc.s 35
-			IL_0a87: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0a8c: pop
-			IL_0a8d: ldarg.0
-			IL_0a8e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0a93: ldstr "Line"
-			IL_0a98: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a9d: ldc.r8 0.0
-			IL_0aa6: box [System.Runtime]System.Double
-			IL_0aab: ldc.i4.1
-			IL_0aac: box [System.Runtime]System.Boolean
-			IL_0ab1: ldc.i4.1
-			IL_0ab2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0a67: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L218C24::.ctor()
+			IL_0a6c: stloc.s 19
+			IL_0a6e: ldarg.0
+			IL_0a6f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0a74: stloc.s 36
+			IL_0a76: ldc.i4.1
+			IL_0a77: newarr [System.Runtime]System.Object
+			IL_0a7c: dup
+			IL_0a7d: ldc.i4.0
+			IL_0a7e: ldarg.0
+			IL_0a7f: stelem.ref
+			IL_0a80: stloc.s 33
+			IL_0a82: ldarg.0
+			IL_0a83: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0a88: ldc.r8 5
+			IL_0a91: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0a96: stloc.s 32
+			IL_0a98: ldloc.s 36
+			IL_0a9a: ldloc.s 33
+			IL_0a9c: ldloc.s 32
+			IL_0a9e: ldarg.0
+			IL_0a9f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0aa4: ldc.r8 1
+			IL_0aad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0ab2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_0ab7: pop
-
 			IL_0ab8: ldarg.0
 			IL_0ab9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
 			IL_0abe: ldstr "Line"
 			IL_0ac3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac8: ldc.r8 11
-			IL_0ad1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ad6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0adb: ldc.i4.0
-			IL_0adc: ceq
-			IL_0ade: stloc.s 34
-			IL_0ae0: ldloc.s 34
-			IL_0ae2: brfalse IL_0b56
+			IL_0ac8: ldc.r8 8
+			IL_0ad1: box [System.Runtime]System.Double
+			IL_0ad6: ldc.i4.1
+			IL_0ad7: box [System.Runtime]System.Boolean
+			IL_0adc: ldc.i4.1
+			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0ae2: pop
 
-			IL_0ae7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L220C25::.ctor()
-			IL_0aec: stloc.s 21
-			IL_0aee: ldarg.0
-			IL_0aef: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0af4: ldc.r8 0.0
-			IL_0afd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0b02: stloc.s 35
-			IL_0b04: ldarg.0
-			IL_0b05: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b0a: ldc.r8 4
-			IL_0b13: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0b18: stloc.s 32
-			IL_0b1a: ldarg.0
-			IL_0b1b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0b20: ldnull
-			IL_0b21: ldloc.s 35
-			IL_0b23: ldloc.s 32
-			IL_0b25: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0b2a: pop
-			IL_0b2b: ldarg.0
-			IL_0b2c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b31: ldstr "Line"
-			IL_0b36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b3b: ldc.r8 11
-			IL_0b44: box [System.Runtime]System.Double
-			IL_0b49: ldc.i4.1
-			IL_0b4a: box [System.Runtime]System.Boolean
-			IL_0b4f: ldc.i4.1
-			IL_0b50: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0b55: pop
+			IL_0ae3: ldarg.0
+			IL_0ae4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ae9: ldstr "Line"
+			IL_0aee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0af3: ldc.r8 0.0
+			IL_0afc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0b01: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0b06: ldc.i4.0
+			IL_0b07: ceq
+			IL_0b09: stloc.s 35
+			IL_0b0b: ldloc.s 35
+			IL_0b0d: brfalse IL_0b8e
 
-			IL_0b56: ldloc.0
-			IL_0b57: ldc.r8 4
-			IL_0b60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b65: ldc.r8 2
-			IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0b73: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0b78: ldc.r8 0.0
-			IL_0b81: clt
-			IL_0b83: brfalse IL_0e07
+			IL_0b12: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L219C24::.ctor()
+			IL_0b17: stloc.s 20
+			IL_0b19: ldarg.0
+			IL_0b1a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0b1f: stloc.s 32
+			IL_0b21: ldc.i4.1
+			IL_0b22: newarr [System.Runtime]System.Object
+			IL_0b27: dup
+			IL_0b28: ldc.i4.0
+			IL_0b29: ldarg.0
+			IL_0b2a: stelem.ref
+			IL_0b2b: stloc.s 33
+			IL_0b2d: ldarg.0
+			IL_0b2e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b33: ldc.r8 1
+			IL_0b3c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b41: stloc.s 36
+			IL_0b43: ldloc.s 32
+			IL_0b45: ldloc.s 33
+			IL_0b47: ldloc.s 36
+			IL_0b49: ldarg.0
+			IL_0b4a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b4f: ldc.r8 0.0
+			IL_0b58: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0b5d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b62: pop
+			IL_0b63: ldarg.0
+			IL_0b64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b69: ldstr "Line"
+			IL_0b6e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b73: ldc.r8 0.0
+			IL_0b7c: box [System.Runtime]System.Double
+			IL_0b81: ldc.i4.1
+			IL_0b82: box [System.Runtime]System.Boolean
+			IL_0b87: ldc.i4.1
+			IL_0b88: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0b8d: pop
 
-			IL_0b88: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24::.ctor()
-			IL_0b8d: stloc.s 22
-			IL_0b8f: ldarg.0
-			IL_0b90: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0b95: ldstr "Line"
-			IL_0b9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b9f: ldc.r8 11
-			IL_0ba8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0bad: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0bb2: ldc.i4.0
-			IL_0bb3: ceq
-			IL_0bb5: stloc.s 34
-			IL_0bb7: ldloc.s 34
-			IL_0bb9: brfalse IL_0c2d
+			IL_0b8e: ldarg.0
+			IL_0b8f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0b94: ldstr "Line"
+			IL_0b99: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b9e: ldc.r8 11
+			IL_0ba7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0bac: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0bb1: ldc.i4.0
+			IL_0bb2: ceq
+			IL_0bb4: stloc.s 35
+			IL_0bb6: ldloc.s 35
+			IL_0bb8: brfalse IL_0c39
 
-			IL_0bbe: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L223C25::.ctor()
-			IL_0bc3: stloc.s 23
-			IL_0bc5: ldarg.0
-			IL_0bc6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0bcb: ldc.r8 4
-			IL_0bd4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0bd9: stloc.s 32
-			IL_0bdb: ldarg.0
-			IL_0bdc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0be1: ldc.r8 0.0
-			IL_0bea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0bef: stloc.s 35
-			IL_0bf1: ldarg.0
-			IL_0bf2: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0bf7: ldnull
-			IL_0bf8: ldloc.s 32
-			IL_0bfa: ldloc.s 35
-			IL_0bfc: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0c01: pop
-			IL_0c02: ldarg.0
-			IL_0c03: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c08: ldstr "Line"
-			IL_0c0d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c12: ldc.r8 11
-			IL_0c1b: box [System.Runtime]System.Double
-			IL_0c20: ldc.i4.1
-			IL_0c21: box [System.Runtime]System.Boolean
-			IL_0c26: ldc.i4.1
-			IL_0c27: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0c2c: pop
+			IL_0bbd: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L216C24/Block_L220C25::.ctor()
+			IL_0bc2: stloc.s 21
+			IL_0bc4: ldarg.0
+			IL_0bc5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0bca: stloc.s 36
+			IL_0bcc: ldc.i4.1
+			IL_0bcd: newarr [System.Runtime]System.Object
+			IL_0bd2: dup
+			IL_0bd3: ldc.i4.0
+			IL_0bd4: ldarg.0
+			IL_0bd5: stelem.ref
+			IL_0bd6: stloc.s 33
+			IL_0bd8: ldarg.0
+			IL_0bd9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0bde: ldc.r8 0.0
+			IL_0be7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0bec: stloc.s 32
+			IL_0bee: ldloc.s 36
+			IL_0bf0: ldloc.s 33
+			IL_0bf2: ldloc.s 32
+			IL_0bf4: ldarg.0
+			IL_0bf5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0bfa: ldc.r8 4
+			IL_0c03: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0c08: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c0d: pop
+			IL_0c0e: ldarg.0
+			IL_0c0f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c14: ldstr "Line"
+			IL_0c19: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c1e: ldc.r8 11
+			IL_0c27: box [System.Runtime]System.Double
+			IL_0c2c: ldc.i4.1
+			IL_0c2d: box [System.Runtime]System.Boolean
+			IL_0c32: ldc.i4.1
+			IL_0c33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0c38: pop
 
-			IL_0c2d: ldarg.0
-			IL_0c2e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c33: ldstr "Line"
-			IL_0c38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0c3d: ldc.r8 3
-			IL_0c46: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0c4b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0c50: ldc.i4.0
-			IL_0c51: ceq
-			IL_0c53: stloc.s 34
-			IL_0c55: ldloc.s 34
-			IL_0c57: brfalse IL_0ccb
+			IL_0c39: ldloc.0
+			IL_0c3a: ldc.r8 4
+			IL_0c43: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c48: ldc.r8 2
+			IL_0c51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c56: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0c5b: ldc.r8 0.0
+			IL_0c64: clt
+			IL_0c66: brfalse IL_0f1e
 
-			IL_0c5c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L224C24::.ctor()
-			IL_0c61: stloc.s 24
-			IL_0c63: ldarg.0
-			IL_0c64: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c69: ldc.r8 0.0
-			IL_0c72: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0c77: stloc.s 35
-			IL_0c79: ldarg.0
-			IL_0c7a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c7f: ldc.r8 3
-			IL_0c88: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0c8d: stloc.s 32
-			IL_0c8f: ldarg.0
-			IL_0c90: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0c95: ldnull
-			IL_0c96: ldloc.s 35
-			IL_0c98: ldloc.s 32
-			IL_0c9a: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0c9f: pop
-			IL_0ca0: ldarg.0
-			IL_0ca1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ca6: ldstr "Line"
-			IL_0cab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cb0: ldc.r8 3
-			IL_0cb9: box [System.Runtime]System.Double
-			IL_0cbe: ldc.i4.1
-			IL_0cbf: box [System.Runtime]System.Boolean
-			IL_0cc4: ldc.i4.1
-			IL_0cc5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0cca: pop
+			IL_0c6b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24::.ctor()
+			IL_0c70: stloc.s 22
+			IL_0c72: ldarg.0
+			IL_0c73: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c78: ldstr "Line"
+			IL_0c7d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0c82: ldc.r8 11
+			IL_0c8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0c90: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0c95: ldc.i4.0
+			IL_0c96: ceq
+			IL_0c98: stloc.s 35
+			IL_0c9a: ldloc.s 35
+			IL_0c9c: brfalse IL_0d1d
 
-			IL_0ccb: ldarg.0
-			IL_0ccc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0cd1: ldstr "Line"
-			IL_0cd6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0cdb: ldc.r8 10
-			IL_0ce4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0ce9: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0cee: ldc.i4.0
-			IL_0cef: ceq
-			IL_0cf1: stloc.s 34
-			IL_0cf3: ldloc.s 34
-			IL_0cf5: brfalse IL_0d69
+			IL_0ca1: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L223C25::.ctor()
+			IL_0ca6: stloc.s 23
+			IL_0ca8: ldarg.0
+			IL_0ca9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0cae: stloc.s 32
+			IL_0cb0: ldc.i4.1
+			IL_0cb1: newarr [System.Runtime]System.Object
+			IL_0cb6: dup
+			IL_0cb7: ldc.i4.0
+			IL_0cb8: ldarg.0
+			IL_0cb9: stelem.ref
+			IL_0cba: stloc.s 33
+			IL_0cbc: ldarg.0
+			IL_0cbd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cc2: ldc.r8 4
+			IL_0ccb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0cd0: stloc.s 36
+			IL_0cd2: ldloc.s 32
+			IL_0cd4: ldloc.s 33
+			IL_0cd6: ldloc.s 36
+			IL_0cd8: ldarg.0
+			IL_0cd9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cde: ldc.r8 0.0
+			IL_0ce7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0cec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0cf1: pop
+			IL_0cf2: ldarg.0
+			IL_0cf3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cf8: ldstr "Line"
+			IL_0cfd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d02: ldc.r8 11
+			IL_0d0b: box [System.Runtime]System.Double
+			IL_0d10: ldc.i4.1
+			IL_0d11: box [System.Runtime]System.Boolean
+			IL_0d16: ldc.i4.1
+			IL_0d17: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0d1c: pop
 
-			IL_0cfa: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L225C25::.ctor()
-			IL_0cff: stloc.s 25
-			IL_0d01: ldarg.0
-			IL_0d02: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d07: ldc.r8 3
-			IL_0d10: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0d15: stloc.s 32
-			IL_0d17: ldarg.0
-			IL_0d18: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d1d: ldc.r8 7
-			IL_0d26: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0d2b: stloc.s 35
-			IL_0d2d: ldarg.0
-			IL_0d2e: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0d33: ldnull
-			IL_0d34: ldloc.s 32
-			IL_0d36: ldloc.s 35
-			IL_0d38: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0d3d: pop
-			IL_0d3e: ldarg.0
-			IL_0d3f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d44: ldstr "Line"
-			IL_0d49: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d4e: ldc.r8 10
-			IL_0d57: box [System.Runtime]System.Double
-			IL_0d5c: ldc.i4.1
-			IL_0d5d: box [System.Runtime]System.Boolean
-			IL_0d62: ldc.i4.1
-			IL_0d63: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0d68: pop
+			IL_0d1d: ldarg.0
+			IL_0d1e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d23: ldstr "Line"
+			IL_0d28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0d2d: ldc.r8 3
+			IL_0d36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0d3b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0d40: ldc.i4.0
+			IL_0d41: ceq
+			IL_0d43: stloc.s 35
+			IL_0d45: ldloc.s 35
+			IL_0d47: brfalse IL_0dc8
 
-			IL_0d69: ldarg.0
-			IL_0d6a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0d6f: ldstr "Line"
-			IL_0d74: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d79: ldc.r8 7
-			IL_0d82: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d87: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0d8c: ldc.i4.0
-			IL_0d8d: ceq
-			IL_0d8f: stloc.s 34
-			IL_0d91: ldloc.s 34
-			IL_0d93: brfalse IL_0e07
+			IL_0d4c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L224C24::.ctor()
+			IL_0d51: stloc.s 24
+			IL_0d53: ldarg.0
+			IL_0d54: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0d59: stloc.s 36
+			IL_0d5b: ldc.i4.1
+			IL_0d5c: newarr [System.Runtime]System.Object
+			IL_0d61: dup
+			IL_0d62: ldc.i4.0
+			IL_0d63: ldarg.0
+			IL_0d64: stelem.ref
+			IL_0d65: stloc.s 33
+			IL_0d67: ldarg.0
+			IL_0d68: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d6d: ldc.r8 0.0
+			IL_0d76: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0d7b: stloc.s 32
+			IL_0d7d: ldloc.s 36
+			IL_0d7f: ldloc.s 33
+			IL_0d81: ldloc.s 32
+			IL_0d83: ldarg.0
+			IL_0d84: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0d89: ldc.r8 3
+			IL_0d92: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0d97: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0d9c: pop
+			IL_0d9d: ldarg.0
+			IL_0d9e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0da3: ldstr "Line"
+			IL_0da8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dad: ldc.r8 3
+			IL_0db6: box [System.Runtime]System.Double
+			IL_0dbb: ldc.i4.1
+			IL_0dbc: box [System.Runtime]System.Boolean
+			IL_0dc1: ldc.i4.1
+			IL_0dc2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0dc7: pop
 
-			IL_0d98: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L226C24::.ctor()
-			IL_0d9d: stloc.s 26
-			IL_0d9f: ldarg.0
-			IL_0da0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0da5: ldc.r8 7
-			IL_0dae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0db3: stloc.s 35
-			IL_0db5: ldarg.0
-			IL_0db6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0dbb: ldc.r8 4
-			IL_0dc4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0dc9: stloc.s 32
-			IL_0dcb: ldarg.0
-			IL_0dcc: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0dd1: ldnull
-			IL_0dd2: ldloc.s 35
-			IL_0dd4: ldloc.s 32
-			IL_0dd6: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0ddb: pop
-			IL_0ddc: ldarg.0
-			IL_0ddd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0de2: ldstr "Line"
-			IL_0de7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0dec: ldc.r8 7
-			IL_0df5: box [System.Runtime]System.Double
-			IL_0dfa: ldc.i4.1
-			IL_0dfb: box [System.Runtime]System.Boolean
-			IL_0e00: ldc.i4.1
-			IL_0e01: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0e06: pop
+			IL_0dc8: ldarg.0
+			IL_0dc9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0dce: ldstr "Line"
+			IL_0dd3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dd8: ldc.r8 10
+			IL_0de1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0de6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0deb: ldc.i4.0
+			IL_0dec: ceq
+			IL_0dee: stloc.s 35
+			IL_0df0: ldloc.s 35
+			IL_0df2: brfalse IL_0e73
 
-			IL_0e07: ldloc.0
-			IL_0e08: ldc.r8 5
-			IL_0e11: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e16: ldc.r8 2
-			IL_0e1f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e24: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0e29: ldc.r8 0.0
-			IL_0e32: clt
-			IL_0e34: brfalse IL_10b8
+			IL_0df7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L225C25::.ctor()
+			IL_0dfc: stloc.s 25
+			IL_0dfe: ldarg.0
+			IL_0dff: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0e04: stloc.s 32
+			IL_0e06: ldc.i4.1
+			IL_0e07: newarr [System.Runtime]System.Object
+			IL_0e0c: dup
+			IL_0e0d: ldc.i4.0
+			IL_0e0e: ldarg.0
+			IL_0e0f: stelem.ref
+			IL_0e10: stloc.s 33
+			IL_0e12: ldarg.0
+			IL_0e13: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e18: ldc.r8 3
+			IL_0e21: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e26: stloc.s 36
+			IL_0e28: ldloc.s 32
+			IL_0e2a: ldloc.s 33
+			IL_0e2c: ldloc.s 36
+			IL_0e2e: ldarg.0
+			IL_0e2f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e34: ldc.r8 7
+			IL_0e3d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0e42: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0e47: pop
+			IL_0e48: ldarg.0
+			IL_0e49: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e4e: ldstr "Line"
+			IL_0e53: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e58: ldc.r8 10
+			IL_0e61: box [System.Runtime]System.Double
+			IL_0e66: ldc.i4.1
+			IL_0e67: box [System.Runtime]System.Boolean
+			IL_0e6c: ldc.i4.1
+			IL_0e6d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0e72: pop
 
-			IL_0e39: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24::.ctor()
-			IL_0e3e: stloc.s 27
-			IL_0e40: ldarg.0
-			IL_0e41: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e46: ldstr "Line"
-			IL_0e4b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0e50: ldc.r8 8
-			IL_0e59: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0e5e: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0e63: ldc.i4.0
-			IL_0e64: ceq
-			IL_0e66: stloc.s 34
-			IL_0e68: ldloc.s 34
-			IL_0e6a: brfalse IL_0ede
+			IL_0e73: ldarg.0
+			IL_0e74: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0e79: ldstr "Line"
+			IL_0e7e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e83: ldc.r8 7
+			IL_0e8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e91: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0e96: ldc.i4.0
+			IL_0e97: ceq
+			IL_0e99: stloc.s 35
+			IL_0e9b: ldloc.s 35
+			IL_0e9d: brfalse IL_0f1e
 
-			IL_0e6f: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L229C24::.ctor()
-			IL_0e74: stloc.s 28
-			IL_0e76: ldarg.0
-			IL_0e77: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e7c: ldc.r8 1
-			IL_0e85: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0e8a: stloc.s 32
-			IL_0e8c: ldarg.0
-			IL_0e8d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0e92: ldc.r8 5
-			IL_0e9b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0ea0: stloc.s 35
-			IL_0ea2: ldarg.0
-			IL_0ea3: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0ea8: ldnull
-			IL_0ea9: ldloc.s 32
-			IL_0eab: ldloc.s 35
-			IL_0ead: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0eb2: pop
-			IL_0eb3: ldarg.0
-			IL_0eb4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0eb9: ldstr "Line"
-			IL_0ebe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ec3: ldc.r8 8
-			IL_0ecc: box [System.Runtime]System.Double
-			IL_0ed1: ldc.i4.1
-			IL_0ed2: box [System.Runtime]System.Boolean
-			IL_0ed7: ldc.i4.1
-			IL_0ed8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0edd: pop
+			IL_0ea2: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L222C24/Block_L226C24::.ctor()
+			IL_0ea7: stloc.s 26
+			IL_0ea9: ldarg.0
+			IL_0eaa: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0eaf: stloc.s 36
+			IL_0eb1: ldc.i4.1
+			IL_0eb2: newarr [System.Runtime]System.Object
+			IL_0eb7: dup
+			IL_0eb8: ldc.i4.0
+			IL_0eb9: ldarg.0
+			IL_0eba: stelem.ref
+			IL_0ebb: stloc.s 33
+			IL_0ebd: ldarg.0
+			IL_0ebe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ec3: ldc.r8 7
+			IL_0ecc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0ed1: stloc.s 32
+			IL_0ed3: ldloc.s 36
+			IL_0ed5: ldloc.s 33
+			IL_0ed7: ldloc.s 32
+			IL_0ed9: ldarg.0
+			IL_0eda: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0edf: ldc.r8 4
+			IL_0ee8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0eed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0ef2: pop
+			IL_0ef3: ldarg.0
+			IL_0ef4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0ef9: ldstr "Line"
+			IL_0efe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f03: ldc.r8 7
+			IL_0f0c: box [System.Runtime]System.Double
+			IL_0f11: ldc.i4.1
+			IL_0f12: box [System.Runtime]System.Boolean
+			IL_0f17: ldc.i4.1
+			IL_0f18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_0f1d: pop
 
-			IL_0ede: ldarg.0
-			IL_0edf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ee4: ldstr "Line"
-			IL_0ee9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0eee: ldc.r8 5
-			IL_0ef7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0efc: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0f01: ldc.i4.0
-			IL_0f02: ceq
-			IL_0f04: stloc.s 34
-			IL_0f06: ldloc.s 34
-			IL_0f08: brfalse IL_0f7c
+			IL_0f1e: ldloc.0
+			IL_0f1f: ldc.r8 5
+			IL_0f28: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f2d: ldc.r8 2
+			IL_0f36: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f3b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0f40: ldc.r8 0.0
+			IL_0f49: clt
+			IL_0f4b: brfalse IL_1203
 
-			IL_0f0d: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L230C24::.ctor()
-			IL_0f12: stloc.s 29
-			IL_0f14: ldarg.0
-			IL_0f15: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f1a: ldc.r8 5
-			IL_0f23: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0f28: stloc.s 35
-			IL_0f2a: ldarg.0
-			IL_0f2b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f30: ldc.r8 6
-			IL_0f39: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0f3e: stloc.s 32
-			IL_0f40: ldarg.0
-			IL_0f41: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0f46: ldnull
-			IL_0f47: ldloc.s 35
-			IL_0f49: ldloc.s 32
-			IL_0f4b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0f50: pop
-			IL_0f51: ldarg.0
-			IL_0f52: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f57: ldstr "Line"
-			IL_0f5c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f61: ldc.r8 5
-			IL_0f6a: box [System.Runtime]System.Double
-			IL_0f6f: ldc.i4.1
-			IL_0f70: box [System.Runtime]System.Boolean
-			IL_0f75: ldc.i4.1
-			IL_0f76: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_0f7b: pop
+			IL_0f50: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24::.ctor()
+			IL_0f55: stloc.s 27
+			IL_0f57: ldarg.0
+			IL_0f58: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0f5d: ldstr "Line"
+			IL_0f62: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0f67: ldc.r8 8
+			IL_0f70: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0f75: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0f7a: ldc.i4.0
+			IL_0f7b: ceq
+			IL_0f7d: stloc.s 35
+			IL_0f7f: ldloc.s 35
+			IL_0f81: brfalse IL_1002
 
-			IL_0f7c: ldarg.0
-			IL_0f7d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0f82: ldstr "Line"
-			IL_0f87: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0f8c: ldc.r8 9
-			IL_0f95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0f9a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0f9f: ldc.i4.0
-			IL_0fa0: ceq
-			IL_0fa2: stloc.s 34
-			IL_0fa4: ldloc.s 34
-			IL_0fa6: brfalse IL_101a
+			IL_0f86: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L229C24::.ctor()
+			IL_0f8b: stloc.s 28
+			IL_0f8d: ldarg.0
+			IL_0f8e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_0f93: stloc.s 32
+			IL_0f95: ldc.i4.1
+			IL_0f96: newarr [System.Runtime]System.Object
+			IL_0f9b: dup
+			IL_0f9c: ldc.i4.0
+			IL_0f9d: ldarg.0
+			IL_0f9e: stelem.ref
+			IL_0f9f: stloc.s 33
+			IL_0fa1: ldarg.0
+			IL_0fa2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fa7: ldc.r8 1
+			IL_0fb0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0fb5: stloc.s 36
+			IL_0fb7: ldloc.s 32
+			IL_0fb9: ldloc.s 33
+			IL_0fbb: ldloc.s 36
+			IL_0fbd: ldarg.0
+			IL_0fbe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fc3: ldc.r8 5
+			IL_0fcc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0fd1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0fd6: pop
+			IL_0fd7: ldarg.0
+			IL_0fd8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0fdd: ldstr "Line"
+			IL_0fe2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0fe7: ldc.r8 8
+			IL_0ff0: box [System.Runtime]System.Double
+			IL_0ff5: ldc.i4.1
+			IL_0ff6: box [System.Runtime]System.Boolean
+			IL_0ffb: ldc.i4.1
+			IL_0ffc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_1001: pop
 
-			IL_0fab: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L231C24::.ctor()
-			IL_0fb0: stloc.s 30
-			IL_0fb2: ldarg.0
-			IL_0fb3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0fb8: ldc.r8 6
-			IL_0fc1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0fc6: stloc.s 32
-			IL_0fc8: ldarg.0
-			IL_0fc9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0fce: ldc.r8 2
-			IL_0fd7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0fdc: stloc.s 35
-			IL_0fde: ldarg.0
-			IL_0fdf: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0fe4: ldnull
-			IL_0fe5: ldloc.s 32
-			IL_0fe7: ldloc.s 35
-			IL_0fe9: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_0fee: pop
-			IL_0fef: ldarg.0
-			IL_0ff0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0ff5: ldstr "Line"
-			IL_0ffa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0fff: ldc.r8 9
-			IL_1008: box [System.Runtime]System.Double
-			IL_100d: ldc.i4.1
-			IL_100e: box [System.Runtime]System.Boolean
-			IL_1013: ldc.i4.1
-			IL_1014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_1019: pop
+			IL_1002: ldarg.0
+			IL_1003: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1008: ldstr "Line"
+			IL_100d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1012: ldc.r8 5
+			IL_101b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1020: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_1025: ldc.i4.0
+			IL_1026: ceq
+			IL_1028: stloc.s 35
+			IL_102a: ldloc.s 35
+			IL_102c: brfalse IL_10ad
 
-			IL_101a: ldarg.0
-			IL_101b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1020: ldstr "Line"
-			IL_1025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_102a: ldc.r8 1
-			IL_1033: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_1038: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_103d: ldc.i4.0
-			IL_103e: ceq
-			IL_1040: stloc.s 34
-			IL_1042: ldloc.s 34
-			IL_1044: brfalse IL_10b8
+			IL_1031: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L230C24::.ctor()
+			IL_1036: stloc.s 29
+			IL_1038: ldarg.0
+			IL_1039: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_103e: stloc.s 36
+			IL_1040: ldc.i4.1
+			IL_1041: newarr [System.Runtime]System.Object
+			IL_1046: dup
+			IL_1047: ldc.i4.0
+			IL_1048: ldarg.0
+			IL_1049: stelem.ref
+			IL_104a: stloc.s 33
+			IL_104c: ldarg.0
+			IL_104d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1052: ldc.r8 5
+			IL_105b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1060: stloc.s 32
+			IL_1062: ldloc.s 36
+			IL_1064: ldloc.s 33
+			IL_1066: ldloc.s 32
+			IL_1068: ldarg.0
+			IL_1069: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_106e: ldc.r8 6
+			IL_1077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_107c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_1081: pop
+			IL_1082: ldarg.0
+			IL_1083: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1088: ldstr "Line"
+			IL_108d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1092: ldc.r8 5
+			IL_109b: box [System.Runtime]System.Double
+			IL_10a0: ldc.i4.1
+			IL_10a1: box [System.Runtime]System.Boolean
+			IL_10a6: ldc.i4.1
+			IL_10a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_10ac: pop
 
-			IL_1049: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L232C24::.ctor()
-			IL_104e: stloc.s 31
-			IL_1050: ldarg.0
-			IL_1051: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1056: ldc.r8 2
-			IL_105f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_1064: stloc.s 35
-			IL_1066: ldarg.0
-			IL_1067: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_106c: ldc.r8 1
-			IL_1075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_107a: stloc.s 32
-			IL_107c: ldarg.0
-			IL_107d: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_1082: ldnull
-			IL_1083: ldloc.s 35
-			IL_1085: ldloc.s 32
-			IL_1087: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-			IL_108c: pop
-			IL_108d: ldarg.0
-			IL_108e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_1093: ldstr "Line"
-			IL_1098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_109d: ldc.r8 1
-			IL_10a6: box [System.Runtime]System.Double
-			IL_10ab: ldc.i4.1
-			IL_10ac: box [System.Runtime]System.Boolean
-			IL_10b1: ldc.i4.1
-			IL_10b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-			IL_10b7: pop
+			IL_10ad: ldarg.0
+			IL_10ae: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_10b3: ldstr "Line"
+			IL_10b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_10bd: ldc.r8 9
+			IL_10c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_10cb: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_10d0: ldc.i4.0
+			IL_10d1: ceq
+			IL_10d3: stloc.s 35
+			IL_10d5: ldloc.s 35
+			IL_10d7: brfalse IL_1158
 
-			IL_10b8: ldarg.0
-			IL_10b9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_10be: stloc.s 33
-			IL_10c0: ldc.i4.s 12
-			IL_10c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_10c7: dup
-			IL_10c8: ldc.i4.0
-			IL_10c9: box [System.Runtime]System.Boolean
-			IL_10ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_10d3: dup
-			IL_10d4: ldc.i4.0
-			IL_10d5: box [System.Runtime]System.Boolean
-			IL_10da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_10df: dup
-			IL_10e0: ldc.i4.0
-			IL_10e1: box [System.Runtime]System.Boolean
-			IL_10e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_10eb: dup
-			IL_10ec: ldc.i4.0
-			IL_10ed: box [System.Runtime]System.Boolean
-			IL_10f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_10f7: dup
-			IL_10f8: ldc.i4.0
-			IL_10f9: box [System.Runtime]System.Boolean
-			IL_10fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1103: dup
-			IL_1104: ldc.i4.0
-			IL_1105: box [System.Runtime]System.Boolean
-			IL_110a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_110f: dup
-			IL_1110: ldc.i4.0
-			IL_1111: box [System.Runtime]System.Boolean
-			IL_1116: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_111b: dup
-			IL_111c: ldc.i4.0
-			IL_111d: box [System.Runtime]System.Boolean
-			IL_1122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1127: dup
-			IL_1128: ldc.i4.0
-			IL_1129: box [System.Runtime]System.Boolean
-			IL_112e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1133: dup
-			IL_1134: ldc.i4.0
-			IL_1135: box [System.Runtime]System.Boolean
-			IL_113a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_113f: dup
-			IL_1140: ldc.i4.0
-			IL_1141: box [System.Runtime]System.Boolean
-			IL_1146: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_114b: dup
-			IL_114c: ldc.i4.0
-			IL_114d: box [System.Runtime]System.Boolean
-			IL_1152: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_1157: stloc.s 36
-			IL_1159: ldloc.s 33
-			IL_115b: ldstr "Line"
-			IL_1160: ldloc.s 36
-			IL_1162: ldc.i4.1
-			IL_1163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_1168: pop
-			IL_1169: ldarg.0
-			IL_116a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_116f: ldstr "LastPx"
-			IL_1174: ldc.r8 0.0
-			IL_117d: ldc.i4.1
-			IL_117e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_1183: pop
-			IL_1184: ldnull
-			IL_1185: ret
+			IL_10dc: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L231C24::.ctor()
+			IL_10e1: stloc.s 30
+			IL_10e3: ldarg.0
+			IL_10e4: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_10e9: stloc.s 32
+			IL_10eb: ldc.i4.1
+			IL_10ec: newarr [System.Runtime]System.Object
+			IL_10f1: dup
+			IL_10f2: ldc.i4.0
+			IL_10f3: ldarg.0
+			IL_10f4: stelem.ref
+			IL_10f5: stloc.s 33
+			IL_10f7: ldarg.0
+			IL_10f8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_10fd: ldc.r8 6
+			IL_1106: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_110b: stloc.s 36
+			IL_110d: ldloc.s 32
+			IL_110f: ldloc.s 33
+			IL_1111: ldloc.s 36
+			IL_1113: ldarg.0
+			IL_1114: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1119: ldc.r8 2
+			IL_1122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_1127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_112c: pop
+			IL_112d: ldarg.0
+			IL_112e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1133: ldstr "Line"
+			IL_1138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_113d: ldc.r8 9
+			IL_1146: box [System.Runtime]System.Double
+			IL_114b: ldc.i4.1
+			IL_114c: box [System.Runtime]System.Boolean
+			IL_1151: ldc.i4.1
+			IL_1152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_1157: pop
+
+			IL_1158: ldarg.0
+			IL_1159: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_115e: ldstr "Line"
+			IL_1163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_1168: ldc.r8 1
+			IL_1171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_1176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_117b: ldc.i4.0
+			IL_117c: ceq
+			IL_117e: stloc.s 35
+			IL_1180: ldloc.s 35
+			IL_1182: brfalse IL_1203
+
+			IL_1187: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/Scope/Block_L228C24/Block_L232C24::.ctor()
+			IL_118c: stloc.s 31
+			IL_118e: ldarg.0
+			IL_118f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawLine
+			IL_1194: stloc.s 36
+			IL_1196: ldc.i4.1
+			IL_1197: newarr [System.Runtime]System.Object
+			IL_119c: dup
+			IL_119d: ldc.i4.0
+			IL_119e: ldarg.0
+			IL_119f: stelem.ref
+			IL_11a0: stloc.s 33
+			IL_11a2: ldarg.0
+			IL_11a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11a8: ldc.r8 2
+			IL_11b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_11b6: stloc.s 32
+			IL_11b8: ldloc.s 36
+			IL_11ba: ldloc.s 33
+			IL_11bc: ldloc.s 32
+			IL_11be: ldarg.0
+			IL_11bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11c4: ldc.r8 1
+			IL_11cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_11d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_11d7: pop
+			IL_11d8: ldarg.0
+			IL_11d9: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_11de: ldstr "Line"
+			IL_11e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_11e8: ldc.r8 1
+			IL_11f1: box [System.Runtime]System.Double
+			IL_11f6: ldc.i4.1
+			IL_11f7: box [System.Runtime]System.Boolean
+			IL_11fc: ldc.i4.1
+			IL_11fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+			IL_1202: pop
+
+			IL_1203: ldarg.0
+			IL_1204: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_1209: stloc.s 34
+			IL_120b: ldc.i4.s 12
+			IL_120d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_1212: dup
+			IL_1213: ldc.i4.0
+			IL_1214: box [System.Runtime]System.Boolean
+			IL_1219: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_121e: dup
+			IL_121f: ldc.i4.0
+			IL_1220: box [System.Runtime]System.Boolean
+			IL_1225: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_122a: dup
+			IL_122b: ldc.i4.0
+			IL_122c: box [System.Runtime]System.Boolean
+			IL_1231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1236: dup
+			IL_1237: ldc.i4.0
+			IL_1238: box [System.Runtime]System.Boolean
+			IL_123d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1242: dup
+			IL_1243: ldc.i4.0
+			IL_1244: box [System.Runtime]System.Boolean
+			IL_1249: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_124e: dup
+			IL_124f: ldc.i4.0
+			IL_1250: box [System.Runtime]System.Boolean
+			IL_1255: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_125a: dup
+			IL_125b: ldc.i4.0
+			IL_125c: box [System.Runtime]System.Boolean
+			IL_1261: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1266: dup
+			IL_1267: ldc.i4.0
+			IL_1268: box [System.Runtime]System.Boolean
+			IL_126d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1272: dup
+			IL_1273: ldc.i4.0
+			IL_1274: box [System.Runtime]System.Boolean
+			IL_1279: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_127e: dup
+			IL_127f: ldc.i4.0
+			IL_1280: box [System.Runtime]System.Boolean
+			IL_1285: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_128a: dup
+			IL_128b: ldc.i4.0
+			IL_128c: box [System.Runtime]System.Boolean
+			IL_1291: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_1296: dup
+			IL_1297: ldc.i4.0
+			IL_1298: box [System.Runtime]System.Boolean
+			IL_129d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_12a2: stloc.s 37
+			IL_12a4: ldloc.s 34
+			IL_12a6: ldstr "Line"
+			IL_12ab: ldloc.s 37
+			IL_12ad: ldc.i4.1
+			IL_12ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_12b3: pop
+			IL_12b4: ldarg.0
+			IL_12b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_12ba: ldstr "LastPx"
+			IL_12bf: ldc.r8 0.0
+			IL_12c8: ldc.i4.1
+			IL_12c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_12ce: pop
+			IL_12cf: ldnull
+			IL_12d0: ret
 		} // end of method DrawQube::__js_call__
 
 	} // end of class DrawQube
@@ -4799,7 +4973,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fac
+					// Method begins at RVA 0x6236
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -4817,7 +4991,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5fa3
+				// Method begins at RVA 0x622d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -4843,9 +5017,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x4af8
+			// Method begins at RVA 0x4c38
 			// Header size: 12
-			// Code size: 865 (0x361)
+			// Code size: 1070 (0x42e)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4855,12 +5029,13 @@
 				[4] object,
 				[5] float64,
 				[6] string,
-				[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[8] object,
+				[7] object[],
+				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[9] object,
 				[10] object,
 				[11] object,
-				[12] class [JavaScriptRuntime]JavaScriptRuntime.Array
+				[12] object[],
+				[13] object
 			)
 
 			IL_0000: ldarg.0
@@ -4911,217 +5086,322 @@
 			// end loop
 
 			IL_0083: ldarg.0
-			IL_0084: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
-			IL_0089: stloc.s 7
-			IL_008b: ldarg.0
-			IL_008c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0091: ldc.r8 8
-			IL_009a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_009f: ldstr "V"
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00a9: ldc.r8 0.0
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_00bc: stloc.s 8
-			IL_00be: ldarg.0
-			IL_00bf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_00c4: ldc.r8 8
-			IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_00d2: ldstr "V"
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00dc: ldc.r8 1
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_00ef: stloc.s 9
-			IL_00f1: ldarg.0
-			IL_00f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_00f7: ldc.r8 8
-			IL_0100: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0105: ldstr "V"
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_010f: ldc.r8 2
-			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
-			IL_0122: stloc.s 10
-			IL_0124: ldarg.0
-			IL_0125: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_012a: ldnull
-			IL_012b: ldloc.s 7
-			IL_012d: ldloc.s 8
-			IL_012f: ldloc.s 9
-			IL_0131: ldloc.s 10
-			IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object, object)
-			IL_0138: stloc.s 7
-			IL_013a: ldarg.0
-			IL_013b: ldloc.s 7
-			IL_013d: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0142: ldarg.0
-			IL_0143: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0148: stloc.s 7
-			IL_014a: ldarg.0
-			IL_014b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0150: ldnull
-			IL_0151: ldloc.s 7
-			IL_0153: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0158: ldc.r8 1
-			IL_0161: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-			IL_0166: stloc.s 7
-			IL_0168: ldarg.0
-			IL_0169: ldloc.s 7
-			IL_016b: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0170: ldarg.0
-			IL_0171: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0176: stloc.s 7
-			IL_0178: ldarg.0
-			IL_0179: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_017e: ldnull
-			IL_017f: ldloc.s 7
-			IL_0181: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0186: ldc.r8 3
-			IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-			IL_0194: stloc.s 7
-			IL_0196: ldarg.0
-			IL_0197: ldloc.s 7
-			IL_0199: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_019e: ldarg.0
-			IL_019f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_01a4: stloc.s 7
-			IL_01a6: ldarg.0
-			IL_01a7: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_01ac: ldnull
-			IL_01ad: ldloc.s 7
-			IL_01af: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01b4: ldc.r8 5
-			IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-			IL_01c2: stloc.s 7
-			IL_01c4: ldarg.0
-			IL_01c5: ldloc.s 7
-			IL_01c7: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_01cc: ldarg.0
-			IL_01cd: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_01d2: stloc.s 7
-			IL_01d4: ldarg.0
-			IL_01d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_01da: ldc.r8 8
-			IL_01e3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01e8: ldstr "V"
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01f2: ldc.r8 0.0
-			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0200: stloc.s 4
-			IL_0202: ldarg.0
-			IL_0203: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0208: ldc.r8 8
-			IL_0211: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0216: ldstr "V"
-			IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0220: ldc.r8 1
-			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_022e: stloc.3
-			IL_022f: ldarg.0
-			IL_0230: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0235: ldc.r8 8
-			IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_0243: ldstr "V"
-			IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_024d: ldc.r8 2
-			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_025b: stloc.s 11
-			IL_025d: ldarg.0
-			IL_025e: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0263: ldnull
-			IL_0264: ldloc.s 7
-			IL_0266: ldloc.s 4
-			IL_0268: ldloc.3
-			IL_0269: ldloc.s 11
-			IL_026b: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object, object)
-			IL_0270: stloc.s 7
-			IL_0272: ldarg.0
-			IL_0273: ldloc.s 7
-			IL_0275: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_027a: ldarg.0
-			IL_027b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0280: stloc.s 7
-			IL_0282: ldarg.0
-			IL_0283: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0288: stloc.s 12
-			IL_028a: ldnull
-			IL_028b: ldloc.s 7
-			IL_028d: ldloc.s 12
-			IL_028f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, object, object)
-			IL_0294: stloc.s 12
-			IL_0296: ldarg.0
-			IL_0297: ldloc.s 12
-			IL_0299: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_029e: ldc.r8 8
-			IL_02a7: stloc.1
-			// loop start (head: IL_02a8)
-				IL_02a8: ldloc.1
-				IL_02a9: ldc.r8 1
-				IL_02b2: neg
-				IL_02b3: cgt
-				IL_02b5: brfalse IL_0319
+			IL_0084: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0089: stloc.s 4
+			IL_008b: ldc.i4.1
+			IL_008c: newarr [System.Runtime]System.Object
+			IL_0091: dup
+			IL_0092: ldc.i4.0
+			IL_0093: ldarg.0
+			IL_0094: stelem.ref
+			IL_0095: stloc.s 7
+			IL_0097: ldarg.0
+			IL_0098: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::I
+			IL_009d: stloc.s 8
+			IL_009f: ldarg.0
+			IL_00a0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_00a5: ldc.r8 8
+			IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00b3: ldstr "V"
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00bd: ldc.r8 0.0
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_00d0: stloc.s 9
+			IL_00d2: ldarg.0
+			IL_00d3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_00d8: ldc.r8 8
+			IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_00e6: ldstr "V"
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f0: ldc.r8 1
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_0103: stloc.s 10
+			IL_0105: ldarg.0
+			IL_0106: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_010b: ldc.r8 8
+			IL_0114: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0119: ldstr "V"
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0123: ldc.r8 2
+			IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::UnaryMinus(object)
+			IL_0136: stloc.s 11
+			IL_0138: ldc.i4.4
+			IL_0139: newarr [System.Runtime]System.Object
+			IL_013e: dup
+			IL_013f: ldc.i4.0
+			IL_0140: ldloc.s 8
+			IL_0142: stelem.ref
+			IL_0143: dup
+			IL_0144: ldc.i4.1
+			IL_0145: ldloc.s 9
+			IL_0147: stelem.ref
+			IL_0148: dup
+			IL_0149: ldc.i4.2
+			IL_014a: ldloc.s 10
+			IL_014c: stelem.ref
+			IL_014d: dup
+			IL_014e: ldc.i4.3
+			IL_014f: ldloc.s 11
+			IL_0151: stelem.ref
+			IL_0152: stloc.s 12
+			IL_0154: ldloc.s 4
+			IL_0156: ldloc.s 7
+			IL_0158: ldloc.s 12
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_015f: stloc.s 4
+			IL_0161: ldarg.0
+			IL_0162: ldloc.s 4
+			IL_0164: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0169: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_016e: ldarg.0
+			IL_016f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateX
+			IL_0174: stloc.s 4
+			IL_0176: ldc.i4.1
+			IL_0177: newarr [System.Runtime]System.Object
+			IL_017c: dup
+			IL_017d: ldc.i4.0
+			IL_017e: ldarg.0
+			IL_017f: stelem.ref
+			IL_0180: stloc.s 12
+			IL_0182: ldarg.0
+			IL_0183: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0188: stloc.s 8
+			IL_018a: ldloc.s 4
+			IL_018c: ldloc.s 12
+			IL_018e: ldloc.s 8
+			IL_0190: ldc.r8 1
+			IL_0199: box [System.Runtime]System.Double
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01a3: stloc.s 4
+			IL_01a5: ldarg.0
+			IL_01a6: ldloc.s 4
+			IL_01a8: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01ad: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_01b2: ldarg.0
+			IL_01b3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateY
+			IL_01b8: stloc.s 4
+			IL_01ba: ldc.i4.1
+			IL_01bb: newarr [System.Runtime]System.Object
+			IL_01c0: dup
+			IL_01c1: ldc.i4.0
+			IL_01c2: ldarg.0
+			IL_01c3: stelem.ref
+			IL_01c4: stloc.s 12
+			IL_01c6: ldarg.0
+			IL_01c7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_01cc: stloc.s 8
+			IL_01ce: ldloc.s 4
+			IL_01d0: ldloc.s 12
+			IL_01d2: ldloc.s 8
+			IL_01d4: ldc.r8 3
+			IL_01dd: box [System.Runtime]System.Double
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01e7: stloc.s 4
+			IL_01e9: ldarg.0
+			IL_01ea: ldloc.s 4
+			IL_01ec: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01f1: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_01f6: ldarg.0
+			IL_01f7: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::RotateZ
+			IL_01fc: stloc.s 4
+			IL_01fe: ldc.i4.1
+			IL_01ff: newarr [System.Runtime]System.Object
+			IL_0204: dup
+			IL_0205: ldc.i4.0
+			IL_0206: ldarg.0
+			IL_0207: stelem.ref
+			IL_0208: stloc.s 12
+			IL_020a: ldarg.0
+			IL_020b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0210: stloc.s 8
+			IL_0212: ldloc.s 4
+			IL_0214: ldloc.s 12
+			IL_0216: ldloc.s 8
+			IL_0218: ldc.r8 5
+			IL_0221: box [System.Runtime]System.Double
+			IL_0226: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_022b: stloc.s 4
+			IL_022d: ldarg.0
+			IL_022e: ldloc.s 4
+			IL_0230: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0235: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_023a: ldarg.0
+			IL_023b: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0240: stloc.s 4
+			IL_0242: ldc.i4.1
+			IL_0243: newarr [System.Runtime]System.Object
+			IL_0248: dup
+			IL_0249: ldc.i4.0
+			IL_024a: ldarg.0
+			IL_024b: stelem.ref
+			IL_024c: stloc.s 12
+			IL_024e: ldarg.0
+			IL_024f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0254: stloc.s 8
+			IL_0256: ldarg.0
+			IL_0257: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_025c: ldc.r8 8
+			IL_0265: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_026a: ldstr "V"
+			IL_026f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0274: ldc.r8 0.0
+			IL_027d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0282: stloc.3
+			IL_0283: ldarg.0
+			IL_0284: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0289: ldc.r8 8
+			IL_0292: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_0297: ldstr "V"
+			IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02a1: ldc.r8 1
+			IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02af: stloc.s 13
+			IL_02b1: ldloc.s 4
+			IL_02b3: ldloc.s 12
+			IL_02b5: ldc.i4.4
+			IL_02b6: newarr [System.Runtime]System.Object
+			IL_02bb: dup
+			IL_02bc: ldc.i4.0
+			IL_02bd: ldloc.s 8
+			IL_02bf: stelem.ref
+			IL_02c0: dup
+			IL_02c1: ldc.i4.1
+			IL_02c2: ldloc.3
+			IL_02c3: stelem.ref
+			IL_02c4: dup
+			IL_02c5: ldc.i4.2
+			IL_02c6: ldloc.s 13
+			IL_02c8: stelem.ref
+			IL_02c9: dup
+			IL_02ca: ldc.i4.3
+			IL_02cb: ldarg.0
+			IL_02cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_02d1: ldc.r8 8
+			IL_02da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_02df: ldstr "V"
+			IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02e9: ldc.r8 2
+			IL_02f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_02f7: stelem.ref
+			IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_02fd: stloc.s 4
+			IL_02ff: ldarg.0
+			IL_0300: ldloc.s 4
+			IL_0302: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0307: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_030c: ldc.i4.1
+			IL_030d: newarr [System.Runtime]System.Object
+			IL_0312: dup
+			IL_0313: ldc.i4.0
+			IL_0314: ldarg.0
+			IL_0315: stelem.ref
+			IL_0316: stloc.s 12
+			IL_0318: ldarg.0
+			IL_0319: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_031e: stloc.s 8
+			IL_0320: ldarg.0
+			IL_0321: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
+			IL_0326: ldloc.s 12
+			IL_0328: ldloc.s 8
+			IL_032a: ldarg.0
+			IL_032b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0335: stloc.s 4
+			IL_0337: ldarg.0
+			IL_0338: ldloc.s 4
+			IL_033a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_033f: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0344: ldc.r8 8
+			IL_034d: stloc.1
+			// loop start (head: IL_034e)
+				IL_034e: ldloc.1
+				IL_034f: ldc.r8 1
+				IL_0358: neg
+				IL_0359: cgt
+				IL_035b: brfalse IL_03d4
 
-				IL_02ba: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/Scope/Block_L249C24::.ctor()
-				IL_02bf: stloc.2
-				IL_02c0: ldarg.0
-				IL_02c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_02c6: ldloc.1
-				IL_02c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_02cc: stloc.s 11
-				IL_02ce: ldarg.0
-				IL_02cf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_02d4: stloc.s 12
-				IL_02d6: ldarg.0
-				IL_02d7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_02dc: ldloc.1
-				IL_02dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_02e2: ldstr "V"
-				IL_02e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02ec: stloc.3
-				IL_02ed: ldnull
-				IL_02ee: ldloc.s 12
-				IL_02f0: ldloc.3
-				IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, object, object)
-				IL_02f6: stloc.s 12
-				IL_02f8: ldloc.s 11
-				IL_02fa: ldstr "V"
-				IL_02ff: ldloc.s 12
-				IL_0301: ldc.i4.1
-				IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0307: pop
-				IL_0308: ldloc.1
-				IL_0309: ldc.r8 1
-				IL_0312: sub
-				IL_0313: stloc.1
-				IL_0314: br IL_02a8
+				IL_0360: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/Scope/Block_L249C24::.ctor()
+				IL_0365: stloc.2
+				IL_0366: ldarg.0
+				IL_0367: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_036c: ldloc.1
+				IL_036d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0372: stloc.s 4
+				IL_0374: ldarg.0
+				IL_0375: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
+				IL_037a: stloc.s 13
+				IL_037c: ldc.i4.1
+				IL_037d: newarr [System.Runtime]System.Object
+				IL_0382: dup
+				IL_0383: ldc.i4.0
+				IL_0384: ldarg.0
+				IL_0385: stelem.ref
+				IL_0386: stloc.s 12
+				IL_0388: ldarg.0
+				IL_0389: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_038e: stloc.s 8
+				IL_0390: ldloc.s 13
+				IL_0392: ldloc.s 12
+				IL_0394: ldloc.s 8
+				IL_0396: ldarg.0
+				IL_0397: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_039c: ldloc.1
+				IL_039d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_03a2: ldstr "V"
+				IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_03b1: stloc.s 13
+				IL_03b3: ldloc.s 4
+				IL_03b5: ldstr "V"
+				IL_03ba: ldloc.s 13
+				IL_03bc: ldc.i4.1
+				IL_03bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_03c2: pop
+				IL_03c3: ldloc.1
+				IL_03c4: ldc.r8 1
+				IL_03cd: sub
+				IL_03ce: stloc.1
+				IL_03cf: br IL_034e
 			// end loop
 
-			IL_0319: ldarg.0
-			IL_031a: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_031f: ldnull
-			IL_0320: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-			IL_0325: pop
-			IL_0326: ldarg.0
-			IL_0327: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_032c: stloc.s 11
-			IL_032e: ldloc.s 11
-			IL_0330: ldstr "LoopCount"
-			IL_0335: ldloc.s 11
-			IL_0337: ldstr "LoopCount"
-			IL_033c: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-			IL_0341: ldc.r8 1
-			IL_034a: add
-			IL_034b: ldc.i4.1
-			IL_034c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0351: pop
-			IL_0352: ldarg.0
-			IL_0353: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0358: ldnull
-			IL_0359: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-			IL_035e: pop
-			IL_035f: ldnull
-			IL_0360: ret
+			IL_03d4: ldarg.0
+			IL_03d5: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
+			IL_03da: ldc.i4.1
+			IL_03db: newarr [System.Runtime]System.Object
+			IL_03e0: dup
+			IL_03e1: ldc.i4.0
+			IL_03e2: ldarg.0
+			IL_03e3: stelem.ref
+			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_03e9: pop
+			IL_03ea: ldarg.0
+			IL_03eb: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_03f0: stloc.s 13
+			IL_03f2: ldloc.s 13
+			IL_03f4: ldstr "LoopCount"
+			IL_03f9: ldloc.s 13
+			IL_03fb: ldstr "LoopCount"
+			IL_0400: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+			IL_0405: ldc.r8 1
+			IL_040e: add
+			IL_040f: ldc.i4.1
+			IL_0410: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0415: pop
+			IL_0416: ldarg.0
+			IL_0417: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
+			IL_041c: ldc.i4.1
+			IL_041d: newarr [System.Runtime]System.Object
+			IL_0422: dup
+			IL_0423: ldc.i4.0
+			IL_0424: ldarg.0
+			IL_0425: stelem.ref
+			IL_0426: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_042b: pop
+			IL_042c: ldnull
+			IL_042d: ret
 		} // end of method Loop::__js_call__
 
 	} // end of class Loop
@@ -5141,7 +5421,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x5fbe
+					// Method begins at RVA 0x6248
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -5159,7 +5439,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5fb5
+				// Method begins at RVA 0x623f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -5186,9 +5466,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x4e68
+			// Method begins at RVA 0x5074
 			// Header size: 12
-			// Code size: 3786 (0xeca)
+			// Code size: 3894 (0xf36)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -5203,9 +5483,10 @@
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[10] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[11] object,
-				[12] object,
+				[12] object[],
 				[13] object,
-				[14] float64
+				[14] object,
+				[15] float64
 			)
 
 			IL_0000: ldarg.0
@@ -6030,7 +6311,7 @@
 				IL_0afc: ldstr "length"
 				IL_0b01: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
 				IL_0b06: clt
-				IL_0b08: brfalse IL_0c10
+				IL_0b08: brfalse IL_0c1d
 
 				IL_0b0d: ldarg.0
 				IL_0b0e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
@@ -6038,308 +6319,364 @@
 				IL_0b18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 				IL_0b1d: stloc.2
 				IL_0b1e: ldarg.0
-				IL_0b1f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b24: stloc.s 10
-				IL_0b26: ldloc.s 10
-				IL_0b28: ldarg.0
-				IL_0b29: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b2e: ldstr "Edge"
-				IL_0b33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b38: ldloc.0
-				IL_0b39: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b3e: ldc.r8 0.0
-				IL_0b47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b4c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0b51: ldstr "V"
-				IL_0b56: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b5b: stloc.s 11
-				IL_0b5d: ldarg.0
-				IL_0b5e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b63: stloc.s 10
-				IL_0b65: ldloc.s 10
-				IL_0b67: ldarg.0
-				IL_0b68: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0b6d: ldstr "Edge"
-				IL_0b72: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b77: ldloc.0
-				IL_0b78: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b7d: ldc.r8 1
-				IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0b8b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0b90: ldstr "V"
-				IL_0b95: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0b9a: stloc.s 12
-				IL_0b9c: ldarg.0
-				IL_0b9d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0ba2: stloc.s 10
-				IL_0ba4: ldloc.s 10
-				IL_0ba6: ldarg.0
-				IL_0ba7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0bac: ldstr "Edge"
-				IL_0bb1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0bb6: ldloc.0
-				IL_0bb7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0bbc: ldc.r8 2
-				IL_0bc5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0bca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-				IL_0bcf: ldstr "V"
-				IL_0bd4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0bd9: stloc.s 13
-				IL_0bdb: ldarg.0
-				IL_0bdc: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-				IL_0be1: ldnull
-				IL_0be2: ldloc.s 11
-				IL_0be4: ldloc.s 12
-				IL_0be6: ldloc.s 13
-				IL_0be8: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
-				IL_0bed: stloc.s 10
-				IL_0bef: ldloc.2
-				IL_0bf0: ldloc.0
-				IL_0bf1: box [System.Runtime]System.Double
-				IL_0bf6: ldloc.s 10
-				IL_0bf8: ldc.i4.1
-				IL_0bf9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_0bfe: pop
-				IL_0bff: ldloc.0
-				IL_0c00: ldc.r8 1
-				IL_0c09: add
-				IL_0c0a: stloc.0
-				IL_0c0b: br IL_0aeb
+				IL_0b1f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CalcNormal
+				IL_0b24: stloc.s 11
+				IL_0b26: ldc.i4.1
+				IL_0b27: newarr [System.Runtime]System.Object
+				IL_0b2c: dup
+				IL_0b2d: ldc.i4.0
+				IL_0b2e: ldarg.0
+				IL_0b2f: stelem.ref
+				IL_0b30: stloc.s 12
+				IL_0b32: ldarg.0
+				IL_0b33: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b38: stloc.s 10
+				IL_0b3a: ldloc.s 10
+				IL_0b3c: ldarg.0
+				IL_0b3d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b42: ldstr "Edge"
+				IL_0b47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b4c: ldloc.0
+				IL_0b4d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b52: ldc.r8 0.0
+				IL_0b5b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b60: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0b65: ldstr "V"
+				IL_0b6a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b6f: stloc.s 13
+				IL_0b71: ldarg.0
+				IL_0b72: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b77: stloc.s 10
+				IL_0b79: ldloc.s 10
+				IL_0b7b: ldarg.0
+				IL_0b7c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0b81: ldstr "Edge"
+				IL_0b86: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0b8b: ldloc.0
+				IL_0b8c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b91: ldc.r8 1
+				IL_0b9a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0b9f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0ba4: ldstr "V"
+				IL_0ba9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bae: stloc.s 14
+				IL_0bb0: ldarg.0
+				IL_0bb1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0bb6: stloc.s 10
+				IL_0bb8: ldloc.s 11
+				IL_0bba: ldloc.s 12
+				IL_0bbc: ldloc.s 13
+				IL_0bbe: ldloc.s 14
+				IL_0bc0: ldloc.s 10
+				IL_0bc2: ldarg.0
+				IL_0bc3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0bc8: ldstr "Edge"
+				IL_0bcd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bd2: ldloc.0
+				IL_0bd3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0bd8: ldc.r8 2
+				IL_0be1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0be6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+				IL_0beb: ldstr "V"
+				IL_0bf0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0bf5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0bfa: stloc.s 14
+				IL_0bfc: ldloc.2
+				IL_0bfd: ldloc.0
+				IL_0bfe: box [System.Runtime]System.Double
+				IL_0c03: ldloc.s 14
+				IL_0c05: ldc.i4.1
+				IL_0c06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0c0b: pop
+				IL_0c0c: ldloc.0
+				IL_0c0d: ldc.r8 1
+				IL_0c16: add
+				IL_0c17: stloc.0
+				IL_0c18: br IL_0aeb
 			// end loop
 
-			IL_0c10: ldarg.0
-			IL_0c11: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0c16: stloc.s 10
-			IL_0c18: ldc.i4.s 12
-			IL_0c1a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0c1f: dup
-			IL_0c20: ldc.i4.0
-			IL_0c21: box [System.Runtime]System.Boolean
-			IL_0c26: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c2b: dup
-			IL_0c2c: ldc.i4.0
-			IL_0c2d: box [System.Runtime]System.Boolean
-			IL_0c32: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c37: dup
-			IL_0c38: ldc.i4.0
-			IL_0c39: box [System.Runtime]System.Boolean
-			IL_0c3e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c43: dup
-			IL_0c44: ldc.i4.0
-			IL_0c45: box [System.Runtime]System.Boolean
-			IL_0c4a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c4f: dup
-			IL_0c50: ldc.i4.0
-			IL_0c51: box [System.Runtime]System.Boolean
-			IL_0c56: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c5b: dup
-			IL_0c5c: ldc.i4.0
-			IL_0c5d: box [System.Runtime]System.Boolean
-			IL_0c62: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c67: dup
-			IL_0c68: ldc.i4.0
-			IL_0c69: box [System.Runtime]System.Boolean
-			IL_0c6e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c73: dup
-			IL_0c74: ldc.i4.0
-			IL_0c75: box [System.Runtime]System.Boolean
-			IL_0c7a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c7f: dup
-			IL_0c80: ldc.i4.0
-			IL_0c81: box [System.Runtime]System.Boolean
-			IL_0c86: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c8b: dup
-			IL_0c8c: ldc.i4.0
-			IL_0c8d: box [System.Runtime]System.Boolean
-			IL_0c92: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0c97: dup
-			IL_0c98: ldc.i4.0
-			IL_0c99: box [System.Runtime]System.Boolean
-			IL_0c9e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0ca3: dup
-			IL_0ca4: ldc.i4.0
-			IL_0ca5: box [System.Runtime]System.Boolean
-			IL_0caa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0caf: stloc.s 5
-			IL_0cb1: ldloc.s 10
-			IL_0cb3: ldstr "Line"
-			IL_0cb8: ldloc.s 5
-			IL_0cba: ldc.i4.1
-			IL_0cbb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0cc0: pop
-			IL_0cc1: ldarg.0
-			IL_0cc2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_0cc7: stloc.s 5
-			IL_0cc9: ldc.r8 9
-			IL_0cd2: ldc.r8 2
-			IL_0cdb: mul
-			IL_0cdc: stloc.s 14
-			IL_0cde: ldloc.s 14
-			IL_0ce0: ldarg.2
-			IL_0ce1: mul
-			IL_0ce2: stloc.s 14
-			IL_0ce4: ldloc.s 5
-			IL_0ce6: ldstr "NumPx"
-			IL_0ceb: ldloc.s 14
-			IL_0ced: ldc.i4.1
-			IL_0cee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_0cf3: pop
-			IL_0cf4: ldc.r8 0.0
-			IL_0cfd: stloc.0
-			// loop start (head: IL_0cfe)
-				IL_0cfe: ldloc.0
-				IL_0cff: ldarg.0
-				IL_0d00: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0d05: ldstr "NumPx"
-				IL_0d0a: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0d0f: clt
-				IL_0d11: brfalse IL_0d6e
+			IL_0c1d: ldarg.0
+			IL_0c1e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0c23: stloc.s 10
+			IL_0c25: ldc.i4.s 12
+			IL_0c27: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0c2c: dup
+			IL_0c2d: ldc.i4.0
+			IL_0c2e: box [System.Runtime]System.Boolean
+			IL_0c33: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c38: dup
+			IL_0c39: ldc.i4.0
+			IL_0c3a: box [System.Runtime]System.Boolean
+			IL_0c3f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c44: dup
+			IL_0c45: ldc.i4.0
+			IL_0c46: box [System.Runtime]System.Boolean
+			IL_0c4b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c50: dup
+			IL_0c51: ldc.i4.0
+			IL_0c52: box [System.Runtime]System.Boolean
+			IL_0c57: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c5c: dup
+			IL_0c5d: ldc.i4.0
+			IL_0c5e: box [System.Runtime]System.Boolean
+			IL_0c63: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c68: dup
+			IL_0c69: ldc.i4.0
+			IL_0c6a: box [System.Runtime]System.Boolean
+			IL_0c6f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c74: dup
+			IL_0c75: ldc.i4.0
+			IL_0c76: box [System.Runtime]System.Boolean
+			IL_0c7b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c80: dup
+			IL_0c81: ldc.i4.0
+			IL_0c82: box [System.Runtime]System.Boolean
+			IL_0c87: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c8c: dup
+			IL_0c8d: ldc.i4.0
+			IL_0c8e: box [System.Runtime]System.Boolean
+			IL_0c93: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0c98: dup
+			IL_0c99: ldc.i4.0
+			IL_0c9a: box [System.Runtime]System.Boolean
+			IL_0c9f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0ca4: dup
+			IL_0ca5: ldc.i4.0
+			IL_0ca6: box [System.Runtime]System.Boolean
+			IL_0cab: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cb0: dup
+			IL_0cb1: ldc.i4.0
+			IL_0cb2: box [System.Runtime]System.Boolean
+			IL_0cb7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0cbc: stloc.s 5
+			IL_0cbe: ldloc.s 10
+			IL_0cc0: ldstr "Line"
+			IL_0cc5: ldloc.s 5
+			IL_0cc7: ldc.i4.1
+			IL_0cc8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0ccd: pop
+			IL_0cce: ldarg.0
+			IL_0ccf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_0cd4: stloc.s 5
+			IL_0cd6: ldc.r8 9
+			IL_0cdf: ldc.r8 2
+			IL_0ce8: mul
+			IL_0ce9: stloc.s 15
+			IL_0ceb: ldloc.s 15
+			IL_0ced: ldarg.2
+			IL_0cee: mul
+			IL_0cef: stloc.s 15
+			IL_0cf1: ldloc.s 5
+			IL_0cf3: ldstr "NumPx"
+			IL_0cf8: ldloc.s 15
+			IL_0cfa: ldc.i4.1
+			IL_0cfb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0d00: pop
+			IL_0d01: ldc.r8 0.0
+			IL_0d0a: stloc.0
+			// loop start (head: IL_0d0b)
+				IL_0d0b: ldloc.0
+				IL_0d0c: ldarg.0
+				IL_0d0d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0d12: ldstr "NumPx"
+				IL_0d17: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0d1c: clt
+				IL_0d1e: brfalse IL_0d7d
 
-				IL_0d16: ldarg.0
-				IL_0d17: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
-				IL_0d1c: stloc.2
-				IL_0d1d: ldloc.2
-				IL_0d1e: ldc.i4.3
-				IL_0d1f: newarr [System.Runtime]System.Object
-				IL_0d24: dup
-				IL_0d25: ldc.i4.0
-				IL_0d26: ldc.r8 0.0
-				IL_0d2f: box [System.Runtime]System.Double
-				IL_0d34: stelem.ref
-				IL_0d35: dup
-				IL_0d36: ldc.i4.1
-				IL_0d37: ldc.r8 0.0
-				IL_0d40: box [System.Runtime]System.Double
-				IL_0d45: stelem.ref
-				IL_0d46: dup
-				IL_0d47: ldc.i4.2
-				IL_0d48: ldc.r8 0.0
-				IL_0d51: box [System.Runtime]System.Double
-				IL_0d56: stelem.ref
-				IL_0d57: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-				IL_0d5c: pop
-				IL_0d5d: ldloc.0
-				IL_0d5e: ldc.r8 1
-				IL_0d67: add
-				IL_0d68: stloc.0
-				IL_0d69: br IL_0cfe
+				IL_0d23: ldarg.0
+				IL_0d24: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::CreateP
+				IL_0d29: stloc.s 14
+				IL_0d2b: ldloc.s 14
+				IL_0d2d: ldc.i4.3
+				IL_0d2e: newarr [System.Runtime]System.Object
+				IL_0d33: dup
+				IL_0d34: ldc.i4.0
+				IL_0d35: ldc.r8 0.0
+				IL_0d3e: box [System.Runtime]System.Double
+				IL_0d43: stelem.ref
+				IL_0d44: dup
+				IL_0d45: ldc.i4.1
+				IL_0d46: ldc.r8 0.0
+				IL_0d4f: box [System.Runtime]System.Double
+				IL_0d54: stelem.ref
+				IL_0d55: dup
+				IL_0d56: ldc.i4.2
+				IL_0d57: ldc.r8 0.0
+				IL_0d60: box [System.Runtime]System.Double
+				IL_0d65: stelem.ref
+				IL_0d66: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+				IL_0d6b: pop
+				IL_0d6c: ldloc.0
+				IL_0d6d: ldc.r8 1
+				IL_0d76: add
+				IL_0d77: stloc.0
+				IL_0d78: br IL_0d0b
 			// end loop
 
-			IL_0d6e: ldarg.0
-			IL_0d6f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0d74: stloc.s 5
-			IL_0d76: ldarg.0
-			IL_0d77: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0d7c: ldstr "V"
-			IL_0d81: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0d86: ldc.r8 0.0
-			IL_0d8f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0d94: stloc.2
-			IL_0d95: ldarg.0
-			IL_0d96: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0d9b: ldstr "V"
-			IL_0da0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0da5: ldc.r8 1
-			IL_0dae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0db3: stloc.s 13
-			IL_0db5: ldarg.0
-			IL_0db6: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
-			IL_0dbb: ldstr "V"
-			IL_0dc0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0dc5: ldc.r8 2
-			IL_0dce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0dd3: stloc.s 12
-			IL_0dd5: ldarg.0
-			IL_0dd6: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0ddb: ldnull
-			IL_0ddc: ldloc.s 5
-			IL_0dde: ldloc.2
-			IL_0ddf: ldloc.s 13
-			IL_0de1: ldloc.s 12
-			IL_0de3: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object, object)
-			IL_0de8: stloc.s 5
-			IL_0dea: ldarg.0
-			IL_0deb: ldloc.s 5
-			IL_0ded: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0d7d: ldarg.0
+			IL_0d7e: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Translate
+			IL_0d83: stloc.s 14
+			IL_0d85: ldc.i4.1
+			IL_0d86: newarr [System.Runtime]System.Object
+			IL_0d8b: dup
+			IL_0d8c: ldc.i4.0
+			IL_0d8d: ldarg.0
+			IL_0d8e: stelem.ref
+			IL_0d8f: stloc.s 12
+			IL_0d91: ldarg.0
+			IL_0d92: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0d97: stloc.s 5
+			IL_0d99: ldarg.0
+			IL_0d9a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0d9f: ldstr "V"
+			IL_0da4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0da9: ldc.r8 0.0
+			IL_0db2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0db7: stloc.2
+			IL_0db8: ldarg.0
+			IL_0db9: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0dbe: ldstr "V"
+			IL_0dc3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0dc8: ldc.r8 1
+			IL_0dd1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0dd6: stloc.s 13
+			IL_0dd8: ldloc.s 14
+			IL_0dda: ldloc.s 12
+			IL_0ddc: ldc.i4.4
+			IL_0ddd: newarr [System.Runtime]System.Object
+			IL_0de2: dup
+			IL_0de3: ldc.i4.0
+			IL_0de4: ldloc.s 5
+			IL_0de6: stelem.ref
+			IL_0de7: dup
+			IL_0de8: ldc.i4.1
+			IL_0de9: ldloc.2
+			IL_0dea: stelem.ref
+			IL_0deb: dup
+			IL_0dec: ldc.i4.2
+			IL_0ded: ldloc.s 13
+			IL_0def: stelem.ref
+			IL_0df0: dup
+			IL_0df1: ldc.i4.3
 			IL_0df2: ldarg.0
-			IL_0df3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-			IL_0df8: stloc.s 5
-			IL_0dfa: ldarg.0
-			IL_0dfb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0e00: stloc.s 10
-			IL_0e02: ldnull
-			IL_0e03: ldloc.s 5
-			IL_0e05: ldloc.s 10
-			IL_0e07: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, object, object)
-			IL_0e0c: stloc.s 10
-			IL_0e0e: ldarg.0
-			IL_0e0f: ldloc.s 10
-			IL_0e11: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
-			IL_0e16: ldc.r8 0.0
-			IL_0e1f: stloc.0
-			// loop start (head: IL_0e20)
-				IL_0e20: ldloc.0
-				IL_0e21: ldc.r8 9
-				IL_0e2a: clt
-				IL_0e2c: brfalse IL_0e92
+			IL_0df3: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Origin
+			IL_0df8: ldstr "V"
+			IL_0dfd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0e02: ldc.r8 2
+			IL_0e0b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0e10: stelem.ref
+			IL_0e11: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0e16: stloc.s 14
+			IL_0e18: ldarg.0
+			IL_0e19: ldloc.s 14
+			IL_0e1b: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e20: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e25: ldc.i4.1
+			IL_0e26: newarr [System.Runtime]System.Object
+			IL_0e2b: dup
+			IL_0e2c: ldc.i4.0
+			IL_0e2d: ldarg.0
+			IL_0e2e: stelem.ref
+			IL_0e2f: stloc.s 12
+			IL_0e31: ldarg.0
+			IL_0e32: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+			IL_0e37: stloc.s 5
+			IL_0e39: ldarg.0
+			IL_0e3a: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MMulti
+			IL_0e3f: ldloc.s 12
+			IL_0e41: ldloc.s 5
+			IL_0e43: ldarg.0
+			IL_0e44: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0e49: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0e4e: stloc.s 14
+			IL_0e50: ldarg.0
+			IL_0e51: ldloc.s 14
+			IL_0e53: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0e58: stfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MQube
+			IL_0e5d: ldc.r8 0.0
+			IL_0e66: stloc.0
+			// loop start (head: IL_0e67)
+				IL_0e67: ldloc.0
+				IL_0e68: ldc.r8 9
+				IL_0e71: clt
+				IL_0e73: brfalse IL_0eec
 
-				IL_0e31: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Init/Scope/Block_L324C23::.ctor()
-				IL_0e36: stloc.1
-				IL_0e37: ldarg.0
-				IL_0e38: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0e3d: ldloc.0
-				IL_0e3e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0e43: stloc.s 12
-				IL_0e45: ldarg.0
-				IL_0e46: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
-				IL_0e4b: stloc.s 10
-				IL_0e4d: ldarg.0
-				IL_0e4e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-				IL_0e53: ldloc.0
-				IL_0e54: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0e59: ldstr "V"
-				IL_0e5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0e63: stloc.s 13
-				IL_0e65: ldnull
-				IL_0e66: ldloc.s 10
-				IL_0e68: ldloc.s 13
-				IL_0e6a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, object, object)
-				IL_0e6f: stloc.s 10
-				IL_0e71: ldloc.s 12
-				IL_0e73: ldstr "V"
-				IL_0e78: ldloc.s 10
-				IL_0e7a: ldc.i4.1
-				IL_0e7b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0e80: pop
-				IL_0e81: ldloc.0
-				IL_0e82: ldc.r8 1
-				IL_0e8b: add
-				IL_0e8c: stloc.0
-				IL_0e8d: br IL_0e20
+				IL_0e78: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Init/Scope/Block_L324C23::.ctor()
+				IL_0e7d: stloc.1
+				IL_0e7e: ldarg.0
+				IL_0e7f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0e84: ldloc.0
+				IL_0e85: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0e8a: stloc.s 14
+				IL_0e8c: ldarg.0
+				IL_0e8d: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::VMulti
+				IL_0e92: stloc.s 13
+				IL_0e94: ldc.i4.1
+				IL_0e95: newarr [System.Runtime]System.Object
+				IL_0e9a: dup
+				IL_0e9b: ldc.i4.0
+				IL_0e9c: ldarg.0
+				IL_0e9d: stelem.ref
+				IL_0e9e: stloc.s 12
+				IL_0ea0: ldarg.0
+				IL_0ea1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::MTrans
+				IL_0ea6: stloc.s 5
+				IL_0ea8: ldloc.s 13
+				IL_0eaa: ldloc.s 12
+				IL_0eac: ldloc.s 5
+				IL_0eae: ldarg.0
+				IL_0eaf: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+				IL_0eb4: ldloc.0
+				IL_0eb5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0eba: ldstr "V"
+				IL_0ebf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0ec4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0ec9: stloc.s 13
+				IL_0ecb: ldloc.s 14
+				IL_0ecd: ldstr "V"
+				IL_0ed2: ldloc.s 13
+				IL_0ed4: ldc.i4.1
+				IL_0ed5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0eda: pop
+				IL_0edb: ldloc.0
+				IL_0edc: ldc.r8 1
+				IL_0ee5: add
+				IL_0ee6: stloc.0
+				IL_0ee7: br IL_0e67
 			// end loop
 
-			IL_0e92: ldarg.0
-			IL_0e93: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0e98: ldnull
-			IL_0e99: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-			IL_0e9e: pop
-			IL_0e9f: ldarg.0
-			IL_0ea0: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
-			IL_0ea5: stloc.s 12
-			IL_0ea7: ldloc.s 12
-			IL_0ea9: ldstr "Init"
-			IL_0eae: ldc.i4.1
-			IL_0eaf: box [System.Runtime]System.Boolean
-			IL_0eb4: ldc.i4.1
-			IL_0eb5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0eba: pop
-			IL_0ebb: ldarg.0
-			IL_0ebc: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0ec1: ldnull
-			IL_0ec2: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-			IL_0ec7: pop
-			IL_0ec8: ldnull
-			IL_0ec9: ret
+			IL_0eec: ldarg.0
+			IL_0eed: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::DrawQube
+			IL_0ef2: ldc.i4.1
+			IL_0ef3: newarr [System.Runtime]System.Object
+			IL_0ef8: dup
+			IL_0ef9: ldc.i4.0
+			IL_0efa: ldarg.0
+			IL_0efb: stelem.ref
+			IL_0efc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0f01: pop
+			IL_0f02: ldarg.0
+			IL_0f03: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Testing
+			IL_0f08: stloc.s 13
+			IL_0f0a: ldloc.s 13
+			IL_0f0c: ldstr "Init"
+			IL_0f11: ldc.i4.1
+			IL_0f12: box [System.Runtime]System.Boolean
+			IL_0f17: ldc.i4.1
+			IL_0f18: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0f1d: pop
+			IL_0f1e: ldarg.0
+			IL_0f1f: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Loop
+			IL_0f24: ldc.i4.1
+			IL_0f25: newarr [System.Runtime]System.Object
+			IL_0f2a: dup
+			IL_0f2b: ldc.i4.0
+			IL_0f2c: ldarg.0
+			IL_0f2d: stelem.ref
+			IL_0f2e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0f33: pop
+			IL_0f34: ldnull
+			IL_0f35: ret
 		} // end of method Init::__js_call__
 
 	} // end of class Init
@@ -6355,7 +6692,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x5fc7
+				// Method begins at RVA 0x6251
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -6381,33 +6718,44 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x5d40
+			// Method begins at RVA 0x5fb8
 			// Header size: 12
-			// Code size: 50 (0x32)
+			// Code size: 68 (0x44)
 			.maxstack 8
 			.locals init (
 				[0] object,
-				[1] object
+				[1] object,
+				[2] object[]
 			)
 
 			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-			IL_0006: ldnull
-			IL_0007: ldc.r8 20
-			IL_0010: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
-			IL_0015: pop
-			IL_0016: ldarg.0
-			IL_0017: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-			IL_0021: stloc.1
-			IL_0022: ldloc.1
-			IL_0023: stloc.0
-			IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0029: ldloc.0
-			IL_002a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_002f: pop
-			IL_0030: ldnull
-			IL_0031: ret
+			IL_0001: ldfld object Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Init
+			IL_0006: stloc.1
+			IL_0007: ldc.i4.1
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: dup
+			IL_000e: ldc.i4.0
+			IL_000f: ldarg.0
+			IL_0010: stelem.ref
+			IL_0011: stloc.2
+			IL_0012: ldloc.1
+			IL_0013: ldloc.2
+			IL_0014: ldc.r8 20
+			IL_001d: box [System.Runtime]System.Double
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0027: pop
+			IL_0028: ldarg.0
+			IL_0029: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::Q
+			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+			IL_0033: stloc.1
+			IL_0034: ldloc.1
+			IL_0035: stloc.0
+			IL_0036: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_003b: ldloc.0
+			IL_003c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0041: pop
+			IL_0042: ldnull
+			IL_0043: ret
 		} // end of method FunctionExpression_L334C23::__js_call__
 
 	} // end of class FunctionExpression_L334C23
@@ -6456,7 +6804,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x5d7e
+			// Method begins at RVA 0x6008
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -6482,7 +6830,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1121 (0x461)
+		// Code size: 1145 (0x479)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope,
@@ -6493,7 +6841,8 @@
 			[5] object,
 			[6] object,
 			[7] object,
-			[8] object
+			[8] object,
+			[9] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::.ctor()
@@ -6881,38 +7230,45 @@
 		IL_0407: ldc.i4.1
 		IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
 		IL_040d: pop
-		IL_040e: ldnull
-		IL_040f: ldstr "dromaeo-3d-cube"
-		IL_0414: ldstr "979cd0f1"
-		IL_0419: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
-		IL_041e: pop
-		IL_041f: ldc.i4.1
-		IL_0420: newarr [System.Runtime]System.Object
-		IL_0425: dup
-		IL_0426: ldc.i4.0
-		IL_0427: ldloc.0
-		IL_0428: stelem.ref
-		IL_0429: ldc.i4.0
-		IL_042a: ldelem.ref
-		IL_042b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_0430: ldftn object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-		IL_0436: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_043b: ldc.i4.0
-		IL_043c: conv.r8
-		IL_043d: ldstr ""
-		IL_0442: ldc.i4.0
-		IL_0443: ldc.i4.1
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0449: stloc.s 8
-		IL_044b: ldnull
-		IL_044c: ldstr "Rotate 3D Cube"
-		IL_0451: ldloc.s 8
-		IL_0453: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, object, object)
-		IL_0458: pop
-		IL_0459: ldnull
-		IL_045a: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
-		IL_045f: pop
-		IL_0460: ret
+		IL_040e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0413: stloc.s 9
+		IL_0415: ldloc.1
+		IL_0416: ldloc.s 9
+		IL_0418: ldstr "dromaeo-3d-cube"
+		IL_041d: ldstr "979cd0f1"
+		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0427: pop
+		IL_0428: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_042d: stloc.s 9
+		IL_042f: ldc.i4.1
+		IL_0430: newarr [System.Runtime]System.Object
+		IL_0435: dup
+		IL_0436: ldc.i4.0
+		IL_0437: ldloc.0
+		IL_0438: stelem.ref
+		IL_0439: ldc.i4.0
+		IL_043a: ldelem.ref
+		IL_043b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
+		IL_0440: ldftn object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+		IL_0446: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_044b: ldc.i4.0
+		IL_044c: conv.r8
+		IL_044d: ldstr ""
+		IL_0452: ldc.i4.0
+		IL_0453: ldc.i4.1
+		IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0459: stloc.s 8
+		IL_045b: ldloc.s 4
+		IL_045d: ldloc.s 9
+		IL_045f: ldstr "Rotate 3D Cube"
+		IL_0464: ldloc.s 8
+		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_046b: pop
+		IL_046c: ldloc.2
+		IL_046d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0477: pop
+		IL_0478: ret
 	} // end of method Compile_Resources_Dromaeo_3d_Cube::__js_module_init__
 
 } // end of class Modules.Compile_Resources_Dromaeo_3d_Cube
@@ -6924,7 +7280,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x5fd0
+		// Method begins at RVA 0x625a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36fe
+				// Method begins at RVA 0x3898
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24a0
+			// Method begins at RVA 0x249c
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -80,7 +80,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3707
+				// Method begins at RVA 0x38a1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -108,7 +108,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x24cc
+			// Method begins at RVA 0x24c8
 			// Header size: 12
 			// Code size: 33 (0x21)
 			.maxstack 8
@@ -144,7 +144,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3710
+				// Method begins at RVA 0x38aa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -168,7 +168,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24fc
+			// Method begins at RVA 0x24f8
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -256,7 +256,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3722
+					// Method begins at RVA 0x38bc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -280,7 +280,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x35e4
+				// Method begins at RVA 0x373c
 				// Header size: 12
 				// Code size: 30 (0x1e)
 				.maxstack 8
@@ -320,7 +320,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x372b
+					// Method begins at RVA 0x38c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3610
+				// Method begins at RVA 0x3768
 				// Header size: 12
 				// Code size: 16 (0x10)
 				.maxstack 8
@@ -376,7 +376,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3734
+					// Method begins at RVA 0x38ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -394,7 +394,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3719
+				// Method begins at RVA 0x38b3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -419,7 +419,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x258c
+			// Method begins at RVA 0x2588
 			// Header size: 12
 			// Code size: 950 (0x3b6)
 			.maxstack 8
@@ -819,7 +819,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x373d
+				// Method begins at RVA 0x38d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -847,7 +847,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2960
+			// Method begins at RVA 0x295c
 			// Header size: 12
 			// Code size: 224 (0xe0)
 			.maxstack 8
@@ -977,7 +977,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x374f
+					// Method begins at RVA 0x38e9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -995,7 +995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3746
+				// Method begins at RVA 0x38e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1020,7 +1020,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a4c
+			// Method begins at RVA 0x2a48
 			// Header size: 12
 			// Code size: 195 (0xc3)
 			.maxstack 8
@@ -1120,7 +1120,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3761
+					// Method begins at RVA 0x38fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1138,7 +1138,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3758
+				// Method begins at RVA 0x38f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1163,7 +1163,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2b1c
+			// Method begins at RVA 0x2b18
 			// Header size: 12
 			// Code size: 171 (0xab)
 			.maxstack 8
@@ -1260,7 +1260,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3773
+					// Method begins at RVA 0x390d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1278,7 +1278,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x376a
+				// Method begins at RVA 0x3904
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1305,7 +1305,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2bd4
+			// Method begins at RVA 0x2bd0
 			// Header size: 12
 			// Code size: 541 (0x21d)
 			.maxstack 8
@@ -1518,7 +1518,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x377c
+				// Method begins at RVA 0x3916
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1542,7 +1542,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e00
+			// Method begins at RVA 0x2dfc
 			// Header size: 12
 			// Code size: 57 (0x39)
 			.maxstack 8
@@ -1598,7 +1598,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x378e
+					// Method begins at RVA 0x3928
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1623,16 +1623,17 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x362c
+				// Method begins at RVA 0x3784
 				// Header size: 12
-				// Code size: 102 (0x66)
+				// Code size: 136 (0x88)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] float64,
 					[2] bool,
 					[3] object,
-					[4] object
+					[4] object[],
+					[5] object
 				)
 
 				IL_0000: ldarg.2
@@ -1660,25 +1661,45 @@
 				IL_003b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0040: stloc.2
 				IL_0041: ldloc.2
-				IL_0042: brfalse IL_0064
+				IL_0042: brfalse IL_0086
 
-				IL_0047: ldnull
-				IL_0048: ldarg.2
-				IL_0049: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
-				IL_004e: stloc.0
-				IL_004f: ldloc.0
-				IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0055: ldc.i4.0
-				IL_0056: ceq
-				IL_0058: stloc.2
-				IL_0059: ldloc.2
-				IL_005a: box [System.Runtime]System.Boolean
-				IL_005f: stloc.s 4
-				IL_0061: ldloc.s 4
-				IL_0063: ret
+				IL_0047: ldc.i4.2
+				IL_0048: newarr [System.Runtime]System.Object
+				IL_004d: dup
+				IL_004e: ldc.i4.0
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.0
+				IL_0051: ldelem.ref
+				IL_0052: stelem.ref
+				IL_0053: dup
+				IL_0054: ldc.i4.1
+				IL_0055: ldarg.0
+				IL_0056: ldc.i4.1
+				IL_0057: ldelem.ref
+				IL_0058: stelem.ref
+				IL_0059: stloc.s 4
+				IL_005b: ldarg.0
+				IL_005c: ldc.i4.0
+				IL_005d: ldelem.ref
+				IL_005e: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0063: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_0068: ldloc.s 4
+				IL_006a: ldarg.2
+				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0070: stloc.0
+				IL_0071: ldloc.0
+				IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0077: ldc.i4.0
+				IL_0078: ceq
+				IL_007a: stloc.2
+				IL_007b: ldloc.2
+				IL_007c: box [System.Runtime]System.Boolean
+				IL_0081: stloc.s 5
+				IL_0083: ldloc.s 5
+				IL_0085: ret
 
-				IL_0064: ldloc.3
-				IL_0065: ret
+				IL_0086: ldloc.3
+				IL_0087: ret
 			} // end of method ArrowFunction_L113C44::__js_call__
 
 		} // end of class ArrowFunction_L113C44
@@ -1690,7 +1711,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3785
+				// Method begins at RVA 0x391f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1718,7 +1739,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2e48
+			// Method begins at RVA 0x2e44
 			// Header size: 12
 			// Code size: 375 (0x177)
 			.maxstack 8
@@ -1885,7 +1906,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37a9
+					// Method begins at RVA 0x3943
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1910,15 +1931,16 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36a0
+				// Method begins at RVA 0x3818
 				// Header size: 12
-				// Code size: 73 (0x49)
+				// Code size: 107 (0x6b)
 				.maxstack 8
 				.locals init (
 					[0] object,
 					[1] bool,
-					[2] object,
-					[3] object
+					[2] object[],
+					[3] object,
+					[4] object
 				)
 
 				IL_0000: ldarg.2
@@ -1936,25 +1958,45 @@
 				IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_0025: stloc.1
 				IL_0026: ldloc.1
-				IL_0027: brfalse IL_0047
+				IL_0027: brfalse IL_0069
 
-				IL_002c: ldnull
-				IL_002d: ldarg.2
-				IL_002e: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
-				IL_0033: stloc.2
-				IL_0034: ldloc.2
-				IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_003a: ldc.i4.0
-				IL_003b: ceq
-				IL_003d: stloc.1
-				IL_003e: ldloc.1
-				IL_003f: box [System.Runtime]System.Boolean
-				IL_0044: stloc.3
-				IL_0045: ldloc.3
-				IL_0046: ret
+				IL_002c: ldc.i4.2
+				IL_002d: newarr [System.Runtime]System.Object
+				IL_0032: dup
+				IL_0033: ldc.i4.0
+				IL_0034: ldarg.0
+				IL_0035: ldc.i4.0
+				IL_0036: ldelem.ref
+				IL_0037: stelem.ref
+				IL_0038: dup
+				IL_0039: ldc.i4.1
+				IL_003a: ldarg.0
+				IL_003b: ldc.i4.1
+				IL_003c: ldelem.ref
+				IL_003d: stelem.ref
+				IL_003e: stloc.2
+				IL_003f: ldarg.0
+				IL_0040: ldc.i4.0
+				IL_0041: ldelem.ref
+				IL_0042: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0047: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_004c: ldloc.2
+				IL_004d: ldarg.2
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0053: stloc.3
+				IL_0054: ldloc.3
+				IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_005a: ldc.i4.0
+				IL_005b: ceq
+				IL_005d: stloc.1
+				IL_005e: ldloc.1
+				IL_005f: box [System.Runtime]System.Boolean
+				IL_0064: stloc.s 4
+				IL_0066: ldloc.s 4
+				IL_0068: ret
 
-				IL_0047: ldloc.0
-				IL_0048: ret
+				IL_0069: ldloc.0
+				IL_006a: ret
 			} // end of method ArrowFunction_L136C51::__js_call__
 
 		} // end of class ArrowFunction_L136C51
@@ -1970,7 +2012,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37a0
+					// Method begins at RVA 0x393a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1990,7 +2032,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x37b2
+					// Method begins at RVA 0x394c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2008,7 +2050,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3797
+				// Method begins at RVA 0x3931
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2034,9 +2076,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
-			// Method begins at RVA 0x2fcc
+			// Method begins at RVA 0x2fc8
 			// Header size: 12
-			// Code size: 1548 (0x60c)
+			// Code size: 1893 (0x765)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -2072,14 +2114,15 @@
 				[30] object,
 				[31] object,
 				[32] object,
-				[33] bool,
-				[34] string,
-				[35] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[36] object,
+				[33] object[],
+				[34] bool,
+				[35] string,
+				[36] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[37] object,
 				[38] object,
 				[39] object,
-				[40] string
+				[40] object,
+				[41] string
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope::.ctor()
@@ -2102,540 +2145,717 @@
 			IL_004b: stloc.s 32
 			IL_004d: ldloc.s 32
 			IL_004f: stloc.2
-			IL_0050: ldarg.0
-			IL_0051: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0056: stloc.s 32
+			IL_0050: ldc.i4.1
+			IL_0051: newarr [System.Runtime]System.Object
+			IL_0056: dup
+			IL_0057: ldc.i4.0
 			IL_0058: ldarg.0
-			IL_0059: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_005e: ldnull
-			IL_005f: ldloc.s 32
-			IL_0061: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0066: stloc.s 32
-			IL_0068: ldloc.s 32
-			IL_006a: stloc.3
-			IL_006b: ldarg.0
-			IL_006c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0071: stloc.s 32
-			IL_0073: ldarg.0
-			IL_0074: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0079: ldnull
-			IL_007a: ldloc.s 32
-			IL_007c: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0081: stloc.s 32
-			IL_0083: ldloc.s 32
-			IL_0085: stloc.s 4
-			IL_0087: ldarg.0
-			IL_0088: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_008d: stloc.s 32
-			IL_008f: ldarg.0
-			IL_0090: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0095: ldnull
-			IL_0096: ldloc.s 32
-			IL_0098: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_009d: stloc.s 32
-			IL_009f: ldloc.s 32
-			IL_00a1: stloc.s 5
-			IL_00a3: ldarg.0
-			IL_00a4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_00a9: stloc.s 32
-			IL_00ab: ldarg.0
-			IL_00ac: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00b1: ldnull
-			IL_00b2: ldloc.s 32
-			IL_00b4: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_00b9: stloc.s 32
-			IL_00bb: ldloc.s 32
-			IL_00bd: stloc.s 6
-			IL_00bf: ldarg.0
-			IL_00c0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_00c5: stloc.s 32
-			IL_00c7: ldarg.0
-			IL_00c8: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00cd: ldnull
-			IL_00ce: ldloc.s 32
-			IL_00d0: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_00d5: stloc.s 32
-			IL_00d7: ldloc.s 32
-			IL_00d9: stloc.s 7
-			IL_00db: ldarg.0
-			IL_00dc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_00e1: stloc.s 32
-			IL_00e3: ldarg.0
-			IL_00e4: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00e9: ldnull
-			IL_00ea: ldloc.s 32
-			IL_00ec: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_00f1: stloc.s 32
-			IL_00f3: ldloc.s 32
-			IL_00f5: stloc.s 8
-			IL_00f7: ldnull
-			IL_00f8: ldloc.3
-			IL_00f9: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
-			IL_00fe: stloc.s 32
-			IL_0100: ldloc.s 32
-			IL_0102: stloc.s 9
-			IL_0104: ldarg.0
-			IL_0105: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_010a: ldnull
-			IL_010b: ldloc.1
-			IL_010c: ldloc.s 9
-			IL_010e: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0113: stloc.s 32
-			IL_0115: ldloc.s 32
-			IL_0117: stloc.s 10
-			IL_0119: ldloc.s 9
-			IL_011b: ldloc.s 10
-			IL_011d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0122: stloc.s 33
-			IL_0124: ldloc.s 33
-			IL_0126: brfalse IL_018b
+			IL_0059: stelem.ref
+			IL_005a: stloc.s 33
+			IL_005c: ldarg.0
+			IL_005d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0062: ldloc.s 33
+			IL_0064: ldarg.0
+			IL_0065: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_006f: stloc.s 32
+			IL_0071: ldloc.s 32
+			IL_0073: stloc.3
+			IL_0074: ldc.i4.1
+			IL_0075: newarr [System.Runtime]System.Object
+			IL_007a: dup
+			IL_007b: ldc.i4.0
+			IL_007c: ldarg.0
+			IL_007d: stelem.ref
+			IL_007e: stloc.s 33
+			IL_0080: ldarg.0
+			IL_0081: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0086: ldloc.s 33
+			IL_0088: ldarg.0
+			IL_0089: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0093: stloc.s 32
+			IL_0095: ldloc.s 32
+			IL_0097: stloc.s 4
+			IL_0099: ldc.i4.1
+			IL_009a: newarr [System.Runtime]System.Object
+			IL_009f: dup
+			IL_00a0: ldc.i4.0
+			IL_00a1: ldarg.0
+			IL_00a2: stelem.ref
+			IL_00a3: stloc.s 33
+			IL_00a5: ldarg.0
+			IL_00a6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00ab: ldloc.s 33
+			IL_00ad: ldarg.0
+			IL_00ae: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00b8: stloc.s 32
+			IL_00ba: ldloc.s 32
+			IL_00bc: stloc.s 5
+			IL_00be: ldc.i4.1
+			IL_00bf: newarr [System.Runtime]System.Object
+			IL_00c4: dup
+			IL_00c5: ldc.i4.0
+			IL_00c6: ldarg.0
+			IL_00c7: stelem.ref
+			IL_00c8: stloc.s 33
+			IL_00ca: ldarg.0
+			IL_00cb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00d0: ldloc.s 33
+			IL_00d2: ldarg.0
+			IL_00d3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00dd: stloc.s 32
+			IL_00df: ldloc.s 32
+			IL_00e1: stloc.s 6
+			IL_00e3: ldc.i4.1
+			IL_00e4: newarr [System.Runtime]System.Object
+			IL_00e9: dup
+			IL_00ea: ldc.i4.0
+			IL_00eb: ldarg.0
+			IL_00ec: stelem.ref
+			IL_00ed: stloc.s 33
+			IL_00ef: ldarg.0
+			IL_00f0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00f5: ldloc.s 33
+			IL_00f7: ldarg.0
+			IL_00f8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0102: stloc.s 32
+			IL_0104: ldloc.s 32
+			IL_0106: stloc.s 7
+			IL_0108: ldc.i4.1
+			IL_0109: newarr [System.Runtime]System.Object
+			IL_010e: dup
+			IL_010f: ldc.i4.0
+			IL_0110: ldarg.0
+			IL_0111: stelem.ref
+			IL_0112: stloc.s 33
+			IL_0114: ldarg.0
+			IL_0115: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_011a: ldloc.s 33
+			IL_011c: ldarg.0
+			IL_011d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0127: stloc.s 32
+			IL_0129: ldloc.s 32
+			IL_012b: stloc.s 8
+			IL_012d: ldarg.0
+			IL_012e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
+			IL_0133: ldc.i4.1
+			IL_0134: newarr [System.Runtime]System.Object
+			IL_0139: dup
+			IL_013a: ldc.i4.0
+			IL_013b: ldarg.0
+			IL_013c: stelem.ref
+			IL_013d: ldloc.3
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0143: stloc.s 32
+			IL_0145: ldloc.s 32
+			IL_0147: stloc.s 9
+			IL_0149: ldarg.0
+			IL_014a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
+			IL_014f: ldc.i4.1
+			IL_0150: newarr [System.Runtime]System.Object
+			IL_0155: dup
+			IL_0156: ldc.i4.0
+			IL_0157: ldarg.0
+			IL_0158: stelem.ref
+			IL_0159: ldloc.1
+			IL_015a: ldloc.s 9
+			IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0161: stloc.s 32
+			IL_0163: ldloc.s 32
+			IL_0165: stloc.s 10
+			IL_0167: ldloc.s 9
+			IL_0169: ldloc.s 10
+			IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0170: stloc.s 34
+			IL_0172: ldloc.s 34
+			IL_0174: brfalse IL_01d9
 
-			IL_012b: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
-			IL_0130: stloc.s 11
-			IL_0132: ldloc.s 9
-			IL_0134: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0139: stloc.s 34
-			IL_013b: ldstr "Version unchanged ("
-			IL_0140: ldloc.s 34
-			IL_0142: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0147: stloc.s 34
-			IL_0149: ldloc.s 34
-			IL_014b: ldstr "); aborting."
-			IL_0150: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0155: stloc.s 34
-			IL_0157: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_015c: ldloc.s 34
-			IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_0163: pop
-			IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016e: stloc.s 32
-			IL_0170: ldloc.s 32
-			IL_0172: ldstr "exit"
-			IL_0177: ldc.r8 1
-			IL_0180: box [System.Runtime]System.Double
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_018a: pop
+			IL_0179: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L130C36::.ctor()
+			IL_017e: stloc.s 11
+			IL_0180: ldloc.s 9
+			IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0187: stloc.s 35
+			IL_0189: ldstr "Version unchanged ("
+			IL_018e: ldloc.s 35
+			IL_0190: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0195: stloc.s 35
+			IL_0197: ldloc.s 35
+			IL_0199: ldstr "); aborting."
+			IL_019e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01a3: stloc.s 35
+			IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01aa: ldloc.s 35
+			IL_01ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_01b1: pop
+			IL_01b2: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bc: stloc.s 32
+			IL_01be: ldloc.s 32
+			IL_01c0: ldstr "exit"
+			IL_01c5: ldc.r8 1
+			IL_01ce: box [System.Runtime]System.Double
+			IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01d8: pop
 
-			IL_018b: ldarg.0
-			IL_018c: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0191: ldnull
-			IL_0192: ldloc.s 8
-			IL_0194: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-			IL_0199: stloc.s 32
-			IL_019b: ldloc.s 32
-			IL_019d: brfalse IL_01ae
-
-			IL_01a2: ldloc.s 32
-			IL_01a4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_01a9: brfalse IL_01bf
-
-			IL_01ae: ldloc.s 32
-			IL_01b0: ldstr ""
-			IL_01b5: ldstr "body"
-			IL_01ba: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
-
-			IL_01bf: ldloc.s 32
-			IL_01c1: ldstr "body"
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01cb: stloc.s 12
-			IL_01cd: ldloc.s 32
-			IL_01cf: ldstr "start"
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d9: stloc.s 13
-			IL_01db: ldloc.s 32
-			IL_01dd: ldstr "end"
-			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e7: stloc.s 14
-			IL_01e9: ldloc.s 12
-			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01d9: ldarg.0
+			IL_01da: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
+			IL_01df: ldc.i4.1
+			IL_01e0: newarr [System.Runtime]System.Object
+			IL_01e5: dup
+			IL_01e6: ldc.i4.0
+			IL_01e7: ldarg.0
+			IL_01e8: stelem.ref
+			IL_01e9: ldloc.s 8
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
 			IL_01f0: stloc.s 32
-			IL_01f2: ldstr "\\r?\\n"
-			IL_01f7: ldstr ""
-			IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0201: stloc.s 35
-			IL_0203: ldloc.s 32
-			IL_0205: ldstr "split"
-			IL_020a: ldloc.s 35
-			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0211: stloc.s 32
-			IL_0213: ldloc.s 32
-			IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021a: stloc.s 32
-			IL_021c: ldnull
-			IL_021d: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
-			IL_0223: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0228: ldc.i4.2
-			IL_0229: newarr [System.Runtime]System.Object
-			IL_022e: dup
-			IL_022f: ldc.i4.0
-			IL_0230: ldarg.0
-			IL_0231: stelem.ref
-			IL_0232: dup
-			IL_0233: ldc.i4.1
-			IL_0234: ldloc.0
-			IL_0235: stelem.ref
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0240: ldc.i4.1
-			IL_0241: conv.r8
-			IL_0242: ldstr ""
-			IL_0247: ldc.i4.0
-			IL_0248: ldc.i4.1
-			IL_0249: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0253: stloc.s 36
-			IL_0255: ldloc.s 32
-			IL_0257: ldstr "some"
-			IL_025c: ldloc.s 36
-			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0263: stloc.s 36
-			IL_0265: ldloc.s 36
-			IL_0267: stloc.s 15
-			IL_0269: ldloc.s 15
-			IL_026b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0270: ldc.i4.0
-			IL_0271: ceq
-			IL_0273: stloc.s 33
-			IL_0275: ldloc.s 33
-			IL_0277: box [System.Runtime]System.Boolean
-			IL_027c: stloc.s 37
-			IL_027e: ldloc.s 37
-			IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0285: stloc.s 33
-			IL_0287: ldloc.s 33
-			IL_0289: brfalse IL_0296
+			IL_01f2: ldloc.s 32
+			IL_01f4: brfalse IL_0205
 
-			IL_028e: ldloc.2
-			IL_028f: stloc.s 39
-			IL_0291: br IL_029a
+			IL_01f9: ldloc.s 32
+			IL_01fb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0200: brfalse IL_0216
 
-			IL_0296: ldloc.s 37
-			IL_0298: stloc.s 39
+			IL_0205: ldloc.s 32
+			IL_0207: ldstr ""
+			IL_020c: ldstr "body"
+			IL_0211: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_029a: ldloc.s 39
-			IL_029c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02a1: stloc.s 33
-			IL_02a3: ldloc.s 33
-			IL_02a5: brfalse IL_038f
+			IL_0216: ldloc.s 32
+			IL_0218: ldstr "body"
+			IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0222: stloc.s 12
+			IL_0224: ldloc.s 32
+			IL_0226: ldstr "start"
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0230: stloc.s 13
+			IL_0232: ldloc.s 32
+			IL_0234: ldstr "end"
+			IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023e: stloc.s 14
+			IL_0240: ldloc.s 12
+			IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0247: stloc.s 32
+			IL_0249: ldstr "\\r?\\n"
+			IL_024e: ldstr ""
+			IL_0253: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0258: stloc.s 36
+			IL_025a: ldloc.s 32
+			IL_025c: ldstr "split"
+			IL_0261: ldloc.s 36
+			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0268: stloc.s 32
+			IL_026a: ldloc.s 32
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0271: stloc.s 32
+			IL_0273: ldnull
+			IL_0274: ldftn object Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51::__js_call__(object[], object, object)
+			IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_027f: ldc.i4.2
+			IL_0280: newarr [System.Runtime]System.Object
+			IL_0285: dup
+			IL_0286: ldc.i4.0
+			IL_0287: ldarg.0
+			IL_0288: stelem.ref
+			IL_0289: dup
+			IL_028a: ldc.i4.1
+			IL_028b: ldloc.0
+			IL_028c: stelem.ref
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0297: ldc.i4.1
+			IL_0298: conv.r8
+			IL_0299: ldstr ""
+			IL_029e: ldc.i4.0
+			IL_029f: ldc.i4.1
+			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_02aa: stloc.s 37
+			IL_02ac: ldloc.s 32
+			IL_02ae: ldstr "some"
+			IL_02b3: ldloc.s 37
+			IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_02ba: stloc.s 37
+			IL_02bc: ldloc.s 37
+			IL_02be: stloc.s 15
+			IL_02c0: ldloc.s 15
+			IL_02c2: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02c7: ldc.i4.0
+			IL_02c8: ceq
+			IL_02ca: stloc.s 34
+			IL_02cc: ldloc.s 34
+			IL_02ce: box [System.Runtime]System.Boolean
+			IL_02d3: stloc.s 38
+			IL_02d5: ldloc.s 38
+			IL_02d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02dc: stloc.s 34
+			IL_02de: ldloc.s 34
+			IL_02e0: brfalse IL_02ed
 
-			IL_02aa: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
-			IL_02af: stloc.s 16
-			IL_02b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02b6: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_02bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02c0: pop
-			IL_02c1: ldnull
-			IL_02c2: ldloc.3
-			IL_02c3: ldloc.s 10
-			IL_02c5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_02ca: stloc.s 36
-			IL_02cc: ldloc.s 36
-			IL_02ce: stloc.s 17
-			IL_02d0: ldnull
-			IL_02d1: ldloc.s 4
-			IL_02d3: ldloc.s 10
-			IL_02d5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_02da: stloc.s 36
-			IL_02dc: ldloc.s 36
-			IL_02de: stloc.s 18
-			IL_02e0: ldnull
-			IL_02e1: ldloc.s 5
-			IL_02e3: ldloc.s 10
-			IL_02e5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_02ea: stloc.s 36
-			IL_02ec: ldloc.s 36
-			IL_02ee: stloc.s 19
-			IL_02f0: ldnull
-			IL_02f1: ldloc.s 6
-			IL_02f3: ldloc.s 10
-			IL_02f5: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_02fa: stloc.s 36
-			IL_02fc: ldloc.s 36
-			IL_02fe: stloc.s 20
-			IL_0300: ldnull
-			IL_0301: ldloc.s 7
-			IL_0303: ldloc.s 10
-			IL_0305: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-			IL_030a: stloc.s 36
-			IL_030c: ldloc.s 36
-			IL_030e: stloc.s 21
-			IL_0310: ldarg.0
-			IL_0311: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0316: stloc.s 36
+			IL_02e5: ldloc.2
+			IL_02e6: stloc.s 40
+			IL_02e8: br IL_02f1
+
+			IL_02ed: ldloc.s 38
+			IL_02ef: stloc.s 40
+
+			IL_02f1: ldloc.s 40
+			IL_02f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02f8: stloc.s 34
+			IL_02fa: ldloc.s 34
+			IL_02fc: brfalse IL_045e
+
+			IL_0301: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/Scope/Block_L137C35::.ctor()
+			IL_0306: stloc.s 16
+			IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_030d: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_0312: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0317: pop
 			IL_0318: ldarg.0
-			IL_0319: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_031e: ldnull
-			IL_031f: ldloc.s 36
-			IL_0321: ldloc.s 17
-			IL_0323: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0328: pop
-			IL_0329: ldarg.0
-			IL_032a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_032f: stloc.s 36
-			IL_0331: ldarg.0
-			IL_0332: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0337: ldnull
-			IL_0338: ldloc.s 36
-			IL_033a: ldloc.s 18
-			IL_033c: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0341: pop
-			IL_0342: ldarg.0
-			IL_0343: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_0348: stloc.s 36
-			IL_034a: ldarg.0
-			IL_034b: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0350: ldnull
-			IL_0351: ldloc.s 36
-			IL_0353: ldloc.s 19
-			IL_0355: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_035a: pop
-			IL_035b: ldarg.0
-			IL_035c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0361: stloc.s 36
+			IL_0319: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_031e: ldc.i4.1
+			IL_031f: newarr [System.Runtime]System.Object
+			IL_0324: dup
+			IL_0325: ldc.i4.0
+			IL_0326: ldarg.0
+			IL_0327: stelem.ref
+			IL_0328: ldloc.3
+			IL_0329: ldloc.s 10
+			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0330: stloc.s 37
+			IL_0332: ldloc.s 37
+			IL_0334: stloc.s 17
+			IL_0336: ldarg.0
+			IL_0337: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_033c: ldc.i4.1
+			IL_033d: newarr [System.Runtime]System.Object
+			IL_0342: dup
+			IL_0343: ldc.i4.0
+			IL_0344: ldarg.0
+			IL_0345: stelem.ref
+			IL_0346: ldloc.s 4
+			IL_0348: ldloc.s 10
+			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_034f: stloc.s 37
+			IL_0351: ldloc.s 37
+			IL_0353: stloc.s 18
+			IL_0355: ldarg.0
+			IL_0356: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_035b: ldc.i4.1
+			IL_035c: newarr [System.Runtime]System.Object
+			IL_0361: dup
+			IL_0362: ldc.i4.0
 			IL_0363: ldarg.0
-			IL_0364: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0369: ldnull
-			IL_036a: ldloc.s 36
-			IL_036c: ldloc.s 20
-			IL_036e: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0373: pop
+			IL_0364: stelem.ref
+			IL_0365: ldloc.s 5
+			IL_0367: ldloc.s 10
+			IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_036e: stloc.s 37
+			IL_0370: ldloc.s 37
+			IL_0372: stloc.s 19
 			IL_0374: ldarg.0
-			IL_0375: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_037a: stloc.s 36
-			IL_037c: ldarg.0
-			IL_037d: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0382: ldnull
-			IL_0383: ldloc.s 36
-			IL_0385: ldloc.s 21
-			IL_0387: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_038c: pop
-			IL_038d: ldnull
-			IL_038e: ret
+			IL_0375: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_037a: ldc.i4.1
+			IL_037b: newarr [System.Runtime]System.Object
+			IL_0380: dup
+			IL_0381: ldc.i4.0
+			IL_0382: ldarg.0
+			IL_0383: stelem.ref
+			IL_0384: ldloc.s 6
+			IL_0386: ldloc.s 10
+			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_038d: stloc.s 37
+			IL_038f: ldloc.s 37
+			IL_0391: stloc.s 20
+			IL_0393: ldarg.0
+			IL_0394: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_0399: ldc.i4.1
+			IL_039a: newarr [System.Runtime]System.Object
+			IL_039f: dup
+			IL_03a0: ldc.i4.0
+			IL_03a1: ldarg.0
+			IL_03a2: stelem.ref
+			IL_03a3: ldloc.s 7
+			IL_03a5: ldloc.s 10
+			IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03ac: stloc.s 37
+			IL_03ae: ldloc.s 37
+			IL_03b0: stloc.s 21
+			IL_03b2: ldc.i4.1
+			IL_03b3: newarr [System.Runtime]System.Object
+			IL_03b8: dup
+			IL_03b9: ldc.i4.0
+			IL_03ba: ldarg.0
+			IL_03bb: stelem.ref
+			IL_03bc: stloc.s 33
+			IL_03be: ldarg.0
+			IL_03bf: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_03c4: ldloc.s 33
+			IL_03c6: ldarg.0
+			IL_03c7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_03cc: ldloc.s 17
+			IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03d3: pop
+			IL_03d4: ldc.i4.1
+			IL_03d5: newarr [System.Runtime]System.Object
+			IL_03da: dup
+			IL_03db: ldc.i4.0
+			IL_03dc: ldarg.0
+			IL_03dd: stelem.ref
+			IL_03de: stloc.s 33
+			IL_03e0: ldarg.0
+			IL_03e1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_03e6: ldloc.s 33
+			IL_03e8: ldarg.0
+			IL_03e9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_03ee: ldloc.s 18
+			IL_03f0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03f5: pop
+			IL_03f6: ldc.i4.1
+			IL_03f7: newarr [System.Runtime]System.Object
+			IL_03fc: dup
+			IL_03fd: ldc.i4.0
+			IL_03fe: ldarg.0
+			IL_03ff: stelem.ref
+			IL_0400: stloc.s 33
+			IL_0402: ldarg.0
+			IL_0403: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0408: ldloc.s 33
+			IL_040a: ldarg.0
+			IL_040b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0410: ldloc.s 19
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0417: pop
+			IL_0418: ldc.i4.1
+			IL_0419: newarr [System.Runtime]System.Object
+			IL_041e: dup
+			IL_041f: ldc.i4.0
+			IL_0420: ldarg.0
+			IL_0421: stelem.ref
+			IL_0422: stloc.s 33
+			IL_0424: ldarg.0
+			IL_0425: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_042a: ldloc.s 33
+			IL_042c: ldarg.0
+			IL_042d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0432: ldloc.s 20
+			IL_0434: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0439: pop
+			IL_043a: ldc.i4.1
+			IL_043b: newarr [System.Runtime]System.Object
+			IL_0440: dup
+			IL_0441: ldc.i4.0
+			IL_0442: ldarg.0
+			IL_0443: stelem.ref
+			IL_0444: stloc.s 33
+			IL_0446: ldarg.0
+			IL_0447: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_044c: ldloc.s 33
+			IL_044e: ldarg.0
+			IL_044f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_0454: ldloc.s 21
+			IL_0456: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_045b: pop
+			IL_045c: ldnull
+			IL_045d: ret
 
-			IL_038f: ldarg.0
-			IL_0390: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0395: ldnull
-			IL_0396: ldloc.s 10
-			IL_0398: ldloc.s 12
-			IL_039a: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_039f: stloc.s 36
-			IL_03a1: ldloc.s 36
-			IL_03a3: stloc.s 22
-			IL_03a5: ldloc.s 8
-			IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ac: stloc.s 36
-			IL_03ae: ldloc.s 36
-			IL_03b0: ldstr "slice"
-			IL_03b5: ldc.r8 0.0
-			IL_03be: box [System.Runtime]System.Double
-			IL_03c3: ldloc.s 13
-			IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03ca: stloc.s 36
-			IL_03cc: ldloc.s 36
-			IL_03ce: stloc.s 23
-			IL_03d0: ldloc.s 8
-			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03d7: stloc.s 36
-			IL_03d9: ldloc.s 36
-			IL_03db: ldstr "slice"
-			IL_03e0: ldloc.s 14
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_03e7: stloc.s 36
-			IL_03e9: ldloc.s 36
-			IL_03eb: stloc.s 24
-			IL_03ed: ldstr "\n_Nothing yet._\n\n"
-			IL_03f2: stloc.s 25
-			IL_03f4: ldloc.s 23
-			IL_03f6: ldloc.s 25
-			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_03fd: stloc.s 39
-			IL_03ff: ldloc.s 39
-			IL_0401: ldloc.s 22
-			IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0408: stloc.s 39
-			IL_040a: ldloc.s 39
-			IL_040c: ldloc.s 24
-			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0413: stloc.s 39
-			IL_0415: ldloc.s 39
-			IL_0417: stloc.s 26
-			IL_0419: ldnull
-			IL_041a: ldloc.3
-			IL_041b: ldloc.s 10
-			IL_041d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0422: stloc.s 36
-			IL_0424: ldloc.s 36
-			IL_0426: stloc.s 27
-			IL_0428: ldnull
-			IL_0429: ldloc.s 4
-			IL_042b: ldloc.s 10
-			IL_042d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0432: stloc.s 36
-			IL_0434: ldloc.s 36
-			IL_0436: stloc.s 28
-			IL_0438: ldnull
-			IL_0439: ldloc.s 5
-			IL_043b: ldloc.s 10
-			IL_043d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0442: stloc.s 36
-			IL_0444: ldloc.s 36
-			IL_0446: stloc.s 29
-			IL_0448: ldnull
-			IL_0449: ldloc.s 6
-			IL_044b: ldloc.s 10
-			IL_044d: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-			IL_0452: stloc.s 36
-			IL_0454: ldloc.s 36
-			IL_0456: stloc.s 30
-			IL_0458: ldnull
-			IL_0459: ldloc.s 7
-			IL_045b: ldloc.s 10
-			IL_045d: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-			IL_0462: stloc.s 36
-			IL_0464: ldloc.s 36
-			IL_0466: stloc.s 31
-			IL_0468: ldarg.0
-			IL_0469: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_046e: stloc.s 36
-			IL_0470: ldarg.0
-			IL_0471: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0476: ldnull
-			IL_0477: ldloc.s 36
-			IL_0479: ldloc.s 26
-			IL_047b: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0480: pop
-			IL_0481: ldarg.0
-			IL_0482: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0487: stloc.s 36
-			IL_0489: ldarg.0
-			IL_048a: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_048f: ldnull
-			IL_0490: ldloc.s 36
-			IL_0492: ldloc.s 27
-			IL_0494: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_0499: pop
-			IL_049a: ldarg.0
-			IL_049b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_04a0: stloc.s 36
-			IL_04a2: ldarg.0
-			IL_04a3: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_04a8: ldnull
-			IL_04a9: ldloc.s 36
-			IL_04ab: ldloc.s 28
-			IL_04ad: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_04b2: pop
-			IL_04b3: ldarg.0
-			IL_04b4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_04b9: stloc.s 36
-			IL_04bb: ldarg.0
-			IL_04bc: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_04c1: ldnull
-			IL_04c2: ldloc.s 36
-			IL_04c4: ldloc.s 29
-			IL_04c6: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_04cb: pop
-			IL_04cc: ldarg.0
-			IL_04cd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_04d2: stloc.s 36
-			IL_04d4: ldarg.0
-			IL_04d5: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_04da: ldnull
-			IL_04db: ldloc.s 36
-			IL_04dd: ldloc.s 30
-			IL_04df: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_04e4: pop
-			IL_04e5: ldarg.0
-			IL_04e6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_04eb: stloc.s 36
-			IL_04ed: ldarg.0
-			IL_04ee: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_04f3: ldnull
-			IL_04f4: ldloc.s 36
-			IL_04f6: ldloc.s 31
-			IL_04f8: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-			IL_04fd: pop
-			IL_04fe: ldloc.s 9
-			IL_0500: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0505: stloc.s 34
-			IL_0507: ldstr "Bumped version: "
-			IL_050c: ldloc.s 34
-			IL_050e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0513: stloc.s 34
-			IL_0515: ldloc.s 34
-			IL_0517: ldstr " -> "
-			IL_051c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0521: stloc.s 34
-			IL_0523: ldloc.s 10
-			IL_0525: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_052a: stloc.s 40
-			IL_052c: ldloc.s 34
-			IL_052e: ldloc.s 40
-			IL_0530: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0535: stloc.s 40
-			IL_0537: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_053c: ldloc.s 40
-			IL_053e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0543: pop
-			IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0549: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_054e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0553: pop
-			IL_0554: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0559: ldstr "\nNext steps:"
-			IL_055e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0563: pop
-			IL_0564: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0569: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_056e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0573: pop
-			IL_0574: ldloc.s 10
-			IL_0576: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_057b: stloc.s 40
-			IL_057d: ldstr "  git commit -m \"chore(release): cut "
-			IL_0582: ldloc.s 40
-			IL_0584: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0589: stloc.s 40
-			IL_058b: ldloc.s 40
-			IL_058d: ldstr "\""
-			IL_0592: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0597: stloc.s 40
-			IL_0599: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_059e: ldloc.s 40
-			IL_05a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05a5: pop
-			IL_05a6: ldloc.s 10
-			IL_05a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05ad: stloc.s 40
-			IL_05af: ldstr "  git tag -a v"
-			IL_05b4: ldloc.s 40
-			IL_05b6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05bb: stloc.s 40
-			IL_05bd: ldloc.s 40
-			IL_05bf: ldstr " -m \"Release "
-			IL_05c4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05c9: stloc.s 40
-			IL_05cb: ldloc.s 10
-			IL_05cd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05d2: stloc.s 34
-			IL_05d4: ldloc.s 40
-			IL_05d6: ldloc.s 34
-			IL_05d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05dd: stloc.s 34
-			IL_05df: ldloc.s 34
-			IL_05e1: ldstr "\""
-			IL_05e6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05eb: stloc.s 34
-			IL_05ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05f2: ldloc.s 34
-			IL_05f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_05f9: pop
-			IL_05fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05ff: ldstr "  git push && git push --tags"
-			IL_0604: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0609: pop
-			IL_060a: ldnull
-			IL_060b: ret
+			IL_045e: ldarg.0
+			IL_045f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
+			IL_0464: ldc.i4.1
+			IL_0465: newarr [System.Runtime]System.Object
+			IL_046a: dup
+			IL_046b: ldc.i4.0
+			IL_046c: ldarg.0
+			IL_046d: stelem.ref
+			IL_046e: ldloc.s 10
+			IL_0470: ldloc.s 12
+			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0477: stloc.s 37
+			IL_0479: ldloc.s 37
+			IL_047b: stloc.s 22
+			IL_047d: ldloc.s 8
+			IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0484: stloc.s 37
+			IL_0486: ldloc.s 37
+			IL_0488: ldstr "slice"
+			IL_048d: ldc.r8 0.0
+			IL_0496: box [System.Runtime]System.Double
+			IL_049b: ldloc.s 13
+			IL_049d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_04a2: stloc.s 37
+			IL_04a4: ldloc.s 37
+			IL_04a6: stloc.s 23
+			IL_04a8: ldloc.s 8
+			IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04af: stloc.s 37
+			IL_04b1: ldloc.s 37
+			IL_04b3: ldstr "slice"
+			IL_04b8: ldloc.s 14
+			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_04bf: stloc.s 37
+			IL_04c1: ldloc.s 37
+			IL_04c3: stloc.s 24
+			IL_04c5: ldstr "\n_Nothing yet._\n\n"
+			IL_04ca: stloc.s 25
+			IL_04cc: ldloc.s 23
+			IL_04ce: ldloc.s 25
+			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04d5: stloc.s 40
+			IL_04d7: ldloc.s 40
+			IL_04d9: ldloc.s 22
+			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04e0: stloc.s 40
+			IL_04e2: ldloc.s 40
+			IL_04e4: ldloc.s 24
+			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_04eb: stloc.s 40
+			IL_04ed: ldloc.s 40
+			IL_04ef: stloc.s 26
+			IL_04f1: ldarg.0
+			IL_04f2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_04f7: ldc.i4.1
+			IL_04f8: newarr [System.Runtime]System.Object
+			IL_04fd: dup
+			IL_04fe: ldc.i4.0
+			IL_04ff: ldarg.0
+			IL_0500: stelem.ref
+			IL_0501: ldloc.3
+			IL_0502: ldloc.s 10
+			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0509: stloc.s 37
+			IL_050b: ldloc.s 37
+			IL_050d: stloc.s 27
+			IL_050f: ldarg.0
+			IL_0510: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0515: ldc.i4.1
+			IL_0516: newarr [System.Runtime]System.Object
+			IL_051b: dup
+			IL_051c: ldc.i4.0
+			IL_051d: ldarg.0
+			IL_051e: stelem.ref
+			IL_051f: ldloc.s 4
+			IL_0521: ldloc.s 10
+			IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0528: stloc.s 37
+			IL_052a: ldloc.s 37
+			IL_052c: stloc.s 28
+			IL_052e: ldarg.0
+			IL_052f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0534: ldc.i4.1
+			IL_0535: newarr [System.Runtime]System.Object
+			IL_053a: dup
+			IL_053b: ldc.i4.0
+			IL_053c: ldarg.0
+			IL_053d: stelem.ref
+			IL_053e: ldloc.s 5
+			IL_0540: ldloc.s 10
+			IL_0542: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0547: stloc.s 37
+			IL_0549: ldloc.s 37
+			IL_054b: stloc.s 29
+			IL_054d: ldarg.0
+			IL_054e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0553: ldc.i4.1
+			IL_0554: newarr [System.Runtime]System.Object
+			IL_0559: dup
+			IL_055a: ldc.i4.0
+			IL_055b: ldarg.0
+			IL_055c: stelem.ref
+			IL_055d: ldloc.s 6
+			IL_055f: ldloc.s 10
+			IL_0561: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0566: stloc.s 37
+			IL_0568: ldloc.s 37
+			IL_056a: stloc.s 30
+			IL_056c: ldarg.0
+			IL_056d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_0572: ldc.i4.1
+			IL_0573: newarr [System.Runtime]System.Object
+			IL_0578: dup
+			IL_0579: ldc.i4.0
+			IL_057a: ldarg.0
+			IL_057b: stelem.ref
+			IL_057c: ldloc.s 7
+			IL_057e: ldloc.s 10
+			IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0585: stloc.s 37
+			IL_0587: ldloc.s 37
+			IL_0589: stloc.s 31
+			IL_058b: ldc.i4.1
+			IL_058c: newarr [System.Runtime]System.Object
+			IL_0591: dup
+			IL_0592: ldc.i4.0
+			IL_0593: ldarg.0
+			IL_0594: stelem.ref
+			IL_0595: stloc.s 33
+			IL_0597: ldarg.0
+			IL_0598: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_059d: ldloc.s 33
+			IL_059f: ldarg.0
+			IL_05a0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_05a5: ldloc.s 26
+			IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ac: pop
+			IL_05ad: ldc.i4.1
+			IL_05ae: newarr [System.Runtime]System.Object
+			IL_05b3: dup
+			IL_05b4: ldc.i4.0
+			IL_05b5: ldarg.0
+			IL_05b6: stelem.ref
+			IL_05b7: stloc.s 33
+			IL_05b9: ldarg.0
+			IL_05ba: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_05bf: ldloc.s 33
+			IL_05c1: ldarg.0
+			IL_05c2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_05c7: ldloc.s 27
+			IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ce: pop
+			IL_05cf: ldc.i4.1
+			IL_05d0: newarr [System.Runtime]System.Object
+			IL_05d5: dup
+			IL_05d6: ldc.i4.0
+			IL_05d7: ldarg.0
+			IL_05d8: stelem.ref
+			IL_05d9: stloc.s 33
+			IL_05db: ldarg.0
+			IL_05dc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_05e1: ldloc.s 33
+			IL_05e3: ldarg.0
+			IL_05e4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_05e9: ldloc.s 28
+			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05f0: pop
+			IL_05f1: ldc.i4.1
+			IL_05f2: newarr [System.Runtime]System.Object
+			IL_05f7: dup
+			IL_05f8: ldc.i4.0
+			IL_05f9: ldarg.0
+			IL_05fa: stelem.ref
+			IL_05fb: stloc.s 33
+			IL_05fd: ldarg.0
+			IL_05fe: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0603: ldloc.s 33
+			IL_0605: ldarg.0
+			IL_0606: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_060b: ldloc.s 29
+			IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0612: pop
+			IL_0613: ldc.i4.1
+			IL_0614: newarr [System.Runtime]System.Object
+			IL_0619: dup
+			IL_061a: ldc.i4.0
+			IL_061b: ldarg.0
+			IL_061c: stelem.ref
+			IL_061d: stloc.s 33
+			IL_061f: ldarg.0
+			IL_0620: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0625: ldloc.s 33
+			IL_0627: ldarg.0
+			IL_0628: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_062d: ldloc.s 30
+			IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0634: pop
+			IL_0635: ldc.i4.1
+			IL_0636: newarr [System.Runtime]System.Object
+			IL_063b: dup
+			IL_063c: ldc.i4.0
+			IL_063d: ldarg.0
+			IL_063e: stelem.ref
+			IL_063f: stloc.s 33
+			IL_0641: ldarg.0
+			IL_0642: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0647: ldloc.s 33
+			IL_0649: ldarg.0
+			IL_064a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_064f: ldloc.s 31
+			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0656: pop
+			IL_0657: ldloc.s 9
+			IL_0659: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_065e: stloc.s 35
+			IL_0660: ldstr "Bumped version: "
+			IL_0665: ldloc.s 35
+			IL_0667: call string [System.Runtime]System.String::Concat(string, string)
+			IL_066c: stloc.s 35
+			IL_066e: ldloc.s 35
+			IL_0670: ldstr " -> "
+			IL_0675: call string [System.Runtime]System.String::Concat(string, string)
+			IL_067a: stloc.s 35
+			IL_067c: ldloc.s 10
+			IL_067e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0683: stloc.s 41
+			IL_0685: ldloc.s 35
+			IL_0687: ldloc.s 41
+			IL_0689: call string [System.Runtime]System.String::Concat(string, string)
+			IL_068e: stloc.s 41
+			IL_0690: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0695: ldloc.s 41
+			IL_0697: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_069c: pop
+			IL_069d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06a2: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_06a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06ac: pop
+			IL_06ad: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06b2: ldstr "\nNext steps:"
+			IL_06b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06bc: pop
+			IL_06bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06c2: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_06c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06cc: pop
+			IL_06cd: ldloc.s 10
+			IL_06cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_06d4: stloc.s 41
+			IL_06d6: ldstr "  git commit -m \"chore(release): cut "
+			IL_06db: ldloc.s 41
+			IL_06dd: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06e2: stloc.s 41
+			IL_06e4: ldloc.s 41
+			IL_06e6: ldstr "\""
+			IL_06eb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06f0: stloc.s 41
+			IL_06f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06f7: ldloc.s 41
+			IL_06f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06fe: pop
+			IL_06ff: ldloc.s 10
+			IL_0701: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0706: stloc.s 41
+			IL_0708: ldstr "  git tag -a v"
+			IL_070d: ldloc.s 41
+			IL_070f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0714: stloc.s 41
+			IL_0716: ldloc.s 41
+			IL_0718: ldstr " -m \"Release "
+			IL_071d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0722: stloc.s 41
+			IL_0724: ldloc.s 10
+			IL_0726: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_072b: stloc.s 35
+			IL_072d: ldloc.s 41
+			IL_072f: ldloc.s 35
+			IL_0731: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0736: stloc.s 35
+			IL_0738: ldloc.s 35
+			IL_073a: ldstr "\""
+			IL_073f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0744: stloc.s 35
+			IL_0746: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_074b: ldloc.s 35
+			IL_074d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0752: pop
+			IL_0753: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0758: ldstr "  git push && git push --tags"
+			IL_075d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0762: pop
+			IL_0763: ldnull
+			IL_0764: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform
@@ -2670,7 +2890,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37bb
+				// Method begins at RVA 0x3955
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2690,7 +2910,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x37c4
+				// Method begins at RVA 0x395e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2728,7 +2948,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x36f5
+			// Method begins at RVA 0x388f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2754,7 +2974,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1073 (0x431)
+		// Code size: 1072 (0x430)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
@@ -3136,64 +3356,63 @@
 		{
 			IL_038f: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C4::.ctor()
 			IL_0394: stloc.s 4
-			IL_0396: ldloc.0
-			IL_0397: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_039c: ldnull
-			IL_039d: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
-			IL_03a2: pop
-			IL_03a3: leave IL_042d
+			IL_0396: ldloc.1
+			IL_0397: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_03a1: pop
+			IL_03a2: leave IL_042c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03a8: stloc.s 5
-			IL_03aa: ldloc.s 5
-			IL_03ac: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03b1: dup
-			IL_03b2: brtrue IL_03c8
+			IL_03a7: stloc.s 5
+			IL_03a9: ldloc.s 5
+			IL_03ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03b0: dup
+			IL_03b1: brtrue IL_03c7
 
-			IL_03b7: pop
-			IL_03b8: ldloc.s 5
-			IL_03ba: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03bf: dup
-			IL_03c0: brtrue IL_03d4
+			IL_03b6: pop
+			IL_03b7: ldloc.s 5
+			IL_03b9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03be: dup
+			IL_03bf: brtrue IL_03d3
 
-			IL_03c5: pop
-			IL_03c6: rethrow
+			IL_03c4: pop
+			IL_03c5: rethrow
 
-			IL_03c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03cd: stloc.s 6
-			IL_03cf: br IL_03d6
+			IL_03c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03cc: stloc.s 6
+			IL_03ce: br IL_03d5
 
-			IL_03d4: stloc.s 6
+			IL_03d3: stloc.s 6
 
-			IL_03d6: ldloc.s 6
-			IL_03d8: stloc.s 10
-			IL_03da: ldloc.s 10
-			IL_03dc: stloc.s 7
-			IL_03de: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C29::.ctor()
-			IL_03e3: stloc.s 8
-			IL_03e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03ea: ldstr "ERROR:"
-			IL_03ef: ldloc.s 7
-			IL_03f1: ldstr "message"
-			IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object, object)
-			IL_0400: pop
-			IL_0401: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_040b: stloc.s 10
-			IL_040d: ldloc.s 10
-			IL_040f: ldstr "exit"
-			IL_0414: ldc.r8 1
-			IL_041d: box [System.Runtime]System.Double
-			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0427: pop
-			IL_0428: leave IL_042d
+			IL_03d5: ldloc.s 6
+			IL_03d7: stloc.s 10
+			IL_03d9: ldloc.s 10
+			IL_03db: stloc.s 7
+			IL_03dd: newobj instance void Modules.Compile_Scripts_BumpVersion/Scope/Block_L180C29::.ctor()
+			IL_03e2: stloc.s 8
+			IL_03e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03e9: ldstr "ERROR:"
+			IL_03ee: ldloc.s 7
+			IL_03f0: ldstr "message"
+			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object, object)
+			IL_03ff: pop
+			IL_0400: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_040a: stloc.s 10
+			IL_040c: ldloc.s 10
+			IL_040e: ldstr "exit"
+			IL_0413: ldc.r8 1
+			IL_041c: box [System.Runtime]System.Double
+			IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0426: pop
+			IL_0427: leave IL_042c
 		} // end handler
 
-		IL_042d: ldnull
-		IL_042e: stloc.s 9
-		IL_0430: ret
+		IL_042c: ldnull
+		IL_042d: stloc.s 9
+		IL_042f: ret
 	} // end of method Compile_Scripts_BumpVersion::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_BumpVersion
@@ -3205,7 +3424,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x37cd
+		// Method begins at RVA 0x3967
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3099
+				// Method begins at RVA 0x30ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -46,7 +46,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30b4
+						// Method begins at RVA 0x30c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -66,7 +66,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30bd
+						// Method begins at RVA 0x30d1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -86,7 +86,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30c6
+						// Method begins at RVA 0x30da
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -106,7 +106,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30cf
+						// Method begins at RVA 0x30e3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -124,7 +124,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30ab
+					// Method begins at RVA 0x30bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -142,7 +142,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a2
+				// Method begins at RVA 0x30b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -449,7 +449,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30e1
+					// Method begins at RVA 0x30f5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -474,7 +474,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2a90
+				// Method begins at RVA 0x2aa4
 				// Header size: 12
 				// Code size: 445 (0x1bd)
 				.maxstack 8
@@ -663,7 +663,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30ea
+					// Method begins at RVA 0x30fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -687,7 +687,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c5c
+				// Method begins at RVA 0x2c70
 				// Header size: 12
 				// Code size: 156 (0x9c)
 				.maxstack 8
@@ -773,7 +773,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f3
+					// Method begins at RVA 0x3107
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -797,7 +797,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d04
+				// Method begins at RVA 0x2d18
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -843,7 +843,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3105
+						// Method begins at RVA 0x3119
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -867,7 +867,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f50
+					// Method begins at RVA 0x2f64
 					// Header size: 12
 					// Code size: 221 (0xdd)
 					.maxstack 8
@@ -990,7 +990,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x310e
+						// Method begins at RVA 0x3122
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1008,7 +1008,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30fc
+					// Method begins at RVA 0x3110
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1034,7 +1034,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d30
+				// Method begins at RVA 0x2d44
 				// Header size: 12
 				// Code size: 530 (0x212)
 				.maxstack 8
@@ -1259,7 +1259,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30d8
+				// Method begins at RVA 0x30ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1511,7 +1511,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3117
+				// Method begins at RVA 0x312b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1539,7 +1539,7 @@
 			)
 			// Method begins at RVA 0x27e0
 			// Header size: 12
-			// Code size: 673 (0x2a1)
+			// Code size: 695 (0x2b7)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1550,236 +1550,249 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] bool,
-				[9] object,
-				[10] string,
+				[8] object[],
+				[9] bool,
+				[10] object,
 				[11] string,
-				[12] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
+				[12] string,
+				[13] class [JavaScriptRuntime]JavaScriptRuntime.RegExp
 			)
 
-			IL_0000: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0005: ldstr "argv"
-			IL_000a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_000f: stloc.s 7
-			IL_0011: ldarg.0
-			IL_0012: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_0017: ldnull
-			IL_0018: ldloc.s 7
-			IL_001a: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-			IL_001f: stloc.s 7
-			IL_0021: ldloc.s 7
-			IL_0023: stloc.0
-			IL_0024: ldloc.0
-			IL_0025: ldstr "inFile"
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_002f: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0034: ldc.i4.0
-			IL_0035: ceq
-			IL_0037: stloc.s 8
-			IL_0039: ldloc.s 8
-			IL_003b: brfalse IL_0069
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::parseArgs
+			IL_0006: stloc.s 7
+			IL_0008: ldc.i4.1
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: stloc.s 8
+			IL_0014: ldloc.s 7
+			IL_0016: ldloc.s 8
+			IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_001d: ldstr "argv"
+			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_002c: stloc.s 7
+			IL_002e: ldloc.s 7
+			IL_0030: stloc.0
+			IL_0031: ldloc.0
+			IL_0032: ldstr "inFile"
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0041: ldc.i4.0
+			IL_0042: ceq
+			IL_0044: stloc.s 9
+			IL_0046: ldloc.s 9
+			IL_0048: brfalse IL_0076
 
-			IL_0040: ldstr "Missing --in <input.html>"
-			IL_0045: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_004f: stloc.s 7
-			IL_0051: ldloc.s 7
-			IL_0053: stloc.1
-			IL_0054: ldloc.1
-			IL_0055: isinst [System.Runtime]System.Exception
-			IL_005a: dup
-			IL_005b: brtrue IL_0068
-
-			IL_0060: pop
+			IL_004d: ldstr "Missing --in <input.html>"
+			IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_005c: stloc.s 7
+			IL_005e: ldloc.s 7
+			IL_0060: stloc.1
 			IL_0061: ldloc.1
-			IL_0062: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0067: throw
+			IL_0062: isinst [System.Runtime]System.Exception
+			IL_0067: dup
+			IL_0068: brtrue IL_0075
 
-			IL_0068: throw
+			IL_006d: pop
+			IL_006e: ldloc.1
+			IL_006f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0074: throw
 
-			IL_0069: ldloc.0
-			IL_006a: ldstr "outFile"
-			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0079: ldc.i4.0
-			IL_007a: ceq
-			IL_007c: stloc.s 8
-			IL_007e: ldloc.s 8
-			IL_0080: brfalse IL_00ae
+			IL_0075: throw
 
-			IL_0085: ldstr "Missing --out <output.md>"
-			IL_008a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_008f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0094: stloc.s 7
-			IL_0096: ldloc.s 7
-			IL_0098: stloc.2
-			IL_0099: ldloc.2
-			IL_009a: isinst [System.Runtime]System.Exception
-			IL_009f: dup
-			IL_00a0: brtrue IL_00ad
+			IL_0076: ldloc.0
+			IL_0077: ldstr "outFile"
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0086: ldc.i4.0
+			IL_0087: ceq
+			IL_0089: stloc.s 9
+			IL_008b: ldloc.s 9
+			IL_008d: brfalse IL_00bb
 
-			IL_00a5: pop
+			IL_0092: ldstr "Missing --out <output.md>"
+			IL_0097: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_009c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00a1: stloc.s 7
+			IL_00a3: ldloc.s 7
+			IL_00a5: stloc.2
 			IL_00a6: ldloc.2
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00ac: throw
+			IL_00a7: isinst [System.Runtime]System.Exception
+			IL_00ac: dup
+			IL_00ad: brtrue IL_00ba
 
-			IL_00ad: throw
+			IL_00b2: pop
+			IL_00b3: ldloc.2
+			IL_00b4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00b9: throw
 
-			IL_00ae: ldarg.0
-			IL_00af: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b9: stloc.s 7
-			IL_00bb: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c5: stloc.s 9
-			IL_00c7: ldloc.s 9
-			IL_00c9: ldstr "cwd"
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_00d3: stloc.s 9
-			IL_00d5: ldloc.s 7
-			IL_00d7: ldstr "resolve"
-			IL_00dc: ldloc.s 9
-			IL_00de: ldloc.0
-			IL_00df: ldstr "inFile"
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_00ee: stloc.s 9
-			IL_00f0: ldloc.s 9
-			IL_00f2: stloc.3
-			IL_00f3: ldarg.0
-			IL_00f4: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fe: stloc.s 9
-			IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010a: stloc.s 7
-			IL_010c: ldloc.s 7
-			IL_010e: ldstr "cwd"
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0118: stloc.s 7
-			IL_011a: ldloc.s 9
-			IL_011c: ldstr "resolve"
-			IL_0121: ldloc.s 7
-			IL_0123: ldloc.0
-			IL_0124: ldstr "outFile"
-			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0133: stloc.s 7
-			IL_0135: ldloc.s 7
-			IL_0137: stloc.s 4
-			IL_0139: ldarg.0
-			IL_013a: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0144: stloc.s 7
-			IL_0146: ldloc.s 7
-			IL_0148: ldstr "readFileSync"
-			IL_014d: ldloc.3
-			IL_014e: ldstr "utf8"
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0158: stloc.s 7
-			IL_015a: ldloc.s 7
-			IL_015c: stloc.s 5
-			IL_015e: ldarg.0
-			IL_015f: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_0164: ldnull
-			IL_0165: ldloc.s 5
-			IL_0167: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-			IL_016c: stloc.s 7
-			IL_016e: ldloc.s 7
-			IL_0170: stloc.s 6
-			IL_0172: ldarg.0
-			IL_0173: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_017d: stloc.s 7
-			IL_017f: ldarg.0
-			IL_0180: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018a: stloc.s 9
-			IL_018c: ldloc.s 9
-			IL_018e: ldstr "dirname"
-			IL_0193: ldloc.s 4
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_019a: stloc.s 9
-			IL_019c: ldloc.s 7
-			IL_019e: ldstr "mkdirSync"
-			IL_01a3: ldloc.s 9
-			IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01aa: dup
-			IL_01ab: ldstr "recursive"
-			IL_01b0: ldc.i4.1
-			IL_01b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01bb: pop
-			IL_01bc: ldarg.0
-			IL_01bd: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c7: stloc.s 9
-			IL_01c9: ldloc.s 9
-			IL_01cb: ldstr "writeFileSync"
-			IL_01d0: ldloc.s 4
-			IL_01d2: ldloc.s 6
-			IL_01d4: ldstr "utf8"
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_01de: pop
-			IL_01df: ldloc.0
-			IL_01e0: ldstr "inFile"
-			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ea: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ef: stloc.s 10
-			IL_01f1: ldstr "Converted "
-			IL_01f6: ldloc.s 10
-			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01fd: stloc.s 10
-			IL_01ff: ldloc.s 10
-			IL_0201: ldstr " -> "
-			IL_0206: call string [System.Runtime]System.String::Concat(string, string)
-			IL_020b: stloc.s 10
-			IL_020d: ldloc.0
-			IL_020e: ldstr "outFile"
-			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0218: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_021d: stloc.s 11
-			IL_021f: ldloc.s 10
-			IL_0221: ldloc.s 11
-			IL_0223: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0228: stloc.s 11
-			IL_022a: ldloc.s 11
-			IL_022c: ldstr " ("
-			IL_0231: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0236: stloc.s 11
-			IL_0238: ldloc.s 6
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_023f: stloc.s 9
-			IL_0241: ldstr "\\n"
-			IL_0246: ldstr ""
-			IL_024b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0250: stloc.s 12
-			IL_0252: ldloc.s 9
-			IL_0254: ldstr "split"
-			IL_0259: ldloc.s 12
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0260: stloc.s 9
-			IL_0262: ldloc.s 9
-			IL_0264: ldstr "length"
-			IL_0269: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026e: stloc.s 9
-			IL_0270: ldloc.s 9
-			IL_0272: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0277: stloc.s 10
-			IL_0279: ldloc.s 11
-			IL_027b: ldloc.s 10
-			IL_027d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0282: stloc.s 10
-			IL_0284: ldloc.s 10
-			IL_0286: ldstr " lines)"
-			IL_028b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0290: stloc.s 10
-			IL_0292: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0297: ldloc.s 10
-			IL_0299: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_029e: pop
-			IL_029f: ldnull
-			IL_02a0: ret
+			IL_00ba: throw
+
+			IL_00bb: ldarg.0
+			IL_00bc: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c6: stloc.s 7
+			IL_00c8: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d2: stloc.s 10
+			IL_00d4: ldloc.s 10
+			IL_00d6: ldstr "cwd"
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_00e0: stloc.s 10
+			IL_00e2: ldloc.s 7
+			IL_00e4: ldstr "resolve"
+			IL_00e9: ldloc.s 10
+			IL_00eb: ldloc.0
+			IL_00ec: ldstr "inFile"
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_00fb: stloc.s 10
+			IL_00fd: ldloc.s 10
+			IL_00ff: stloc.3
+			IL_0100: ldarg.0
+			IL_0101: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010b: stloc.s 10
+			IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0117: stloc.s 7
+			IL_0119: ldloc.s 7
+			IL_011b: ldstr "cwd"
+			IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0125: stloc.s 7
+			IL_0127: ldloc.s 10
+			IL_0129: ldstr "resolve"
+			IL_012e: ldloc.s 7
+			IL_0130: ldloc.0
+			IL_0131: ldstr "outFile"
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0140: stloc.s 7
+			IL_0142: ldloc.s 7
+			IL_0144: stloc.s 4
+			IL_0146: ldarg.0
+			IL_0147: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0151: stloc.s 7
+			IL_0153: ldloc.s 7
+			IL_0155: ldstr "readFileSync"
+			IL_015a: ldloc.3
+			IL_015b: ldstr "utf8"
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0165: stloc.s 7
+			IL_0167: ldloc.s 7
+			IL_0169: stloc.s 5
+			IL_016b: ldarg.0
+			IL_016c: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::convertHtmlToMarkdown
+			IL_0171: ldc.i4.1
+			IL_0172: newarr [System.Runtime]System.Object
+			IL_0177: dup
+			IL_0178: ldc.i4.0
+			IL_0179: ldarg.0
+			IL_017a: stelem.ref
+			IL_017b: ldloc.s 5
+			IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0182: stloc.s 7
+			IL_0184: ldloc.s 7
+			IL_0186: stloc.s 6
+			IL_0188: ldarg.0
+			IL_0189: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0193: stloc.s 7
+			IL_0195: ldarg.0
+			IL_0196: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::path
+			IL_019b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a0: stloc.s 10
+			IL_01a2: ldloc.s 10
+			IL_01a4: ldstr "dirname"
+			IL_01a9: ldloc.s 4
+			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b0: stloc.s 10
+			IL_01b2: ldloc.s 7
+			IL_01b4: ldstr "mkdirSync"
+			IL_01b9: ldloc.s 10
+			IL_01bb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01c0: dup
+			IL_01c1: ldstr "recursive"
+			IL_01c6: ldc.i4.1
+			IL_01c7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01d1: pop
+			IL_01d2: ldarg.0
+			IL_01d3: ldfld object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope::fs
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01dd: stloc.s 10
+			IL_01df: ldloc.s 10
+			IL_01e1: ldstr "writeFileSync"
+			IL_01e6: ldloc.s 4
+			IL_01e8: ldloc.s 6
+			IL_01ea: ldstr "utf8"
+			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01f4: pop
+			IL_01f5: ldloc.0
+			IL_01f6: ldstr "inFile"
+			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0200: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0205: stloc.s 11
+			IL_0207: ldstr "Converted "
+			IL_020c: ldloc.s 11
+			IL_020e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0213: stloc.s 11
+			IL_0215: ldloc.s 11
+			IL_0217: ldstr " -> "
+			IL_021c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0221: stloc.s 11
+			IL_0223: ldloc.0
+			IL_0224: ldstr "outFile"
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_022e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0233: stloc.s 12
+			IL_0235: ldloc.s 11
+			IL_0237: ldloc.s 12
+			IL_0239: call string [System.Runtime]System.String::Concat(string, string)
+			IL_023e: stloc.s 12
+			IL_0240: ldloc.s 12
+			IL_0242: ldstr " ("
+			IL_0247: call string [System.Runtime]System.String::Concat(string, string)
+			IL_024c: stloc.s 12
+			IL_024e: ldloc.s 6
+			IL_0250: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0255: stloc.s 10
+			IL_0257: ldstr "\\n"
+			IL_025c: ldstr ""
+			IL_0261: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0266: stloc.s 13
+			IL_0268: ldloc.s 10
+			IL_026a: ldstr "split"
+			IL_026f: ldloc.s 13
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0276: stloc.s 10
+			IL_0278: ldloc.s 10
+			IL_027a: ldstr "length"
+			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0284: stloc.s 10
+			IL_0286: ldloc.s 10
+			IL_0288: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_028d: stloc.s 11
+			IL_028f: ldloc.s 12
+			IL_0291: ldloc.s 11
+			IL_0293: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0298: stloc.s 11
+			IL_029a: ldloc.s 11
+			IL_029c: ldstr " lines)"
+			IL_02a1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a6: stloc.s 11
+			IL_02a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02ad: ldloc.s 11
+			IL_02af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02b4: pop
+			IL_02b5: ldnull
+			IL_02b6: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1811,7 +1824,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3129
+					// Method begins at RVA 0x313d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1831,7 +1844,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3132
+					// Method begins at RVA 0x3146
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1849,7 +1862,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3120
+				// Method begins at RVA 0x3134
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1875,7 +1888,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3090
+			// Method begins at RVA 0x30a4
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1901,7 +1914,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 467 (0x1d3)
+		// Code size: 466 (0x1d2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
@@ -2013,7 +2026,7 @@
 		IL_00e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 		IL_00ed: stloc.s 11
 		IL_00ef: ldloc.s 11
-		IL_00f1: brfalse IL_01cf
+		IL_00f1: brfalse IL_01ce
 
 		IL_00f6: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29::.ctor()
 		IL_00fb: stloc.2
@@ -2021,90 +2034,89 @@
 		{
 			IL_00fc: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L132C6::.ctor()
 			IL_0101: stloc.3
-			IL_0102: ldloc.0
-			IL_0103: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-			IL_0108: ldnull
-			IL_0109: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
-			IL_010e: pop
-			IL_010f: leave IL_01cf
+			IL_0102: ldloc.1
+			IL_0103: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_010d: pop
+			IL_010e: leave IL_01ce
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0114: stloc.s 4
-			IL_0116: ldloc.s 4
-			IL_0118: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_011d: dup
-			IL_011e: brtrue IL_0134
+			IL_0113: stloc.s 4
+			IL_0115: ldloc.s 4
+			IL_0117: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_011c: dup
+			IL_011d: brtrue IL_0133
 
-			IL_0123: pop
-			IL_0124: ldloc.s 4
-			IL_0126: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_012b: dup
-			IL_012c: brtrue IL_0140
+			IL_0122: pop
+			IL_0123: ldloc.s 4
+			IL_0125: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_012a: dup
+			IL_012b: brtrue IL_013f
 
-			IL_0131: pop
-			IL_0132: rethrow
+			IL_0130: pop
+			IL_0131: rethrow
 
-			IL_0134: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0139: stloc.s 5
-			IL_013b: br IL_0142
+			IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0138: stloc.s 5
+			IL_013a: br IL_0141
 
-			IL_0140: stloc.s 5
+			IL_013f: stloc.s 5
 
-			IL_0142: ldloc.s 5
-			IL_0144: stloc.s 10
-			IL_0146: ldloc.s 10
-			IL_0148: stloc.s 6
-			IL_014a: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L134C16::.ctor()
-			IL_014f: stloc.s 7
-			IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0156: stloc.s 12
-			IL_0158: ldloc.s 6
-			IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_015f: stloc.s 11
-			IL_0161: ldloc.s 11
-			IL_0163: brfalse IL_017b
+			IL_0141: ldloc.s 5
+			IL_0143: stloc.s 10
+			IL_0145: ldloc.s 10
+			IL_0147: stloc.s 6
+			IL_0149: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope/Block_L131C29/Block_L134C16::.ctor()
+			IL_014e: stloc.s 7
+			IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0155: stloc.s 12
+			IL_0157: ldloc.s 6
+			IL_0159: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_015e: stloc.s 11
+			IL_0160: ldloc.s 11
+			IL_0162: brfalse IL_017a
 
-			IL_0168: ldloc.s 6
-			IL_016a: ldstr "message"
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0174: stloc.s 14
-			IL_0176: br IL_017f
+			IL_0167: ldloc.s 6
+			IL_0169: ldstr "message"
+			IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0173: stloc.s 14
+			IL_0175: br IL_017e
 
-			IL_017b: ldloc.s 6
-			IL_017d: stloc.s 14
+			IL_017a: ldloc.s 6
+			IL_017c: stloc.s 14
 
-			IL_017f: ldloc.s 14
-			IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0186: stloc.s 11
-			IL_0188: ldloc.s 11
-			IL_018a: brfalse IL_01a2
+			IL_017e: ldloc.s 14
+			IL_0180: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0185: stloc.s 11
+			IL_0187: ldloc.s 11
+			IL_0189: brfalse IL_01a1
 
-			IL_018f: ldloc.s 6
-			IL_0191: ldstr "message"
-			IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_019b: stloc.s 8
-			IL_019d: br IL_01a6
+			IL_018e: ldloc.s 6
+			IL_0190: ldstr "message"
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_019a: stloc.s 8
+			IL_019c: br IL_01a5
 
-			IL_01a2: ldloc.s 6
-			IL_01a4: stloc.s 8
+			IL_01a1: ldloc.s 6
+			IL_01a3: stloc.s 8
 
-			IL_01a6: ldloc.s 12
-			IL_01a8: ldloc.s 8
-			IL_01aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_01af: pop
-			IL_01b0: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_01b5: ldstr "exitCode"
-			IL_01ba: ldc.r8 1
-			IL_01c3: ldc.i4.1
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_01c9: pop
-			IL_01ca: leave IL_01cf
+			IL_01a5: ldloc.s 12
+			IL_01a7: ldloc.s 8
+			IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_01ae: pop
+			IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_01b4: ldstr "exitCode"
+			IL_01b9: ldc.r8 1
+			IL_01c2: ldc.i4.1
+			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_01c8: pop
+			IL_01c9: leave IL_01ce
 		} // end handler
 
-		IL_01cf: ldnull
-		IL_01d0: stloc.s 9
-		IL_01d2: ret
+		IL_01ce: ldnull
+		IL_01cf: stloc.s 9
+		IL_01d1: ret
 	} // end of method Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
@@ -2124,7 +2136,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3144
+				// Method begins at RVA 0x3158
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2147,7 +2159,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3039
+			// Method begins at RVA 0x304d
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -2176,7 +2188,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x314d
+				// Method begins at RVA 0x3161
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2201,7 +2213,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x303c
+			// Method begins at RVA 0x3050
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -2238,7 +2250,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3156
+				// Method begins at RVA 0x316a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2262,7 +2274,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3054
+			// Method begins at RVA 0x3068
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -2316,7 +2328,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x313b
+			// Method begins at RVA 0x314f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2418,7 +2430,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x315f
+		// Method begins at RVA 0x3173
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3040
+				// Method begins at RVA 0x307c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -128,7 +128,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3049
+				// Method begins at RVA 0x3085
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -257,7 +257,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3064
+					// Method begins at RVA 0x30a0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -281,7 +281,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2fcc
+				// Method begins at RVA 0x3008
 				// Header size: 12
 				// Code size: 21 (0x15)
 				.maxstack 8
@@ -319,7 +319,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x306d
+					// Method begins at RVA 0x30a9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -344,7 +344,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2ff0
+				// Method begins at RVA 0x302c
 				// Header size: 12
 				// Code size: 59 (0x3b)
 				.maxstack 8
@@ -396,7 +396,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x305b
+					// Method begins at RVA 0x3097
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -417,7 +417,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3052
+				// Method begins at RVA 0x308e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -445,7 +445,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3088
+						// Method begins at RVA 0x30c4
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -463,7 +463,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x307f
+					// Method begins at RVA 0x30bb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -481,7 +481,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3076
+				// Method begins at RVA 0x30b2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -787,7 +787,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x309a
+					// Method begins at RVA 0x30d6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -805,7 +805,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3091
+				// Method begins at RVA 0x30cd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -835,7 +835,7 @@
 			)
 			// Method begins at RVA 0x2620
 			// Header size: 12
-			// Code size: 297 (0x129)
+			// Code size: 319 (0x13f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -846,153 +846,165 @@
 				[5] string,
 				[6] object,
 				[7] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17,
-				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[8] object[],
 				[9] object,
 				[10] string,
 				[11] bool
 			)
 
-			IL_0000: ldarg.0
-			IL_0001: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_0006: ldnull
-			IL_0007: ldarg.2
-			IL_0008: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-			IL_000d: stloc.s 8
-			IL_000f: ldloc.s 8
-			IL_0011: brfalse IL_0022
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.2
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: brfalse IL_002f
 
-			IL_0016: ldloc.s 8
-			IL_0018: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_001d: brfalse IL_0033
+			IL_0023: ldloc.s 9
+			IL_0025: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_002a: brfalse IL_0040
 
-			IL_0022: ldloc.s 8
-			IL_0024: ldstr ""
-			IL_0029: ldstr "0"
-			IL_002e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_002f: ldloc.s 9
+			IL_0031: ldstr ""
+			IL_0036: ldstr "0"
+			IL_003b: call void [JavaScriptRuntime]JavaScriptRuntime.Object::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0033: ldloc.s 8
-			IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-			IL_003a: stloc.0
-			IL_003b: ldc.i4.0
-			IL_003c: stloc.1
-			IL_003d: ldc.i4.0
-			IL_003e: stloc.2
+			IL_0040: ldloc.s 9
+			IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+			IL_0047: stloc.0
+			IL_0048: ldc.i4.0
+			IL_0049: stloc.1
+			IL_004a: ldc.i4.0
+			IL_004b: stloc.2
 			.try
 			{
-				IL_003f: ldloc.2
-				IL_0040: brtrue IL_0067
+				IL_004c: ldloc.2
+				IL_004d: brtrue IL_0074
 
-				IL_0045: ldloc.0
-				IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_004b: stloc.s 9
-				IL_004d: ldloc.s 9
-				IL_004f: brfalse IL_0065
+				IL_0052: ldloc.0
+				IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_0058: stloc.s 9
+				IL_005a: ldloc.s 9
+				IL_005c: brfalse IL_0072
 
-				IL_0054: ldloc.s 9
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_005b: stloc.s 9
-				IL_005d: ldloc.s 9
-				IL_005f: stloc.3
-				IL_0060: br IL_0069
+				IL_0061: ldloc.s 9
+				IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_0068: stloc.s 9
+				IL_006a: ldloc.s 9
+				IL_006c: stloc.3
+				IL_006d: br IL_0076
 
-				IL_0065: ldc.i4.1
-				IL_0066: stloc.2
+				IL_0072: ldc.i4.1
+				IL_0073: stloc.2
 
-				IL_0067: ldnull
-				IL_0068: stloc.3
+				IL_0074: ldnull
+				IL_0075: stloc.3
 
-				IL_0069: ldloc.2
-				IL_006a: brtrue IL_0092
+				IL_0076: ldloc.2
+				IL_0077: brtrue IL_009f
 
-				IL_006f: ldloc.0
-				IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
-				IL_0075: stloc.s 9
-				IL_0077: ldloc.s 9
-				IL_0079: brfalse IL_0090
+				IL_007c: ldloc.0
+				IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStep(object)
+				IL_0082: stloc.s 9
+				IL_0084: ldloc.s 9
+				IL_0086: brfalse IL_009d
 
-				IL_007e: ldloc.s 9
-				IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
-				IL_0085: stloc.s 9
-				IL_0087: ldloc.s 9
-				IL_0089: stloc.s 4
-				IL_008b: br IL_0095
+				IL_008b: ldloc.s 9
+				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorDestructuringStepValue(object)
+				IL_0092: stloc.s 9
+				IL_0094: ldloc.s 9
+				IL_0096: stloc.s 4
+				IL_0098: br IL_00a2
 
-				IL_0090: ldc.i4.1
-				IL_0091: stloc.2
+				IL_009d: ldc.i4.1
+				IL_009e: stloc.2
 
-				IL_0092: ldnull
-				IL_0093: stloc.s 4
+				IL_009f: ldnull
+				IL_00a0: stloc.s 4
 
-				IL_0095: ldloc.2
-				IL_0096: brtrue IL_00a3
+				IL_00a2: ldloc.2
+				IL_00a3: brtrue IL_00b0
 
-				IL_009b: ldc.i4.1
-				IL_009c: stloc.1
-				IL_009d: ldloc.0
-				IL_009e: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_00a8: ldc.i4.1
+				IL_00a9: stloc.1
+				IL_00aa: ldloc.0
+				IL_00ab: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
 
-				IL_00a3: ldc.i4.1
-				IL_00a4: stloc.1
-				IL_00a5: leave IL_00bd
+				IL_00b0: ldc.i4.1
+				IL_00b1: stloc.1
+				IL_00b2: leave IL_00ca
 			} // end .try
 			finally
 			{
-				IL_00aa: ldloc.1
-				IL_00ab: brtrue IL_00bc
+				IL_00b7: ldloc.1
+				IL_00b8: brtrue IL_00c9
 
-				IL_00b0: ldloc.2
-				IL_00b1: brtrue IL_00bc
+				IL_00bd: ldloc.2
+				IL_00be: brtrue IL_00c9
 
-				IL_00b6: ldloc.0
-				IL_00b7: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_00c3: ldloc.0
+				IL_00c4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_00bc: endfinally
+				IL_00c9: endfinally
 			} // end handler
 
-			IL_00bd: ldarg.3
-			IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00c3: stloc.s 10
-			IL_00c5: ldstr ""
-			IL_00ca: ldloc.s 10
-			IL_00cc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00d1: stloc.s 10
-			IL_00d3: ldloc.s 10
-			IL_00d5: ldstr ".dll"
-			IL_00da: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00df: stloc.s 10
-			IL_00e1: ldloc.s 10
-			IL_00e3: stloc.s 5
-			IL_00e5: ldarg.0
-			IL_00e6: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_00eb: ldnull
-			IL_00ec: ldloc.3
-			IL_00ed: ldloc.s 5
-			IL_00ef: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_00f4: stloc.s 9
-			IL_00f6: ldloc.s 9
-			IL_00f8: stloc.s 6
-			IL_00fa: ldloc.s 6
-			IL_00fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0101: stloc.s 11
-			IL_0103: ldloc.s 11
-			IL_0105: brfalse IL_0114
+			IL_00ca: ldarg.3
+			IL_00cb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00d0: stloc.s 10
+			IL_00d2: ldstr ""
+			IL_00d7: ldloc.s 10
+			IL_00d9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00de: stloc.s 10
+			IL_00e0: ldloc.s 10
+			IL_00e2: ldstr ".dll"
+			IL_00e7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ec: stloc.s 10
+			IL_00ee: ldloc.s 10
+			IL_00f0: stloc.s 5
+			IL_00f2: ldarg.0
+			IL_00f3: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssemblyInRoot
+			IL_00f8: ldc.i4.1
+			IL_00f9: newarr [System.Runtime]System.Object
+			IL_00fe: dup
+			IL_00ff: ldc.i4.0
+			IL_0100: ldarg.0
+			IL_0101: stelem.ref
+			IL_0102: ldloc.3
+			IL_0103: ldloc.s 5
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_010a: stloc.s 9
+			IL_010c: ldloc.s 9
+			IL_010e: stloc.s 6
+			IL_0110: ldloc.s 6
+			IL_0112: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0117: stloc.s 11
+			IL_0119: ldloc.s 11
+			IL_011b: brfalse IL_012a
 
-			IL_010a: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17::.ctor()
-			IL_010f: stloc.s 7
-			IL_0111: ldloc.s 6
-			IL_0113: ret
+			IL_0120: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/Scope/Block_L70C17::.ctor()
+			IL_0125: stloc.s 7
+			IL_0127: ldloc.s 6
+			IL_0129: ret
 
-			IL_0114: ldarg.0
-			IL_0115: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_011a: ldnull
-			IL_011b: ldloc.s 4
-			IL_011d: ldloc.s 5
-			IL_011f: tail.
-			IL_0121: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_0126: ret
+			IL_012a: ldarg.0
+			IL_012b: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
+			IL_0130: ldnull
+			IL_0131: ldloc.s 4
+			IL_0133: ldloc.s 5
+			IL_0135: tail.
+			IL_0137: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+			IL_013c: ret
 
-			IL_0127: ldnull
-			IL_0128: ret
+			IL_013d: ldnull
+			IL_013e: ret
 		} // end of method tryFindLatestGeneratedAssembly::__js_call__
 
 	} // end of class tryFindLatestGeneratedAssembly
@@ -1016,7 +1028,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30b5
+						// Method begins at RVA 0x30f1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1034,7 +1046,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30ac
+					// Method begins at RVA 0x30e8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1052,7 +1064,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30a3
+				// Method begins at RVA 0x30df
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1079,7 +1091,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2768
+			// Method begins at RVA 0x277c
 			// Header size: 12
 			// Code size: 400 (0x190)
 			.maxstack 8
@@ -1273,7 +1285,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30be
+				// Method begins at RVA 0x30fa
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1300,7 +1312,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x2904
+			// Method begins at RVA 0x2918
 			// Header size: 12
 			// Code size: 151 (0x97)
 			.maxstack 8
@@ -1384,7 +1396,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30d0
+					// Method begins at RVA 0x310c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1408,7 +1420,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30e2
+						// Method begins at RVA 0x311e
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1426,7 +1438,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30d9
+					// Method begins at RVA 0x3115
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1446,7 +1458,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30eb
+					// Method begins at RVA 0x3127
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1470,7 +1482,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30fd
+						// Method begins at RVA 0x3139
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1488,7 +1500,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f4
+					// Method begins at RVA 0x3130
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1508,7 +1520,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3106
+					// Method begins at RVA 0x3142
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1528,7 +1540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x310f
+					// Method begins at RVA 0x314b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1546,7 +1558,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c7
+				// Method begins at RVA 0x3103
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1572,9 +1584,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0c 00 00 02
 			)
-			// Method begins at RVA 0x29a8
+			// Method begins at RVA 0x29bc
 			// Header size: 12
-			// Code size: 1543 (0x607)
+			// Code size: 1584 (0x630)
 			.maxstack 9
 			.locals init (
 				[0] object,
@@ -1590,7 +1602,7 @@
 				[10] object,
 				[11] object,
 				[12] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21,
-				[13] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[13] object,
 				[14] float64,
 				[15] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54,
 				[16] class Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6,
@@ -1886,216 +1898,237 @@
 			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 			IL_03aa: pop
 
-			IL_03ab: ldnull
-			IL_03ac: ldloc.3
-			IL_03ad: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
-			IL_03b2: stloc.s 22
-			IL_03b4: ldloc.s 22
-			IL_03b6: stloc.s 10
-			IL_03b8: ldarg.0
-			IL_03b9: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_03be: ldnull
-			IL_03bf: ldloc.2
-			IL_03c0: ldloc.s 10
-			IL_03c2: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-			IL_03c7: stloc.s 22
-			IL_03c9: ldloc.s 22
-			IL_03cb: brfalse IL_03e5
+			IL_03ab: ldarg.0
+			IL_03ac: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_03b1: ldc.i4.1
+			IL_03b2: newarr [System.Runtime]System.Object
+			IL_03b7: dup
+			IL_03b8: ldc.i4.0
+			IL_03b9: ldarg.0
+			IL_03ba: stelem.ref
+			IL_03bb: ldloc.3
+			IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03c1: stloc.s 22
+			IL_03c3: ldloc.s 22
+			IL_03c5: stloc.s 10
+			IL_03c7: ldarg.0
+			IL_03c8: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_03cd: ldc.i4.1
+			IL_03ce: newarr [System.Runtime]System.Object
+			IL_03d3: dup
+			IL_03d4: ldc.i4.0
+			IL_03d5: ldarg.0
+			IL_03d6: stelem.ref
+			IL_03d7: ldloc.2
+			IL_03d8: ldloc.s 10
+			IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03df: stloc.s 22
+			IL_03e1: ldloc.s 22
+			IL_03e3: brfalse IL_03fd
 
-			IL_03d0: ldloc.s 22
-			IL_03d2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03d7: brtrue IL_03e5
+			IL_03e8: ldloc.s 22
+			IL_03ea: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03ef: brtrue IL_03fd
 
-			IL_03dc: ldloc.s 22
-			IL_03de: stloc.s 28
-			IL_03e0: br IL_03ed
+			IL_03f4: ldloc.s 22
+			IL_03f6: stloc.s 28
+			IL_03f8: br IL_0405
 
-			IL_03e5: ldc.i4.0
-			IL_03e6: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03eb: stloc.s 28
+			IL_03fd: ldc.i4.0
+			IL_03fe: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0403: stloc.s 28
 
-			IL_03ed: ldloc.s 28
-			IL_03ef: stloc.s 11
-			IL_03f1: ldloc.s 11
-			IL_03f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_03f8: ldc.i4.0
-			IL_03f9: ceq
-			IL_03fb: stloc.s 26
-			IL_03fd: ldloc.s 26
-			IL_03ff: brfalse IL_051c
+			IL_0405: ldloc.s 28
+			IL_0407: stloc.s 11
+			IL_0409: ldloc.s 11
+			IL_040b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0410: ldc.i4.0
+			IL_0411: ceq
+			IL_0413: stloc.s 26
+			IL_0415: ldloc.s 26
+			IL_0417: brfalse IL_053c
 
-			IL_0404: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
-			IL_0409: stloc.s 12
-			IL_040b: ldloc.2
-			IL_040c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0411: stloc.s 24
-			IL_0413: ldstr "Assembly not found for category '"
-			IL_0418: ldloc.s 24
-			IL_041a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_041f: stloc.s 24
-			IL_0421: ldloc.s 24
-			IL_0423: ldstr "' and test '"
-			IL_0428: call string [System.Runtime]System.String::Concat(string, string)
-			IL_042d: stloc.s 24
-			IL_042f: ldloc.3
-			IL_0430: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0435: stloc.s 23
-			IL_0437: ldloc.s 24
-			IL_0439: ldloc.s 23
-			IL_043b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0440: stloc.s 23
-			IL_0442: ldloc.s 23
-			IL_0444: ldstr "'."
-			IL_0449: call string [System.Runtime]System.String::Concat(string, string)
-			IL_044e: stloc.s 23
-			IL_0450: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0455: ldloc.s 23
-			IL_0457: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_045c: pop
-			IL_045d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0462: ldstr "Looked under:"
-			IL_0467: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_046c: pop
-			IL_046d: ldarg.0
-			IL_046e: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-			IL_0473: ldnull
-			IL_0474: ldloc.2
-			IL_0475: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-			IL_047a: stloc.s 25
-			IL_047c: ldloc.s 25
-			IL_047e: stloc.s 13
-			IL_0480: ldc.r8 0.0
-			IL_0489: stloc.s 14
-			// loop start (head: IL_048b)
-				IL_048b: ldloc.s 14
-				IL_048d: ldloc.s 13
-				IL_048f: callvirt instance int32 [JavaScriptRuntime]JavaScriptRuntime.Array::get_Count()
-				IL_0494: conv.r8
-				IL_0495: clt
-				IL_0497: brfalse IL_04e5
+			IL_041c: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L166C21::.ctor()
+			IL_0421: stloc.s 12
+			IL_0423: ldloc.2
+			IL_0424: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0429: stloc.s 24
+			IL_042b: ldstr "Assembly not found for category '"
+			IL_0430: ldloc.s 24
+			IL_0432: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0437: stloc.s 24
+			IL_0439: ldloc.s 24
+			IL_043b: ldstr "' and test '"
+			IL_0440: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0445: stloc.s 24
+			IL_0447: ldloc.3
+			IL_0448: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_044d: stloc.s 23
+			IL_044f: ldloc.s 24
+			IL_0451: ldloc.s 23
+			IL_0453: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0458: stloc.s 23
+			IL_045a: ldloc.s 23
+			IL_045c: ldstr "'."
+			IL_0461: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0466: stloc.s 23
+			IL_0468: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_046d: ldloc.s 23
+			IL_046f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0474: pop
+			IL_0475: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_047a: ldstr "Looked under:"
+			IL_047f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0484: pop
+			IL_0485: ldarg.0
+			IL_0486: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_048b: ldc.i4.1
+			IL_048c: newarr [System.Runtime]System.Object
+			IL_0491: dup
+			IL_0492: ldc.i4.0
+			IL_0493: ldarg.0
+			IL_0494: stelem.ref
+			IL_0495: ldloc.2
+			IL_0496: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_049b: stloc.s 22
+			IL_049d: ldloc.s 22
+			IL_049f: stloc.s 13
+			IL_04a1: ldc.r8 0.0
+			IL_04aa: stloc.s 14
+			// loop start (head: IL_04ac)
+				IL_04ac: ldloc.s 14
+				IL_04ae: ldloc.s 13
+				IL_04b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Object::GetLength(object)
+				IL_04b5: clt
+				IL_04b7: brfalse IL_0505
 
-				IL_049c: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
-				IL_04a1: stloc.s 15
-				IL_04a3: ldloc.s 13
-				IL_04a5: ldloc.s 14
-				IL_04a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_04ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_04b1: stloc.s 23
-				IL_04b3: ldstr "  - "
-				IL_04b8: ldloc.s 23
-				IL_04ba: call string [System.Runtime]System.String::Concat(string, string)
-				IL_04bf: stloc.s 23
-				IL_04c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_04c6: ldloc.s 23
-				IL_04c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_04cd: pop
-				IL_04ce: ldloc.s 14
-				IL_04d0: ldc.r8 1
-				IL_04d9: add
-				IL_04da: stloc.s 29
-				IL_04dc: ldloc.s 29
-				IL_04de: stloc.s 14
-				IL_04e0: br IL_048b
+				IL_04bc: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Scope_For_L170C9/Block_L170C54::.ctor()
+				IL_04c1: stloc.s 15
+				IL_04c3: ldloc.s 13
+				IL_04c5: ldloc.s 14
+				IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_04cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_04d1: stloc.s 23
+				IL_04d3: ldstr "  - "
+				IL_04d8: ldloc.s 23
+				IL_04da: call string [System.Runtime]System.String::Concat(string, string)
+				IL_04df: stloc.s 23
+				IL_04e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_04e6: ldloc.s 23
+				IL_04e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_04ed: pop
+				IL_04ee: ldloc.s 14
+				IL_04f0: ldc.r8 1
+				IL_04f9: add
+				IL_04fa: stloc.s 29
+				IL_04fc: ldloc.s 29
+				IL_04fe: stloc.s 14
+				IL_0500: br IL_04ac
 			// end loop
 
-			IL_04e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04ea: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_04ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-			IL_04f4: pop
-			IL_04f5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04ff: stloc.s 22
-			IL_0501: ldloc.s 22
-			IL_0503: ldstr "exit"
-			IL_0508: ldc.r8 1
-			IL_0511: box [System.Runtime]System.Double
-			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_051b: pop
+			IL_0505: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_050a: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_050f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+			IL_0514: pop
+			IL_0515: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_051a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_051f: stloc.s 22
+			IL_0521: ldloc.s 22
+			IL_0523: ldstr "exit"
+			IL_0528: ldc.r8 1
+			IL_0531: box [System.Runtime]System.Double
+			IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_053b: pop
 
-			IL_051c: ldloc.s 11
-			IL_051e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0523: stloc.s 23
-			IL_0525: ldstr "Found assembly: "
-			IL_052a: ldloc.s 23
-			IL_052c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0531: stloc.s 23
-			IL_0533: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0538: ldloc.s 23
-			IL_053a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_053f: pop
+			IL_053c: ldloc.s 11
+			IL_053e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0543: stloc.s 23
+			IL_0545: ldstr "Found assembly: "
+			IL_054a: ldloc.s 23
+			IL_054c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0551: stloc.s 23
+			IL_0553: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0558: ldloc.s 23
+			IL_055a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_055f: pop
 			.try
 			{
-				IL_0540: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
-				IL_0545: stloc.s 16
-				IL_0547: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_054c: ldstr "Opening in ILSpy..."
-				IL_0551: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0556: pop
-				IL_0557: ldarg.0
-				IL_0558: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-				IL_055d: ldnull
-				IL_055e: ldloc.s 11
-				IL_0560: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-				IL_0565: pop
-				IL_0566: leave IL_05f1
+				IL_0560: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L180C6::.ctor()
+				IL_0565: stloc.s 16
+				IL_0567: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_056c: ldstr "Opening in ILSpy..."
+				IL_0571: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0576: pop
+				IL_0577: ldarg.0
+				IL_0578: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_057d: ldc.i4.1
+				IL_057e: newarr [System.Runtime]System.Object
+				IL_0583: dup
+				IL_0584: ldc.i4.0
+				IL_0585: ldarg.0
+				IL_0586: stelem.ref
+				IL_0587: ldloc.s 11
+				IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_058e: pop
+				IL_058f: leave IL_061a
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_056b: stloc.s 17
-				IL_056d: ldloc.s 17
-				IL_056f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0574: dup
-				IL_0575: brtrue IL_058b
+				IL_0594: stloc.s 17
+				IL_0596: ldloc.s 17
+				IL_0598: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_059d: dup
+				IL_059e: brtrue IL_05b4
 
-				IL_057a: pop
-				IL_057b: ldloc.s 17
-				IL_057d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0582: dup
-				IL_0583: brtrue IL_0597
+				IL_05a3: pop
+				IL_05a4: ldloc.s 17
+				IL_05a6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_05ab: dup
+				IL_05ac: brtrue IL_05c0
 
-				IL_0588: pop
-				IL_0589: rethrow
+				IL_05b1: pop
+				IL_05b2: rethrow
 
-				IL_058b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0590: stloc.s 18
-				IL_0592: br IL_0599
+				IL_05b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_05b9: stloc.s 18
+				IL_05bb: br IL_05c2
 
-				IL_0597: stloc.s 18
+				IL_05c0: stloc.s 18
 
-				IL_0599: ldloc.s 18
-				IL_059b: stloc.s 22
-				IL_059d: ldloc.s 22
-				IL_059f: stloc.s 19
-				IL_05a1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
-				IL_05a6: stloc.s 20
-				IL_05a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_05ad: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_05b2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_05b7: pop
-				IL_05b8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_05bd: ldloc.s 19
-				IL_05bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
-				IL_05c4: pop
-				IL_05c5: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-				IL_05ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_05cf: stloc.s 22
-				IL_05d1: ldloc.s 22
-				IL_05d3: ldstr "exit"
-				IL_05d8: ldc.r8 1
-				IL_05e1: box [System.Runtime]System.Double
-				IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_05eb: pop
-				IL_05ec: leave IL_05f1
+				IL_05c2: ldloc.s 18
+				IL_05c4: stloc.s 22
+				IL_05c6: ldloc.s 22
+				IL_05c8: stloc.s 19
+				IL_05ca: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/Scope/Block_L183C16::.ctor()
+				IL_05cf: stloc.s 20
+				IL_05d1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05d6: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_05db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05e0: pop
+				IL_05e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_05e6: ldloc.s 19
+				IL_05e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::'error'(object)
+				IL_05ed: pop
+				IL_05ee: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+				IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_05f8: stloc.s 22
+				IL_05fa: ldloc.s 22
+				IL_05fc: ldstr "exit"
+				IL_0601: ldc.r8 1
+				IL_060a: box [System.Runtime]System.Double
+				IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_0614: pop
+				IL_0615: leave IL_061a
 			} // end handler
 
-			IL_05f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05f6: ldstr "Done!"
-			IL_05fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0600: pop
-			IL_0601: ldnull
-			IL_0602: stloc.s 21
-			IL_0604: ldloc.s 21
-			IL_0606: ret
+			IL_061a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_061f: ldstr "Done!"
+			IL_0624: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0629: pop
+			IL_062a: ldnull
+			IL_062b: stloc.s 21
+			IL_062d: ldloc.s 21
+			IL_062f: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2144,7 +2177,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3037
+			// Method begins at RVA 0x3073
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2170,13 +2203,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 442 (0x1ba)
+		// Code size: 444 (0x1bc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_DecompileGeneratorTest/Scope,
 			[1] object,
 			[2] object,
-			[3] object
+			[3] object,
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/Scope::.ctor()
@@ -2346,21 +2380,21 @@
 		IL_018f: ldloc.0
 		IL_0190: ldloc.3
 		IL_0191: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::os
-		IL_0196: ldloc.0
-		IL_0197: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_019c: ldnull
-		IL_019d: ldarg.s __dirname
-		IL_019f: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_01a4: stloc.3
-		IL_01a5: ldloc.0
-		IL_01a6: ldloc.3
-		IL_01a7: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-		IL_01ac: ldloc.0
-		IL_01ad: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_01b2: ldnull
-		IL_01b3: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
-		IL_01b8: pop
-		IL_01b9: ret
+		IL_0196: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_019b: stloc.s 4
+		IL_019d: ldloc.1
+		IL_019e: ldloc.s 4
+		IL_01a0: ldarg.s __dirname
+		IL_01a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_01a7: stloc.3
+		IL_01a8: ldloc.0
+		IL_01a9: ldloc.3
+		IL_01aa: stfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+		IL_01af: ldloc.2
+		IL_01b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_01ba: pop
+		IL_01bb: ret
 	} // end of method Compile_Scripts_DecompileGeneratorTest::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_DecompileGeneratorTest
@@ -2372,7 +2406,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3118
+		// Method begins at RVA 0x3154
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44fb
+				// Method begins at RVA 0x460f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2324
+			// Method begins at RVA 0x2320
 			// Header size: 12
 			// Code size: 265 (0x109)
 			.maxstack 8
@@ -192,7 +192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4504
+				// Method begins at RVA 0x4618
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -216,7 +216,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x243c
+			// Method begins at RVA 0x2438
 			// Header size: 12
 			// Code size: 176 (0xb0)
 			.maxstack 8
@@ -324,7 +324,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x44f2
+			// Method begins at RVA 0x4606
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -350,7 +350,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 141 (0x8d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope,
@@ -382,43 +382,38 @@
 		IL_0035: stloc.2
 		IL_0036: ldloc.2
 		IL_0037: stloc.1
-		IL_0038: ldc.i4.1
-		IL_0039: newarr [System.Runtime]System.Object
-		IL_003e: dup
-		IL_003f: ldc.i4.0
-		IL_0040: ldloc.0
-		IL_0041: stelem.ref
-		IL_0042: ldnull
-		IL_0043: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
-		IL_0048: stloc.2
-		IL_0049: ldloc.2
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.2
-		IL_0050: ldnull
-		IL_0051: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L8C13::__js_call__(object, object)
-		IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_005c: ldc.i4.1
-		IL_005d: newarr [System.Runtime]System.Object
-		IL_0062: dup
-		IL_0063: ldc.i4.0
-		IL_0064: ldloc.0
-		IL_0065: stelem.ref
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0070: ldc.i4.1
-		IL_0071: conv.r8
-		IL_0072: ldstr ""
-		IL_0077: ldc.i4.0
-		IL_0078: ldc.i4.1
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0083: stloc.3
-		IL_0084: ldloc.2
-		IL_0085: ldstr "catch"
-		IL_008a: ldloc.3
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_0038: ldloc.1
+		IL_0039: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0043: stloc.2
+		IL_0044: ldloc.2
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_004a: stloc.2
+		IL_004b: ldnull
+		IL_004c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L8C13::__js_call__(object, object)
+		IL_0052: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_006b: ldc.i4.1
+		IL_006c: conv.r8
+		IL_006d: ldstr ""
+		IL_0072: ldc.i4.0
+		IL_0073: ldc.i4.1
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_007e: stloc.3
+		IL_007f: ldloc.2
+		IL_0080: ldstr "catch"
+		IL_0085: ldloc.3
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008b: pop
+		IL_008c: ret
 	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_AutoMode::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
@@ -442,7 +437,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x451f
+					// Method begins at RVA 0x4633
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -460,7 +455,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4516
+				// Method begins at RVA 0x462a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -485,7 +480,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24f8
+			// Method begins at RVA 0x24f4
 			// Header size: 12
 			// Code size: 306 (0x132)
 			.maxstack 8
@@ -612,7 +607,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4528
+				// Method begins at RVA 0x463c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -640,7 +635,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4543
+						// Method begins at RVA 0x4657
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -660,7 +655,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x454c
+						// Method begins at RVA 0x4660
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -680,7 +675,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4555
+						// Method begins at RVA 0x4669
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -700,7 +695,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x455e
+						// Method begins at RVA 0x4672
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -720,7 +715,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4567
+						// Method begins at RVA 0x467b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -740,7 +735,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4570
+						// Method begins at RVA 0x4684
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -758,7 +753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x453a
+					// Method begins at RVA 0x464e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4531
+				// Method begins at RVA 0x4645
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -803,7 +798,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2638
+			// Method begins at RVA 0x2634
 			// Header size: 12
 			// Code size: 756 (0x2f4)
 			.maxstack 8
@@ -1130,7 +1125,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45ca
+							// Method begins at RVA 0x46de
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1155,7 +1150,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4474
+						// Method begins at RVA 0x4588
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1194,7 +1189,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45d3
+							// Method begins at RVA 0x46e7
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1218,7 +1213,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44a4
+						// Method begins at RVA 0x45b8
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1291,7 +1286,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x45b8
+								// Method begins at RVA 0x46cc
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1309,7 +1304,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45af
+							// Method begins at RVA 0x46c3
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1329,7 +1324,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45c1
+							// Method begins at RVA 0x46d5
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1351,7 +1346,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a6
+						// Method begins at RVA 0x46ba
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1376,9 +1371,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4008
+					// Method begins at RVA 0x40fc
 					// Header size: 12
-					// Code size: 1119 (0x45f)
+					// Code size: 1151 (0x47f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1401,8 +1396,7 @@
 						[17] string,
 						[18] object,
 						[19] object,
-						[20] object,
-						[21] string
+						[20] string
 					)
 
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
@@ -1482,7 +1476,7 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 8
 					IL_00d6: ldloc.s 8
-					IL_00d8: brfalse IL_025e
+					IL_00d8: brfalse IL_027e
 
 					IL_00dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00e2: stloc.3
@@ -1599,262 +1593,284 @@
 					IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 					IL_01f0: pop
 					IL_01f1: ldarg.0
-					IL_01f2: ldc.i4.1
+					IL_01f2: ldc.i4.0
 					IL_01f3: ldelem.ref
-					IL_01f4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_01f9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_01fe: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0203: ldc.r8 1
-					IL_020c: sub
-					IL_020d: box [System.Runtime]System.Double
-					IL_0212: stloc.s 19
+					IL_01f4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01f9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_01fe: stloc.s 18
+					IL_0200: ldc.i4.3
+					IL_0201: newarr [System.Runtime]System.Object
+					IL_0206: dup
+					IL_0207: ldc.i4.0
+					IL_0208: ldarg.0
+					IL_0209: ldc.i4.0
+					IL_020a: ldelem.ref
+					IL_020b: stelem.ref
+					IL_020c: dup
+					IL_020d: ldc.i4.1
+					IL_020e: ldarg.0
+					IL_020f: ldc.i4.1
+					IL_0210: ldelem.ref
+					IL_0211: stelem.ref
+					IL_0212: dup
+					IL_0213: ldc.i4.2
 					IL_0214: ldarg.0
-					IL_0215: ldc.i4.0
+					IL_0215: ldc.i4.2
 					IL_0216: ldelem.ref
-					IL_0217: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_021c: ldnull
-					IL_021d: ldloc.s 5
-					IL_021f: ldloc.s 19
-					IL_0221: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-					IL_0226: stloc.s 18
-					IL_0228: ldloc.s 18
-					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_022f: stloc.s 18
-					IL_0231: ldarg.0
-					IL_0232: ldc.i4.2
-					IL_0233: ldelem.ref
-					IL_0234: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0239: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_023e: stloc.s 7
-					IL_0240: ldloc.s 18
-					IL_0242: ldstr "then"
-					IL_0247: ldloc.s 7
-					IL_0249: ldarg.0
-					IL_024a: ldc.i4.2
-					IL_024b: ldelem.ref
-					IL_024c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0251: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_025b: pop
-					IL_025c: ldnull
-					IL_025d: ret
+					IL_0217: stelem.ref
+					IL_0218: stloc.s 16
+					IL_021a: ldloc.s 18
+					IL_021c: ldloc.s 16
+					IL_021e: ldloc.s 5
+					IL_0220: ldarg.0
+					IL_0221: ldc.i4.1
+					IL_0222: ldelem.ref
+					IL_0223: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0228: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_022d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0232: ldc.r8 1
+					IL_023b: sub
+					IL_023c: box [System.Runtime]System.Double
+					IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_0246: stloc.s 18
+					IL_0248: ldloc.s 18
+					IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_024f: stloc.s 18
+					IL_0251: ldarg.0
+					IL_0252: ldc.i4.2
+					IL_0253: ldelem.ref
+					IL_0254: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0259: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_025e: stloc.s 7
+					IL_0260: ldloc.s 18
+					IL_0262: ldstr "then"
+					IL_0267: ldloc.s 7
+					IL_0269: ldarg.0
+					IL_026a: ldc.i4.2
+					IL_026b: ldelem.ref
+					IL_026c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0271: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_027b: pop
+					IL_027c: ldnull
+					IL_027d: ret
 
-					IL_025e: ldloc.1
-					IL_025f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0264: stloc.s 11
-					IL_0266: ldloc.s 11
-					IL_0268: ldc.r8 200
-					IL_0271: clt
-					IL_0273: stloc.s 8
-					IL_0275: ldloc.s 8
-					IL_0277: box [System.Runtime]System.Boolean
-					IL_027c: stloc.s 12
-					IL_027e: ldloc.s 12
-					IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0285: stloc.s 8
-					IL_0287: ldloc.s 8
-					IL_0289: brtrue IL_02ba
+					IL_027e: ldloc.1
+					IL_027f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0284: stloc.s 11
+					IL_0286: ldloc.s 11
+					IL_0288: ldc.r8 200
+					IL_0291: clt
+					IL_0293: stloc.s 8
+					IL_0295: ldloc.s 8
+					IL_0297: box [System.Runtime]System.Boolean
+					IL_029c: stloc.s 12
+					IL_029e: ldloc.s 12
+					IL_02a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a5: stloc.s 8
+					IL_02a7: ldloc.s 8
+					IL_02a9: brtrue IL_02da
 
-					IL_028e: ldloc.1
-					IL_028f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0294: stloc.s 11
-					IL_0296: ldloc.s 11
-					IL_0298: ldc.r8 300
-					IL_02a1: clt
-					IL_02a3: ldc.i4.0
-					IL_02a4: ceq
-					IL_02a6: stloc.s 8
-					IL_02a8: ldloc.s 8
-					IL_02aa: box [System.Runtime]System.Boolean
-					IL_02af: stloc.s 13
-					IL_02b1: ldloc.s 13
-					IL_02b3: stloc.s 20
-					IL_02b5: br IL_02be
+					IL_02ae: ldloc.1
+					IL_02af: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02b4: stloc.s 11
+					IL_02b6: ldloc.s 11
+					IL_02b8: ldc.r8 300
+					IL_02c1: clt
+					IL_02c3: ldc.i4.0
+					IL_02c4: ceq
+					IL_02c6: stloc.s 8
+					IL_02c8: ldloc.s 8
+					IL_02ca: box [System.Runtime]System.Boolean
+					IL_02cf: stloc.s 13
+					IL_02d1: ldloc.s 13
+					IL_02d3: stloc.s 19
+					IL_02d5: br IL_02de
 
-					IL_02ba: ldloc.s 12
-					IL_02bc: stloc.s 20
+					IL_02da: ldloc.s 12
+					IL_02dc: stloc.s 19
 
-					IL_02be: ldloc.s 20
-					IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02c5: stloc.s 8
-					IL_02c7: ldloc.s 8
-					IL_02c9: brfalse IL_0372
+					IL_02de: ldloc.s 19
+					IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02e5: stloc.s 8
+					IL_02e7: ldloc.s 8
+					IL_02e9: brfalse IL_0392
 
-					IL_02ce: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_02d3: stloc.s 6
-					IL_02d5: ldarg.2
-					IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02db: stloc.s 7
-					IL_02dd: ldloc.s 7
-					IL_02df: ldstr "resume"
-					IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02e9: pop
-					IL_02ea: ldarg.0
-					IL_02eb: ldc.i4.2
-					IL_02ec: ldelem.ref
-					IL_02ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02f2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_02f7: stloc.s 7
-					IL_02f9: ldc.i4.3
-					IL_02fa: newarr [System.Runtime]System.Object
-					IL_02ff: dup
-					IL_0300: ldc.i4.0
-					IL_0301: ldarg.0
-					IL_0302: ldc.i4.0
-					IL_0303: ldelem.ref
-					IL_0304: stelem.ref
-					IL_0305: dup
-					IL_0306: ldc.i4.1
-					IL_0307: ldarg.0
-					IL_0308: ldc.i4.1
-					IL_0309: ldelem.ref
-					IL_030a: stelem.ref
-					IL_030b: dup
-					IL_030c: ldc.i4.2
-					IL_030d: ldarg.0
-					IL_030e: ldc.i4.2
-					IL_030f: ldelem.ref
-					IL_0310: stelem.ref
-					IL_0311: stloc.s 16
-					IL_0313: ldloc.1
-					IL_0314: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0319: stloc.s 17
-					IL_031b: ldstr "HTTP "
-					IL_0320: ldloc.s 17
-					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0327: stloc.s 17
-					IL_0329: ldloc.s 17
-					IL_032b: ldstr " fetching "
-					IL_0330: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0335: stloc.s 17
-					IL_0337: ldarg.0
-					IL_0338: ldc.i4.1
-					IL_0339: ldelem.ref
-					IL_033a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_033f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0344: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0349: stloc.s 21
-					IL_034b: ldloc.s 17
-					IL_034d: ldloc.s 21
-					IL_034f: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0354: stloc.s 21
-					IL_0356: ldloc.s 21
-					IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0362: stloc.s 18
-					IL_0364: ldloc.s 7
-					IL_0366: ldloc.s 16
-					IL_0368: ldloc.s 18
-					IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_036f: pop
-					IL_0370: ldnull
-					IL_0371: ret
+					IL_02ee: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_02f3: stloc.s 6
+					IL_02f5: ldarg.2
+					IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02fb: stloc.s 7
+					IL_02fd: ldloc.s 7
+					IL_02ff: ldstr "resume"
+					IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0309: pop
+					IL_030a: ldarg.0
+					IL_030b: ldc.i4.2
+					IL_030c: ldelem.ref
+					IL_030d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0312: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0317: stloc.s 7
+					IL_0319: ldc.i4.3
+					IL_031a: newarr [System.Runtime]System.Object
+					IL_031f: dup
+					IL_0320: ldc.i4.0
+					IL_0321: ldarg.0
+					IL_0322: ldc.i4.0
+					IL_0323: ldelem.ref
+					IL_0324: stelem.ref
+					IL_0325: dup
+					IL_0326: ldc.i4.1
+					IL_0327: ldarg.0
+					IL_0328: ldc.i4.1
+					IL_0329: ldelem.ref
+					IL_032a: stelem.ref
+					IL_032b: dup
+					IL_032c: ldc.i4.2
+					IL_032d: ldarg.0
+					IL_032e: ldc.i4.2
+					IL_032f: ldelem.ref
+					IL_0330: stelem.ref
+					IL_0331: stloc.s 16
+					IL_0333: ldloc.1
+					IL_0334: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0339: stloc.s 17
+					IL_033b: ldstr "HTTP "
+					IL_0340: ldloc.s 17
+					IL_0342: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0347: stloc.s 17
+					IL_0349: ldloc.s 17
+					IL_034b: ldstr " fetching "
+					IL_0350: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0355: stloc.s 17
+					IL_0357: ldarg.0
+					IL_0358: ldc.i4.1
+					IL_0359: ldelem.ref
+					IL_035a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_035f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0364: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0369: stloc.s 20
+					IL_036b: ldloc.s 17
+					IL_036d: ldloc.s 20
+					IL_036f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0374: stloc.s 20
+					IL_0376: ldloc.s 20
+					IL_0378: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_037d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0382: stloc.s 18
+					IL_0384: ldloc.s 7
+					IL_0386: ldloc.s 16
+					IL_0388: ldloc.s 18
+					IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_038f: pop
+					IL_0390: ldnull
+					IL_0391: ret
 
-					IL_0372: ldarg.2
-					IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0378: stloc.s 18
-					IL_037a: ldloc.s 18
-					IL_037c: ldstr "setEncoding"
-					IL_0381: ldstr "utf8"
-					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_038b: pop
-					IL_038c: ldloc.0
-					IL_038d: ldstr ""
-					IL_0392: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0397: ldarg.2
-					IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_039d: stloc.s 18
-					IL_039f: ldnull
-					IL_03a0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_03a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_03ab: ldc.i4.4
-					IL_03ac: newarr [System.Runtime]System.Object
-					IL_03b1: dup
-					IL_03b2: ldc.i4.0
-					IL_03b3: ldarg.0
-					IL_03b4: ldc.i4.0
-					IL_03b5: ldelem.ref
-					IL_03b6: stelem.ref
-					IL_03b7: dup
-					IL_03b8: ldc.i4.1
-					IL_03b9: ldarg.0
-					IL_03ba: ldc.i4.1
-					IL_03bb: ldelem.ref
-					IL_03bc: stelem.ref
-					IL_03bd: dup
-					IL_03be: ldc.i4.2
-					IL_03bf: ldarg.0
-					IL_03c0: ldc.i4.2
-					IL_03c1: ldelem.ref
-					IL_03c2: stelem.ref
-					IL_03c3: dup
-					IL_03c4: ldc.i4.3
-					IL_03c5: ldloc.0
-					IL_03c6: stelem.ref
-					IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03d1: ldc.i4.1
-					IL_03d2: conv.r8
-					IL_03d3: ldstr ""
-					IL_03d8: ldc.i4.0
-					IL_03d9: ldc.i4.1
-					IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_03e4: stloc.s 7
-					IL_03e6: ldloc.s 18
-					IL_03e8: ldstr "on"
-					IL_03ed: ldstr "data"
-					IL_03f2: ldloc.s 7
-					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_03f9: pop
-					IL_03fa: ldarg.2
-					IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0400: stloc.s 7
-					IL_0402: ldnull
-					IL_0403: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_0409: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_040e: ldc.i4.4
-					IL_040f: newarr [System.Runtime]System.Object
-					IL_0414: dup
-					IL_0415: ldc.i4.0
-					IL_0416: ldarg.0
-					IL_0417: ldc.i4.0
-					IL_0418: ldelem.ref
-					IL_0419: stelem.ref
-					IL_041a: dup
-					IL_041b: ldc.i4.1
-					IL_041c: ldarg.0
-					IL_041d: ldc.i4.1
-					IL_041e: ldelem.ref
-					IL_041f: stelem.ref
-					IL_0420: dup
-					IL_0421: ldc.i4.2
-					IL_0422: ldarg.0
-					IL_0423: ldc.i4.2
-					IL_0424: ldelem.ref
-					IL_0425: stelem.ref
-					IL_0426: dup
-					IL_0427: ldc.i4.3
-					IL_0428: ldloc.0
-					IL_0429: stelem.ref
-					IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0434: ldc.i4.0
-					IL_0435: conv.r8
-					IL_0436: ldstr ""
-					IL_043b: ldc.i4.0
-					IL_043c: ldc.i4.1
-					IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0447: stloc.s 18
-					IL_0449: ldloc.s 7
-					IL_044b: ldstr "on"
-					IL_0450: ldstr "end"
-					IL_0455: ldloc.s 18
-					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_045c: pop
-					IL_045d: ldnull
-					IL_045e: ret
+					IL_0392: ldarg.2
+					IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0398: stloc.s 18
+					IL_039a: ldloc.s 18
+					IL_039c: ldstr "setEncoding"
+					IL_03a1: ldstr "utf8"
+					IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_03ab: pop
+					IL_03ac: ldloc.0
+					IL_03ad: ldstr ""
+					IL_03b2: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_03b7: ldarg.2
+					IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03bd: stloc.s 18
+					IL_03bf: ldnull
+					IL_03c0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03cb: ldc.i4.4
+					IL_03cc: newarr [System.Runtime]System.Object
+					IL_03d1: dup
+					IL_03d2: ldc.i4.0
+					IL_03d3: ldarg.0
+					IL_03d4: ldc.i4.0
+					IL_03d5: ldelem.ref
+					IL_03d6: stelem.ref
+					IL_03d7: dup
+					IL_03d8: ldc.i4.1
+					IL_03d9: ldarg.0
+					IL_03da: ldc.i4.1
+					IL_03db: ldelem.ref
+					IL_03dc: stelem.ref
+					IL_03dd: dup
+					IL_03de: ldc.i4.2
+					IL_03df: ldarg.0
+					IL_03e0: ldc.i4.2
+					IL_03e1: ldelem.ref
+					IL_03e2: stelem.ref
+					IL_03e3: dup
+					IL_03e4: ldc.i4.3
+					IL_03e5: ldloc.0
+					IL_03e6: stelem.ref
+					IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03f1: ldc.i4.1
+					IL_03f2: conv.r8
+					IL_03f3: ldstr ""
+					IL_03f8: ldc.i4.0
+					IL_03f9: ldc.i4.1
+					IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0404: stloc.s 7
+					IL_0406: ldloc.s 18
+					IL_0408: ldstr "on"
+					IL_040d: ldstr "data"
+					IL_0412: ldloc.s 7
+					IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0419: pop
+					IL_041a: ldarg.2
+					IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0420: stloc.s 7
+					IL_0422: ldnull
+					IL_0423: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0429: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_042e: ldc.i4.4
+					IL_042f: newarr [System.Runtime]System.Object
+					IL_0434: dup
+					IL_0435: ldc.i4.0
+					IL_0436: ldarg.0
+					IL_0437: ldc.i4.0
+					IL_0438: ldelem.ref
+					IL_0439: stelem.ref
+					IL_043a: dup
+					IL_043b: ldc.i4.1
+					IL_043c: ldarg.0
+					IL_043d: ldc.i4.1
+					IL_043e: ldelem.ref
+					IL_043f: stelem.ref
+					IL_0440: dup
+					IL_0441: ldc.i4.2
+					IL_0442: ldarg.0
+					IL_0443: ldc.i4.2
+					IL_0444: ldelem.ref
+					IL_0445: stelem.ref
+					IL_0446: dup
+					IL_0447: ldc.i4.3
+					IL_0448: ldloc.0
+					IL_0449: stelem.ref
+					IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0454: ldc.i4.0
+					IL_0455: conv.r8
+					IL_0456: ldstr ""
+					IL_045b: ldc.i4.0
+					IL_045c: ldc.i4.1
+					IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0467: stloc.s 18
+					IL_0469: ldloc.s 7
+					IL_046b: ldstr "on"
+					IL_0470: ldstr "end"
+					IL_0475: ldloc.s 18
+					IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_047c: pop
+					IL_047d: ldnull
+					IL_047e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1876,7 +1892,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4594
+						// Method begins at RVA 0x46a8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1896,7 +1912,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x459d
+						// Method begins at RVA 0x46b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1919,7 +1935,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x458b
+					// Method begins at RVA 0x469f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1945,7 +1961,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3dec
+				// Method begins at RVA 0x3ee0
 				// Header size: 12
 				// Code size: 512 (0x200)
 				.maxstack 8
@@ -2190,7 +2206,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4582
+					// Method begins at RVA 0x4696
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2212,7 +2228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4579
+				// Method begins at RVA 0x468d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2240,7 +2256,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2938
+			// Method begins at RVA 0x2934
 			// Header size: 12
 			// Code size: 113 (0x71)
 			.maxstack 8
@@ -2311,7 +2327,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45dc
+				// Method begins at RVA 0x46f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2335,7 +2351,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29b8
+			// Method begins at RVA 0x29b4
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -2378,7 +2394,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ee
+					// Method begins at RVA 0x4702
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2402,7 +2418,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4600
+						// Method begins at RVA 0x4714
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2420,7 +2436,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45f7
+					// Method begins at RVA 0x470b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2438,7 +2454,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45e5
+				// Method begins at RVA 0x46f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2466,7 +2482,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x29f0
+			// Method begins at RVA 0x29ec
 			// Header size: 12
 			// Code size: 558 (0x22e)
 			.maxstack 8
@@ -2712,7 +2728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4612
+					// Method begins at RVA 0x4726
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2732,7 +2748,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x461b
+					// Method begins at RVA 0x472f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2752,7 +2768,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4624
+					// Method begins at RVA 0x4738
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2772,7 +2788,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x462d
+					// Method begins at RVA 0x4741
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2796,7 +2812,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x463f
+						// Method begins at RVA 0x4753
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2816,7 +2832,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4648
+						// Method begins at RVA 0x475c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2840,7 +2856,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x465a
+							// Method begins at RVA 0x476e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2858,7 +2874,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4651
+						// Method begins at RVA 0x4765
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2878,7 +2894,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4663
+						// Method begins at RVA 0x4777
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2896,7 +2912,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4636
+					// Method begins at RVA 0x474a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2914,7 +2930,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4609
+				// Method begins at RVA 0x471d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2942,9 +2958,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2c2c
+			// Method begins at RVA 0x2c28
 			// Header size: 12
-			// Code size: 1096 (0x448)
+			// Code size: 1124 (0x464)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -2974,10 +2990,11 @@
 				[24] string,
 				[25] object,
 				[26] float64,
-				[27] bool,
-				[28] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[29] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[30] string
+				[27] object[],
+				[28] bool,
+				[29] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[30] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[31] string
 			)
 
 			IL_0000: ldarg.3
@@ -3126,241 +3143,255 @@
 
 			IL_019e: throw
 
-			IL_019f: ldarg.0
-			IL_01a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_01a5: ldnull
-			IL_01a6: ldarg.2
-			IL_01a7: ldloc.s 6
-			IL_01a9: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_01ae: stloc.s 25
-			IL_01b0: ldloc.s 25
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
-			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01bb: ldc.i4.0
-			IL_01bc: ceq
-			IL_01be: stloc.s 27
-			IL_01c0: ldloc.s 27
-			IL_01c2: brfalse IL_021b
+			IL_019f: ldc.i4.1
+			IL_01a0: newarr [System.Runtime]System.Object
+			IL_01a5: dup
+			IL_01a6: ldc.i4.0
+			IL_01a7: ldarg.0
+			IL_01a8: stelem.ref
+			IL_01a9: stloc.s 27
+			IL_01ab: ldarg.0
+			IL_01ac: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_01b1: ldloc.s 27
+			IL_01b3: ldarg.2
+			IL_01b4: ldloc.s 6
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01bb: stloc.s 25
+			IL_01bd: ldloc.s 25
+			IL_01bf: stloc.s 9
+			IL_01c1: ldloc.s 9
+			IL_01c3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01c8: ldc.i4.0
+			IL_01c9: ceq
+			IL_01cb: stloc.s 28
+			IL_01cd: ldloc.s 28
+			IL_01cf: brfalse IL_0228
 
-			IL_01c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
-			IL_01cc: stloc.s 10
-			IL_01ce: ldarg.3
-			IL_01cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d4: stloc.s 24
-			IL_01d6: ldstr "Could not determine tag name for id '"
-			IL_01db: ldloc.s 24
-			IL_01dd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e2: stloc.s 24
-			IL_01e4: ldloc.s 24
-			IL_01e6: ldstr "'."
-			IL_01eb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f0: stloc.s 24
-			IL_01f2: ldloc.s 24
-			IL_01f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01fe: stloc.s 25
-			IL_0200: ldloc.s 25
-			IL_0202: stloc.s 11
-			IL_0204: ldloc.s 11
-			IL_0206: isinst [System.Runtime]System.Exception
-			IL_020b: dup
-			IL_020c: brtrue IL_021a
+			IL_01d4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
+			IL_01d9: stloc.s 10
+			IL_01db: ldarg.3
+			IL_01dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e1: stloc.s 24
+			IL_01e3: ldstr "Could not determine tag name for id '"
+			IL_01e8: ldloc.s 24
+			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ef: stloc.s 24
+			IL_01f1: ldloc.s 24
+			IL_01f3: ldstr "'."
+			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fd: stloc.s 24
+			IL_01ff: ldloc.s 24
+			IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0206: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_020b: stloc.s 25
+			IL_020d: ldloc.s 25
+			IL_020f: stloc.s 11
+			IL_0211: ldloc.s 11
+			IL_0213: isinst [System.Runtime]System.Exception
+			IL_0218: dup
+			IL_0219: brtrue IL_0227
 
-			IL_0211: pop
-			IL_0212: ldloc.s 11
-			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0219: throw
+			IL_021e: pop
+			IL_021f: ldloc.s 11
+			IL_0221: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0226: throw
 
-			IL_021a: throw
+			IL_0227: throw
 
-			IL_021b: ldnull
-			IL_021c: ldloc.s 9
-			IL_021e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-			IL_0223: stloc.s 25
-			IL_0225: ldloc.s 25
-			IL_0227: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_022c: stloc.s 24
-			IL_022e: ldstr "<\\/?"
-			IL_0233: ldloc.s 24
-			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
-			IL_023a: stloc.s 24
-			IL_023c: ldloc.s 24
-			IL_023e: ldstr "\\b[^>]*>"
-			IL_0243: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0228: ldarg.0
+			IL_0229: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_022e: ldc.i4.1
+			IL_022f: newarr [System.Runtime]System.Object
+			IL_0234: dup
+			IL_0235: ldc.i4.0
+			IL_0236: ldarg.0
+			IL_0237: stelem.ref
+			IL_0238: ldloc.s 9
+			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_023f: stloc.s 25
+			IL_0241: ldloc.s 25
+			IL_0243: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0248: stloc.s 24
-			IL_024a: ldloc.s 24
-			IL_024c: ldstr "gi"
-			IL_0251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0256: stloc.s 28
-			IL_0258: ldloc.s 28
-			IL_025a: stloc.s 12
-			IL_025c: ldloc.s 12
-			IL_025e: ldstr "lastIndex"
-			IL_0263: ldloc.s 6
-			IL_0265: ldc.i4.1
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_026b: pop
-			IL_026c: ldc.r8 0.0
-			IL_0275: stloc.s 13
-			IL_0277: ldc.r8 1
-			IL_0280: neg
-			IL_0281: box [System.Runtime]System.Double
-			IL_0286: stloc.s 14
-			// loop start (head: IL_0288)
-				IL_0288: ldc.i4.1
-				IL_0289: brfalse IL_03d7
+			IL_024a: ldstr "<\\/?"
+			IL_024f: ldloc.s 24
+			IL_0251: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0256: stloc.s 24
+			IL_0258: ldloc.s 24
+			IL_025a: ldstr "\\b[^>]*>"
+			IL_025f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0264: stloc.s 24
+			IL_0266: ldloc.s 24
+			IL_0268: ldstr "gi"
+			IL_026d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0272: stloc.s 29
+			IL_0274: ldloc.s 29
+			IL_0276: stloc.s 12
+			IL_0278: ldloc.s 12
+			IL_027a: ldstr "lastIndex"
+			IL_027f: ldloc.s 6
+			IL_0281: ldc.i4.1
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0287: pop
+			IL_0288: ldc.r8 0.0
+			IL_0291: stloc.s 13
+			IL_0293: ldc.r8 1
+			IL_029c: neg
+			IL_029d: box [System.Runtime]System.Double
+			IL_02a2: stloc.s 14
+			// loop start (head: IL_02a4)
+				IL_02a4: ldc.i4.1
+				IL_02a5: brfalse IL_03f3
 
-				IL_028e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_0293: stloc.s 15
-				IL_0295: ldloc.s 12
-				IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_029c: stloc.s 25
-				IL_029e: ldloc.s 25
-				IL_02a0: ldstr "exec"
-				IL_02a5: ldarg.2
-				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02ab: stloc.s 25
-				IL_02ad: ldloc.s 25
-				IL_02af: stloc.s 16
-				IL_02b1: ldloc.s 16
-				IL_02b3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02b8: ldc.i4.0
-				IL_02b9: ceq
-				IL_02bb: stloc.s 27
-				IL_02bd: ldloc.s 27
-				IL_02bf: brfalse IL_02d0
+				IL_02aa: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
+				IL_02af: stloc.s 15
+				IL_02b1: ldloc.s 12
+				IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02b8: stloc.s 25
+				IL_02ba: ldloc.s 25
+				IL_02bc: ldstr "exec"
+				IL_02c1: ldarg.2
+				IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02c7: stloc.s 25
+				IL_02c9: ldloc.s 25
+				IL_02cb: stloc.s 16
+				IL_02cd: ldloc.s 16
+				IL_02cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02d4: ldc.i4.0
+				IL_02d5: ceq
+				IL_02d7: stloc.s 28
+				IL_02d9: ldloc.s 28
+				IL_02db: brfalse IL_02ec
 
-				IL_02c4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
-				IL_02c9: stloc.s 17
-				IL_02cb: br IL_03d7
+				IL_02e0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
+				IL_02e5: stloc.s 17
+				IL_02e7: br IL_03f3
 
-				IL_02d0: ldloc.s 16
-				IL_02d2: ldc.r8 0.0
-				IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02e0: stloc.s 18
-				IL_02e2: ldloc.s 14
-				IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_02e9: stloc.s 26
-				IL_02eb: ldloc.s 26
-				IL_02ed: ldc.r8 0.0
-				IL_02f6: clt
-				IL_02f8: brfalse IL_0316
+				IL_02ec: ldloc.s 16
+				IL_02ee: ldc.r8 0.0
+				IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02fc: stloc.s 18
+				IL_02fe: ldloc.s 14
+				IL_0300: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0305: stloc.s 26
+				IL_0307: ldloc.s 26
+				IL_0309: ldc.r8 0.0
+				IL_0312: clt
+				IL_0314: brfalse IL_0332
 
-				IL_02fd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
-				IL_0302: stloc.s 19
-				IL_0304: ldloc.s 16
-				IL_0306: ldstr "index"
-				IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0310: stloc.s 25
-				IL_0312: ldloc.s 25
-				IL_0314: stloc.s 14
+				IL_0319: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
+				IL_031e: stloc.s 19
+				IL_0320: ldloc.s 16
+				IL_0322: ldstr "index"
+				IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_032c: stloc.s 25
+				IL_032e: ldloc.s 25
+				IL_0330: stloc.s 14
 
-				IL_0316: ldloc.s 18
-				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_031d: stloc.s 25
-				IL_031f: ldloc.s 25
-				IL_0321: ldstr "startsWith"
-				IL_0326: ldstr "</"
-				IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0330: stloc.s 25
-				IL_0332: ldloc.s 25
-				IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0339: stloc.s 27
-				IL_033b: ldloc.s 27
-				IL_033d: brfalse IL_03bd
+				IL_0332: ldloc.s 18
+				IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0339: stloc.s 25
+				IL_033b: ldloc.s 25
+				IL_033d: ldstr "startsWith"
+				IL_0342: ldstr "</"
+				IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_034c: stloc.s 25
+				IL_034e: ldloc.s 25
+				IL_0350: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0355: stloc.s 28
+				IL_0357: ldloc.s 28
+				IL_0359: brfalse IL_03d9
 
-				IL_0342: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
-				IL_0347: stloc.s 20
-				IL_0349: ldloc.s 13
-				IL_034b: ldc.r8 1
-				IL_0354: sub
-				IL_0355: stloc.s 13
-				IL_0357: ldloc.s 13
-				IL_0359: ldc.r8 0.0
-				IL_0362: ceq
-				IL_0364: brfalse IL_03b8
+				IL_035e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
+				IL_0363: stloc.s 20
+				IL_0365: ldloc.s 13
+				IL_0367: ldc.r8 1
+				IL_0370: sub
+				IL_0371: stloc.s 13
+				IL_0373: ldloc.s 13
+				IL_0375: ldc.r8 0.0
+				IL_037e: ceq
+				IL_0380: brfalse IL_03d4
 
-				IL_0369: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
-				IL_036e: stloc.s 21
-				IL_0370: ldarg.2
-				IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0376: stloc.s 25
-				IL_0378: ldloc.s 25
-				IL_037a: ldstr "substring"
-				IL_037f: ldloc.s 14
-				IL_0381: ldloc.s 12
-				IL_0383: ldstr "lastIndex"
-				IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0385: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
+				IL_038a: stloc.s 21
+				IL_038c: ldarg.2
+				IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0392: stloc.s 25
-				IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0399: dup
-				IL_039a: ldstr "tagName"
-				IL_039f: ldloc.s 9
-				IL_03a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03a6: dup
-				IL_03a7: ldstr "html"
-				IL_03ac: ldloc.s 25
-				IL_03ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03b3: stloc.s 29
-				IL_03b5: ldloc.s 29
-				IL_03b7: ret
+				IL_0394: ldloc.s 25
+				IL_0396: ldstr "substring"
+				IL_039b: ldloc.s 14
+				IL_039d: ldloc.s 12
+				IL_039f: ldstr "lastIndex"
+				IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_03ae: stloc.s 25
+				IL_03b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_03b5: dup
+				IL_03b6: ldstr "tagName"
+				IL_03bb: ldloc.s 9
+				IL_03bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03c2: dup
+				IL_03c3: ldstr "html"
+				IL_03c8: ldloc.s 25
+				IL_03ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03cf: stloc.s 30
+				IL_03d1: ldloc.s 30
+				IL_03d3: ret
 
-				IL_03b8: br IL_03d2
+				IL_03d4: br IL_03ee
 
-				IL_03bd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
-				IL_03c2: stloc.s 22
-				IL_03c4: ldloc.s 13
-				IL_03c6: ldc.r8 1
-				IL_03cf: add
-				IL_03d0: stloc.s 13
+				IL_03d9: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
+				IL_03de: stloc.s 22
+				IL_03e0: ldloc.s 13
+				IL_03e2: ldc.r8 1
+				IL_03eb: add
+				IL_03ec: stloc.s 13
 
-				IL_03d2: br IL_0288
+				IL_03ee: br IL_02a4
 			// end loop
 
-			IL_03d7: ldloc.s 9
-			IL_03d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03de: stloc.s 24
-			IL_03e0: ldstr "Could not find a matching closing </"
-			IL_03e5: ldloc.s 24
-			IL_03e7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03ec: stloc.s 24
-			IL_03ee: ldloc.s 24
-			IL_03f0: ldstr "> for id '"
-			IL_03f5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03f3: ldloc.s 9
+			IL_03f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_03fa: stloc.s 24
-			IL_03fc: ldarg.3
-			IL_03fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0402: stloc.s 30
-			IL_0404: ldloc.s 24
-			IL_0406: ldloc.s 30
-			IL_0408: call string [System.Runtime]System.String::Concat(string, string)
-			IL_040d: stloc.s 30
-			IL_040f: ldloc.s 30
-			IL_0411: ldstr "'."
-			IL_0416: call string [System.Runtime]System.String::Concat(string, string)
-			IL_041b: stloc.s 30
-			IL_041d: ldloc.s 30
-			IL_041f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0424: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0429: stloc.s 25
-			IL_042b: ldloc.s 25
-			IL_042d: stloc.s 23
-			IL_042f: ldloc.s 23
-			IL_0431: isinst [System.Runtime]System.Exception
-			IL_0436: dup
-			IL_0437: brtrue IL_0445
+			IL_03fc: ldstr "Could not find a matching closing </"
+			IL_0401: ldloc.s 24
+			IL_0403: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0408: stloc.s 24
+			IL_040a: ldloc.s 24
+			IL_040c: ldstr "> for id '"
+			IL_0411: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0416: stloc.s 24
+			IL_0418: ldarg.3
+			IL_0419: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_041e: stloc.s 31
+			IL_0420: ldloc.s 24
+			IL_0422: ldloc.s 31
+			IL_0424: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0429: stloc.s 31
+			IL_042b: ldloc.s 31
+			IL_042d: ldstr "'."
+			IL_0432: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0437: stloc.s 31
+			IL_0439: ldloc.s 31
+			IL_043b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0440: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0445: stloc.s 25
+			IL_0447: ldloc.s 25
+			IL_0449: stloc.s 23
+			IL_044b: ldloc.s 23
+			IL_044d: isinst [System.Runtime]System.Exception
+			IL_0452: dup
+			IL_0453: brtrue IL_0461
 
-			IL_043c: pop
-			IL_043d: ldloc.s 23
-			IL_043f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0444: throw
+			IL_0458: pop
+			IL_0459: ldloc.s 23
+			IL_045b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0460: throw
 
-			IL_0445: throw
+			IL_0461: throw
 
-			IL_0446: ldnull
-			IL_0447: ret
+			IL_0462: ldnull
+			IL_0463: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3380,7 +3411,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4675
+					// Method begins at RVA 0x4789
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3398,7 +3429,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x466c
+				// Method begins at RVA 0x4780
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3426,9 +3457,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3080
+			// Method begins at RVA 0x3098
 			// Header size: 12
-			// Code size: 487 (0x1e7)
+			// Code size: 506 (0x1fa)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3439,191 +3470,201 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] string,
-				[10] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[11] bool,
-				[12] object,
+				[8] object[],
+				[9] object,
+				[10] string,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[12] bool,
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] float64,
-				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[16] object,
+				[17] float64,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.3
-			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-			IL_0007: stloc.s 8
-			IL_0009: ldloc.s 8
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0012: stloc.s 9
-			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_0019: ldloc.s 9
-			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0020: stloc.s 9
-			IL_0022: ldloc.s 9
-			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002e: stloc.s 9
-			IL_0030: ldloc.s 9
-			IL_0032: ldstr "i"
-			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_003c: stloc.s 10
-			IL_003e: ldloc.s 10
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.s 8
-			IL_0049: ldloc.s 8
-			IL_004b: ldstr "exec"
-			IL_0050: ldarg.2
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0056: stloc.s 8
-			IL_0058: ldloc.s 8
-			IL_005a: stloc.2
-			IL_005b: ldloc.2
-			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0061: stloc.s 11
-			IL_0063: ldloc.s 11
-			IL_0065: brfalse IL_00ae
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.3
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0025: stloc.s 10
+			IL_0027: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_002c: ldloc.s 10
+			IL_002e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0033: stloc.s 10
+			IL_0035: ldloc.s 10
+			IL_0037: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.s 10
+			IL_0043: ldloc.s 10
+			IL_0045: ldstr "i"
+			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_004f: stloc.s 11
+			IL_0051: ldloc.s 11
+			IL_0053: stloc.1
+			IL_0054: ldloc.1
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005a: stloc.s 9
+			IL_005c: ldloc.s 9
+			IL_005e: ldstr "exec"
+			IL_0063: ldarg.2
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0069: stloc.s 9
+			IL_006b: ldloc.s 9
+			IL_006d: stloc.2
+			IL_006e: ldloc.2
+			IL_006f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0074: stloc.s 12
+			IL_0076: ldloc.s 12
+			IL_0078: brfalse IL_00c1
 
-			IL_006a: ldloc.2
-			IL_006b: ldc.r8 1
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0079: stloc.s 8
-			IL_007b: ldloc.s 8
-			IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0082: stloc.s 11
-			IL_0084: ldloc.s 11
-			IL_0086: brtrue IL_00a1
+			IL_007d: ldloc.2
+			IL_007e: ldc.r8 1
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_008c: stloc.s 9
+			IL_008e: ldloc.s 9
+			IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0095: stloc.s 12
+			IL_0097: ldloc.s 12
+			IL_0099: brtrue IL_00b4
 
-			IL_008b: ldloc.2
-			IL_008c: ldc.r8 2
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009a: stloc.s 13
-			IL_009c: br IL_00a5
+			IL_009e: ldloc.2
+			IL_009f: ldc.r8 2
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00ad: stloc.s 14
+			IL_00af: br IL_00b8
 
-			IL_00a1: ldloc.s 8
-			IL_00a3: stloc.s 13
+			IL_00b4: ldloc.s 9
+			IL_00b6: stloc.s 14
 
-			IL_00a5: ldloc.s 13
-			IL_00a7: stloc.s 14
-			IL_00a9: br IL_00b1
+			IL_00b8: ldloc.s 14
+			IL_00ba: stloc.s 15
+			IL_00bc: br IL_00c4
 
-			IL_00ae: ldloc.2
-			IL_00af: stloc.s 14
+			IL_00c1: ldloc.2
+			IL_00c2: stloc.s 15
 
-			IL_00b1: ldloc.s 14
-			IL_00b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b8: stloc.s 11
-			IL_00ba: ldloc.s 11
-			IL_00bc: brtrue IL_00cd
+			IL_00c4: ldloc.s 15
+			IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00cb: stloc.s 12
+			IL_00cd: ldloc.s 12
+			IL_00cf: brtrue IL_00e0
 
-			IL_00c1: ldstr ""
-			IL_00c6: stloc.s 14
-			IL_00c8: br IL_00cd
+			IL_00d4: ldstr ""
+			IL_00d9: stloc.s 15
+			IL_00db: br IL_00e0
 
-			IL_00cd: ldloc.s 14
-			IL_00cf: stloc.3
-			IL_00d0: ldloc.3
-			IL_00d1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00d6: ldc.i4.0
-			IL_00d7: ceq
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
-			IL_00dd: brfalse IL_00f0
-
-			IL_00e2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
-			IL_00e7: stloc.s 4
+			IL_00e0: ldloc.s 15
+			IL_00e2: stloc.3
+			IL_00e3: ldloc.3
+			IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_00e9: ldc.i4.0
-			IL_00ea: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00ef: ret
+			IL_00ea: ceq
+			IL_00ec: stloc.s 12
+			IL_00ee: ldloc.s 12
+			IL_00f0: brfalse IL_0103
 
-			IL_00f0: ldloc.3
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f6: stloc.s 8
-			IL_00f8: ldloc.s 8
-			IL_00fa: ldstr "indexOf"
-			IL_00ff: ldstr "#"
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0109: stloc.s 8
-			IL_010b: ldloc.s 8
-			IL_010d: stloc.s 5
-			IL_010f: ldloc.s 5
-			IL_0111: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0116: stloc.s 16
-			IL_0118: ldloc.s 16
-			IL_011a: ldc.r8 0.0
-			IL_0123: clt
-			IL_0125: ldc.i4.0
-			IL_0126: ceq
-			IL_0128: brfalse IL_015c
+			IL_00f5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
+			IL_00fa: stloc.s 4
+			IL_00fc: ldc.i4.0
+			IL_00fd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0102: ret
 
-			IL_012d: ldloc.3
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0133: stloc.s 8
-			IL_0135: ldloc.s 8
-			IL_0137: ldstr "substring"
-			IL_013c: ldc.r8 0.0
-			IL_0145: box [System.Runtime]System.Double
-			IL_014a: ldloc.s 5
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0151: stloc.s 8
-			IL_0153: ldloc.s 8
-			IL_0155: stloc.s 6
-			IL_0157: br IL_015f
+			IL_0103: ldloc.3
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0109: stloc.s 9
+			IL_010b: ldloc.s 9
+			IL_010d: ldstr "indexOf"
+			IL_0112: ldstr "#"
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_011c: stloc.s 9
+			IL_011e: ldloc.s 9
+			IL_0120: stloc.s 5
+			IL_0122: ldloc.s 5
+			IL_0124: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0129: stloc.s 17
+			IL_012b: ldloc.s 17
+			IL_012d: ldc.r8 0.0
+			IL_0136: clt
+			IL_0138: ldc.i4.0
+			IL_0139: ceq
+			IL_013b: brfalse IL_016f
 
-			IL_015c: ldloc.3
-			IL_015d: stloc.s 6
+			IL_0140: ldloc.3
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: stloc.s 9
+			IL_0148: ldloc.s 9
+			IL_014a: ldstr "substring"
+			IL_014f: ldc.r8 0.0
+			IL_0158: box [System.Runtime]System.Double
+			IL_015d: ldloc.s 5
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0164: stloc.s 9
+			IL_0166: ldloc.s 9
+			IL_0168: stloc.s 6
+			IL_016a: br IL_0172
 
-			IL_015f: ldloc.s 5
-			IL_0161: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0166: stloc.s 16
-			IL_0168: ldloc.s 16
-			IL_016a: ldc.r8 0.0
-			IL_0173: clt
-			IL_0175: ldc.i4.0
-			IL_0176: ceq
-			IL_0178: brfalse IL_01b0
+			IL_016f: ldloc.3
+			IL_0170: stloc.s 6
 
-			IL_017d: ldloc.3
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 5
-			IL_0187: ldc.r8 1
-			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0195: stloc.s 14
-			IL_0197: ldloc.s 8
-			IL_0199: ldstr "substring"
-			IL_019e: ldloc.s 14
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01a5: stloc.s 8
-			IL_01a7: ldloc.s 8
-			IL_01a9: stloc.s 7
-			IL_01ab: br IL_01b7
+			IL_0172: ldloc.s 5
+			IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0179: stloc.s 17
+			IL_017b: ldloc.s 17
+			IL_017d: ldc.r8 0.0
+			IL_0186: clt
+			IL_0188: ldc.i4.0
+			IL_0189: ceq
+			IL_018b: brfalse IL_01c3
 
-			IL_01b0: ldstr ""
-			IL_01b5: stloc.s 7
+			IL_0190: ldloc.3
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0196: stloc.s 9
+			IL_0198: ldloc.s 5
+			IL_019a: ldc.r8 1
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01a8: stloc.s 15
+			IL_01aa: ldloc.s 9
+			IL_01ac: ldstr "substring"
+			IL_01b1: ldloc.s 15
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b8: stloc.s 9
+			IL_01ba: ldloc.s 9
+			IL_01bc: stloc.s 7
+			IL_01be: br IL_01ca
 
-			IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01bc: dup
-			IL_01bd: ldstr "href"
-			IL_01c2: ldloc.3
-			IL_01c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01c8: dup
-			IL_01c9: ldstr "filePart"
-			IL_01ce: ldloc.s 6
-			IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01d5: dup
-			IL_01d6: ldstr "fragment"
-			IL_01db: ldloc.s 7
-			IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01e2: stloc.s 17
-			IL_01e4: ldloc.s 17
-			IL_01e6: ret
+			IL_01c3: ldstr ""
+			IL_01c8: stloc.s 7
+
+			IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01cf: dup
+			IL_01d0: ldstr "href"
+			IL_01d5: ldloc.3
+			IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01db: dup
+			IL_01dc: ldstr "filePart"
+			IL_01e1: ldloc.s 6
+			IL_01e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01e8: dup
+			IL_01e9: ldstr "fragment"
+			IL_01ee: ldloc.s 7
+			IL_01f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01f5: stloc.s 18
+			IL_01f7: ldloc.s 18
+			IL_01f9: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3639,7 +3680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x467e
+				// Method begins at RVA 0x4792
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3665,7 +3706,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3274
+			// Method begins at RVA 0x32a0
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -3772,7 +3813,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4690
+					// Method begins at RVA 0x47a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3792,7 +3833,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4699
+					// Method begins at RVA 0x47ad
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3812,7 +3853,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46a2
+					// Method begins at RVA 0x47b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3836,7 +3877,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46b4
+						// Method begins at RVA 0x47c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3856,7 +3897,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46bd
+						// Method begins at RVA 0x47d1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3874,7 +3915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46ab
+					// Method begins at RVA 0x47bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3894,7 +3935,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46c6
+					// Method begins at RVA 0x47da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3914,7 +3955,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46cf
+					// Method begins at RVA 0x47e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3954,7 +3995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4687
+				// Method begins at RVA 0x479b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3978,9 +4019,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3318
+			// Method begins at RVA 0x3344
 			// Header size: 12
-			// Code size: 2757 (0xac5)
+			// Code size: 2958 (0xb8e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4013,14 +4054,14 @@
 				[27] object,
 				[28] object,
 				[29] object,
-				[30] bool,
-				[31] object,
+				[30] object[],
+				[31] bool,
 				[32] object,
-				[33] string,
-				[34] string,
-				[35] object,
-				[36] object,
-				[37] object[],
+				[33] object,
+				[34] object,
+				[35] string,
+				[36] string,
+				[37] object,
 				[38] object
 			)
 
@@ -4190,1045 +4231,1144 @@
 
 			IL_0130: ldloc.0
 			IL_0131: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0136: switch (IL_014b, IL_04a2, IL_06d9, IL_0842)
+			IL_0136: switch (IL_014b, IL_04c5, IL_0723, IL_089b)
 
-			IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0150: ldstr "argv"
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015a: stloc.s 29
-			IL_015c: ldarg.0
-			IL_015d: ldc.i4.1
-			IL_015e: ldelem.ref
-			IL_015f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0164: ldnull
-			IL_0165: ldloc.s 29
-			IL_0167: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-			IL_016c: stloc.s 29
-			IL_016e: ldloc.s 29
-			IL_0170: stloc.1
-			IL_0171: ldloc.1
-			IL_0172: ldstr "section"
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_017c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0181: ldc.i4.0
-			IL_0182: ceq
-			IL_0184: stloc.s 30
-			IL_0186: ldloc.s 30
-			IL_0188: brfalse IL_01d6
+			IL_014b: ldarg.0
+			IL_014c: ldc.i4.1
+			IL_014d: ldelem.ref
+			IL_014e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0153: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
+			IL_0158: stloc.s 29
+			IL_015a: ldc.i4.1
+			IL_015b: newarr [System.Runtime]System.Object
+			IL_0160: dup
+			IL_0161: ldc.i4.0
+			IL_0162: ldarg.0
+			IL_0163: ldc.i4.1
+			IL_0164: ldelem.ref
+			IL_0165: stelem.ref
+			IL_0166: stloc.s 30
+			IL_0168: ldloc.s 29
+			IL_016a: ldloc.s 30
+			IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0171: ldstr "argv"
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0180: stloc.s 29
+			IL_0182: ldloc.s 29
+			IL_0184: stloc.1
+			IL_0185: ldloc.1
+			IL_0186: ldstr "section"
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0195: ldc.i4.0
+			IL_0196: ceq
+			IL_0198: stloc.s 31
+			IL_019a: ldloc.s 31
+			IL_019c: brfalse IL_01ea
 
-			IL_018d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
-			IL_0192: stloc.2
-			IL_0193: ldstr "Missing required --section (e.g. 27.3)."
-			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01a2: stloc.s 29
-			IL_01a4: ldloc.s 29
-			IL_01a6: stloc.3
-			IL_01a7: ldloc.0
-			IL_01a8: ldc.i4.m1
-			IL_01a9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01ae: ldloc.0
-			IL_01af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01b9: ldarg.0
-			IL_01ba: ldc.i4.1
-			IL_01bb: newarr [System.Runtime]System.Object
-			IL_01c0: dup
-			IL_01c1: ldc.i4.0
-			IL_01c2: ldloc.3
-			IL_01c3: stelem.ref
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01c9: pop
-			IL_01ca: ldloc.0
-			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01d0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01d5: ret
+			IL_01a1: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
+			IL_01a6: stloc.2
+			IL_01a7: ldstr "Missing required --section (e.g. 27.3)."
+			IL_01ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01b6: stloc.s 29
+			IL_01b8: ldloc.s 29
+			IL_01ba: stloc.3
+			IL_01bb: ldloc.0
+			IL_01bc: ldc.i4.m1
+			IL_01bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c2: ldloc.0
+			IL_01c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01cd: ldarg.0
+			IL_01ce: ldc.i4.1
+			IL_01cf: newarr [System.Runtime]System.Object
+			IL_01d4: dup
+			IL_01d5: ldc.i4.0
+			IL_01d6: ldloc.3
+			IL_01d7: stelem.ref
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01dd: pop
+			IL_01de: ldloc.0
+			IL_01df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01e9: ret
 
-			IL_01d6: ldloc.1
-			IL_01d7: ldstr "outFile"
-			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01e6: ldc.i4.0
-			IL_01e7: ceq
-			IL_01e9: stloc.s 30
-			IL_01eb: ldloc.s 30
-			IL_01ed: brfalse IL_023e
+			IL_01ea: ldloc.1
+			IL_01eb: ldstr "outFile"
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01fa: ldc.i4.0
+			IL_01fb: ceq
+			IL_01fd: stloc.s 31
+			IL_01ff: ldloc.s 31
+			IL_0201: brfalse IL_0252
 
-			IL_01f2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
-			IL_01f7: stloc.s 4
-			IL_01f9: ldstr "Missing required --out <output.html>."
-			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0208: stloc.s 29
-			IL_020a: ldloc.s 29
-			IL_020c: stloc.s 5
-			IL_020e: ldloc.0
-			IL_020f: ldc.i4.m1
-			IL_0210: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0215: ldloc.0
-			IL_0216: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0220: ldarg.0
-			IL_0221: ldc.i4.1
-			IL_0222: newarr [System.Runtime]System.Object
-			IL_0227: dup
-			IL_0228: ldc.i4.0
-			IL_0229: ldloc.s 5
-			IL_022b: stelem.ref
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0231: pop
-			IL_0232: ldloc.0
-			IL_0233: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0238: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_023d: ret
+			IL_0206: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
+			IL_020b: stloc.s 4
+			IL_020d: ldstr "Missing required --out <output.html>."
+			IL_0212: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0217: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_021c: stloc.s 29
+			IL_021e: ldloc.s 29
+			IL_0220: stloc.s 5
+			IL_0222: ldloc.0
+			IL_0223: ldc.i4.m1
+			IL_0224: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0229: ldloc.0
+			IL_022a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0234: ldarg.0
+			IL_0235: ldc.i4.1
+			IL_0236: newarr [System.Runtime]System.Object
+			IL_023b: dup
+			IL_023c: ldc.i4.0
+			IL_023d: ldloc.s 5
+			IL_023f: stelem.ref
+			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0245: pop
+			IL_0246: ldloc.0
+			IL_0247: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_024c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0251: ret
 
-			IL_023e: ldloc.1
-			IL_023f: ldstr "url"
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_024e: stloc.s 30
-			IL_0250: ldloc.s 30
-			IL_0252: brfalse IL_026c
+			IL_0252: ldloc.1
+			IL_0253: ldstr "url"
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0262: stloc.s 31
+			IL_0264: ldloc.s 31
+			IL_0266: brfalse IL_0280
 
-			IL_0257: ldc.r8 1
-			IL_0260: box [System.Runtime]System.Double
-			IL_0265: stloc.s 6
-			IL_0267: br IL_027c
+			IL_026b: ldc.r8 1
+			IL_0274: box [System.Runtime]System.Double
+			IL_0279: stloc.s 6
+			IL_027b: br IL_0290
 
-			IL_026c: ldc.r8 0.0
-			IL_0275: box [System.Runtime]System.Double
-			IL_027a: stloc.s 6
+			IL_0280: ldc.r8 0.0
+			IL_0289: box [System.Runtime]System.Double
+			IL_028e: stloc.s 6
 
-			IL_027c: ldloc.1
-			IL_027d: ldstr "auto"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_028c: stloc.s 30
-			IL_028e: ldloc.s 30
-			IL_0290: brfalse IL_02aa
+			IL_0290: ldloc.1
+			IL_0291: ldstr "auto"
+			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a0: stloc.s 31
+			IL_02a2: ldloc.s 31
+			IL_02a4: brfalse IL_02be
 
-			IL_0295: ldc.r8 1
-			IL_029e: box [System.Runtime]System.Double
-			IL_02a3: stloc.s 7
-			IL_02a5: br IL_02ba
+			IL_02a9: ldc.r8 1
+			IL_02b2: box [System.Runtime]System.Double
+			IL_02b7: stloc.s 7
+			IL_02b9: br IL_02ce
 
-			IL_02aa: ldc.r8 0.0
-			IL_02b3: box [System.Runtime]System.Double
-			IL_02b8: stloc.s 7
+			IL_02be: ldc.r8 0.0
+			IL_02c7: box [System.Runtime]System.Double
+			IL_02cc: stloc.s 7
 
-			IL_02ba: ldloc.s 6
-			IL_02bc: ldloc.s 7
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02c3: stloc.s 31
-			IL_02c5: ldloc.s 31
-			IL_02c7: stloc.s 8
-			IL_02c9: ldloc.s 8
-			IL_02cb: ldc.r8 1
-			IL_02d4: box [System.Runtime]System.Double
-			IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02de: stloc.s 30
-			IL_02e0: ldloc.s 30
-			IL_02e2: brfalse IL_0333
+			IL_02ce: ldloc.s 6
+			IL_02d0: ldloc.s 7
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d7: stloc.s 32
+			IL_02d9: ldloc.s 32
+			IL_02db: stloc.s 8
+			IL_02dd: ldloc.s 8
+			IL_02df: ldc.r8 1
+			IL_02e8: box [System.Runtime]System.Double
+			IL_02ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02f2: stloc.s 31
+			IL_02f4: ldloc.s 31
+			IL_02f6: brfalse IL_0347
 
-			IL_02e7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
-			IL_02ec: stloc.s 9
-			IL_02ee: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_02f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_02fd: stloc.s 29
-			IL_02ff: ldloc.s 29
-			IL_0301: stloc.s 10
-			IL_0303: ldloc.0
-			IL_0304: ldc.i4.m1
-			IL_0305: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_030a: ldloc.0
-			IL_030b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0310: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0315: ldarg.0
-			IL_0316: ldc.i4.1
-			IL_0317: newarr [System.Runtime]System.Object
-			IL_031c: dup
-			IL_031d: ldc.i4.0
-			IL_031e: ldloc.s 10
-			IL_0320: stelem.ref
-			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0326: pop
-			IL_0327: ldloc.0
-			IL_0328: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_032d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0332: ret
+			IL_02fb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
+			IL_0300: stloc.s 9
+			IL_0302: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0307: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_030c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0311: stloc.s 29
+			IL_0313: ldloc.s 29
+			IL_0315: stloc.s 10
+			IL_0317: ldloc.0
+			IL_0318: ldc.i4.m1
+			IL_0319: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_031e: ldloc.0
+			IL_031f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0324: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0329: ldarg.0
+			IL_032a: ldc.i4.1
+			IL_032b: newarr [System.Runtime]System.Object
+			IL_0330: dup
+			IL_0331: ldc.i4.0
+			IL_0332: ldloc.s 10
+			IL_0334: stelem.ref
+			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_033a: pop
+			IL_033b: ldloc.0
+			IL_033c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0341: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0346: ret
 
-			IL_0333: ldnull
-			IL_0334: stloc.s 11
-			IL_0336: ldloc.1
-			IL_0337: ldstr "id"
-			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0341: stloc.s 29
-			IL_0343: ldloc.s 29
-			IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_034a: stloc.s 30
-			IL_034c: ldloc.s 30
-			IL_034e: brtrue IL_035f
+			IL_0347: ldnull
+			IL_0348: stloc.s 11
+			IL_034a: ldloc.1
+			IL_034b: ldstr "id"
+			IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0355: stloc.s 29
+			IL_0357: ldloc.s 29
+			IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_035e: stloc.s 31
+			IL_0360: ldloc.s 31
+			IL_0362: brtrue IL_0373
 
-			IL_0353: ldstr ""
-			IL_0358: stloc.s 32
-			IL_035a: br IL_0363
+			IL_0367: ldstr ""
+			IL_036c: stloc.s 33
+			IL_036e: br IL_0377
 
-			IL_035f: ldloc.s 29
-			IL_0361: stloc.s 32
+			IL_0373: ldloc.s 29
+			IL_0375: stloc.s 33
 
-			IL_0363: ldloc.s 32
-			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_036a: stloc.s 29
-			IL_036c: ldloc.s 29
-			IL_036e: ldstr "trim"
-			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0378: stloc.s 29
-			IL_037a: ldloc.s 29
-			IL_037c: stloc.s 12
-			IL_037e: ldstr ""
-			IL_0383: stloc.s 13
-			IL_0385: ldloc.1
-			IL_0386: ldstr "auto"
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0395: stloc.s 30
-			IL_0397: ldloc.s 30
-			IL_0399: brfalse IL_073e
+			IL_0377: ldloc.s 33
+			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_037e: stloc.s 29
+			IL_0380: ldloc.s 29
+			IL_0382: ldstr "trim"
+			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_038c: stloc.s 29
+			IL_038e: ldloc.s 29
+			IL_0390: stloc.s 12
+			IL_0392: ldstr ""
+			IL_0397: stloc.s 13
+			IL_0399: ldloc.1
+			IL_039a: ldstr "auto"
+			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a9: stloc.s 31
+			IL_03ab: ldloc.s 31
+			IL_03ad: brfalse IL_0788
 
-			IL_039e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_03a3: stloc.s 14
-			IL_03a5: ldloc.1
-			IL_03a6: ldstr "indexUrl"
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b5: stloc.s 29
-			IL_03b7: ldloc.s 29
-			IL_03b9: ldstr "trim"
-			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03c3: stloc.s 29
-			IL_03c5: ldloc.s 29
-			IL_03c7: stloc.s 15
-			IL_03c9: ldarg.0
-			IL_03ca: ldc.i4.1
-			IL_03cb: ldelem.ref
-			IL_03cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03d1: ldnull
-			IL_03d2: ldloc.s 15
-			IL_03d4: ldnull
-			IL_03d5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_03da: stloc.s 29
-			IL_03dc: ldloc.0
-			IL_03dd: ldc.i4.1
-			IL_03de: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03e3: ldloc.0
-			IL_03e4: ldloc.s 29
-			IL_03e6: ldarg.0
-			IL_03e7: ldc.i4.1
-			IL_03e8: ldloc.0
-			IL_03e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03f3: ldloc.0
-			IL_03f4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03f9: dup
-			IL_03fa: ldc.i4.0
-			IL_03fb: ldloc.1
-			IL_03fc: stelem.ref
-			IL_03fd: dup
-			IL_03fe: ldc.i4.1
-			IL_03ff: ldloc.2
-			IL_0400: stelem.ref
-			IL_0401: dup
-			IL_0402: ldc.i4.2
-			IL_0403: ldloc.3
-			IL_0404: stelem.ref
-			IL_0405: dup
-			IL_0406: ldc.i4.3
-			IL_0407: ldloc.s 4
-			IL_0409: stelem.ref
-			IL_040a: dup
-			IL_040b: ldc.i4.4
-			IL_040c: ldloc.s 5
-			IL_040e: stelem.ref
-			IL_040f: dup
-			IL_0410: ldc.i4.5
-			IL_0411: ldloc.s 6
-			IL_0413: stelem.ref
-			IL_0414: dup
-			IL_0415: ldc.i4.6
-			IL_0416: ldloc.s 7
-			IL_0418: stelem.ref
-			IL_0419: dup
-			IL_041a: ldc.i4.7
-			IL_041b: ldloc.s 8
-			IL_041d: stelem.ref
-			IL_041e: dup
-			IL_041f: ldc.i4.8
-			IL_0420: ldloc.s 9
-			IL_0422: stelem.ref
-			IL_0423: dup
-			IL_0424: ldc.i4.s 9
-			IL_0426: ldloc.s 10
-			IL_0428: stelem.ref
-			IL_0429: dup
-			IL_042a: ldc.i4.s 10
-			IL_042c: ldloc.s 11
-			IL_042e: stelem.ref
-			IL_042f: dup
-			IL_0430: ldc.i4.s 11
-			IL_0432: ldloc.s 12
-			IL_0434: stelem.ref
-			IL_0435: dup
-			IL_0436: ldc.i4.s 12
-			IL_0438: ldloc.s 13
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.s 13
-			IL_043e: ldloc.s 14
+			IL_03b2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
+			IL_03b7: stloc.s 14
+			IL_03b9: ldloc.1
+			IL_03ba: ldstr "indexUrl"
+			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03c9: stloc.s 29
+			IL_03cb: ldloc.s 29
+			IL_03cd: ldstr "trim"
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03d7: stloc.s 29
+			IL_03d9: ldloc.s 29
+			IL_03db: stloc.s 15
+			IL_03dd: ldarg.0
+			IL_03de: ldc.i4.1
+			IL_03df: ldelem.ref
+			IL_03e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_03ea: ldc.i4.1
+			IL_03eb: newarr [System.Runtime]System.Object
+			IL_03f0: dup
+			IL_03f1: ldc.i4.0
+			IL_03f2: ldarg.0
+			IL_03f3: ldc.i4.1
+			IL_03f4: ldelem.ref
+			IL_03f5: stelem.ref
+			IL_03f6: ldloc.s 15
+			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03fd: stloc.s 29
+			IL_03ff: ldloc.0
+			IL_0400: ldc.i4.1
+			IL_0401: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0406: ldloc.0
+			IL_0407: ldloc.s 29
+			IL_0409: ldarg.0
+			IL_040a: ldc.i4.1
+			IL_040b: ldloc.0
+			IL_040c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0411: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0416: ldloc.0
+			IL_0417: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_041c: dup
+			IL_041d: ldc.i4.0
+			IL_041e: ldloc.1
+			IL_041f: stelem.ref
+			IL_0420: dup
+			IL_0421: ldc.i4.1
+			IL_0422: ldloc.2
+			IL_0423: stelem.ref
+			IL_0424: dup
+			IL_0425: ldc.i4.2
+			IL_0426: ldloc.3
+			IL_0427: stelem.ref
+			IL_0428: dup
+			IL_0429: ldc.i4.3
+			IL_042a: ldloc.s 4
+			IL_042c: stelem.ref
+			IL_042d: dup
+			IL_042e: ldc.i4.4
+			IL_042f: ldloc.s 5
+			IL_0431: stelem.ref
+			IL_0432: dup
+			IL_0433: ldc.i4.5
+			IL_0434: ldloc.s 6
+			IL_0436: stelem.ref
+			IL_0437: dup
+			IL_0438: ldc.i4.6
+			IL_0439: ldloc.s 7
+			IL_043b: stelem.ref
+			IL_043c: dup
+			IL_043d: ldc.i4.7
+			IL_043e: ldloc.s 8
 			IL_0440: stelem.ref
 			IL_0441: dup
-			IL_0442: ldc.i4.s 14
-			IL_0444: ldloc.s 15
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.s 15
-			IL_044a: ldloc.s 16
-			IL_044c: stelem.ref
-			IL_044d: dup
-			IL_044e: ldc.i4.s 16
-			IL_0450: ldloc.s 17
-			IL_0452: stelem.ref
-			IL_0453: dup
-			IL_0454: ldc.i4.s 17
-			IL_0456: ldloc.s 18
-			IL_0458: stelem.ref
-			IL_0459: dup
-			IL_045a: ldc.i4.s 18
-			IL_045c: ldloc.s 19
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.s 19
-			IL_0462: ldloc.s 20
-			IL_0464: stelem.ref
-			IL_0465: dup
-			IL_0466: ldc.i4.s 20
-			IL_0468: ldloc.s 21
-			IL_046a: stelem.ref
-			IL_046b: dup
-			IL_046c: ldc.i4.s 21
-			IL_046e: ldloc.s 22
-			IL_0470: stelem.ref
-			IL_0471: dup
-			IL_0472: ldc.i4.s 22
-			IL_0474: ldloc.s 23
-			IL_0476: stelem.ref
-			IL_0477: dup
-			IL_0478: ldc.i4.s 23
-			IL_047a: ldloc.s 24
-			IL_047c: stelem.ref
-			IL_047d: dup
-			IL_047e: ldc.i4.s 24
-			IL_0480: ldloc.s 25
-			IL_0482: stelem.ref
-			IL_0483: dup
-			IL_0484: ldc.i4.s 25
-			IL_0486: ldloc.s 26
-			IL_0488: stelem.ref
-			IL_0489: dup
-			IL_048a: ldc.i4.s 26
-			IL_048c: ldloc.s 27
-			IL_048e: stelem.ref
-			IL_048f: dup
-			IL_0490: ldc.i4.s 27
-			IL_0492: ldloc.s 28
-			IL_0494: stelem.ref
-			IL_0495: pop
-			IL_0496: ldloc.0
-			IL_0497: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_049c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04a1: ret
+			IL_0442: ldc.i4.8
+			IL_0443: ldloc.s 9
+			IL_0445: stelem.ref
+			IL_0446: dup
+			IL_0447: ldc.i4.s 9
+			IL_0449: ldloc.s 10
+			IL_044b: stelem.ref
+			IL_044c: dup
+			IL_044d: ldc.i4.s 10
+			IL_044f: ldloc.s 11
+			IL_0451: stelem.ref
+			IL_0452: dup
+			IL_0453: ldc.i4.s 11
+			IL_0455: ldloc.s 12
+			IL_0457: stelem.ref
+			IL_0458: dup
+			IL_0459: ldc.i4.s 12
+			IL_045b: ldloc.s 13
+			IL_045d: stelem.ref
+			IL_045e: dup
+			IL_045f: ldc.i4.s 13
+			IL_0461: ldloc.s 14
+			IL_0463: stelem.ref
+			IL_0464: dup
+			IL_0465: ldc.i4.s 14
+			IL_0467: ldloc.s 15
+			IL_0469: stelem.ref
+			IL_046a: dup
+			IL_046b: ldc.i4.s 15
+			IL_046d: ldloc.s 16
+			IL_046f: stelem.ref
+			IL_0470: dup
+			IL_0471: ldc.i4.s 16
+			IL_0473: ldloc.s 17
+			IL_0475: stelem.ref
+			IL_0476: dup
+			IL_0477: ldc.i4.s 17
+			IL_0479: ldloc.s 18
+			IL_047b: stelem.ref
+			IL_047c: dup
+			IL_047d: ldc.i4.s 18
+			IL_047f: ldloc.s 19
+			IL_0481: stelem.ref
+			IL_0482: dup
+			IL_0483: ldc.i4.s 19
+			IL_0485: ldloc.s 20
+			IL_0487: stelem.ref
+			IL_0488: dup
+			IL_0489: ldc.i4.s 20
+			IL_048b: ldloc.s 21
+			IL_048d: stelem.ref
+			IL_048e: dup
+			IL_048f: ldc.i4.s 21
+			IL_0491: ldloc.s 22
+			IL_0493: stelem.ref
+			IL_0494: dup
+			IL_0495: ldc.i4.s 22
+			IL_0497: ldloc.s 23
+			IL_0499: stelem.ref
+			IL_049a: dup
+			IL_049b: ldc.i4.s 23
+			IL_049d: ldloc.s 24
+			IL_049f: stelem.ref
+			IL_04a0: dup
+			IL_04a1: ldc.i4.s 24
+			IL_04a3: ldloc.s 25
+			IL_04a5: stelem.ref
+			IL_04a6: dup
+			IL_04a7: ldc.i4.s 25
+			IL_04a9: ldloc.s 26
+			IL_04ab: stelem.ref
+			IL_04ac: dup
+			IL_04ad: ldc.i4.s 26
+			IL_04af: ldloc.s 27
+			IL_04b1: stelem.ref
+			IL_04b2: dup
+			IL_04b3: ldc.i4.s 27
+			IL_04b5: ldloc.s 28
+			IL_04b7: stelem.ref
+			IL_04b8: pop
+			IL_04b9: ldloc.0
+			IL_04ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c4: ret
 
-			IL_04a2: ldloc.0
-			IL_04a3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_04a8: stloc.s 29
-			IL_04aa: ldloc.s 29
-			IL_04ac: stloc.s 16
-			IL_04ae: ldloc.1
-			IL_04af: ldstr "section"
-			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04be: stloc.s 29
-			IL_04c0: ldloc.s 29
-			IL_04c2: ldstr "trim"
-			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_04cc: stloc.s 29
-			IL_04ce: ldarg.0
-			IL_04cf: ldc.i4.1
-			IL_04d0: ldelem.ref
-			IL_04d1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_04d6: ldnull
-			IL_04d7: ldloc.s 16
-			IL_04d9: ldloc.s 29
-			IL_04db: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_04e0: stloc.s 29
-			IL_04e2: ldloc.s 29
-			IL_04e4: stloc.s 17
-			IL_04e6: ldloc.s 17
-			IL_04e8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04ed: ldc.i4.0
-			IL_04ee: ceq
-			IL_04f0: stloc.s 30
-			IL_04f2: ldloc.s 30
-			IL_04f4: brfalse IL_0584
+			IL_04c5: ldloc.0
+			IL_04c6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04cb: stloc.s 29
+			IL_04cd: ldloc.s 29
+			IL_04cf: stloc.s 16
+			IL_04d1: ldarg.0
+			IL_04d2: ldc.i4.1
+			IL_04d3: ldelem.ref
+			IL_04d4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04d9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_04de: stloc.s 29
+			IL_04e0: ldc.i4.1
+			IL_04e1: newarr [System.Runtime]System.Object
+			IL_04e6: dup
+			IL_04e7: ldc.i4.0
+			IL_04e8: ldarg.0
+			IL_04e9: ldc.i4.1
+			IL_04ea: ldelem.ref
+			IL_04eb: stelem.ref
+			IL_04ec: stloc.s 30
+			IL_04ee: ldloc.1
+			IL_04ef: ldstr "section"
+			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04fe: stloc.s 34
+			IL_0500: ldloc.s 34
+			IL_0502: ldstr "trim"
+			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_050c: stloc.s 34
+			IL_050e: ldloc.s 29
+			IL_0510: ldloc.s 30
+			IL_0512: ldloc.s 16
+			IL_0514: ldloc.s 34
+			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_051b: stloc.s 34
+			IL_051d: ldloc.s 34
+			IL_051f: stloc.s 17
+			IL_0521: ldloc.s 17
+			IL_0523: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0528: ldc.i4.0
+			IL_0529: ceq
+			IL_052b: stloc.s 31
+			IL_052d: ldloc.s 31
+			IL_052f: brfalse IL_05bf
 
-			IL_04f9: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
-			IL_04fe: stloc.s 18
-			IL_0500: ldloc.1
-			IL_0501: ldstr "section"
-			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0510: stloc.s 33
-			IL_0512: ldstr "Could not find section '"
-			IL_0517: ldloc.s 33
-			IL_0519: call string [System.Runtime]System.String::Concat(string, string)
-			IL_051e: stloc.s 33
-			IL_0520: ldloc.s 33
-			IL_0522: ldstr "' in multipage index: "
-			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
-			IL_052c: stloc.s 33
-			IL_052e: ldloc.s 15
-			IL_0530: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0535: stloc.s 34
-			IL_0537: ldloc.s 33
-			IL_0539: ldloc.s 34
-			IL_053b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0540: stloc.s 34
-			IL_0542: ldloc.s 34
-			IL_0544: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_054e: stloc.s 29
-			IL_0550: ldloc.s 29
-			IL_0552: stloc.s 19
-			IL_0554: ldloc.0
-			IL_0555: ldc.i4.m1
-			IL_0556: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_055b: ldloc.0
-			IL_055c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0561: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0566: ldarg.0
-			IL_0567: ldc.i4.1
-			IL_0568: newarr [System.Runtime]System.Object
-			IL_056d: dup
-			IL_056e: ldc.i4.0
-			IL_056f: ldloc.s 19
-			IL_0571: stelem.ref
-			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0577: pop
-			IL_0578: ldloc.0
-			IL_0579: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_057e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0583: ret
+			IL_0534: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
+			IL_0539: stloc.s 18
+			IL_053b: ldloc.1
+			IL_053c: ldstr "section"
+			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0546: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_054b: stloc.s 35
+			IL_054d: ldstr "Could not find section '"
+			IL_0552: ldloc.s 35
+			IL_0554: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0559: stloc.s 35
+			IL_055b: ldloc.s 35
+			IL_055d: ldstr "' in multipage index: "
+			IL_0562: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0567: stloc.s 35
+			IL_0569: ldloc.s 15
+			IL_056b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0570: stloc.s 36
+			IL_0572: ldloc.s 35
+			IL_0574: ldloc.s 36
+			IL_0576: call string [System.Runtime]System.String::Concat(string, string)
+			IL_057b: stloc.s 36
+			IL_057d: ldloc.s 36
+			IL_057f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0584: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0589: stloc.s 34
+			IL_058b: ldloc.s 34
+			IL_058d: stloc.s 19
+			IL_058f: ldloc.0
+			IL_0590: ldc.i4.m1
+			IL_0591: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0596: ldloc.0
+			IL_0597: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_059c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_05a1: ldarg.0
+			IL_05a2: ldc.i4.1
+			IL_05a3: newarr [System.Runtime]System.Object
+			IL_05a8: dup
+			IL_05a9: ldc.i4.0
+			IL_05aa: ldloc.s 19
+			IL_05ac: stelem.ref
+			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05b2: pop
+			IL_05b3: ldloc.0
+			IL_05b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05b9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05be: ret
 
-			IL_0584: ldarg.0
-			IL_0585: ldc.i4.1
-			IL_0586: ldelem.ref
-			IL_0587: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_058c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0591: stloc.s 29
-			IL_0593: ldloc.s 17
-			IL_0595: ldstr "filePart"
-			IL_059a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_059f: stloc.s 35
-			IL_05a1: ldloc.s 35
-			IL_05a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05a8: stloc.s 30
-			IL_05aa: ldloc.s 30
-			IL_05ac: brtrue IL_05c4
+			IL_05bf: ldarg.0
+			IL_05c0: ldc.i4.1
+			IL_05c1: ldelem.ref
+			IL_05c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05c7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_05cc: stloc.s 34
+			IL_05ce: ldloc.s 17
+			IL_05d0: ldstr "filePart"
+			IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05da: stloc.s 29
+			IL_05dc: ldloc.s 29
+			IL_05de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05e3: stloc.s 31
+			IL_05e5: ldloc.s 31
+			IL_05e7: brtrue IL_05ff
 
-			IL_05b1: ldloc.s 17
-			IL_05b3: ldstr "href"
-			IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05bd: stloc.s 36
-			IL_05bf: br IL_05c8
+			IL_05ec: ldloc.s 17
+			IL_05ee: ldstr "href"
+			IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f8: stloc.s 37
+			IL_05fa: br IL_0603
 
-			IL_05c4: ldloc.s 35
-			IL_05c6: stloc.s 36
+			IL_05ff: ldloc.s 29
+			IL_0601: stloc.s 37
 
-			IL_05c8: ldc.i4.2
-			IL_05c9: newarr [System.Runtime]System.Object
-			IL_05ce: dup
-			IL_05cf: ldc.i4.0
-			IL_05d0: ldloc.s 36
-			IL_05d2: stelem.ref
-			IL_05d3: dup
-			IL_05d4: ldc.i4.1
-			IL_05d5: ldloc.s 15
-			IL_05d7: stelem.ref
-			IL_05d8: stloc.s 37
-			IL_05da: ldloc.s 29
-			IL_05dc: ldloc.s 37
-			IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_05e3: stloc.s 29
-			IL_05e5: ldloc.s 29
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ec: stloc.s 29
-			IL_05ee: ldloc.s 29
-			IL_05f0: ldstr "toString"
-			IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_05fa: stloc.s 29
-			IL_05fc: ldloc.s 29
-			IL_05fe: stloc.s 20
-			IL_0600: ldarg.0
-			IL_0601: ldc.i4.1
-			IL_0602: ldelem.ref
-			IL_0603: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0608: ldnull
-			IL_0609: ldloc.s 20
-			IL_060b: ldnull
-			IL_060c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0611: stloc.s 29
-			IL_0613: ldloc.0
-			IL_0614: ldc.i4.2
-			IL_0615: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_061a: ldloc.0
-			IL_061b: ldloc.s 29
-			IL_061d: ldarg.0
-			IL_061e: ldc.i4.2
-			IL_061f: ldloc.0
-			IL_0620: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_062a: ldloc.0
-			IL_062b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0630: dup
-			IL_0631: ldc.i4.0
-			IL_0632: ldloc.1
-			IL_0633: stelem.ref
-			IL_0634: dup
-			IL_0635: ldc.i4.1
-			IL_0636: ldloc.2
-			IL_0637: stelem.ref
-			IL_0638: dup
-			IL_0639: ldc.i4.2
-			IL_063a: ldloc.3
-			IL_063b: stelem.ref
-			IL_063c: dup
-			IL_063d: ldc.i4.3
-			IL_063e: ldloc.s 4
-			IL_0640: stelem.ref
-			IL_0641: dup
-			IL_0642: ldc.i4.4
-			IL_0643: ldloc.s 5
-			IL_0645: stelem.ref
-			IL_0646: dup
-			IL_0647: ldc.i4.5
-			IL_0648: ldloc.s 6
-			IL_064a: stelem.ref
-			IL_064b: dup
-			IL_064c: ldc.i4.6
-			IL_064d: ldloc.s 7
-			IL_064f: stelem.ref
-			IL_0650: dup
-			IL_0651: ldc.i4.7
-			IL_0652: ldloc.s 8
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.8
-			IL_0657: ldloc.s 9
-			IL_0659: stelem.ref
-			IL_065a: dup
-			IL_065b: ldc.i4.s 9
-			IL_065d: ldloc.s 10
-			IL_065f: stelem.ref
-			IL_0660: dup
-			IL_0661: ldc.i4.s 10
-			IL_0663: ldloc.s 11
-			IL_0665: stelem.ref
-			IL_0666: dup
-			IL_0667: ldc.i4.s 11
-			IL_0669: ldloc.s 12
-			IL_066b: stelem.ref
-			IL_066c: dup
-			IL_066d: ldc.i4.s 12
-			IL_066f: ldloc.s 13
-			IL_0671: stelem.ref
-			IL_0672: dup
-			IL_0673: ldc.i4.s 13
-			IL_0675: ldloc.s 14
-			IL_0677: stelem.ref
-			IL_0678: dup
-			IL_0679: ldc.i4.s 14
-			IL_067b: ldloc.s 15
+			IL_0603: ldc.i4.2
+			IL_0604: newarr [System.Runtime]System.Object
+			IL_0609: dup
+			IL_060a: ldc.i4.0
+			IL_060b: ldloc.s 37
+			IL_060d: stelem.ref
+			IL_060e: dup
+			IL_060f: ldc.i4.1
+			IL_0610: ldloc.s 15
+			IL_0612: stelem.ref
+			IL_0613: stloc.s 30
+			IL_0615: ldloc.s 34
+			IL_0617: ldloc.s 30
+			IL_0619: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_061e: stloc.s 34
+			IL_0620: ldloc.s 34
+			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0627: stloc.s 34
+			IL_0629: ldloc.s 34
+			IL_062b: ldstr "toString"
+			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0635: stloc.s 34
+			IL_0637: ldloc.s 34
+			IL_0639: stloc.s 20
+			IL_063b: ldarg.0
+			IL_063c: ldc.i4.1
+			IL_063d: ldelem.ref
+			IL_063e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0643: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0648: ldc.i4.1
+			IL_0649: newarr [System.Runtime]System.Object
+			IL_064e: dup
+			IL_064f: ldc.i4.0
+			IL_0650: ldarg.0
+			IL_0651: ldc.i4.1
+			IL_0652: ldelem.ref
+			IL_0653: stelem.ref
+			IL_0654: ldloc.s 20
+			IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_065b: stloc.s 34
+			IL_065d: ldloc.0
+			IL_065e: ldc.i4.2
+			IL_065f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0664: ldloc.0
+			IL_0665: ldloc.s 34
+			IL_0667: ldarg.0
+			IL_0668: ldc.i4.2
+			IL_0669: ldloc.0
+			IL_066a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_066f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0674: ldloc.0
+			IL_0675: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_067a: dup
+			IL_067b: ldc.i4.0
+			IL_067c: ldloc.1
 			IL_067d: stelem.ref
 			IL_067e: dup
-			IL_067f: ldc.i4.s 15
-			IL_0681: ldloc.s 16
-			IL_0683: stelem.ref
-			IL_0684: dup
-			IL_0685: ldc.i4.s 16
-			IL_0687: ldloc.s 17
-			IL_0689: stelem.ref
-			IL_068a: dup
-			IL_068b: ldc.i4.s 17
-			IL_068d: ldloc.s 18
+			IL_067f: ldc.i4.1
+			IL_0680: ldloc.2
+			IL_0681: stelem.ref
+			IL_0682: dup
+			IL_0683: ldc.i4.2
+			IL_0684: ldloc.3
+			IL_0685: stelem.ref
+			IL_0686: dup
+			IL_0687: ldc.i4.3
+			IL_0688: ldloc.s 4
+			IL_068a: stelem.ref
+			IL_068b: dup
+			IL_068c: ldc.i4.4
+			IL_068d: ldloc.s 5
 			IL_068f: stelem.ref
 			IL_0690: dup
-			IL_0691: ldc.i4.s 18
-			IL_0693: ldloc.s 19
-			IL_0695: stelem.ref
-			IL_0696: dup
-			IL_0697: ldc.i4.s 19
-			IL_0699: ldloc.s 20
-			IL_069b: stelem.ref
-			IL_069c: dup
-			IL_069d: ldc.i4.s 20
-			IL_069f: ldloc.s 21
-			IL_06a1: stelem.ref
-			IL_06a2: dup
-			IL_06a3: ldc.i4.s 21
-			IL_06a5: ldloc.s 22
-			IL_06a7: stelem.ref
-			IL_06a8: dup
-			IL_06a9: ldc.i4.s 22
-			IL_06ab: ldloc.s 23
-			IL_06ad: stelem.ref
-			IL_06ae: dup
-			IL_06af: ldc.i4.s 23
-			IL_06b1: ldloc.s 24
-			IL_06b3: stelem.ref
-			IL_06b4: dup
-			IL_06b5: ldc.i4.s 24
-			IL_06b7: ldloc.s 25
-			IL_06b9: stelem.ref
-			IL_06ba: dup
-			IL_06bb: ldc.i4.s 25
-			IL_06bd: ldloc.s 26
-			IL_06bf: stelem.ref
-			IL_06c0: dup
-			IL_06c1: ldc.i4.s 26
-			IL_06c3: ldloc.s 27
-			IL_06c5: stelem.ref
-			IL_06c6: dup
-			IL_06c7: ldc.i4.s 27
-			IL_06c9: ldloc.s 28
-			IL_06cb: stelem.ref
-			IL_06cc: pop
-			IL_06cd: ldloc.0
-			IL_06ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06d8: ret
+			IL_0691: ldc.i4.5
+			IL_0692: ldloc.s 6
+			IL_0694: stelem.ref
+			IL_0695: dup
+			IL_0696: ldc.i4.6
+			IL_0697: ldloc.s 7
+			IL_0699: stelem.ref
+			IL_069a: dup
+			IL_069b: ldc.i4.7
+			IL_069c: ldloc.s 8
+			IL_069e: stelem.ref
+			IL_069f: dup
+			IL_06a0: ldc.i4.8
+			IL_06a1: ldloc.s 9
+			IL_06a3: stelem.ref
+			IL_06a4: dup
+			IL_06a5: ldc.i4.s 9
+			IL_06a7: ldloc.s 10
+			IL_06a9: stelem.ref
+			IL_06aa: dup
+			IL_06ab: ldc.i4.s 10
+			IL_06ad: ldloc.s 11
+			IL_06af: stelem.ref
+			IL_06b0: dup
+			IL_06b1: ldc.i4.s 11
+			IL_06b3: ldloc.s 12
+			IL_06b5: stelem.ref
+			IL_06b6: dup
+			IL_06b7: ldc.i4.s 12
+			IL_06b9: ldloc.s 13
+			IL_06bb: stelem.ref
+			IL_06bc: dup
+			IL_06bd: ldc.i4.s 13
+			IL_06bf: ldloc.s 14
+			IL_06c1: stelem.ref
+			IL_06c2: dup
+			IL_06c3: ldc.i4.s 14
+			IL_06c5: ldloc.s 15
+			IL_06c7: stelem.ref
+			IL_06c8: dup
+			IL_06c9: ldc.i4.s 15
+			IL_06cb: ldloc.s 16
+			IL_06cd: stelem.ref
+			IL_06ce: dup
+			IL_06cf: ldc.i4.s 16
+			IL_06d1: ldloc.s 17
+			IL_06d3: stelem.ref
+			IL_06d4: dup
+			IL_06d5: ldc.i4.s 17
+			IL_06d7: ldloc.s 18
+			IL_06d9: stelem.ref
+			IL_06da: dup
+			IL_06db: ldc.i4.s 18
+			IL_06dd: ldloc.s 19
+			IL_06df: stelem.ref
+			IL_06e0: dup
+			IL_06e1: ldc.i4.s 19
+			IL_06e3: ldloc.s 20
+			IL_06e5: stelem.ref
+			IL_06e6: dup
+			IL_06e7: ldc.i4.s 20
+			IL_06e9: ldloc.s 21
+			IL_06eb: stelem.ref
+			IL_06ec: dup
+			IL_06ed: ldc.i4.s 21
+			IL_06ef: ldloc.s 22
+			IL_06f1: stelem.ref
+			IL_06f2: dup
+			IL_06f3: ldc.i4.s 22
+			IL_06f5: ldloc.s 23
+			IL_06f7: stelem.ref
+			IL_06f8: dup
+			IL_06f9: ldc.i4.s 23
+			IL_06fb: ldloc.s 24
+			IL_06fd: stelem.ref
+			IL_06fe: dup
+			IL_06ff: ldc.i4.s 24
+			IL_0701: ldloc.s 25
+			IL_0703: stelem.ref
+			IL_0704: dup
+			IL_0705: ldc.i4.s 25
+			IL_0707: ldloc.s 26
+			IL_0709: stelem.ref
+			IL_070a: dup
+			IL_070b: ldc.i4.s 26
+			IL_070d: ldloc.s 27
+			IL_070f: stelem.ref
+			IL_0710: dup
+			IL_0711: ldc.i4.s 27
+			IL_0713: ldloc.s 28
+			IL_0715: stelem.ref
+			IL_0716: pop
+			IL_0717: ldloc.0
+			IL_0718: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_071d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0722: ret
 
-			IL_06d9: ldloc.0
-			IL_06da: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_06df: stloc.s 29
-			IL_06e1: ldloc.s 29
-			IL_06e3: stloc.s 11
-			IL_06e5: ldloc.s 20
-			IL_06e7: stloc.s 29
-			IL_06e9: ldloc.s 29
-			IL_06eb: stloc.s 13
-			IL_06ed: ldloc.s 12
-			IL_06ef: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06f4: ldc.i4.0
-			IL_06f5: ceq
-			IL_06f7: stloc.s 30
-			IL_06f9: ldloc.s 30
-			IL_06fb: brfalse IL_0739
+			IL_0723: ldloc.0
+			IL_0724: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0729: stloc.s 34
+			IL_072b: ldloc.s 34
+			IL_072d: stloc.s 11
+			IL_072f: ldloc.s 20
+			IL_0731: stloc.s 34
+			IL_0733: ldloc.s 34
+			IL_0735: stloc.s 13
+			IL_0737: ldloc.s 12
+			IL_0739: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_073e: ldc.i4.0
+			IL_073f: ceq
+			IL_0741: stloc.s 31
+			IL_0743: ldloc.s 31
+			IL_0745: brfalse IL_0783
 
-			IL_0700: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_0705: stloc.s 21
-			IL_0707: ldloc.s 17
-			IL_0709: ldstr "fragment"
-			IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0713: stloc.s 29
-			IL_0715: ldloc.s 29
-			IL_0717: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_071c: stloc.s 30
-			IL_071e: ldloc.s 30
-			IL_0720: brtrue IL_0731
+			IL_074a: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_074f: stloc.s 21
+			IL_0751: ldloc.s 17
+			IL_0753: ldstr "fragment"
+			IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_075d: stloc.s 34
+			IL_075f: ldloc.s 34
+			IL_0761: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0766: stloc.s 31
+			IL_0768: ldloc.s 31
+			IL_076a: brtrue IL_077b
 
-			IL_0725: ldstr ""
-			IL_072a: stloc.s 38
-			IL_072c: br IL_0735
+			IL_076f: ldstr ""
+			IL_0774: stloc.s 38
+			IL_0776: br IL_077f
 
-			IL_0731: ldloc.s 29
-			IL_0733: stloc.s 38
+			IL_077b: ldloc.s 34
+			IL_077d: stloc.s 38
 
-			IL_0735: ldloc.s 38
-			IL_0737: stloc.s 12
+			IL_077f: ldloc.s 38
+			IL_0781: stloc.s 12
 
-			IL_0739: br IL_0856
+			IL_0783: br IL_08af
 
-			IL_073e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_0743: stloc.s 22
-			IL_0745: ldloc.1
-			IL_0746: ldstr "url"
-			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0755: stloc.s 29
-			IL_0757: ldloc.s 29
-			IL_0759: ldstr "trim"
-			IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0763: stloc.s 29
-			IL_0765: ldloc.s 29
-			IL_0767: stloc.s 23
-			IL_0769: ldarg.0
-			IL_076a: ldc.i4.1
-			IL_076b: ldelem.ref
-			IL_076c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0771: ldnull
-			IL_0772: ldloc.s 23
-			IL_0774: ldnull
-			IL_0775: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_077a: stloc.s 29
-			IL_077c: ldloc.0
-			IL_077d: ldc.i4.3
-			IL_077e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0783: ldloc.0
-			IL_0784: ldloc.s 29
-			IL_0786: ldarg.0
-			IL_0787: ldc.i4.3
-			IL_0788: ldloc.0
-			IL_0789: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_078e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0793: ldloc.0
-			IL_0794: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0799: dup
-			IL_079a: ldc.i4.0
-			IL_079b: ldloc.1
-			IL_079c: stelem.ref
-			IL_079d: dup
-			IL_079e: ldc.i4.1
-			IL_079f: ldloc.2
-			IL_07a0: stelem.ref
-			IL_07a1: dup
-			IL_07a2: ldc.i4.2
-			IL_07a3: ldloc.3
-			IL_07a4: stelem.ref
-			IL_07a5: dup
-			IL_07a6: ldc.i4.3
-			IL_07a7: ldloc.s 4
-			IL_07a9: stelem.ref
-			IL_07aa: dup
-			IL_07ab: ldc.i4.4
-			IL_07ac: ldloc.s 5
-			IL_07ae: stelem.ref
-			IL_07af: dup
-			IL_07b0: ldc.i4.5
-			IL_07b1: ldloc.s 6
-			IL_07b3: stelem.ref
-			IL_07b4: dup
-			IL_07b5: ldc.i4.6
-			IL_07b6: ldloc.s 7
-			IL_07b8: stelem.ref
-			IL_07b9: dup
-			IL_07ba: ldc.i4.7
-			IL_07bb: ldloc.s 8
-			IL_07bd: stelem.ref
-			IL_07be: dup
-			IL_07bf: ldc.i4.8
-			IL_07c0: ldloc.s 9
-			IL_07c2: stelem.ref
-			IL_07c3: dup
-			IL_07c4: ldc.i4.s 9
-			IL_07c6: ldloc.s 10
-			IL_07c8: stelem.ref
-			IL_07c9: dup
-			IL_07ca: ldc.i4.s 10
-			IL_07cc: ldloc.s 11
-			IL_07ce: stelem.ref
-			IL_07cf: dup
-			IL_07d0: ldc.i4.s 11
-			IL_07d2: ldloc.s 12
-			IL_07d4: stelem.ref
-			IL_07d5: dup
-			IL_07d6: ldc.i4.s 12
-			IL_07d8: ldloc.s 13
-			IL_07da: stelem.ref
-			IL_07db: dup
-			IL_07dc: ldc.i4.s 13
-			IL_07de: ldloc.s 14
-			IL_07e0: stelem.ref
-			IL_07e1: dup
-			IL_07e2: ldc.i4.s 14
-			IL_07e4: ldloc.s 15
-			IL_07e6: stelem.ref
-			IL_07e7: dup
-			IL_07e8: ldc.i4.s 15
-			IL_07ea: ldloc.s 16
-			IL_07ec: stelem.ref
-			IL_07ed: dup
-			IL_07ee: ldc.i4.s 16
-			IL_07f0: ldloc.s 17
-			IL_07f2: stelem.ref
-			IL_07f3: dup
-			IL_07f4: ldc.i4.s 17
-			IL_07f6: ldloc.s 18
-			IL_07f8: stelem.ref
-			IL_07f9: dup
-			IL_07fa: ldc.i4.s 18
-			IL_07fc: ldloc.s 19
-			IL_07fe: stelem.ref
-			IL_07ff: dup
-			IL_0800: ldc.i4.s 19
-			IL_0802: ldloc.s 20
-			IL_0804: stelem.ref
-			IL_0805: dup
-			IL_0806: ldc.i4.s 20
-			IL_0808: ldloc.s 21
-			IL_080a: stelem.ref
-			IL_080b: dup
-			IL_080c: ldc.i4.s 21
-			IL_080e: ldloc.s 22
-			IL_0810: stelem.ref
-			IL_0811: dup
-			IL_0812: ldc.i4.s 22
-			IL_0814: ldloc.s 23
+			IL_0788: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_078d: stloc.s 22
+			IL_078f: ldloc.1
+			IL_0790: ldstr "url"
+			IL_0795: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_079f: stloc.s 34
+			IL_07a1: ldloc.s 34
+			IL_07a3: ldstr "trim"
+			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_07ad: stloc.s 34
+			IL_07af: ldloc.s 34
+			IL_07b1: stloc.s 23
+			IL_07b3: ldarg.0
+			IL_07b4: ldc.i4.1
+			IL_07b5: ldelem.ref
+			IL_07b6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07bb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_07c0: ldc.i4.1
+			IL_07c1: newarr [System.Runtime]System.Object
+			IL_07c6: dup
+			IL_07c7: ldc.i4.0
+			IL_07c8: ldarg.0
+			IL_07c9: ldc.i4.1
+			IL_07ca: ldelem.ref
+			IL_07cb: stelem.ref
+			IL_07cc: ldloc.s 23
+			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07d3: stloc.s 34
+			IL_07d5: ldloc.0
+			IL_07d6: ldc.i4.3
+			IL_07d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07dc: ldloc.0
+			IL_07dd: ldloc.s 34
+			IL_07df: ldarg.0
+			IL_07e0: ldc.i4.3
+			IL_07e1: ldloc.0
+			IL_07e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07ec: ldloc.0
+			IL_07ed: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07f2: dup
+			IL_07f3: ldc.i4.0
+			IL_07f4: ldloc.1
+			IL_07f5: stelem.ref
+			IL_07f6: dup
+			IL_07f7: ldc.i4.1
+			IL_07f8: ldloc.2
+			IL_07f9: stelem.ref
+			IL_07fa: dup
+			IL_07fb: ldc.i4.2
+			IL_07fc: ldloc.3
+			IL_07fd: stelem.ref
+			IL_07fe: dup
+			IL_07ff: ldc.i4.3
+			IL_0800: ldloc.s 4
+			IL_0802: stelem.ref
+			IL_0803: dup
+			IL_0804: ldc.i4.4
+			IL_0805: ldloc.s 5
+			IL_0807: stelem.ref
+			IL_0808: dup
+			IL_0809: ldc.i4.5
+			IL_080a: ldloc.s 6
+			IL_080c: stelem.ref
+			IL_080d: dup
+			IL_080e: ldc.i4.6
+			IL_080f: ldloc.s 7
+			IL_0811: stelem.ref
+			IL_0812: dup
+			IL_0813: ldc.i4.7
+			IL_0814: ldloc.s 8
 			IL_0816: stelem.ref
 			IL_0817: dup
-			IL_0818: ldc.i4.s 23
-			IL_081a: ldloc.s 24
-			IL_081c: stelem.ref
-			IL_081d: dup
-			IL_081e: ldc.i4.s 24
-			IL_0820: ldloc.s 25
-			IL_0822: stelem.ref
-			IL_0823: dup
-			IL_0824: ldc.i4.s 25
-			IL_0826: ldloc.s 26
-			IL_0828: stelem.ref
-			IL_0829: dup
-			IL_082a: ldc.i4.s 26
-			IL_082c: ldloc.s 27
-			IL_082e: stelem.ref
-			IL_082f: dup
-			IL_0830: ldc.i4.s 27
-			IL_0832: ldloc.s 28
-			IL_0834: stelem.ref
-			IL_0835: pop
-			IL_0836: ldloc.0
-			IL_0837: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_083c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0841: ret
+			IL_0818: ldc.i4.8
+			IL_0819: ldloc.s 9
+			IL_081b: stelem.ref
+			IL_081c: dup
+			IL_081d: ldc.i4.s 9
+			IL_081f: ldloc.s 10
+			IL_0821: stelem.ref
+			IL_0822: dup
+			IL_0823: ldc.i4.s 10
+			IL_0825: ldloc.s 11
+			IL_0827: stelem.ref
+			IL_0828: dup
+			IL_0829: ldc.i4.s 11
+			IL_082b: ldloc.s 12
+			IL_082d: stelem.ref
+			IL_082e: dup
+			IL_082f: ldc.i4.s 12
+			IL_0831: ldloc.s 13
+			IL_0833: stelem.ref
+			IL_0834: dup
+			IL_0835: ldc.i4.s 13
+			IL_0837: ldloc.s 14
+			IL_0839: stelem.ref
+			IL_083a: dup
+			IL_083b: ldc.i4.s 14
+			IL_083d: ldloc.s 15
+			IL_083f: stelem.ref
+			IL_0840: dup
+			IL_0841: ldc.i4.s 15
+			IL_0843: ldloc.s 16
+			IL_0845: stelem.ref
+			IL_0846: dup
+			IL_0847: ldc.i4.s 16
+			IL_0849: ldloc.s 17
+			IL_084b: stelem.ref
+			IL_084c: dup
+			IL_084d: ldc.i4.s 17
+			IL_084f: ldloc.s 18
+			IL_0851: stelem.ref
+			IL_0852: dup
+			IL_0853: ldc.i4.s 18
+			IL_0855: ldloc.s 19
+			IL_0857: stelem.ref
+			IL_0858: dup
+			IL_0859: ldc.i4.s 19
+			IL_085b: ldloc.s 20
+			IL_085d: stelem.ref
+			IL_085e: dup
+			IL_085f: ldc.i4.s 20
+			IL_0861: ldloc.s 21
+			IL_0863: stelem.ref
+			IL_0864: dup
+			IL_0865: ldc.i4.s 21
+			IL_0867: ldloc.s 22
+			IL_0869: stelem.ref
+			IL_086a: dup
+			IL_086b: ldc.i4.s 22
+			IL_086d: ldloc.s 23
+			IL_086f: stelem.ref
+			IL_0870: dup
+			IL_0871: ldc.i4.s 23
+			IL_0873: ldloc.s 24
+			IL_0875: stelem.ref
+			IL_0876: dup
+			IL_0877: ldc.i4.s 24
+			IL_0879: ldloc.s 25
+			IL_087b: stelem.ref
+			IL_087c: dup
+			IL_087d: ldc.i4.s 25
+			IL_087f: ldloc.s 26
+			IL_0881: stelem.ref
+			IL_0882: dup
+			IL_0883: ldc.i4.s 26
+			IL_0885: ldloc.s 27
+			IL_0887: stelem.ref
+			IL_0888: dup
+			IL_0889: ldc.i4.s 27
+			IL_088b: ldloc.s 28
+			IL_088d: stelem.ref
+			IL_088e: pop
+			IL_088f: ldloc.0
+			IL_0890: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0895: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_089a: ret
 
-			IL_0842: ldloc.0
-			IL_0843: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_0848: stloc.s 29
-			IL_084a: ldloc.s 29
-			IL_084c: stloc.s 11
-			IL_084e: ldloc.s 23
-			IL_0850: stloc.s 29
-			IL_0852: ldloc.s 29
-			IL_0854: stloc.s 13
+			IL_089b: ldloc.0
+			IL_089c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_08a1: stloc.s 34
+			IL_08a3: ldloc.s 34
+			IL_08a5: stloc.s 11
+			IL_08a7: ldloc.s 23
+			IL_08a9: stloc.s 34
+			IL_08ab: ldloc.s 34
+			IL_08ad: stloc.s 13
 
-			IL_0856: ldloc.s 12
-			IL_0858: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_085d: ldc.i4.0
-			IL_085e: ceq
-			IL_0860: stloc.s 30
-			IL_0862: ldloc.s 30
-			IL_0864: brfalse IL_08e0
+			IL_08af: ldloc.s 12
+			IL_08b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08b6: ldc.i4.0
+			IL_08b7: ceq
+			IL_08b9: stloc.s 31
+			IL_08bb: ldloc.s 31
+			IL_08bd: brfalse IL_0939
 
-			IL_0869: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_086e: stloc.s 24
-			IL_0870: ldloc.1
-			IL_0871: ldstr "section"
-			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_087b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0880: stloc.s 34
-			IL_0882: ldstr "Could not infer an element id for section '"
-			IL_0887: ldloc.s 34
-			IL_0889: call string [System.Runtime]System.String::Concat(string, string)
-			IL_088e: stloc.s 34
-			IL_0890: ldloc.s 34
-			IL_0892: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0897: call string [System.Runtime]System.String::Concat(string, string)
-			IL_089c: stloc.s 34
-			IL_089e: ldloc.s 34
-			IL_08a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_08aa: stloc.s 29
-			IL_08ac: ldloc.s 29
-			IL_08ae: stloc.s 25
-			IL_08b0: ldloc.0
-			IL_08b1: ldc.i4.m1
-			IL_08b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08b7: ldloc.0
-			IL_08b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_08c2: ldarg.0
-			IL_08c3: ldc.i4.1
-			IL_08c4: newarr [System.Runtime]System.Object
-			IL_08c9: dup
-			IL_08ca: ldc.i4.0
-			IL_08cb: ldloc.s 25
-			IL_08cd: stelem.ref
-			IL_08ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08d3: pop
-			IL_08d4: ldloc.0
-			IL_08d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08df: ret
+			IL_08c2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_08c7: stloc.s 24
+			IL_08c9: ldloc.1
+			IL_08ca: ldstr "section"
+			IL_08cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08d4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08d9: stloc.s 36
+			IL_08db: ldstr "Could not infer an element id for section '"
+			IL_08e0: ldloc.s 36
+			IL_08e2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08e7: stloc.s 36
+			IL_08e9: ldloc.s 36
+			IL_08eb: ldstr "'. Try passing --id sec-... explicitly."
+			IL_08f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08f5: stloc.s 36
+			IL_08f7: ldloc.s 36
+			IL_08f9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0903: stloc.s 34
+			IL_0905: ldloc.s 34
+			IL_0907: stloc.s 25
+			IL_0909: ldloc.0
+			IL_090a: ldc.i4.m1
+			IL_090b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0910: ldloc.0
+			IL_0911: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0916: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_091b: ldarg.0
+			IL_091c: ldc.i4.1
+			IL_091d: newarr [System.Runtime]System.Object
+			IL_0922: dup
+			IL_0923: ldc.i4.0
+			IL_0924: ldloc.s 25
+			IL_0926: stelem.ref
+			IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_092c: pop
+			IL_092d: ldloc.0
+			IL_092e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0933: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0938: ret
 
-			IL_08e0: ldarg.0
-			IL_08e1: ldc.i4.1
-			IL_08e2: ldelem.ref
-			IL_08e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_08e8: ldnull
-			IL_08e9: ldloc.s 11
-			IL_08eb: ldloc.s 12
-			IL_08ed: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_08f2: stloc.s 29
-			IL_08f4: ldloc.s 29
-			IL_08f6: stloc.s 26
-			IL_08f8: ldarg.0
-			IL_08f9: ldc.i4.1
-			IL_08fa: ldelem.ref
-			IL_08fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0900: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_090a: stloc.s 29
-			IL_090c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0911: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0916: stloc.s 35
-			IL_0918: ldloc.s 35
-			IL_091a: ldstr "cwd"
-			IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0924: stloc.s 35
-			IL_0926: ldloc.s 29
-			IL_0928: ldstr "join"
-			IL_092d: ldloc.s 35
-			IL_092f: ldloc.1
-			IL_0930: ldstr "outFile"
-			IL_0935: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_093f: stloc.s 35
-			IL_0941: ldloc.s 35
-			IL_0943: stloc.s 27
-			IL_0945: ldloc.s 26
-			IL_0947: ldstr "html"
-			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0951: stloc.s 35
-			IL_0953: ldloc.1
-			IL_0954: ldstr "section"
-			IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_095e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0963: stloc.s 34
-			IL_0965: ldstr "ECMA-262 "
-			IL_096a: ldloc.s 34
-			IL_096c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0971: stloc.s 34
-			IL_0973: ldnull
-			IL_0974: ldloc.s 35
-			IL_0976: ldloc.s 34
-			IL_0978: ldloc.s 13
-			IL_097a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-			IL_097f: stloc.s 35
-			IL_0981: ldloc.s 35
-			IL_0983: stloc.s 28
-			IL_0985: ldarg.0
-			IL_0986: ldc.i4.1
-			IL_0987: ldelem.ref
-			IL_0988: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_098d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0992: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0997: stloc.s 35
-			IL_0999: ldloc.s 35
-			IL_099b: ldstr "writeFileSync"
-			IL_09a0: ldloc.s 27
-			IL_09a2: ldloc.s 28
-			IL_09a4: ldstr "utf8"
-			IL_09a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_09ae: pop
-			IL_09af: ldloc.1
-			IL_09b0: ldstr "section"
-			IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09bf: stloc.s 34
-			IL_09c1: ldstr "Extracted section "
-			IL_09c6: ldloc.s 34
-			IL_09c8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09cd: stloc.s 34
-			IL_09cf: ldloc.s 34
-			IL_09d1: ldstr " (id="
-			IL_09d6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09db: stloc.s 34
-			IL_09dd: ldloc.s 12
-			IL_09df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09e4: stloc.s 33
-			IL_09e6: ldloc.s 34
-			IL_09e8: ldloc.s 33
-			IL_09ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ef: stloc.s 33
-			IL_09f1: ldloc.s 33
-			IL_09f3: ldstr ", tag="
-			IL_09f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09fd: stloc.s 33
-			IL_09ff: ldloc.s 26
-			IL_0a01: ldstr "tagName"
-			IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a0b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a10: stloc.s 34
-			IL_0a12: ldloc.s 33
-			IL_0a14: ldloc.s 34
-			IL_0a16: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a1b: stloc.s 34
-			IL_0a1d: ldloc.s 34
-			IL_0a1f: ldstr ") -> "
-			IL_0a24: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a29: stloc.s 34
-			IL_0a2b: ldloc.s 27
-			IL_0a2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a32: stloc.s 33
-			IL_0a34: ldloc.s 34
-			IL_0a36: ldloc.s 33
-			IL_0a38: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a3d: stloc.s 33
-			IL_0a3f: ldnull
-			IL_0a40: ldloc.s 33
-			IL_0a42: ldloc.s 27
-			IL_0a44: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0a49: stloc.s 35
-			IL_0a4b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a50: ldloc.s 35
-			IL_0a52: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a57: pop
-			IL_0a58: ldarg.0
-			IL_0a59: ldc.i4.1
-			IL_0a5a: ldelem.ref
-			IL_0a5b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a60: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a6a: stloc.s 35
-			IL_0a6c: ldloc.s 35
-			IL_0a6e: ldstr "readFileSync"
-			IL_0a73: ldloc.s 27
-			IL_0a75: ldstr "utf8"
-			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a7f: stloc.s 35
-			IL_0a81: ldnull
-			IL_0a82: ldloc.s 35
-			IL_0a84: ldloc.s 27
-			IL_0a86: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0a8b: stloc.s 35
-			IL_0a8d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a92: ldloc.s 35
-			IL_0a94: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a99: pop
-			IL_0a9a: ldloc.0
-			IL_0a9b: ldc.i4.m1
-			IL_0a9c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0aa1: ldloc.0
-			IL_0aa2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0aa7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0aac: ldarg.0
-			IL_0aad: ldc.i4.1
-			IL_0aae: newarr [System.Runtime]System.Object
-			IL_0ab3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0ab8: pop
-			IL_0ab9: ldloc.0
-			IL_0aba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0abf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ac4: ret
+			IL_0939: ldarg.0
+			IL_093a: ldc.i4.1
+			IL_093b: ldelem.ref
+			IL_093c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0941: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0946: ldc.i4.1
+			IL_0947: newarr [System.Runtime]System.Object
+			IL_094c: dup
+			IL_094d: ldc.i4.0
+			IL_094e: ldarg.0
+			IL_094f: ldc.i4.1
+			IL_0950: ldelem.ref
+			IL_0951: stelem.ref
+			IL_0952: ldloc.s 11
+			IL_0954: ldloc.s 12
+			IL_0956: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_095b: stloc.s 34
+			IL_095d: ldloc.s 34
+			IL_095f: stloc.s 26
+			IL_0961: ldarg.0
+			IL_0962: ldc.i4.1
+			IL_0963: ldelem.ref
+			IL_0964: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0969: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_096e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0973: stloc.s 34
+			IL_0975: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_097a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_097f: stloc.s 29
+			IL_0981: ldloc.s 29
+			IL_0983: ldstr "cwd"
+			IL_0988: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_098d: stloc.s 29
+			IL_098f: ldloc.s 34
+			IL_0991: ldstr "join"
+			IL_0996: ldloc.s 29
+			IL_0998: ldloc.1
+			IL_0999: ldstr "outFile"
+			IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_09a8: stloc.s 29
+			IL_09aa: ldloc.s 29
+			IL_09ac: stloc.s 27
+			IL_09ae: ldarg.0
+			IL_09af: ldc.i4.1
+			IL_09b0: ldelem.ref
+			IL_09b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09bb: stloc.s 29
+			IL_09bd: ldc.i4.1
+			IL_09be: newarr [System.Runtime]System.Object
+			IL_09c3: dup
+			IL_09c4: ldc.i4.0
+			IL_09c5: ldarg.0
+			IL_09c6: ldc.i4.1
+			IL_09c7: ldelem.ref
+			IL_09c8: stelem.ref
+			IL_09c9: stloc.s 30
+			IL_09cb: ldloc.s 26
+			IL_09cd: ldstr "html"
+			IL_09d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d7: stloc.s 34
+			IL_09d9: ldloc.1
+			IL_09da: ldstr "section"
+			IL_09df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09e9: stloc.s 36
+			IL_09eb: ldstr "ECMA-262 "
+			IL_09f0: ldloc.s 36
+			IL_09f2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09f7: stloc.s 36
+			IL_09f9: ldloc.s 29
+			IL_09fb: ldloc.s 30
+			IL_09fd: ldloc.s 34
+			IL_09ff: ldloc.s 36
+			IL_0a01: ldloc.s 13
+			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a08: stloc.s 34
+			IL_0a0a: ldloc.s 34
+			IL_0a0c: stloc.s 28
+			IL_0a0e: ldarg.0
+			IL_0a0f: ldc.i4.1
+			IL_0a10: ldelem.ref
+			IL_0a11: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a16: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a20: stloc.s 34
+			IL_0a22: ldloc.s 34
+			IL_0a24: ldstr "writeFileSync"
+			IL_0a29: ldloc.s 27
+			IL_0a2b: ldloc.s 28
+			IL_0a2d: ldstr "utf8"
+			IL_0a32: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0a37: pop
+			IL_0a38: ldarg.0
+			IL_0a39: ldc.i4.1
+			IL_0a3a: ldelem.ref
+			IL_0a3b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a40: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a45: stloc.s 34
+			IL_0a47: ldc.i4.1
+			IL_0a48: newarr [System.Runtime]System.Object
+			IL_0a4d: dup
+			IL_0a4e: ldc.i4.0
+			IL_0a4f: ldarg.0
+			IL_0a50: ldc.i4.1
+			IL_0a51: ldelem.ref
+			IL_0a52: stelem.ref
+			IL_0a53: stloc.s 30
+			IL_0a55: ldloc.1
+			IL_0a56: ldstr "section"
+			IL_0a5b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a60: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a65: stloc.s 36
+			IL_0a67: ldstr "Extracted section "
+			IL_0a6c: ldloc.s 36
+			IL_0a6e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a73: stloc.s 36
+			IL_0a75: ldloc.s 36
+			IL_0a77: ldstr " (id="
+			IL_0a7c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a81: stloc.s 36
+			IL_0a83: ldloc.s 12
+			IL_0a85: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a8a: stloc.s 35
+			IL_0a8c: ldloc.s 36
+			IL_0a8e: ldloc.s 35
+			IL_0a90: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a95: stloc.s 35
+			IL_0a97: ldloc.s 35
+			IL_0a99: ldstr ", tag="
+			IL_0a9e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0aa3: stloc.s 35
+			IL_0aa5: ldloc.s 26
+			IL_0aa7: ldstr "tagName"
+			IL_0aac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ab1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ab6: stloc.s 36
+			IL_0ab8: ldloc.s 35
+			IL_0aba: ldloc.s 36
+			IL_0abc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ac1: stloc.s 36
+			IL_0ac3: ldloc.s 36
+			IL_0ac5: ldstr ") -> "
+			IL_0aca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0acf: stloc.s 36
+			IL_0ad1: ldloc.s 27
+			IL_0ad3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ad8: stloc.s 35
+			IL_0ada: ldloc.s 36
+			IL_0adc: ldloc.s 35
+			IL_0ade: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae3: stloc.s 35
+			IL_0ae5: ldloc.s 34
+			IL_0ae7: ldloc.s 30
+			IL_0ae9: ldloc.s 35
+			IL_0aeb: ldloc.s 27
+			IL_0aed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0af2: stloc.s 34
+			IL_0af4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0af9: ldloc.s 34
+			IL_0afb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b00: pop
+			IL_0b01: ldarg.0
+			IL_0b02: ldc.i4.1
+			IL_0b03: ldelem.ref
+			IL_0b04: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b09: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b0e: stloc.s 34
+			IL_0b10: ldc.i4.1
+			IL_0b11: newarr [System.Runtime]System.Object
+			IL_0b16: dup
+			IL_0b17: ldc.i4.0
+			IL_0b18: ldarg.0
+			IL_0b19: ldc.i4.1
+			IL_0b1a: ldelem.ref
+			IL_0b1b: stelem.ref
+			IL_0b1c: stloc.s 30
+			IL_0b1e: ldarg.0
+			IL_0b1f: ldc.i4.1
+			IL_0b20: ldelem.ref
+			IL_0b21: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b26: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b30: stloc.s 29
+			IL_0b32: ldloc.s 29
+			IL_0b34: ldstr "readFileSync"
+			IL_0b39: ldloc.s 27
+			IL_0b3b: ldstr "utf8"
+			IL_0b40: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b45: stloc.s 29
+			IL_0b47: ldloc.s 34
+			IL_0b49: ldloc.s 30
+			IL_0b4b: ldloc.s 29
+			IL_0b4d: ldloc.s 27
+			IL_0b4f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b54: stloc.s 29
+			IL_0b56: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b5b: ldloc.s 29
+			IL_0b5d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b62: pop
+			IL_0b63: ldloc.0
+			IL_0b64: ldc.i4.m1
+			IL_0b65: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b6a: ldloc.0
+			IL_0b6b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b70: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0b75: ldarg.0
+			IL_0b76: ldc.i4.1
+			IL_0b77: newarr [System.Runtime]System.Object
+			IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0b81: pop
+			IL_0b82: ldloc.0
+			IL_0b83: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b88: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0b8d: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5268,7 +5408,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x450d
+			// Method begins at RVA 0x4621
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5292,7 +5432,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20f0
+		// Method begins at RVA 0x20ec
 		// Header size: 12
 		// Code size: 551 (0x227)
 		.maxstack 8
@@ -5534,7 +5674,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x46d8
+		// Method begins at RVA 0x47ec
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x44fb
+				// Method begins at RVA 0x460f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -52,7 +52,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2324
+			// Method begins at RVA 0x2320
 			// Header size: 12
 			// Code size: 265 (0x109)
 			.maxstack 8
@@ -192,7 +192,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4504
+				// Method begins at RVA 0x4618
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -216,7 +216,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x243c
+			// Method begins at RVA 0x2438
 			// Header size: 12
 			// Code size: 176 (0xb0)
 			.maxstack 8
@@ -324,7 +324,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x44f2
+			// Method begins at RVA 0x4606
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -350,7 +350,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 146 (0x92)
+		// Code size: 141 (0x8d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope,
@@ -382,43 +382,38 @@
 		IL_0035: stloc.2
 		IL_0036: ldloc.2
 		IL_0037: stloc.1
-		IL_0038: ldc.i4.1
-		IL_0039: newarr [System.Runtime]System.Object
-		IL_003e: dup
-		IL_003f: ldc.i4.0
-		IL_0040: ldloc.0
-		IL_0041: stelem.ref
-		IL_0042: ldnull
-		IL_0043: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
-		IL_0048: stloc.2
-		IL_0049: ldloc.2
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_004f: stloc.2
-		IL_0050: ldnull
-		IL_0051: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L8C13::__js_call__(object, object)
-		IL_0057: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_005c: ldc.i4.1
-		IL_005d: newarr [System.Runtime]System.Object
-		IL_0062: dup
-		IL_0063: ldc.i4.0
-		IL_0064: ldloc.0
-		IL_0065: stelem.ref
-		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0070: ldc.i4.1
-		IL_0071: conv.r8
-		IL_0072: ldstr ""
-		IL_0077: ldc.i4.0
-		IL_0078: ldc.i4.1
-		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0083: stloc.3
-		IL_0084: ldloc.2
-		IL_0085: ldstr "catch"
-		IL_008a: ldloc.3
-		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0090: pop
-		IL_0091: ret
+		IL_0038: ldloc.1
+		IL_0039: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0043: stloc.2
+		IL_0044: ldloc.2
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_004a: stloc.2
+		IL_004b: ldnull
+		IL_004c: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L8C13::__js_call__(object, object)
+		IL_0052: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0057: ldc.i4.1
+		IL_0058: newarr [System.Runtime]System.Object
+		IL_005d: dup
+		IL_005e: ldc.i4.0
+		IL_005f: ldloc.0
+		IL_0060: stelem.ref
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_006b: ldc.i4.1
+		IL_006c: conv.r8
+		IL_006d: ldstr ""
+		IL_0072: ldc.i4.0
+		IL_0073: ldc.i4.1
+		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_007e: stloc.3
+		IL_007f: ldloc.2
+		IL_0080: ldstr "catch"
+		IL_0085: ldloc.3
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_008b: pop
+		IL_008c: ret
 	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_UrlMode::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
@@ -442,7 +437,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x451f
+					// Method begins at RVA 0x4633
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -460,7 +455,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4516
+				// Method begins at RVA 0x462a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -485,7 +480,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x24f8
+			// Method begins at RVA 0x24f4
 			// Header size: 12
 			// Code size: 306 (0x132)
 			.maxstack 8
@@ -612,7 +607,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4528
+				// Method begins at RVA 0x463c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -640,7 +635,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4543
+						// Method begins at RVA 0x4657
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -660,7 +655,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x454c
+						// Method begins at RVA 0x4660
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -680,7 +675,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4555
+						// Method begins at RVA 0x4669
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -700,7 +695,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x455e
+						// Method begins at RVA 0x4672
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -720,7 +715,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4567
+						// Method begins at RVA 0x467b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -740,7 +735,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4570
+						// Method begins at RVA 0x4684
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -758,7 +753,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x453a
+					// Method begins at RVA 0x464e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -776,7 +771,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4531
+				// Method begins at RVA 0x4645
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -803,7 +798,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2638
+			// Method begins at RVA 0x2634
 			// Header size: 12
 			// Code size: 756 (0x2f4)
 			.maxstack 8
@@ -1130,7 +1125,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45ca
+							// Method begins at RVA 0x46de
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1155,7 +1150,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x4474
+						// Method begins at RVA 0x4588
 						// Header size: 12
 						// Code size: 36 (0x24)
 						.maxstack 8
@@ -1194,7 +1189,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45d3
+							// Method begins at RVA 0x46e7
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1218,7 +1213,7 @@
 						.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 							01 00 02 00 00 00 00 00
 						)
-						// Method begins at RVA 0x44a4
+						// Method begins at RVA 0x45b8
 						// Header size: 12
 						// Code size: 66 (0x42)
 						.maxstack 8
@@ -1291,7 +1286,7 @@
 							.method public hidebysig specialname rtspecialname 
 								instance void .ctor () cil managed 
 							{
-								// Method begins at RVA 0x45b8
+								// Method begins at RVA 0x46cc
 								// Header size: 1
 								// Code size: 8 (0x8)
 								.maxstack 8
@@ -1309,7 +1304,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45af
+							// Method begins at RVA 0x46c3
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1329,7 +1324,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x45c1
+							// Method begins at RVA 0x46d5
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -1351,7 +1346,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x45a6
+						// Method begins at RVA 0x46ba
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1376,9 +1371,9 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x4008
+					// Method begins at RVA 0x40fc
 					// Header size: 12
-					// Code size: 1119 (0x45f)
+					// Code size: 1151 (0x47f)
 					.maxstack 8
 					.locals init (
 						[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope,
@@ -1401,8 +1396,7 @@
 						[17] string,
 						[18] object,
 						[19] object,
-						[20] object,
-						[21] string
+						[20] string
 					)
 
 					IL_0000: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::.ctor()
@@ -1482,7 +1476,7 @@
 					IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00d4: stloc.s 8
 					IL_00d6: ldloc.s 8
-					IL_00d8: brfalse IL_025e
+					IL_00d8: brfalse IL_027e
 
 					IL_00dd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L95C55::.ctor()
 					IL_00e2: stloc.3
@@ -1599,262 +1593,284 @@
 					IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 					IL_01f0: pop
 					IL_01f1: ldarg.0
-					IL_01f2: ldc.i4.1
+					IL_01f2: ldc.i4.0
 					IL_01f3: ldelem.ref
-					IL_01f4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_01f9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
-					IL_01fe: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0203: ldc.r8 1
-					IL_020c: sub
-					IL_020d: box [System.Runtime]System.Double
-					IL_0212: stloc.s 19
+					IL_01f4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+					IL_01f9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+					IL_01fe: stloc.s 18
+					IL_0200: ldc.i4.3
+					IL_0201: newarr [System.Runtime]System.Object
+					IL_0206: dup
+					IL_0207: ldc.i4.0
+					IL_0208: ldarg.0
+					IL_0209: ldc.i4.0
+					IL_020a: ldelem.ref
+					IL_020b: stelem.ref
+					IL_020c: dup
+					IL_020d: ldc.i4.1
+					IL_020e: ldarg.0
+					IL_020f: ldc.i4.1
+					IL_0210: ldelem.ref
+					IL_0211: stelem.ref
+					IL_0212: dup
+					IL_0213: ldc.i4.2
 					IL_0214: ldarg.0
-					IL_0215: ldc.i4.0
+					IL_0215: ldc.i4.2
 					IL_0216: ldelem.ref
-					IL_0217: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-					IL_021c: ldnull
-					IL_021d: ldloc.s 5
-					IL_021f: ldloc.s 19
-					IL_0221: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-					IL_0226: stloc.s 18
-					IL_0228: ldloc.s 18
-					IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_022f: stloc.s 18
-					IL_0231: ldarg.0
-					IL_0232: ldc.i4.2
-					IL_0233: ldelem.ref
-					IL_0234: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0239: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
-					IL_023e: stloc.s 7
-					IL_0240: ldloc.s 18
-					IL_0242: ldstr "then"
-					IL_0247: ldloc.s 7
-					IL_0249: ldarg.0
-					IL_024a: ldc.i4.2
-					IL_024b: ldelem.ref
-					IL_024c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_0251: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_025b: pop
-					IL_025c: ldnull
-					IL_025d: ret
+					IL_0217: stelem.ref
+					IL_0218: stloc.s 16
+					IL_021a: ldloc.s 18
+					IL_021c: ldloc.s 16
+					IL_021e: ldloc.s 5
+					IL_0220: ldarg.0
+					IL_0221: ldc.i4.1
+					IL_0222: ldelem.ref
+					IL_0223: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_0228: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::maxRedirects
+					IL_022d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0232: ldc.r8 1
+					IL_023b: sub
+					IL_023c: box [System.Runtime]System.Double
+					IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_0246: stloc.s 18
+					IL_0248: ldloc.s 18
+					IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_024f: stloc.s 18
+					IL_0251: ldarg.0
+					IL_0252: ldc.i4.2
+					IL_0253: ldelem.ref
+					IL_0254: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0259: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::resolve
+					IL_025e: stloc.s 7
+					IL_0260: ldloc.s 18
+					IL_0262: ldstr "then"
+					IL_0267: ldloc.s 7
+					IL_0269: ldarg.0
+					IL_026a: ldc.i4.2
+					IL_026b: ldelem.ref
+					IL_026c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0271: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_027b: pop
+					IL_027c: ldnull
+					IL_027d: ret
 
-					IL_025e: ldloc.1
-					IL_025f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0264: stloc.s 11
-					IL_0266: ldloc.s 11
-					IL_0268: ldc.r8 200
-					IL_0271: clt
-					IL_0273: stloc.s 8
-					IL_0275: ldloc.s 8
-					IL_0277: box [System.Runtime]System.Boolean
-					IL_027c: stloc.s 12
-					IL_027e: ldloc.s 12
-					IL_0280: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0285: stloc.s 8
-					IL_0287: ldloc.s 8
-					IL_0289: brtrue IL_02ba
+					IL_027e: ldloc.1
+					IL_027f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0284: stloc.s 11
+					IL_0286: ldloc.s 11
+					IL_0288: ldc.r8 200
+					IL_0291: clt
+					IL_0293: stloc.s 8
+					IL_0295: ldloc.s 8
+					IL_0297: box [System.Runtime]System.Boolean
+					IL_029c: stloc.s 12
+					IL_029e: ldloc.s 12
+					IL_02a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02a5: stloc.s 8
+					IL_02a7: ldloc.s 8
+					IL_02a9: brtrue IL_02da
 
-					IL_028e: ldloc.1
-					IL_028f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-					IL_0294: stloc.s 11
-					IL_0296: ldloc.s 11
-					IL_0298: ldc.r8 300
-					IL_02a1: clt
-					IL_02a3: ldc.i4.0
-					IL_02a4: ceq
-					IL_02a6: stloc.s 8
-					IL_02a8: ldloc.s 8
-					IL_02aa: box [System.Runtime]System.Boolean
-					IL_02af: stloc.s 13
-					IL_02b1: ldloc.s 13
-					IL_02b3: stloc.s 20
-					IL_02b5: br IL_02be
+					IL_02ae: ldloc.1
+					IL_02af: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_02b4: stloc.s 11
+					IL_02b6: ldloc.s 11
+					IL_02b8: ldc.r8 300
+					IL_02c1: clt
+					IL_02c3: ldc.i4.0
+					IL_02c4: ceq
+					IL_02c6: stloc.s 8
+					IL_02c8: ldloc.s 8
+					IL_02ca: box [System.Runtime]System.Boolean
+					IL_02cf: stloc.s 13
+					IL_02d1: ldloc.s 13
+					IL_02d3: stloc.s 19
+					IL_02d5: br IL_02de
 
-					IL_02ba: ldloc.s 12
-					IL_02bc: stloc.s 20
+					IL_02da: ldloc.s 12
+					IL_02dc: stloc.s 19
 
-					IL_02be: ldloc.s 20
-					IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_02c5: stloc.s 8
-					IL_02c7: ldloc.s 8
-					IL_02c9: brfalse IL_0372
+					IL_02de: ldloc.s 19
+					IL_02e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_02e5: stloc.s 8
+					IL_02e7: ldloc.s 8
+					IL_02e9: brfalse IL_0392
 
-					IL_02ce: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
-					IL_02d3: stloc.s 6
-					IL_02d5: ldarg.2
-					IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_02db: stloc.s 7
-					IL_02dd: ldloc.s 7
-					IL_02df: ldstr "resume"
-					IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-					IL_02e9: pop
-					IL_02ea: ldarg.0
-					IL_02eb: ldc.i4.2
-					IL_02ec: ldelem.ref
-					IL_02ed: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
-					IL_02f2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
-					IL_02f7: stloc.s 7
-					IL_02f9: ldc.i4.3
-					IL_02fa: newarr [System.Runtime]System.Object
-					IL_02ff: dup
-					IL_0300: ldc.i4.0
-					IL_0301: ldarg.0
-					IL_0302: ldc.i4.0
-					IL_0303: ldelem.ref
-					IL_0304: stelem.ref
-					IL_0305: dup
-					IL_0306: ldc.i4.1
-					IL_0307: ldarg.0
-					IL_0308: ldc.i4.1
-					IL_0309: ldelem.ref
-					IL_030a: stelem.ref
-					IL_030b: dup
-					IL_030c: ldc.i4.2
-					IL_030d: ldarg.0
-					IL_030e: ldc.i4.2
-					IL_030f: ldelem.ref
-					IL_0310: stelem.ref
-					IL_0311: stloc.s 16
-					IL_0313: ldloc.1
-					IL_0314: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0319: stloc.s 17
-					IL_031b: ldstr "HTTP "
-					IL_0320: ldloc.s 17
-					IL_0322: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0327: stloc.s 17
-					IL_0329: ldloc.s 17
-					IL_032b: ldstr " fetching "
-					IL_0330: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0335: stloc.s 17
-					IL_0337: ldarg.0
-					IL_0338: ldc.i4.1
-					IL_0339: ldelem.ref
-					IL_033a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
-					IL_033f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
-					IL_0344: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0349: stloc.s 21
-					IL_034b: ldloc.s 17
-					IL_034d: ldloc.s 21
-					IL_034f: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0354: stloc.s 21
-					IL_0356: ldloc.s 21
-					IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0362: stloc.s 18
-					IL_0364: ldloc.s 7
-					IL_0366: ldloc.s 16
-					IL_0368: ldloc.s 18
-					IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-					IL_036f: pop
-					IL_0370: ldnull
-					IL_0371: ret
+					IL_02ee: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope/Block_L108C43::.ctor()
+					IL_02f3: stloc.s 6
+					IL_02f5: ldarg.2
+					IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_02fb: stloc.s 7
+					IL_02fd: ldloc.s 7
+					IL_02ff: ldstr "resume"
+					IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+					IL_0309: pop
+					IL_030a: ldarg.0
+					IL_030b: ldc.i4.2
+					IL_030c: ldelem.ref
+					IL_030d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope
+					IL_0312: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/Scope::reject
+					IL_0317: stloc.s 7
+					IL_0319: ldc.i4.3
+					IL_031a: newarr [System.Runtime]System.Object
+					IL_031f: dup
+					IL_0320: ldc.i4.0
+					IL_0321: ldarg.0
+					IL_0322: ldc.i4.0
+					IL_0323: ldelem.ref
+					IL_0324: stelem.ref
+					IL_0325: dup
+					IL_0326: ldc.i4.1
+					IL_0327: ldarg.0
+					IL_0328: ldc.i4.1
+					IL_0329: ldelem.ref
+					IL_032a: stelem.ref
+					IL_032b: dup
+					IL_032c: ldc.i4.2
+					IL_032d: ldarg.0
+					IL_032e: ldc.i4.2
+					IL_032f: ldelem.ref
+					IL_0330: stelem.ref
+					IL_0331: stloc.s 16
+					IL_0333: ldloc.1
+					IL_0334: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0339: stloc.s 17
+					IL_033b: ldstr "HTTP "
+					IL_0340: ldloc.s 17
+					IL_0342: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0347: stloc.s 17
+					IL_0349: ldloc.s 17
+					IL_034b: ldstr " fetching "
+					IL_0350: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0355: stloc.s 17
+					IL_0357: ldarg.0
+					IL_0358: ldc.i4.1
+					IL_0359: ldelem.ref
+					IL_035a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope
+					IL_035f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/Scope::urlString
+					IL_0364: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0369: stloc.s 20
+					IL_036b: ldloc.s 17
+					IL_036d: ldloc.s 20
+					IL_036f: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0374: stloc.s 20
+					IL_0376: ldloc.s 20
+					IL_0378: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_037d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_0382: stloc.s 18
+					IL_0384: ldloc.s 7
+					IL_0386: ldloc.s 16
+					IL_0388: ldloc.s 18
+					IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_038f: pop
+					IL_0390: ldnull
+					IL_0391: ret
 
-					IL_0372: ldarg.2
-					IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0378: stloc.s 18
-					IL_037a: ldloc.s 18
-					IL_037c: ldstr "setEncoding"
-					IL_0381: ldstr "utf8"
-					IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-					IL_038b: pop
-					IL_038c: ldloc.0
-					IL_038d: ldstr ""
-					IL_0392: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
-					IL_0397: ldarg.2
-					IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_039d: stloc.s 18
-					IL_039f: ldnull
-					IL_03a0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
-					IL_03a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-					IL_03ab: ldc.i4.4
-					IL_03ac: newarr [System.Runtime]System.Object
-					IL_03b1: dup
-					IL_03b2: ldc.i4.0
-					IL_03b3: ldarg.0
-					IL_03b4: ldc.i4.0
-					IL_03b5: ldelem.ref
-					IL_03b6: stelem.ref
-					IL_03b7: dup
-					IL_03b8: ldc.i4.1
-					IL_03b9: ldarg.0
-					IL_03ba: ldc.i4.1
-					IL_03bb: ldelem.ref
-					IL_03bc: stelem.ref
-					IL_03bd: dup
-					IL_03be: ldc.i4.2
-					IL_03bf: ldarg.0
-					IL_03c0: ldc.i4.2
-					IL_03c1: ldelem.ref
-					IL_03c2: stelem.ref
-					IL_03c3: dup
-					IL_03c4: ldc.i4.3
-					IL_03c5: ldloc.0
-					IL_03c6: stelem.ref
-					IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_03d1: ldc.i4.1
-					IL_03d2: conv.r8
-					IL_03d3: ldstr ""
-					IL_03d8: ldc.i4.0
-					IL_03d9: ldc.i4.1
-					IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_03e4: stloc.s 7
-					IL_03e6: ldloc.s 18
-					IL_03e8: ldstr "on"
-					IL_03ed: ldstr "data"
-					IL_03f2: ldloc.s 7
-					IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_03f9: pop
-					IL_03fa: ldarg.2
-					IL_03fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0400: stloc.s 7
-					IL_0402: ldnull
-					IL_0403: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
-					IL_0409: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-					IL_040e: ldc.i4.4
-					IL_040f: newarr [System.Runtime]System.Object
-					IL_0414: dup
-					IL_0415: ldc.i4.0
-					IL_0416: ldarg.0
-					IL_0417: ldc.i4.0
-					IL_0418: ldelem.ref
-					IL_0419: stelem.ref
-					IL_041a: dup
-					IL_041b: ldc.i4.1
-					IL_041c: ldarg.0
-					IL_041d: ldc.i4.1
-					IL_041e: ldelem.ref
-					IL_041f: stelem.ref
-					IL_0420: dup
-					IL_0421: ldc.i4.2
-					IL_0422: ldarg.0
-					IL_0423: ldc.i4.2
-					IL_0424: ldelem.ref
-					IL_0425: stelem.ref
-					IL_0426: dup
-					IL_0427: ldc.i4.3
-					IL_0428: ldloc.0
-					IL_0429: stelem.ref
-					IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-					IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-					IL_0434: ldc.i4.0
-					IL_0435: conv.r8
-					IL_0436: ldstr ""
-					IL_043b: ldc.i4.0
-					IL_043c: ldc.i4.1
-					IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-					IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-					IL_0447: stloc.s 18
-					IL_0449: ldloc.s 7
-					IL_044b: ldstr "on"
-					IL_0450: ldstr "end"
-					IL_0455: ldloc.s 18
-					IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-					IL_045c: pop
-					IL_045d: ldnull
-					IL_045e: ret
+					IL_0392: ldarg.2
+					IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0398: stloc.s 18
+					IL_039a: ldloc.s 18
+					IL_039c: ldstr "setEncoding"
+					IL_03a1: ldstr "utf8"
+					IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+					IL_03ab: pop
+					IL_03ac: ldloc.0
+					IL_03ad: ldstr ""
+					IL_03b2: stfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/Scope::data
+					IL_03b7: ldarg.2
+					IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_03bd: stloc.s 18
+					IL_03bf: ldnull
+					IL_03c0: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L116C24::__js_call__(object[], object, object)
+					IL_03c6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+					IL_03cb: ldc.i4.4
+					IL_03cc: newarr [System.Runtime]System.Object
+					IL_03d1: dup
+					IL_03d2: ldc.i4.0
+					IL_03d3: ldarg.0
+					IL_03d4: ldc.i4.0
+					IL_03d5: ldelem.ref
+					IL_03d6: stelem.ref
+					IL_03d7: dup
+					IL_03d8: ldc.i4.1
+					IL_03d9: ldarg.0
+					IL_03da: ldc.i4.1
+					IL_03db: ldelem.ref
+					IL_03dc: stelem.ref
+					IL_03dd: dup
+					IL_03de: ldc.i4.2
+					IL_03df: ldarg.0
+					IL_03e0: ldc.i4.2
+					IL_03e1: ldelem.ref
+					IL_03e2: stelem.ref
+					IL_03e3: dup
+					IL_03e4: ldc.i4.3
+					IL_03e5: ldloc.0
+					IL_03e6: stelem.ref
+					IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_03f1: ldc.i4.1
+					IL_03f2: conv.r8
+					IL_03f3: ldstr ""
+					IL_03f8: ldc.i4.0
+					IL_03f9: ldc.i4.1
+					IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0404: stloc.s 7
+					IL_0406: ldloc.s 18
+					IL_0408: ldstr "on"
+					IL_040d: ldstr "data"
+					IL_0412: ldloc.s 7
+					IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_0419: pop
+					IL_041a: ldarg.2
+					IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0420: stloc.s 7
+					IL_0422: ldnull
+					IL_0423: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/ArrowFunction_L72C22/ArrowFunction_L91C7/ArrowFunction_L119C23::__js_call__(object[], object)
+					IL_0429: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+					IL_042e: ldc.i4.4
+					IL_042f: newarr [System.Runtime]System.Object
+					IL_0434: dup
+					IL_0435: ldc.i4.0
+					IL_0436: ldarg.0
+					IL_0437: ldc.i4.0
+					IL_0438: ldelem.ref
+					IL_0439: stelem.ref
+					IL_043a: dup
+					IL_043b: ldc.i4.1
+					IL_043c: ldarg.0
+					IL_043d: ldc.i4.1
+					IL_043e: ldelem.ref
+					IL_043f: stelem.ref
+					IL_0440: dup
+					IL_0441: ldc.i4.2
+					IL_0442: ldarg.0
+					IL_0443: ldc.i4.2
+					IL_0444: ldelem.ref
+					IL_0445: stelem.ref
+					IL_0446: dup
+					IL_0447: ldc.i4.3
+					IL_0448: ldloc.0
+					IL_0449: stelem.ref
+					IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+					IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+					IL_0454: ldc.i4.0
+					IL_0455: conv.r8
+					IL_0456: ldstr ""
+					IL_045b: ldc.i4.0
+					IL_045c: ldc.i4.1
+					IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+					IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+					IL_0467: stloc.s 18
+					IL_0469: ldloc.s 7
+					IL_046b: ldstr "on"
+					IL_0470: ldstr "end"
+					IL_0475: ldloc.s 18
+					IL_0477: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+					IL_047c: pop
+					IL_047d: ldnull
+					IL_047e: ret
 				} // end of method ArrowFunction_L91C7::__js_call__
 
 			} // end of class ArrowFunction_L91C7
@@ -1876,7 +1892,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4594
+						// Method begins at RVA 0x46a8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1896,7 +1912,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x459d
+						// Method begins at RVA 0x46b1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1919,7 +1935,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x458b
+					// Method begins at RVA 0x469f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1945,7 +1961,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3dec
+				// Method begins at RVA 0x3ee0
 				// Header size: 12
 				// Code size: 512 (0x200)
 				.maxstack 8
@@ -2190,7 +2206,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4582
+					// Method begins at RVA 0x4696
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2212,7 +2228,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4579
+				// Method begins at RVA 0x468d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2240,7 +2256,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2938
+			// Method begins at RVA 0x2934
 			// Header size: 12
 			// Code size: 113 (0x71)
 			.maxstack 8
@@ -2311,7 +2327,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45dc
+				// Method begins at RVA 0x46f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2335,7 +2351,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29b8
+			// Method begins at RVA 0x29b4
 			// Header size: 12
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -2378,7 +2394,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45ee
+					// Method begins at RVA 0x4702
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2402,7 +2418,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4600
+						// Method begins at RVA 0x4714
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2420,7 +2436,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x45f7
+					// Method begins at RVA 0x470b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2438,7 +2454,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x45e5
+				// Method begins at RVA 0x46f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2466,7 +2482,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x29f0
+			// Method begins at RVA 0x29ec
 			// Header size: 12
 			// Code size: 558 (0x22e)
 			.maxstack 8
@@ -2712,7 +2728,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4612
+					// Method begins at RVA 0x4726
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2732,7 +2748,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x461b
+					// Method begins at RVA 0x472f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2752,7 +2768,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4624
+					// Method begins at RVA 0x4738
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2772,7 +2788,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x462d
+					// Method begins at RVA 0x4741
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2796,7 +2812,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x463f
+						// Method begins at RVA 0x4753
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2816,7 +2832,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4648
+						// Method begins at RVA 0x475c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2840,7 +2856,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x465a
+							// Method begins at RVA 0x476e
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2858,7 +2874,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4651
+						// Method begins at RVA 0x4765
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2878,7 +2894,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x4663
+						// Method begins at RVA 0x4777
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2896,7 +2912,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4636
+					// Method begins at RVA 0x474a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2914,7 +2930,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4609
+				// Method begins at RVA 0x471d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2942,9 +2958,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x2c2c
+			// Method begins at RVA 0x2c28
 			// Header size: 12
-			// Code size: 1096 (0x448)
+			// Code size: 1124 (0x464)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -2974,10 +2990,11 @@
 				[24] string,
 				[25] object,
 				[26] float64,
-				[27] bool,
-				[28] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[29] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[30] string
+				[27] object[],
+				[28] bool,
+				[29] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[30] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+				[31] string
 			)
 
 			IL_0000: ldarg.3
@@ -3126,241 +3143,255 @@
 
 			IL_019e: throw
 
-			IL_019f: ldarg.0
-			IL_01a0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_01a5: ldnull
-			IL_01a6: ldarg.2
-			IL_01a7: ldloc.s 6
-			IL_01a9: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_01ae: stloc.s 25
-			IL_01b0: ldloc.s 25
-			IL_01b2: stloc.s 9
-			IL_01b4: ldloc.s 9
-			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01bb: ldc.i4.0
-			IL_01bc: ceq
-			IL_01be: stloc.s 27
-			IL_01c0: ldloc.s 27
-			IL_01c2: brfalse IL_021b
+			IL_019f: ldc.i4.1
+			IL_01a0: newarr [System.Runtime]System.Object
+			IL_01a5: dup
+			IL_01a6: ldc.i4.0
+			IL_01a7: ldarg.0
+			IL_01a8: stelem.ref
+			IL_01a9: stloc.s 27
+			IL_01ab: ldarg.0
+			IL_01ac: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_01b1: ldloc.s 27
+			IL_01b3: ldarg.2
+			IL_01b4: ldloc.s 6
+			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01bb: stloc.s 25
+			IL_01bd: ldloc.s 25
+			IL_01bf: stloc.s 9
+			IL_01c1: ldloc.s 9
+			IL_01c3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01c8: ldc.i4.0
+			IL_01c9: ceq
+			IL_01cb: stloc.s 28
+			IL_01cd: ldloc.s 28
+			IL_01cf: brfalse IL_0228
 
-			IL_01c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
-			IL_01cc: stloc.s 10
-			IL_01ce: ldarg.3
-			IL_01cf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d4: stloc.s 24
-			IL_01d6: ldstr "Could not determine tag name for id '"
-			IL_01db: ldloc.s 24
-			IL_01dd: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e2: stloc.s 24
-			IL_01e4: ldloc.s 24
-			IL_01e6: ldstr "'."
-			IL_01eb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01f0: stloc.s 24
-			IL_01f2: ldloc.s 24
-			IL_01f4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01fe: stloc.s 25
-			IL_0200: ldloc.s 25
-			IL_0202: stloc.s 11
-			IL_0204: ldloc.s 11
-			IL_0206: isinst [System.Runtime]System.Exception
-			IL_020b: dup
-			IL_020c: brtrue IL_021a
+			IL_01d4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L170C16::.ctor()
+			IL_01d9: stloc.s 10
+			IL_01db: ldarg.3
+			IL_01dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01e1: stloc.s 24
+			IL_01e3: ldstr "Could not determine tag name for id '"
+			IL_01e8: ldloc.s 24
+			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ef: stloc.s 24
+			IL_01f1: ldloc.s 24
+			IL_01f3: ldstr "'."
+			IL_01f8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01fd: stloc.s 24
+			IL_01ff: ldloc.s 24
+			IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0206: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_020b: stloc.s 25
+			IL_020d: ldloc.s 25
+			IL_020f: stloc.s 11
+			IL_0211: ldloc.s 11
+			IL_0213: isinst [System.Runtime]System.Exception
+			IL_0218: dup
+			IL_0219: brtrue IL_0227
 
-			IL_0211: pop
-			IL_0212: ldloc.s 11
-			IL_0214: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0219: throw
+			IL_021e: pop
+			IL_021f: ldloc.s 11
+			IL_0221: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0226: throw
 
-			IL_021a: throw
+			IL_0227: throw
 
-			IL_021b: ldnull
-			IL_021c: ldloc.s 9
-			IL_021e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-			IL_0223: stloc.s 25
-			IL_0225: ldloc.s 25
-			IL_0227: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_022c: stloc.s 24
-			IL_022e: ldstr "<\\/?"
-			IL_0233: ldloc.s 24
-			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
-			IL_023a: stloc.s 24
-			IL_023c: ldloc.s 24
-			IL_023e: ldstr "\\b[^>]*>"
-			IL_0243: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0228: ldarg.0
+			IL_0229: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_022e: ldc.i4.1
+			IL_022f: newarr [System.Runtime]System.Object
+			IL_0234: dup
+			IL_0235: ldc.i4.0
+			IL_0236: ldarg.0
+			IL_0237: stelem.ref
+			IL_0238: ldloc.s 9
+			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_023f: stloc.s 25
+			IL_0241: ldloc.s 25
+			IL_0243: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0248: stloc.s 24
-			IL_024a: ldloc.s 24
-			IL_024c: ldstr "gi"
-			IL_0251: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0256: stloc.s 28
-			IL_0258: ldloc.s 28
-			IL_025a: stloc.s 12
-			IL_025c: ldloc.s 12
-			IL_025e: ldstr "lastIndex"
-			IL_0263: ldloc.s 6
-			IL_0265: ldc.i4.1
-			IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_026b: pop
-			IL_026c: ldc.r8 0.0
-			IL_0275: stloc.s 13
-			IL_0277: ldc.r8 1
-			IL_0280: neg
-			IL_0281: box [System.Runtime]System.Double
-			IL_0286: stloc.s 14
-			// loop start (head: IL_0288)
-				IL_0288: ldc.i4.1
-				IL_0289: brfalse IL_03d7
+			IL_024a: ldstr "<\\/?"
+			IL_024f: ldloc.s 24
+			IL_0251: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0256: stloc.s 24
+			IL_0258: ldloc.s 24
+			IL_025a: ldstr "\\b[^>]*>"
+			IL_025f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0264: stloc.s 24
+			IL_0266: ldloc.s 24
+			IL_0268: ldstr "gi"
+			IL_026d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0272: stloc.s 29
+			IL_0274: ldloc.s 29
+			IL_0276: stloc.s 12
+			IL_0278: ldloc.s 12
+			IL_027a: ldstr "lastIndex"
+			IL_027f: ldloc.s 6
+			IL_0281: ldc.i4.1
+			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0287: pop
+			IL_0288: ldc.r8 0.0
+			IL_0291: stloc.s 13
+			IL_0293: ldc.r8 1
+			IL_029c: neg
+			IL_029d: box [System.Runtime]System.Double
+			IL_02a2: stloc.s 14
+			// loop start (head: IL_02a4)
+				IL_02a4: ldc.i4.1
+				IL_02a5: brfalse IL_03f3
 
-				IL_028e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
-				IL_0293: stloc.s 15
-				IL_0295: ldloc.s 12
-				IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_029c: stloc.s 25
-				IL_029e: ldloc.s 25
-				IL_02a0: ldstr "exec"
-				IL_02a5: ldarg.2
-				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_02ab: stloc.s 25
-				IL_02ad: ldloc.s 25
-				IL_02af: stloc.s 16
-				IL_02b1: ldloc.s 16
-				IL_02b3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02b8: ldc.i4.0
-				IL_02b9: ceq
-				IL_02bb: stloc.s 27
-				IL_02bd: ldloc.s 27
-				IL_02bf: brfalse IL_02d0
+				IL_02aa: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15::.ctor()
+				IL_02af: stloc.s 15
+				IL_02b1: ldloc.s 12
+				IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02b8: stloc.s 25
+				IL_02ba: ldloc.s 25
+				IL_02bc: ldstr "exec"
+				IL_02c1: ldarg.2
+				IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_02c7: stloc.s 25
+				IL_02c9: ldloc.s 25
+				IL_02cb: stloc.s 16
+				IL_02cd: ldloc.s 16
+				IL_02cf: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02d4: ldc.i4.0
+				IL_02d5: ceq
+				IL_02d7: stloc.s 28
+				IL_02d9: ldloc.s 28
+				IL_02db: brfalse IL_02ec
 
-				IL_02c4: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
-				IL_02c9: stloc.s 17
-				IL_02cb: br IL_03d7
+				IL_02e0: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L182C16::.ctor()
+				IL_02e5: stloc.s 17
+				IL_02e7: br IL_03f3
 
-				IL_02d0: ldloc.s 16
-				IL_02d2: ldc.r8 0.0
-				IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02e0: stloc.s 18
-				IL_02e2: ldloc.s 14
-				IL_02e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_02e9: stloc.s 26
-				IL_02eb: ldloc.s 26
-				IL_02ed: ldc.r8 0.0
-				IL_02f6: clt
-				IL_02f8: brfalse IL_0316
+				IL_02ec: ldloc.s 16
+				IL_02ee: ldc.r8 0.0
+				IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02fc: stloc.s 18
+				IL_02fe: ldloc.s 14
+				IL_0300: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0305: stloc.s 26
+				IL_0307: ldloc.s 26
+				IL_0309: ldc.r8 0.0
+				IL_0312: clt
+				IL_0314: brfalse IL_0332
 
-				IL_02fd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
-				IL_0302: stloc.s 19
-				IL_0304: ldloc.s 16
-				IL_0306: ldstr "index"
-				IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0310: stloc.s 25
-				IL_0312: ldloc.s 25
-				IL_0314: stloc.s 14
+				IL_0319: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L187C24::.ctor()
+				IL_031e: stloc.s 19
+				IL_0320: ldloc.s 16
+				IL_0322: ldstr "index"
+				IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_032c: stloc.s 25
+				IL_032e: ldloc.s 25
+				IL_0330: stloc.s 14
 
-				IL_0316: ldloc.s 18
-				IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_031d: stloc.s 25
-				IL_031f: ldloc.s 25
-				IL_0321: ldstr "startsWith"
-				IL_0326: ldstr "</"
-				IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-				IL_0330: stloc.s 25
-				IL_0332: ldloc.s 25
-				IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0339: stloc.s 27
-				IL_033b: ldloc.s 27
-				IL_033d: brfalse IL_03bd
+				IL_0332: ldloc.s 18
+				IL_0334: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0339: stloc.s 25
+				IL_033b: ldloc.s 25
+				IL_033d: ldstr "startsWith"
+				IL_0342: ldstr "</"
+				IL_0347: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+				IL_034c: stloc.s 25
+				IL_034e: ldloc.s 25
+				IL_0350: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0355: stloc.s 28
+				IL_0357: ldloc.s 28
+				IL_0359: brfalse IL_03d9
 
-				IL_0342: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
-				IL_0347: stloc.s 20
-				IL_0349: ldloc.s 13
-				IL_034b: ldc.r8 1
-				IL_0354: sub
-				IL_0355: stloc.s 13
-				IL_0357: ldloc.s 13
-				IL_0359: ldc.r8 0.0
-				IL_0362: ceq
-				IL_0364: brfalse IL_03b8
+				IL_035e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32::.ctor()
+				IL_0363: stloc.s 20
+				IL_0365: ldloc.s 13
+				IL_0367: ldc.r8 1
+				IL_0370: sub
+				IL_0371: stloc.s 13
+				IL_0373: ldloc.s 13
+				IL_0375: ldc.r8 0.0
+				IL_037e: ceq
+				IL_0380: brfalse IL_03d4
 
-				IL_0369: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
-				IL_036e: stloc.s 21
-				IL_0370: ldarg.2
-				IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0376: stloc.s 25
-				IL_0378: ldloc.s 25
-				IL_037a: ldstr "substring"
-				IL_037f: ldloc.s 14
-				IL_0381: ldloc.s 12
-				IL_0383: ldstr "lastIndex"
-				IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_0385: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L191C32/Block_L193C23::.ctor()
+				IL_038a: stloc.s 21
+				IL_038c: ldarg.2
+				IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_0392: stloc.s 25
-				IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0399: dup
-				IL_039a: ldstr "tagName"
-				IL_039f: ldloc.s 9
-				IL_03a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03a6: dup
-				IL_03a7: ldstr "html"
-				IL_03ac: ldloc.s 25
-				IL_03ae: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_03b3: stloc.s 29
-				IL_03b5: ldloc.s 29
-				IL_03b7: ret
+				IL_0394: ldloc.s 25
+				IL_0396: ldstr "substring"
+				IL_039b: ldloc.s 14
+				IL_039d: ldloc.s 12
+				IL_039f: ldstr "lastIndex"
+				IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+				IL_03ae: stloc.s 25
+				IL_03b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_03b5: dup
+				IL_03b6: ldstr "tagName"
+				IL_03bb: ldloc.s 9
+				IL_03bd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03c2: dup
+				IL_03c3: ldstr "html"
+				IL_03c8: ldloc.s 25
+				IL_03ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_03cf: stloc.s 30
+				IL_03d1: ldloc.s 30
+				IL_03d3: ret
 
-				IL_03b8: br IL_03d2
+				IL_03d4: br IL_03ee
 
-				IL_03bd: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
-				IL_03c2: stloc.s 22
-				IL_03c4: ldloc.s 13
-				IL_03c6: ldc.r8 1
-				IL_03cf: add
-				IL_03d0: stloc.s 13
+				IL_03d9: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/Scope/Block_L180C15/Block_L199C11::.ctor()
+				IL_03de: stloc.s 22
+				IL_03e0: ldloc.s 13
+				IL_03e2: ldc.r8 1
+				IL_03eb: add
+				IL_03ec: stloc.s 13
 
-				IL_03d2: br IL_0288
+				IL_03ee: br IL_02a4
 			// end loop
 
-			IL_03d7: ldloc.s 9
-			IL_03d9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_03de: stloc.s 24
-			IL_03e0: ldstr "Could not find a matching closing </"
-			IL_03e5: ldloc.s 24
-			IL_03e7: call string [System.Runtime]System.String::Concat(string, string)
-			IL_03ec: stloc.s 24
-			IL_03ee: ldloc.s 24
-			IL_03f0: ldstr "> for id '"
-			IL_03f5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_03f3: ldloc.s 9
+			IL_03f5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_03fa: stloc.s 24
-			IL_03fc: ldarg.3
-			IL_03fd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0402: stloc.s 30
-			IL_0404: ldloc.s 24
-			IL_0406: ldloc.s 30
-			IL_0408: call string [System.Runtime]System.String::Concat(string, string)
-			IL_040d: stloc.s 30
-			IL_040f: ldloc.s 30
-			IL_0411: ldstr "'."
-			IL_0416: call string [System.Runtime]System.String::Concat(string, string)
-			IL_041b: stloc.s 30
-			IL_041d: ldloc.s 30
-			IL_041f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0424: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0429: stloc.s 25
-			IL_042b: ldloc.s 25
-			IL_042d: stloc.s 23
-			IL_042f: ldloc.s 23
-			IL_0431: isinst [System.Runtime]System.Exception
-			IL_0436: dup
-			IL_0437: brtrue IL_0445
+			IL_03fc: ldstr "Could not find a matching closing </"
+			IL_0401: ldloc.s 24
+			IL_0403: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0408: stloc.s 24
+			IL_040a: ldloc.s 24
+			IL_040c: ldstr "> for id '"
+			IL_0411: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0416: stloc.s 24
+			IL_0418: ldarg.3
+			IL_0419: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_041e: stloc.s 31
+			IL_0420: ldloc.s 24
+			IL_0422: ldloc.s 31
+			IL_0424: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0429: stloc.s 31
+			IL_042b: ldloc.s 31
+			IL_042d: ldstr "'."
+			IL_0432: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0437: stloc.s 31
+			IL_0439: ldloc.s 31
+			IL_043b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0440: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0445: stloc.s 25
+			IL_0447: ldloc.s 25
+			IL_0449: stloc.s 23
+			IL_044b: ldloc.s 23
+			IL_044d: isinst [System.Runtime]System.Exception
+			IL_0452: dup
+			IL_0453: brtrue IL_0461
 
-			IL_043c: pop
-			IL_043d: ldloc.s 23
-			IL_043f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0444: throw
+			IL_0458: pop
+			IL_0459: ldloc.s 23
+			IL_045b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0460: throw
 
-			IL_0445: throw
+			IL_0461: throw
 
-			IL_0446: ldnull
-			IL_0447: ret
+			IL_0462: ldnull
+			IL_0463: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -3380,7 +3411,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4675
+					// Method begins at RVA 0x4789
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3398,7 +3429,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x466c
+				// Method begins at RVA 0x4780
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3426,9 +3457,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
-			// Method begins at RVA 0x3080
+			// Method begins at RVA 0x3098
 			// Header size: 12
-			// Code size: 487 (0x1e7)
+			// Code size: 506 (0x1fa)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3439,191 +3470,201 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] object,
-				[9] string,
-				[10] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
-				[11] bool,
-				[12] object,
+				[8] object[],
+				[9] object,
+				[10] string,
+				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
+				[12] bool,
 				[13] object,
 				[14] object,
 				[15] object,
-				[16] float64,
-				[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+				[16] object,
+				[17] float64,
+				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.3
-			IL_0002: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-			IL_0007: stloc.s 8
-			IL_0009: ldloc.s 8
-			IL_000b: stloc.0
-			IL_000c: ldloc.0
-			IL_000d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0012: stloc.s 9
-			IL_0014: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
-			IL_0019: ldloc.s 9
-			IL_001b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0020: stloc.s 9
-			IL_0022: ldloc.s 9
-			IL_0024: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
-			IL_0029: call string [System.Runtime]System.String::Concat(string, string)
-			IL_002e: stloc.s 9
-			IL_0030: ldloc.s 9
-			IL_0032: ldstr "i"
-			IL_0037: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_003c: stloc.s 10
-			IL_003e: ldloc.s 10
-			IL_0040: stloc.1
-			IL_0041: ldloc.1
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0047: stloc.s 8
-			IL_0049: ldloc.s 8
-			IL_004b: ldstr "exec"
-			IL_0050: ldarg.2
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0056: stloc.s 8
-			IL_0058: ldloc.s 8
-			IL_005a: stloc.2
-			IL_005b: ldloc.2
-			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0061: stloc.s 11
-			IL_0063: ldloc.s 11
-			IL_0065: brfalse IL_00ae
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.s 8
+			IL_000c: ldarg.0
+			IL_000d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_0012: ldloc.s 8
+			IL_0014: ldarg.3
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001a: stloc.s 9
+			IL_001c: ldloc.s 9
+			IL_001e: stloc.0
+			IL_001f: ldloc.0
+			IL_0020: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0025: stloc.s 10
+			IL_0027: ldstr "<a\\b[^>]*href=(?:\"([^\"]+)\"|'([^']+)')[^>]*>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<span\\b[^>]*class=(?:\"secnum\"|'secnum')[^>]*>\\s*"
+			IL_002c: ldloc.s 10
+			IL_002e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0033: stloc.s 10
+			IL_0035: ldloc.s 10
+			IL_0037: ldstr "\\s*<\\/span>(?:(?!<\\/a>)[\\s\\S]){0,4000}?<\\/a>"
+			IL_003c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0041: stloc.s 10
+			IL_0043: ldloc.s 10
+			IL_0045: ldstr "i"
+			IL_004a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_004f: stloc.s 11
+			IL_0051: ldloc.s 11
+			IL_0053: stloc.1
+			IL_0054: ldloc.1
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005a: stloc.s 9
+			IL_005c: ldloc.s 9
+			IL_005e: ldstr "exec"
+			IL_0063: ldarg.2
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0069: stloc.s 9
+			IL_006b: ldloc.s 9
+			IL_006d: stloc.2
+			IL_006e: ldloc.2
+			IL_006f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0074: stloc.s 12
+			IL_0076: ldloc.s 12
+			IL_0078: brfalse IL_00c1
 
-			IL_006a: ldloc.2
-			IL_006b: ldc.r8 1
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0079: stloc.s 8
-			IL_007b: ldloc.s 8
-			IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0082: stloc.s 11
-			IL_0084: ldloc.s 11
-			IL_0086: brtrue IL_00a1
+			IL_007d: ldloc.2
+			IL_007e: ldc.r8 1
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_008c: stloc.s 9
+			IL_008e: ldloc.s 9
+			IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0095: stloc.s 12
+			IL_0097: ldloc.s 12
+			IL_0099: brtrue IL_00b4
 
-			IL_008b: ldloc.2
-			IL_008c: ldc.r8 2
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_009a: stloc.s 13
-			IL_009c: br IL_00a5
+			IL_009e: ldloc.2
+			IL_009f: ldc.r8 2
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_00ad: stloc.s 14
+			IL_00af: br IL_00b8
 
-			IL_00a1: ldloc.s 8
-			IL_00a3: stloc.s 13
+			IL_00b4: ldloc.s 9
+			IL_00b6: stloc.s 14
 
-			IL_00a5: ldloc.s 13
-			IL_00a7: stloc.s 14
-			IL_00a9: br IL_00b1
+			IL_00b8: ldloc.s 14
+			IL_00ba: stloc.s 15
+			IL_00bc: br IL_00c4
 
-			IL_00ae: ldloc.2
-			IL_00af: stloc.s 14
+			IL_00c1: ldloc.2
+			IL_00c2: stloc.s 15
 
-			IL_00b1: ldloc.s 14
-			IL_00b3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b8: stloc.s 11
-			IL_00ba: ldloc.s 11
-			IL_00bc: brtrue IL_00cd
+			IL_00c4: ldloc.s 15
+			IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00cb: stloc.s 12
+			IL_00cd: ldloc.s 12
+			IL_00cf: brtrue IL_00e0
 
-			IL_00c1: ldstr ""
-			IL_00c6: stloc.s 14
-			IL_00c8: br IL_00cd
+			IL_00d4: ldstr ""
+			IL_00d9: stloc.s 15
+			IL_00db: br IL_00e0
 
-			IL_00cd: ldloc.s 14
-			IL_00cf: stloc.3
-			IL_00d0: ldloc.3
-			IL_00d1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00d6: ldc.i4.0
-			IL_00d7: ceq
-			IL_00d9: stloc.s 11
-			IL_00db: ldloc.s 11
-			IL_00dd: brfalse IL_00f0
-
-			IL_00e2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
-			IL_00e7: stloc.s 4
+			IL_00e0: ldloc.s 15
+			IL_00e2: stloc.3
+			IL_00e3: ldloc.3
+			IL_00e4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_00e9: ldc.i4.0
-			IL_00ea: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_00ef: ret
+			IL_00ea: ceq
+			IL_00ec: stloc.s 12
+			IL_00ee: ldloc.s 12
+			IL_00f0: brfalse IL_0103
 
-			IL_00f0: ldloc.3
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00f6: stloc.s 8
-			IL_00f8: ldloc.s 8
-			IL_00fa: ldstr "indexOf"
-			IL_00ff: ldstr "#"
-			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0109: stloc.s 8
-			IL_010b: ldloc.s 8
-			IL_010d: stloc.s 5
-			IL_010f: ldloc.s 5
-			IL_0111: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0116: stloc.s 16
-			IL_0118: ldloc.s 16
-			IL_011a: ldc.r8 0.0
-			IL_0123: clt
-			IL_0125: ldc.i4.0
-			IL_0126: ceq
-			IL_0128: brfalse IL_015c
+			IL_00f5: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/Scope/Block_L215C13::.ctor()
+			IL_00fa: stloc.s 4
+			IL_00fc: ldc.i4.0
+			IL_00fd: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0102: ret
 
-			IL_012d: ldloc.3
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0133: stloc.s 8
-			IL_0135: ldloc.s 8
-			IL_0137: ldstr "substring"
-			IL_013c: ldc.r8 0.0
-			IL_0145: box [System.Runtime]System.Double
-			IL_014a: ldloc.s 5
-			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0151: stloc.s 8
-			IL_0153: ldloc.s 8
-			IL_0155: stloc.s 6
-			IL_0157: br IL_015f
+			IL_0103: ldloc.3
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0109: stloc.s 9
+			IL_010b: ldloc.s 9
+			IL_010d: ldstr "indexOf"
+			IL_0112: ldstr "#"
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_011c: stloc.s 9
+			IL_011e: ldloc.s 9
+			IL_0120: stloc.s 5
+			IL_0122: ldloc.s 5
+			IL_0124: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0129: stloc.s 17
+			IL_012b: ldloc.s 17
+			IL_012d: ldc.r8 0.0
+			IL_0136: clt
+			IL_0138: ldc.i4.0
+			IL_0139: ceq
+			IL_013b: brfalse IL_016f
 
-			IL_015c: ldloc.3
-			IL_015d: stloc.s 6
+			IL_0140: ldloc.3
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: stloc.s 9
+			IL_0148: ldloc.s 9
+			IL_014a: ldstr "substring"
+			IL_014f: ldc.r8 0.0
+			IL_0158: box [System.Runtime]System.Double
+			IL_015d: ldloc.s 5
+			IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0164: stloc.s 9
+			IL_0166: ldloc.s 9
+			IL_0168: stloc.s 6
+			IL_016a: br IL_0172
 
-			IL_015f: ldloc.s 5
-			IL_0161: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0166: stloc.s 16
-			IL_0168: ldloc.s 16
-			IL_016a: ldc.r8 0.0
-			IL_0173: clt
-			IL_0175: ldc.i4.0
-			IL_0176: ceq
-			IL_0178: brfalse IL_01b0
+			IL_016f: ldloc.3
+			IL_0170: stloc.s 6
 
-			IL_017d: ldloc.3
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0183: stloc.s 8
-			IL_0185: ldloc.s 5
-			IL_0187: ldc.r8 1
-			IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0195: stloc.s 14
-			IL_0197: ldloc.s 8
-			IL_0199: ldstr "substring"
-			IL_019e: ldloc.s 14
-			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_01a5: stloc.s 8
-			IL_01a7: ldloc.s 8
-			IL_01a9: stloc.s 7
-			IL_01ab: br IL_01b7
+			IL_0172: ldloc.s 5
+			IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0179: stloc.s 17
+			IL_017b: ldloc.s 17
+			IL_017d: ldc.r8 0.0
+			IL_0186: clt
+			IL_0188: ldc.i4.0
+			IL_0189: ceq
+			IL_018b: brfalse IL_01c3
 
-			IL_01b0: ldstr ""
-			IL_01b5: stloc.s 7
+			IL_0190: ldloc.3
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0196: stloc.s 9
+			IL_0198: ldloc.s 5
+			IL_019a: ldc.r8 1
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01a8: stloc.s 15
+			IL_01aa: ldloc.s 9
+			IL_01ac: ldstr "substring"
+			IL_01b1: ldloc.s 15
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_01b8: stloc.s 9
+			IL_01ba: ldloc.s 9
+			IL_01bc: stloc.s 7
+			IL_01be: br IL_01ca
 
-			IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01bc: dup
-			IL_01bd: ldstr "href"
-			IL_01c2: ldloc.3
-			IL_01c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01c8: dup
-			IL_01c9: ldstr "filePart"
-			IL_01ce: ldloc.s 6
-			IL_01d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01d5: dup
-			IL_01d6: ldstr "fragment"
-			IL_01db: ldloc.s 7
-			IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01e2: stloc.s 17
-			IL_01e4: ldloc.s 17
-			IL_01e6: ret
+			IL_01c3: ldstr ""
+			IL_01c8: stloc.s 7
+
+			IL_01ca: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01cf: dup
+			IL_01d0: ldstr "href"
+			IL_01d5: ldloc.3
+			IL_01d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01db: dup
+			IL_01dc: ldstr "filePart"
+			IL_01e1: ldloc.s 6
+			IL_01e3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01e8: dup
+			IL_01e9: ldstr "fragment"
+			IL_01ee: ldloc.s 7
+			IL_01f0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01f5: stloc.s 18
+			IL_01f7: ldloc.s 18
+			IL_01f9: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -3639,7 +3680,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x467e
+				// Method begins at RVA 0x4792
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3665,7 +3706,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3274
+			// Method begins at RVA 0x32a0
 			// Header size: 12
 			// Code size: 152 (0x98)
 			.maxstack 8
@@ -3772,7 +3813,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4690
+					// Method begins at RVA 0x47a4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3792,7 +3833,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x4699
+					// Method begins at RVA 0x47ad
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3812,7 +3853,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46a2
+					// Method begins at RVA 0x47b6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3836,7 +3877,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46b4
+						// Method begins at RVA 0x47c8
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3856,7 +3897,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x46bd
+						// Method begins at RVA 0x47d1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -3874,7 +3915,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46ab
+					// Method begins at RVA 0x47bf
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3894,7 +3935,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46c6
+					// Method begins at RVA 0x47da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3914,7 +3955,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x46cf
+					// Method begins at RVA 0x47e3
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -3954,7 +3995,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x4687
+				// Method begins at RVA 0x479b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3978,9 +4019,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3318
+			// Method begins at RVA 0x3344
 			// Header size: 12
-			// Code size: 2757 (0xac5)
+			// Code size: 2958 (0xb8e)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -4013,14 +4054,14 @@
 				[27] object,
 				[28] object,
 				[29] object,
-				[30] bool,
-				[31] object,
+				[30] object[],
+				[31] bool,
 				[32] object,
-				[33] string,
-				[34] string,
-				[35] object,
-				[36] object,
-				[37] object[],
+				[33] object,
+				[34] object,
+				[35] string,
+				[36] string,
+				[37] object,
 				[38] object
 			)
 
@@ -4190,1045 +4231,1144 @@
 
 			IL_0130: ldloc.0
 			IL_0131: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0136: switch (IL_014b, IL_04a2, IL_06d9, IL_0842)
+			IL_0136: switch (IL_014b, IL_04c5, IL_0723, IL_089b)
 
-			IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0150: ldstr "argv"
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015a: stloc.s 29
-			IL_015c: ldarg.0
-			IL_015d: ldc.i4.1
-			IL_015e: ldelem.ref
-			IL_015f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0164: ldnull
-			IL_0165: ldloc.s 29
-			IL_0167: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-			IL_016c: stloc.s 29
-			IL_016e: ldloc.s 29
-			IL_0170: stloc.1
-			IL_0171: ldloc.1
-			IL_0172: ldstr "section"
-			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_017c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0181: ldc.i4.0
-			IL_0182: ceq
-			IL_0184: stloc.s 30
-			IL_0186: ldloc.s 30
-			IL_0188: brfalse IL_01d6
+			IL_014b: ldarg.0
+			IL_014c: ldc.i4.1
+			IL_014d: ldelem.ref
+			IL_014e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0153: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::parseArgs
+			IL_0158: stloc.s 29
+			IL_015a: ldc.i4.1
+			IL_015b: newarr [System.Runtime]System.Object
+			IL_0160: dup
+			IL_0161: ldc.i4.0
+			IL_0162: ldarg.0
+			IL_0163: ldc.i4.1
+			IL_0164: ldelem.ref
+			IL_0165: stelem.ref
+			IL_0166: stloc.s 30
+			IL_0168: ldloc.s 29
+			IL_016a: ldloc.s 30
+			IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_0171: ldstr "argv"
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0180: stloc.s 29
+			IL_0182: ldloc.s 29
+			IL_0184: stloc.1
+			IL_0185: ldloc.1
+			IL_0186: ldstr "section"
+			IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0195: ldc.i4.0
+			IL_0196: ceq
+			IL_0198: stloc.s 31
+			IL_019a: ldloc.s 31
+			IL_019c: brfalse IL_01ea
 
-			IL_018d: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
-			IL_0192: stloc.2
-			IL_0193: ldstr "Missing required --section (e.g. 27.3)."
-			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_019d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01a2: stloc.s 29
-			IL_01a4: ldloc.s 29
-			IL_01a6: stloc.3
-			IL_01a7: ldloc.0
-			IL_01a8: ldc.i4.m1
-			IL_01a9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01ae: ldloc.0
-			IL_01af: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_01b9: ldarg.0
-			IL_01ba: ldc.i4.1
-			IL_01bb: newarr [System.Runtime]System.Object
-			IL_01c0: dup
-			IL_01c1: ldc.i4.0
-			IL_01c2: ldloc.3
-			IL_01c3: stelem.ref
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_01c9: pop
-			IL_01ca: ldloc.0
-			IL_01cb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01d0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01d5: ret
+			IL_01a1: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L254C21::.ctor()
+			IL_01a6: stloc.2
+			IL_01a7: ldstr "Missing required --section (e.g. 27.3)."
+			IL_01ac: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01b6: stloc.s 29
+			IL_01b8: ldloc.s 29
+			IL_01ba: stloc.3
+			IL_01bb: ldloc.0
+			IL_01bc: ldc.i4.m1
+			IL_01bd: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_01c2: ldloc.0
+			IL_01c3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_01cd: ldarg.0
+			IL_01ce: ldc.i4.1
+			IL_01cf: newarr [System.Runtime]System.Object
+			IL_01d4: dup
+			IL_01d5: ldc.i4.0
+			IL_01d6: ldloc.3
+			IL_01d7: stelem.ref
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_01dd: pop
+			IL_01de: ldloc.0
+			IL_01df: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01e4: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01e9: ret
 
-			IL_01d6: ldloc.1
-			IL_01d7: ldstr "outFile"
-			IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01e6: ldc.i4.0
-			IL_01e7: ceq
-			IL_01e9: stloc.s 30
-			IL_01eb: ldloc.s 30
-			IL_01ed: brfalse IL_023e
+			IL_01ea: ldloc.1
+			IL_01eb: ldstr "outFile"
+			IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01fa: ldc.i4.0
+			IL_01fb: ceq
+			IL_01fd: stloc.s 31
+			IL_01ff: ldloc.s 31
+			IL_0201: brfalse IL_0252
 
-			IL_01f2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
-			IL_01f7: stloc.s 4
-			IL_01f9: ldstr "Missing required --out <output.html>."
-			IL_01fe: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0203: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0208: stloc.s 29
-			IL_020a: ldloc.s 29
-			IL_020c: stloc.s 5
-			IL_020e: ldloc.0
-			IL_020f: ldc.i4.m1
-			IL_0210: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0215: ldloc.0
-			IL_0216: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0220: ldarg.0
-			IL_0221: ldc.i4.1
-			IL_0222: newarr [System.Runtime]System.Object
-			IL_0227: dup
-			IL_0228: ldc.i4.0
-			IL_0229: ldloc.s 5
-			IL_022b: stelem.ref
-			IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0231: pop
-			IL_0232: ldloc.0
-			IL_0233: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0238: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_023d: ret
+			IL_0206: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L258C21::.ctor()
+			IL_020b: stloc.s 4
+			IL_020d: ldstr "Missing required --out <output.html>."
+			IL_0212: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0217: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_021c: stloc.s 29
+			IL_021e: ldloc.s 29
+			IL_0220: stloc.s 5
+			IL_0222: ldloc.0
+			IL_0223: ldc.i4.m1
+			IL_0224: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0229: ldloc.0
+			IL_022a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_022f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0234: ldarg.0
+			IL_0235: ldc.i4.1
+			IL_0236: newarr [System.Runtime]System.Object
+			IL_023b: dup
+			IL_023c: ldc.i4.0
+			IL_023d: ldloc.s 5
+			IL_023f: stelem.ref
+			IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0245: pop
+			IL_0246: ldloc.0
+			IL_0247: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_024c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0251: ret
 
-			IL_023e: ldloc.1
-			IL_023f: ldstr "url"
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_024e: stloc.s 30
-			IL_0250: ldloc.s 30
-			IL_0252: brfalse IL_026c
+			IL_0252: ldloc.1
+			IL_0253: ldstr "url"
+			IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0262: stloc.s 31
+			IL_0264: ldloc.s 31
+			IL_0266: brfalse IL_0280
 
-			IL_0257: ldc.r8 1
-			IL_0260: box [System.Runtime]System.Double
-			IL_0265: stloc.s 6
-			IL_0267: br IL_027c
+			IL_026b: ldc.r8 1
+			IL_0274: box [System.Runtime]System.Double
+			IL_0279: stloc.s 6
+			IL_027b: br IL_0290
 
-			IL_026c: ldc.r8 0.0
-			IL_0275: box [System.Runtime]System.Double
-			IL_027a: stloc.s 6
+			IL_0280: ldc.r8 0.0
+			IL_0289: box [System.Runtime]System.Double
+			IL_028e: stloc.s 6
 
-			IL_027c: ldloc.1
-			IL_027d: ldstr "auto"
-			IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0287: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_028c: stloc.s 30
-			IL_028e: ldloc.s 30
-			IL_0290: brfalse IL_02aa
+			IL_0290: ldloc.1
+			IL_0291: ldstr "auto"
+			IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02a0: stloc.s 31
+			IL_02a2: ldloc.s 31
+			IL_02a4: brfalse IL_02be
 
-			IL_0295: ldc.r8 1
-			IL_029e: box [System.Runtime]System.Double
-			IL_02a3: stloc.s 7
-			IL_02a5: br IL_02ba
+			IL_02a9: ldc.r8 1
+			IL_02b2: box [System.Runtime]System.Double
+			IL_02b7: stloc.s 7
+			IL_02b9: br IL_02ce
 
-			IL_02aa: ldc.r8 0.0
-			IL_02b3: box [System.Runtime]System.Double
-			IL_02b8: stloc.s 7
+			IL_02be: ldc.r8 0.0
+			IL_02c7: box [System.Runtime]System.Double
+			IL_02cc: stloc.s 7
 
-			IL_02ba: ldloc.s 6
-			IL_02bc: ldloc.s 7
-			IL_02be: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_02c3: stloc.s 31
-			IL_02c5: ldloc.s 31
-			IL_02c7: stloc.s 8
-			IL_02c9: ldloc.s 8
-			IL_02cb: ldc.r8 1
-			IL_02d4: box [System.Runtime]System.Double
-			IL_02d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_02de: stloc.s 30
-			IL_02e0: ldloc.s 30
-			IL_02e2: brfalse IL_0333
+			IL_02ce: ldloc.s 6
+			IL_02d0: ldloc.s 7
+			IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02d7: stloc.s 32
+			IL_02d9: ldloc.s 32
+			IL_02db: stloc.s 8
+			IL_02dd: ldloc.s 8
+			IL_02df: ldc.r8 1
+			IL_02e8: box [System.Runtime]System.Double
+			IL_02ed: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_02f2: stloc.s 31
+			IL_02f4: ldloc.s 31
+			IL_02f6: brfalse IL_0347
 
-			IL_02e7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
-			IL_02ec: stloc.s 9
-			IL_02ee: ldstr "Provide exactly one input mode: --url or --auto."
-			IL_02f3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_02fd: stloc.s 29
-			IL_02ff: ldloc.s 29
-			IL_0301: stloc.s 10
-			IL_0303: ldloc.0
-			IL_0304: ldc.i4.m1
-			IL_0305: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_030a: ldloc.0
-			IL_030b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0310: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0315: ldarg.0
-			IL_0316: ldc.i4.1
-			IL_0317: newarr [System.Runtime]System.Object
-			IL_031c: dup
-			IL_031d: ldc.i4.0
-			IL_031e: ldloc.s 10
-			IL_0320: stelem.ref
-			IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0326: pop
-			IL_0327: ldloc.0
-			IL_0328: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_032d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0332: ret
+			IL_02fb: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L263C28::.ctor()
+			IL_0300: stloc.s 9
+			IL_0302: ldstr "Provide exactly one input mode: --url or --auto."
+			IL_0307: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_030c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0311: stloc.s 29
+			IL_0313: ldloc.s 29
+			IL_0315: stloc.s 10
+			IL_0317: ldloc.0
+			IL_0318: ldc.i4.m1
+			IL_0319: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_031e: ldloc.0
+			IL_031f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0324: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0329: ldarg.0
+			IL_032a: ldc.i4.1
+			IL_032b: newarr [System.Runtime]System.Object
+			IL_0330: dup
+			IL_0331: ldc.i4.0
+			IL_0332: ldloc.s 10
+			IL_0334: stelem.ref
+			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_033a: pop
+			IL_033b: ldloc.0
+			IL_033c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0341: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0346: ret
 
-			IL_0333: ldnull
-			IL_0334: stloc.s 11
-			IL_0336: ldloc.1
-			IL_0337: ldstr "id"
-			IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0341: stloc.s 29
-			IL_0343: ldloc.s 29
-			IL_0345: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_034a: stloc.s 30
-			IL_034c: ldloc.s 30
-			IL_034e: brtrue IL_035f
+			IL_0347: ldnull
+			IL_0348: stloc.s 11
+			IL_034a: ldloc.1
+			IL_034b: ldstr "id"
+			IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0355: stloc.s 29
+			IL_0357: ldloc.s 29
+			IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_035e: stloc.s 31
+			IL_0360: ldloc.s 31
+			IL_0362: brtrue IL_0373
 
-			IL_0353: ldstr ""
-			IL_0358: stloc.s 32
-			IL_035a: br IL_0363
+			IL_0367: ldstr ""
+			IL_036c: stloc.s 33
+			IL_036e: br IL_0377
 
-			IL_035f: ldloc.s 29
-			IL_0361: stloc.s 32
+			IL_0373: ldloc.s 29
+			IL_0375: stloc.s 33
 
-			IL_0363: ldloc.s 32
-			IL_0365: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_036a: stloc.s 29
-			IL_036c: ldloc.s 29
-			IL_036e: ldstr "trim"
-			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0378: stloc.s 29
-			IL_037a: ldloc.s 29
-			IL_037c: stloc.s 12
-			IL_037e: ldstr ""
-			IL_0383: stloc.s 13
-			IL_0385: ldloc.1
-			IL_0386: ldstr "auto"
-			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0390: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0395: stloc.s 30
-			IL_0397: ldloc.s 30
-			IL_0399: brfalse IL_073e
+			IL_0377: ldloc.s 33
+			IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_037e: stloc.s 29
+			IL_0380: ldloc.s 29
+			IL_0382: ldstr "trim"
+			IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_038c: stloc.s 29
+			IL_038e: ldloc.s 29
+			IL_0390: stloc.s 12
+			IL_0392: ldstr ""
+			IL_0397: stloc.s 13
+			IL_0399: ldloc.1
+			IL_039a: ldstr "auto"
+			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03a9: stloc.s 31
+			IL_03ab: ldloc.s 31
+			IL_03ad: brfalse IL_0788
 
-			IL_039e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
-			IL_03a3: stloc.s 14
-			IL_03a5: ldloc.1
-			IL_03a6: ldstr "indexUrl"
-			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b5: stloc.s 29
-			IL_03b7: ldloc.s 29
-			IL_03b9: ldstr "trim"
-			IL_03be: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_03c3: stloc.s 29
-			IL_03c5: ldloc.s 29
-			IL_03c7: stloc.s 15
-			IL_03c9: ldarg.0
-			IL_03ca: ldc.i4.1
-			IL_03cb: ldelem.ref
-			IL_03cc: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_03d1: ldnull
-			IL_03d2: ldloc.s 15
-			IL_03d4: ldnull
-			IL_03d5: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_03da: stloc.s 29
-			IL_03dc: ldloc.0
-			IL_03dd: ldc.i4.1
-			IL_03de: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03e3: ldloc.0
-			IL_03e4: ldloc.s 29
-			IL_03e6: ldarg.0
-			IL_03e7: ldc.i4.1
-			IL_03e8: ldloc.0
-			IL_03e9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03ee: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03f3: ldloc.0
-			IL_03f4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_03f9: dup
-			IL_03fa: ldc.i4.0
-			IL_03fb: ldloc.1
-			IL_03fc: stelem.ref
-			IL_03fd: dup
-			IL_03fe: ldc.i4.1
-			IL_03ff: ldloc.2
-			IL_0400: stelem.ref
-			IL_0401: dup
-			IL_0402: ldc.i4.2
-			IL_0403: ldloc.3
-			IL_0404: stelem.ref
-			IL_0405: dup
-			IL_0406: ldc.i4.3
-			IL_0407: ldloc.s 4
-			IL_0409: stelem.ref
-			IL_040a: dup
-			IL_040b: ldc.i4.4
-			IL_040c: ldloc.s 5
-			IL_040e: stelem.ref
-			IL_040f: dup
-			IL_0410: ldc.i4.5
-			IL_0411: ldloc.s 6
-			IL_0413: stelem.ref
-			IL_0414: dup
-			IL_0415: ldc.i4.6
-			IL_0416: ldloc.s 7
-			IL_0418: stelem.ref
-			IL_0419: dup
-			IL_041a: ldc.i4.7
-			IL_041b: ldloc.s 8
-			IL_041d: stelem.ref
-			IL_041e: dup
-			IL_041f: ldc.i4.8
-			IL_0420: ldloc.s 9
-			IL_0422: stelem.ref
-			IL_0423: dup
-			IL_0424: ldc.i4.s 9
-			IL_0426: ldloc.s 10
-			IL_0428: stelem.ref
-			IL_0429: dup
-			IL_042a: ldc.i4.s 10
-			IL_042c: ldloc.s 11
-			IL_042e: stelem.ref
-			IL_042f: dup
-			IL_0430: ldc.i4.s 11
-			IL_0432: ldloc.s 12
-			IL_0434: stelem.ref
-			IL_0435: dup
-			IL_0436: ldc.i4.s 12
-			IL_0438: ldloc.s 13
-			IL_043a: stelem.ref
-			IL_043b: dup
-			IL_043c: ldc.i4.s 13
-			IL_043e: ldloc.s 14
+			IL_03b2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17::.ctor()
+			IL_03b7: stloc.s 14
+			IL_03b9: ldloc.1
+			IL_03ba: ldstr "indexUrl"
+			IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03c9: stloc.s 29
+			IL_03cb: ldloc.s 29
+			IL_03cd: ldstr "trim"
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_03d7: stloc.s 29
+			IL_03d9: ldloc.s 29
+			IL_03db: stloc.s 15
+			IL_03dd: ldarg.0
+			IL_03de: ldc.i4.1
+			IL_03df: ldelem.ref
+			IL_03e0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_03e5: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_03ea: ldc.i4.1
+			IL_03eb: newarr [System.Runtime]System.Object
+			IL_03f0: dup
+			IL_03f1: ldc.i4.0
+			IL_03f2: ldarg.0
+			IL_03f3: ldc.i4.1
+			IL_03f4: ldelem.ref
+			IL_03f5: stelem.ref
+			IL_03f6: ldloc.s 15
+			IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_03fd: stloc.s 29
+			IL_03ff: ldloc.0
+			IL_0400: ldc.i4.1
+			IL_0401: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0406: ldloc.0
+			IL_0407: ldloc.s 29
+			IL_0409: ldarg.0
+			IL_040a: ldc.i4.1
+			IL_040b: ldloc.0
+			IL_040c: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0411: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0416: ldloc.0
+			IL_0417: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_041c: dup
+			IL_041d: ldc.i4.0
+			IL_041e: ldloc.1
+			IL_041f: stelem.ref
+			IL_0420: dup
+			IL_0421: ldc.i4.1
+			IL_0422: ldloc.2
+			IL_0423: stelem.ref
+			IL_0424: dup
+			IL_0425: ldc.i4.2
+			IL_0426: ldloc.3
+			IL_0427: stelem.ref
+			IL_0428: dup
+			IL_0429: ldc.i4.3
+			IL_042a: ldloc.s 4
+			IL_042c: stelem.ref
+			IL_042d: dup
+			IL_042e: ldc.i4.4
+			IL_042f: ldloc.s 5
+			IL_0431: stelem.ref
+			IL_0432: dup
+			IL_0433: ldc.i4.5
+			IL_0434: ldloc.s 6
+			IL_0436: stelem.ref
+			IL_0437: dup
+			IL_0438: ldc.i4.6
+			IL_0439: ldloc.s 7
+			IL_043b: stelem.ref
+			IL_043c: dup
+			IL_043d: ldc.i4.7
+			IL_043e: ldloc.s 8
 			IL_0440: stelem.ref
 			IL_0441: dup
-			IL_0442: ldc.i4.s 14
-			IL_0444: ldloc.s 15
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.s 15
-			IL_044a: ldloc.s 16
-			IL_044c: stelem.ref
-			IL_044d: dup
-			IL_044e: ldc.i4.s 16
-			IL_0450: ldloc.s 17
-			IL_0452: stelem.ref
-			IL_0453: dup
-			IL_0454: ldc.i4.s 17
-			IL_0456: ldloc.s 18
-			IL_0458: stelem.ref
-			IL_0459: dup
-			IL_045a: ldc.i4.s 18
-			IL_045c: ldloc.s 19
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.s 19
-			IL_0462: ldloc.s 20
-			IL_0464: stelem.ref
-			IL_0465: dup
-			IL_0466: ldc.i4.s 20
-			IL_0468: ldloc.s 21
-			IL_046a: stelem.ref
-			IL_046b: dup
-			IL_046c: ldc.i4.s 21
-			IL_046e: ldloc.s 22
-			IL_0470: stelem.ref
-			IL_0471: dup
-			IL_0472: ldc.i4.s 22
-			IL_0474: ldloc.s 23
-			IL_0476: stelem.ref
-			IL_0477: dup
-			IL_0478: ldc.i4.s 23
-			IL_047a: ldloc.s 24
-			IL_047c: stelem.ref
-			IL_047d: dup
-			IL_047e: ldc.i4.s 24
-			IL_0480: ldloc.s 25
-			IL_0482: stelem.ref
-			IL_0483: dup
-			IL_0484: ldc.i4.s 25
-			IL_0486: ldloc.s 26
-			IL_0488: stelem.ref
-			IL_0489: dup
-			IL_048a: ldc.i4.s 26
-			IL_048c: ldloc.s 27
-			IL_048e: stelem.ref
-			IL_048f: dup
-			IL_0490: ldc.i4.s 27
-			IL_0492: ldloc.s 28
-			IL_0494: stelem.ref
-			IL_0495: pop
-			IL_0496: ldloc.0
-			IL_0497: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_049c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_04a1: ret
+			IL_0442: ldc.i4.8
+			IL_0443: ldloc.s 9
+			IL_0445: stelem.ref
+			IL_0446: dup
+			IL_0447: ldc.i4.s 9
+			IL_0449: ldloc.s 10
+			IL_044b: stelem.ref
+			IL_044c: dup
+			IL_044d: ldc.i4.s 10
+			IL_044f: ldloc.s 11
+			IL_0451: stelem.ref
+			IL_0452: dup
+			IL_0453: ldc.i4.s 11
+			IL_0455: ldloc.s 12
+			IL_0457: stelem.ref
+			IL_0458: dup
+			IL_0459: ldc.i4.s 12
+			IL_045b: ldloc.s 13
+			IL_045d: stelem.ref
+			IL_045e: dup
+			IL_045f: ldc.i4.s 13
+			IL_0461: ldloc.s 14
+			IL_0463: stelem.ref
+			IL_0464: dup
+			IL_0465: ldc.i4.s 14
+			IL_0467: ldloc.s 15
+			IL_0469: stelem.ref
+			IL_046a: dup
+			IL_046b: ldc.i4.s 15
+			IL_046d: ldloc.s 16
+			IL_046f: stelem.ref
+			IL_0470: dup
+			IL_0471: ldc.i4.s 16
+			IL_0473: ldloc.s 17
+			IL_0475: stelem.ref
+			IL_0476: dup
+			IL_0477: ldc.i4.s 17
+			IL_0479: ldloc.s 18
+			IL_047b: stelem.ref
+			IL_047c: dup
+			IL_047d: ldc.i4.s 18
+			IL_047f: ldloc.s 19
+			IL_0481: stelem.ref
+			IL_0482: dup
+			IL_0483: ldc.i4.s 19
+			IL_0485: ldloc.s 20
+			IL_0487: stelem.ref
+			IL_0488: dup
+			IL_0489: ldc.i4.s 20
+			IL_048b: ldloc.s 21
+			IL_048d: stelem.ref
+			IL_048e: dup
+			IL_048f: ldc.i4.s 21
+			IL_0491: ldloc.s 22
+			IL_0493: stelem.ref
+			IL_0494: dup
+			IL_0495: ldc.i4.s 22
+			IL_0497: ldloc.s 23
+			IL_0499: stelem.ref
+			IL_049a: dup
+			IL_049b: ldc.i4.s 23
+			IL_049d: ldloc.s 24
+			IL_049f: stelem.ref
+			IL_04a0: dup
+			IL_04a1: ldc.i4.s 24
+			IL_04a3: ldloc.s 25
+			IL_04a5: stelem.ref
+			IL_04a6: dup
+			IL_04a7: ldc.i4.s 25
+			IL_04a9: ldloc.s 26
+			IL_04ab: stelem.ref
+			IL_04ac: dup
+			IL_04ad: ldc.i4.s 26
+			IL_04af: ldloc.s 27
+			IL_04b1: stelem.ref
+			IL_04b2: dup
+			IL_04b3: ldc.i4.s 27
+			IL_04b5: ldloc.s 28
+			IL_04b7: stelem.ref
+			IL_04b8: pop
+			IL_04b9: ldloc.0
+			IL_04ba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c4: ret
 
-			IL_04a2: ldloc.0
-			IL_04a3: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_04a8: stloc.s 29
-			IL_04aa: ldloc.s 29
-			IL_04ac: stloc.s 16
-			IL_04ae: ldloc.1
-			IL_04af: ldstr "section"
-			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04be: stloc.s 29
-			IL_04c0: ldloc.s 29
-			IL_04c2: ldstr "trim"
-			IL_04c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_04cc: stloc.s 29
-			IL_04ce: ldarg.0
-			IL_04cf: ldc.i4.1
-			IL_04d0: ldelem.ref
-			IL_04d1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_04d6: ldnull
-			IL_04d7: ldloc.s 16
-			IL_04d9: ldloc.s 29
-			IL_04db: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_04e0: stloc.s 29
-			IL_04e2: ldloc.s 29
-			IL_04e4: stloc.s 17
-			IL_04e6: ldloc.s 17
-			IL_04e8: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_04ed: ldc.i4.0
-			IL_04ee: ceq
-			IL_04f0: stloc.s 30
-			IL_04f2: ldloc.s 30
-			IL_04f4: brfalse IL_0584
+			IL_04c5: ldloc.0
+			IL_04c6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_04cb: stloc.s 29
+			IL_04cd: ldloc.s 29
+			IL_04cf: stloc.s 16
+			IL_04d1: ldarg.0
+			IL_04d2: ldc.i4.1
+			IL_04d3: ldelem.ref
+			IL_04d4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_04d9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_04de: stloc.s 29
+			IL_04e0: ldc.i4.1
+			IL_04e1: newarr [System.Runtime]System.Object
+			IL_04e6: dup
+			IL_04e7: ldc.i4.0
+			IL_04e8: ldarg.0
+			IL_04e9: ldc.i4.1
+			IL_04ea: ldelem.ref
+			IL_04eb: stelem.ref
+			IL_04ec: stloc.s 30
+			IL_04ee: ldloc.1
+			IL_04ef: ldstr "section"
+			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04fe: stloc.s 34
+			IL_0500: ldloc.s 34
+			IL_0502: ldstr "trim"
+			IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_050c: stloc.s 34
+			IL_050e: ldloc.s 29
+			IL_0510: ldloc.s 30
+			IL_0512: ldloc.s 16
+			IL_0514: ldloc.s 34
+			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_051b: stloc.s 34
+			IL_051d: ldloc.s 34
+			IL_051f: stloc.s 17
+			IL_0521: ldloc.s 17
+			IL_0523: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0528: ldc.i4.0
+			IL_0529: ceq
+			IL_052b: stloc.s 31
+			IL_052d: ldloc.s 31
+			IL_052f: brfalse IL_05bf
 
-			IL_04f9: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
-			IL_04fe: stloc.s 18
-			IL_0500: ldloc.1
-			IL_0501: ldstr "section"
-			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_050b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0510: stloc.s 33
-			IL_0512: ldstr "Could not find section '"
-			IL_0517: ldloc.s 33
-			IL_0519: call string [System.Runtime]System.String::Concat(string, string)
-			IL_051e: stloc.s 33
-			IL_0520: ldloc.s 33
-			IL_0522: ldstr "' in multipage index: "
-			IL_0527: call string [System.Runtime]System.String::Concat(string, string)
-			IL_052c: stloc.s 33
-			IL_052e: ldloc.s 15
-			IL_0530: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0535: stloc.s 34
-			IL_0537: ldloc.s 33
-			IL_0539: ldloc.s 34
-			IL_053b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0540: stloc.s 34
-			IL_0542: ldloc.s 34
-			IL_0544: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0549: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_054e: stloc.s 29
-			IL_0550: ldloc.s 29
-			IL_0552: stloc.s 19
-			IL_0554: ldloc.0
-			IL_0555: ldc.i4.m1
-			IL_0556: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_055b: ldloc.0
-			IL_055c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0561: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0566: ldarg.0
-			IL_0567: ldc.i4.1
-			IL_0568: newarr [System.Runtime]System.Object
-			IL_056d: dup
-			IL_056e: ldc.i4.0
-			IL_056f: ldloc.s 19
-			IL_0571: stelem.ref
-			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0577: pop
-			IL_0578: ldloc.0
-			IL_0579: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_057e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0583: ret
+			IL_0534: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L275C15::.ctor()
+			IL_0539: stloc.s 18
+			IL_053b: ldloc.1
+			IL_053c: ldstr "section"
+			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0546: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_054b: stloc.s 35
+			IL_054d: ldstr "Could not find section '"
+			IL_0552: ldloc.s 35
+			IL_0554: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0559: stloc.s 35
+			IL_055b: ldloc.s 35
+			IL_055d: ldstr "' in multipage index: "
+			IL_0562: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0567: stloc.s 35
+			IL_0569: ldloc.s 15
+			IL_056b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0570: stloc.s 36
+			IL_0572: ldloc.s 35
+			IL_0574: ldloc.s 36
+			IL_0576: call string [System.Runtime]System.String::Concat(string, string)
+			IL_057b: stloc.s 36
+			IL_057d: ldloc.s 36
+			IL_057f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0584: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0589: stloc.s 34
+			IL_058b: ldloc.s 34
+			IL_058d: stloc.s 19
+			IL_058f: ldloc.0
+			IL_0590: ldc.i4.m1
+			IL_0591: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0596: ldloc.0
+			IL_0597: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_059c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_05a1: ldarg.0
+			IL_05a2: ldc.i4.1
+			IL_05a3: newarr [System.Runtime]System.Object
+			IL_05a8: dup
+			IL_05a9: ldc.i4.0
+			IL_05aa: ldloc.s 19
+			IL_05ac: stelem.ref
+			IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_05b2: pop
+			IL_05b3: ldloc.0
+			IL_05b4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_05b9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_05be: ret
 
-			IL_0584: ldarg.0
-			IL_0585: ldc.i4.1
-			IL_0586: ldelem.ref
-			IL_0587: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_058c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0591: stloc.s 29
-			IL_0593: ldloc.s 17
-			IL_0595: ldstr "filePart"
-			IL_059a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_059f: stloc.s 35
-			IL_05a1: ldloc.s 35
-			IL_05a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_05a8: stloc.s 30
-			IL_05aa: ldloc.s 30
-			IL_05ac: brtrue IL_05c4
+			IL_05bf: ldarg.0
+			IL_05c0: ldc.i4.1
+			IL_05c1: ldelem.ref
+			IL_05c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_05c7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_05cc: stloc.s 34
+			IL_05ce: ldloc.s 17
+			IL_05d0: ldstr "filePart"
+			IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05da: stloc.s 29
+			IL_05dc: ldloc.s 29
+			IL_05de: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_05e3: stloc.s 31
+			IL_05e5: ldloc.s 31
+			IL_05e7: brtrue IL_05ff
 
-			IL_05b1: ldloc.s 17
-			IL_05b3: ldstr "href"
-			IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05bd: stloc.s 36
-			IL_05bf: br IL_05c8
+			IL_05ec: ldloc.s 17
+			IL_05ee: ldstr "href"
+			IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05f8: stloc.s 37
+			IL_05fa: br IL_0603
 
-			IL_05c4: ldloc.s 35
-			IL_05c6: stloc.s 36
+			IL_05ff: ldloc.s 29
+			IL_0601: stloc.s 37
 
-			IL_05c8: ldc.i4.2
-			IL_05c9: newarr [System.Runtime]System.Object
-			IL_05ce: dup
-			IL_05cf: ldc.i4.0
-			IL_05d0: ldloc.s 36
-			IL_05d2: stelem.ref
-			IL_05d3: dup
-			IL_05d4: ldc.i4.1
-			IL_05d5: ldloc.s 15
-			IL_05d7: stelem.ref
-			IL_05d8: stloc.s 37
-			IL_05da: ldloc.s 29
-			IL_05dc: ldloc.s 37
-			IL_05de: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
-			IL_05e3: stloc.s 29
-			IL_05e5: ldloc.s 29
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ec: stloc.s 29
-			IL_05ee: ldloc.s 29
-			IL_05f0: ldstr "toString"
-			IL_05f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_05fa: stloc.s 29
-			IL_05fc: ldloc.s 29
-			IL_05fe: stloc.s 20
-			IL_0600: ldarg.0
-			IL_0601: ldc.i4.1
-			IL_0602: ldelem.ref
-			IL_0603: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0608: ldnull
-			IL_0609: ldloc.s 20
-			IL_060b: ldnull
-			IL_060c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_0611: stloc.s 29
-			IL_0613: ldloc.0
-			IL_0614: ldc.i4.2
-			IL_0615: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_061a: ldloc.0
-			IL_061b: ldloc.s 29
-			IL_061d: ldarg.0
-			IL_061e: ldc.i4.2
-			IL_061f: ldloc.0
-			IL_0620: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_062a: ldloc.0
-			IL_062b: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0630: dup
-			IL_0631: ldc.i4.0
-			IL_0632: ldloc.1
-			IL_0633: stelem.ref
-			IL_0634: dup
-			IL_0635: ldc.i4.1
-			IL_0636: ldloc.2
-			IL_0637: stelem.ref
-			IL_0638: dup
-			IL_0639: ldc.i4.2
-			IL_063a: ldloc.3
-			IL_063b: stelem.ref
-			IL_063c: dup
-			IL_063d: ldc.i4.3
-			IL_063e: ldloc.s 4
-			IL_0640: stelem.ref
-			IL_0641: dup
-			IL_0642: ldc.i4.4
-			IL_0643: ldloc.s 5
-			IL_0645: stelem.ref
-			IL_0646: dup
-			IL_0647: ldc.i4.5
-			IL_0648: ldloc.s 6
-			IL_064a: stelem.ref
-			IL_064b: dup
-			IL_064c: ldc.i4.6
-			IL_064d: ldloc.s 7
-			IL_064f: stelem.ref
-			IL_0650: dup
-			IL_0651: ldc.i4.7
-			IL_0652: ldloc.s 8
-			IL_0654: stelem.ref
-			IL_0655: dup
-			IL_0656: ldc.i4.8
-			IL_0657: ldloc.s 9
-			IL_0659: stelem.ref
-			IL_065a: dup
-			IL_065b: ldc.i4.s 9
-			IL_065d: ldloc.s 10
-			IL_065f: stelem.ref
-			IL_0660: dup
-			IL_0661: ldc.i4.s 10
-			IL_0663: ldloc.s 11
-			IL_0665: stelem.ref
-			IL_0666: dup
-			IL_0667: ldc.i4.s 11
-			IL_0669: ldloc.s 12
-			IL_066b: stelem.ref
-			IL_066c: dup
-			IL_066d: ldc.i4.s 12
-			IL_066f: ldloc.s 13
-			IL_0671: stelem.ref
-			IL_0672: dup
-			IL_0673: ldc.i4.s 13
-			IL_0675: ldloc.s 14
-			IL_0677: stelem.ref
-			IL_0678: dup
-			IL_0679: ldc.i4.s 14
-			IL_067b: ldloc.s 15
+			IL_0603: ldc.i4.2
+			IL_0604: newarr [System.Runtime]System.Object
+			IL_0609: dup
+			IL_060a: ldc.i4.0
+			IL_060b: ldloc.s 37
+			IL_060d: stelem.ref
+			IL_060e: dup
+			IL_060f: ldc.i4.1
+			IL_0610: ldloc.s 15
+			IL_0612: stelem.ref
+			IL_0613: stloc.s 30
+			IL_0615: ldloc.s 34
+			IL_0617: ldloc.s 30
+			IL_0619: call object [JavaScriptRuntime]JavaScriptRuntime.Object::ConstructValue(object, object[])
+			IL_061e: stloc.s 34
+			IL_0620: ldloc.s 34
+			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0627: stloc.s 34
+			IL_0629: ldloc.s 34
+			IL_062b: ldstr "toString"
+			IL_0630: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0635: stloc.s 34
+			IL_0637: ldloc.s 34
+			IL_0639: stloc.s 20
+			IL_063b: ldarg.0
+			IL_063c: ldc.i4.1
+			IL_063d: ldelem.ref
+			IL_063e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0643: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0648: ldc.i4.1
+			IL_0649: newarr [System.Runtime]System.Object
+			IL_064e: dup
+			IL_064f: ldc.i4.0
+			IL_0650: ldarg.0
+			IL_0651: ldc.i4.1
+			IL_0652: ldelem.ref
+			IL_0653: stelem.ref
+			IL_0654: ldloc.s 20
+			IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_065b: stloc.s 34
+			IL_065d: ldloc.0
+			IL_065e: ldc.i4.2
+			IL_065f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0664: ldloc.0
+			IL_0665: ldloc.s 34
+			IL_0667: ldarg.0
+			IL_0668: ldc.i4.2
+			IL_0669: ldloc.0
+			IL_066a: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_066f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0674: ldloc.0
+			IL_0675: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_067a: dup
+			IL_067b: ldc.i4.0
+			IL_067c: ldloc.1
 			IL_067d: stelem.ref
 			IL_067e: dup
-			IL_067f: ldc.i4.s 15
-			IL_0681: ldloc.s 16
-			IL_0683: stelem.ref
-			IL_0684: dup
-			IL_0685: ldc.i4.s 16
-			IL_0687: ldloc.s 17
-			IL_0689: stelem.ref
-			IL_068a: dup
-			IL_068b: ldc.i4.s 17
-			IL_068d: ldloc.s 18
+			IL_067f: ldc.i4.1
+			IL_0680: ldloc.2
+			IL_0681: stelem.ref
+			IL_0682: dup
+			IL_0683: ldc.i4.2
+			IL_0684: ldloc.3
+			IL_0685: stelem.ref
+			IL_0686: dup
+			IL_0687: ldc.i4.3
+			IL_0688: ldloc.s 4
+			IL_068a: stelem.ref
+			IL_068b: dup
+			IL_068c: ldc.i4.4
+			IL_068d: ldloc.s 5
 			IL_068f: stelem.ref
 			IL_0690: dup
-			IL_0691: ldc.i4.s 18
-			IL_0693: ldloc.s 19
-			IL_0695: stelem.ref
-			IL_0696: dup
-			IL_0697: ldc.i4.s 19
-			IL_0699: ldloc.s 20
-			IL_069b: stelem.ref
-			IL_069c: dup
-			IL_069d: ldc.i4.s 20
-			IL_069f: ldloc.s 21
-			IL_06a1: stelem.ref
-			IL_06a2: dup
-			IL_06a3: ldc.i4.s 21
-			IL_06a5: ldloc.s 22
-			IL_06a7: stelem.ref
-			IL_06a8: dup
-			IL_06a9: ldc.i4.s 22
-			IL_06ab: ldloc.s 23
-			IL_06ad: stelem.ref
-			IL_06ae: dup
-			IL_06af: ldc.i4.s 23
-			IL_06b1: ldloc.s 24
-			IL_06b3: stelem.ref
-			IL_06b4: dup
-			IL_06b5: ldc.i4.s 24
-			IL_06b7: ldloc.s 25
-			IL_06b9: stelem.ref
-			IL_06ba: dup
-			IL_06bb: ldc.i4.s 25
-			IL_06bd: ldloc.s 26
-			IL_06bf: stelem.ref
-			IL_06c0: dup
-			IL_06c1: ldc.i4.s 26
-			IL_06c3: ldloc.s 27
-			IL_06c5: stelem.ref
-			IL_06c6: dup
-			IL_06c7: ldc.i4.s 27
-			IL_06c9: ldloc.s 28
-			IL_06cb: stelem.ref
-			IL_06cc: pop
-			IL_06cd: ldloc.0
-			IL_06ce: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06d3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_06d8: ret
+			IL_0691: ldc.i4.5
+			IL_0692: ldloc.s 6
+			IL_0694: stelem.ref
+			IL_0695: dup
+			IL_0696: ldc.i4.6
+			IL_0697: ldloc.s 7
+			IL_0699: stelem.ref
+			IL_069a: dup
+			IL_069b: ldc.i4.7
+			IL_069c: ldloc.s 8
+			IL_069e: stelem.ref
+			IL_069f: dup
+			IL_06a0: ldc.i4.8
+			IL_06a1: ldloc.s 9
+			IL_06a3: stelem.ref
+			IL_06a4: dup
+			IL_06a5: ldc.i4.s 9
+			IL_06a7: ldloc.s 10
+			IL_06a9: stelem.ref
+			IL_06aa: dup
+			IL_06ab: ldc.i4.s 10
+			IL_06ad: ldloc.s 11
+			IL_06af: stelem.ref
+			IL_06b0: dup
+			IL_06b1: ldc.i4.s 11
+			IL_06b3: ldloc.s 12
+			IL_06b5: stelem.ref
+			IL_06b6: dup
+			IL_06b7: ldc.i4.s 12
+			IL_06b9: ldloc.s 13
+			IL_06bb: stelem.ref
+			IL_06bc: dup
+			IL_06bd: ldc.i4.s 13
+			IL_06bf: ldloc.s 14
+			IL_06c1: stelem.ref
+			IL_06c2: dup
+			IL_06c3: ldc.i4.s 14
+			IL_06c5: ldloc.s 15
+			IL_06c7: stelem.ref
+			IL_06c8: dup
+			IL_06c9: ldc.i4.s 15
+			IL_06cb: ldloc.s 16
+			IL_06cd: stelem.ref
+			IL_06ce: dup
+			IL_06cf: ldc.i4.s 16
+			IL_06d1: ldloc.s 17
+			IL_06d3: stelem.ref
+			IL_06d4: dup
+			IL_06d5: ldc.i4.s 17
+			IL_06d7: ldloc.s 18
+			IL_06d9: stelem.ref
+			IL_06da: dup
+			IL_06db: ldc.i4.s 18
+			IL_06dd: ldloc.s 19
+			IL_06df: stelem.ref
+			IL_06e0: dup
+			IL_06e1: ldc.i4.s 19
+			IL_06e3: ldloc.s 20
+			IL_06e5: stelem.ref
+			IL_06e6: dup
+			IL_06e7: ldc.i4.s 20
+			IL_06e9: ldloc.s 21
+			IL_06eb: stelem.ref
+			IL_06ec: dup
+			IL_06ed: ldc.i4.s 21
+			IL_06ef: ldloc.s 22
+			IL_06f1: stelem.ref
+			IL_06f2: dup
+			IL_06f3: ldc.i4.s 22
+			IL_06f5: ldloc.s 23
+			IL_06f7: stelem.ref
+			IL_06f8: dup
+			IL_06f9: ldc.i4.s 23
+			IL_06fb: ldloc.s 24
+			IL_06fd: stelem.ref
+			IL_06fe: dup
+			IL_06ff: ldc.i4.s 24
+			IL_0701: ldloc.s 25
+			IL_0703: stelem.ref
+			IL_0704: dup
+			IL_0705: ldc.i4.s 25
+			IL_0707: ldloc.s 26
+			IL_0709: stelem.ref
+			IL_070a: dup
+			IL_070b: ldc.i4.s 26
+			IL_070d: ldloc.s 27
+			IL_070f: stelem.ref
+			IL_0710: dup
+			IL_0711: ldc.i4.s 27
+			IL_0713: ldloc.s 28
+			IL_0715: stelem.ref
+			IL_0716: pop
+			IL_0717: ldloc.0
+			IL_0718: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_071d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0722: ret
 
-			IL_06d9: ldloc.0
-			IL_06da: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_06df: stloc.s 29
-			IL_06e1: ldloc.s 29
-			IL_06e3: stloc.s 11
-			IL_06e5: ldloc.s 20
-			IL_06e7: stloc.s 29
-			IL_06e9: ldloc.s 29
-			IL_06eb: stloc.s 13
-			IL_06ed: ldloc.s 12
-			IL_06ef: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_06f4: ldc.i4.0
-			IL_06f5: ceq
-			IL_06f7: stloc.s 30
-			IL_06f9: ldloc.s 30
-			IL_06fb: brfalse IL_0739
+			IL_0723: ldloc.0
+			IL_0724: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_0729: stloc.s 34
+			IL_072b: ldloc.s 34
+			IL_072d: stloc.s 11
+			IL_072f: ldloc.s 20
+			IL_0731: stloc.s 34
+			IL_0733: ldloc.s 34
+			IL_0735: stloc.s 13
+			IL_0737: ldloc.s 12
+			IL_0739: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_073e: ldc.i4.0
+			IL_073f: ceq
+			IL_0741: stloc.s 31
+			IL_0743: ldloc.s 31
+			IL_0745: brfalse IL_0783
 
-			IL_0700: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
-			IL_0705: stloc.s 21
-			IL_0707: ldloc.s 17
-			IL_0709: ldstr "fragment"
-			IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0713: stloc.s 29
-			IL_0715: ldloc.s 29
-			IL_0717: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_071c: stloc.s 30
-			IL_071e: ldloc.s 30
-			IL_0720: brtrue IL_0731
+			IL_074a: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L271C17/Block_L282C20::.ctor()
+			IL_074f: stloc.s 21
+			IL_0751: ldloc.s 17
+			IL_0753: ldstr "fragment"
+			IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_075d: stloc.s 34
+			IL_075f: ldloc.s 34
+			IL_0761: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0766: stloc.s 31
+			IL_0768: ldloc.s 31
+			IL_076a: brtrue IL_077b
 
-			IL_0725: ldstr ""
-			IL_072a: stloc.s 38
-			IL_072c: br IL_0735
+			IL_076f: ldstr ""
+			IL_0774: stloc.s 38
+			IL_0776: br IL_077f
 
-			IL_0731: ldloc.s 29
-			IL_0733: stloc.s 38
+			IL_077b: ldloc.s 34
+			IL_077d: stloc.s 38
 
-			IL_0735: ldloc.s 38
-			IL_0737: stloc.s 12
+			IL_077f: ldloc.s 38
+			IL_0781: stloc.s 12
 
-			IL_0739: br IL_0856
+			IL_0783: br IL_08af
 
-			IL_073e: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
-			IL_0743: stloc.s 22
-			IL_0745: ldloc.1
-			IL_0746: ldstr "url"
-			IL_074b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0755: stloc.s 29
-			IL_0757: ldloc.s 29
-			IL_0759: ldstr "trim"
-			IL_075e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0763: stloc.s 29
-			IL_0765: ldloc.s 29
-			IL_0767: stloc.s 23
-			IL_0769: ldarg.0
-			IL_076a: ldc.i4.1
-			IL_076b: ldelem.ref
-			IL_076c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0771: ldnull
-			IL_0772: ldloc.s 23
-			IL_0774: ldnull
-			IL_0775: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_077a: stloc.s 29
-			IL_077c: ldloc.0
-			IL_077d: ldc.i4.3
-			IL_077e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0783: ldloc.0
-			IL_0784: ldloc.s 29
-			IL_0786: ldarg.0
-			IL_0787: ldc.i4.3
-			IL_0788: ldloc.0
-			IL_0789: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_078e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0793: ldloc.0
-			IL_0794: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0799: dup
-			IL_079a: ldc.i4.0
-			IL_079b: ldloc.1
-			IL_079c: stelem.ref
-			IL_079d: dup
-			IL_079e: ldc.i4.1
-			IL_079f: ldloc.2
-			IL_07a0: stelem.ref
-			IL_07a1: dup
-			IL_07a2: ldc.i4.2
-			IL_07a3: ldloc.3
-			IL_07a4: stelem.ref
-			IL_07a5: dup
-			IL_07a6: ldc.i4.3
-			IL_07a7: ldloc.s 4
-			IL_07a9: stelem.ref
-			IL_07aa: dup
-			IL_07ab: ldc.i4.4
-			IL_07ac: ldloc.s 5
-			IL_07ae: stelem.ref
-			IL_07af: dup
-			IL_07b0: ldc.i4.5
-			IL_07b1: ldloc.s 6
-			IL_07b3: stelem.ref
-			IL_07b4: dup
-			IL_07b5: ldc.i4.6
-			IL_07b6: ldloc.s 7
-			IL_07b8: stelem.ref
-			IL_07b9: dup
-			IL_07ba: ldc.i4.7
-			IL_07bb: ldloc.s 8
-			IL_07bd: stelem.ref
-			IL_07be: dup
-			IL_07bf: ldc.i4.8
-			IL_07c0: ldloc.s 9
-			IL_07c2: stelem.ref
-			IL_07c3: dup
-			IL_07c4: ldc.i4.s 9
-			IL_07c6: ldloc.s 10
-			IL_07c8: stelem.ref
-			IL_07c9: dup
-			IL_07ca: ldc.i4.s 10
-			IL_07cc: ldloc.s 11
-			IL_07ce: stelem.ref
-			IL_07cf: dup
-			IL_07d0: ldc.i4.s 11
-			IL_07d2: ldloc.s 12
-			IL_07d4: stelem.ref
-			IL_07d5: dup
-			IL_07d6: ldc.i4.s 12
-			IL_07d8: ldloc.s 13
-			IL_07da: stelem.ref
-			IL_07db: dup
-			IL_07dc: ldc.i4.s 13
-			IL_07de: ldloc.s 14
-			IL_07e0: stelem.ref
-			IL_07e1: dup
-			IL_07e2: ldc.i4.s 14
-			IL_07e4: ldloc.s 15
-			IL_07e6: stelem.ref
-			IL_07e7: dup
-			IL_07e8: ldc.i4.s 15
-			IL_07ea: ldloc.s 16
-			IL_07ec: stelem.ref
-			IL_07ed: dup
-			IL_07ee: ldc.i4.s 16
-			IL_07f0: ldloc.s 17
-			IL_07f2: stelem.ref
-			IL_07f3: dup
-			IL_07f4: ldc.i4.s 17
-			IL_07f6: ldloc.s 18
-			IL_07f8: stelem.ref
-			IL_07f9: dup
-			IL_07fa: ldc.i4.s 18
-			IL_07fc: ldloc.s 19
-			IL_07fe: stelem.ref
-			IL_07ff: dup
-			IL_0800: ldc.i4.s 19
-			IL_0802: ldloc.s 20
-			IL_0804: stelem.ref
-			IL_0805: dup
-			IL_0806: ldc.i4.s 20
-			IL_0808: ldloc.s 21
-			IL_080a: stelem.ref
-			IL_080b: dup
-			IL_080c: ldc.i4.s 21
-			IL_080e: ldloc.s 22
-			IL_0810: stelem.ref
-			IL_0811: dup
-			IL_0812: ldc.i4.s 22
-			IL_0814: ldloc.s 23
+			IL_0788: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L285C9::.ctor()
+			IL_078d: stloc.s 22
+			IL_078f: ldloc.1
+			IL_0790: ldstr "url"
+			IL_0795: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_079f: stloc.s 34
+			IL_07a1: ldloc.s 34
+			IL_07a3: ldstr "trim"
+			IL_07a8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_07ad: stloc.s 34
+			IL_07af: ldloc.s 34
+			IL_07b1: stloc.s 23
+			IL_07b3: ldarg.0
+			IL_07b4: ldc.i4.1
+			IL_07b5: ldelem.ref
+			IL_07b6: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_07bb: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_07c0: ldc.i4.1
+			IL_07c1: newarr [System.Runtime]System.Object
+			IL_07c6: dup
+			IL_07c7: ldc.i4.0
+			IL_07c8: ldarg.0
+			IL_07c9: ldc.i4.1
+			IL_07ca: ldelem.ref
+			IL_07cb: stelem.ref
+			IL_07cc: ldloc.s 23
+			IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_07d3: stloc.s 34
+			IL_07d5: ldloc.0
+			IL_07d6: ldc.i4.3
+			IL_07d7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_07dc: ldloc.0
+			IL_07dd: ldloc.s 34
+			IL_07df: ldarg.0
+			IL_07e0: ldc.i4.3
+			IL_07e1: ldloc.0
+			IL_07e2: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_07e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_07ec: ldloc.0
+			IL_07ed: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_07f2: dup
+			IL_07f3: ldc.i4.0
+			IL_07f4: ldloc.1
+			IL_07f5: stelem.ref
+			IL_07f6: dup
+			IL_07f7: ldc.i4.1
+			IL_07f8: ldloc.2
+			IL_07f9: stelem.ref
+			IL_07fa: dup
+			IL_07fb: ldc.i4.2
+			IL_07fc: ldloc.3
+			IL_07fd: stelem.ref
+			IL_07fe: dup
+			IL_07ff: ldc.i4.3
+			IL_0800: ldloc.s 4
+			IL_0802: stelem.ref
+			IL_0803: dup
+			IL_0804: ldc.i4.4
+			IL_0805: ldloc.s 5
+			IL_0807: stelem.ref
+			IL_0808: dup
+			IL_0809: ldc.i4.5
+			IL_080a: ldloc.s 6
+			IL_080c: stelem.ref
+			IL_080d: dup
+			IL_080e: ldc.i4.6
+			IL_080f: ldloc.s 7
+			IL_0811: stelem.ref
+			IL_0812: dup
+			IL_0813: ldc.i4.7
+			IL_0814: ldloc.s 8
 			IL_0816: stelem.ref
 			IL_0817: dup
-			IL_0818: ldc.i4.s 23
-			IL_081a: ldloc.s 24
-			IL_081c: stelem.ref
-			IL_081d: dup
-			IL_081e: ldc.i4.s 24
-			IL_0820: ldloc.s 25
-			IL_0822: stelem.ref
-			IL_0823: dup
-			IL_0824: ldc.i4.s 25
-			IL_0826: ldloc.s 26
-			IL_0828: stelem.ref
-			IL_0829: dup
-			IL_082a: ldc.i4.s 26
-			IL_082c: ldloc.s 27
-			IL_082e: stelem.ref
-			IL_082f: dup
-			IL_0830: ldc.i4.s 27
-			IL_0832: ldloc.s 28
-			IL_0834: stelem.ref
-			IL_0835: pop
-			IL_0836: ldloc.0
-			IL_0837: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_083c: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0841: ret
+			IL_0818: ldc.i4.8
+			IL_0819: ldloc.s 9
+			IL_081b: stelem.ref
+			IL_081c: dup
+			IL_081d: ldc.i4.s 9
+			IL_081f: ldloc.s 10
+			IL_0821: stelem.ref
+			IL_0822: dup
+			IL_0823: ldc.i4.s 10
+			IL_0825: ldloc.s 11
+			IL_0827: stelem.ref
+			IL_0828: dup
+			IL_0829: ldc.i4.s 11
+			IL_082b: ldloc.s 12
+			IL_082d: stelem.ref
+			IL_082e: dup
+			IL_082f: ldc.i4.s 12
+			IL_0831: ldloc.s 13
+			IL_0833: stelem.ref
+			IL_0834: dup
+			IL_0835: ldc.i4.s 13
+			IL_0837: ldloc.s 14
+			IL_0839: stelem.ref
+			IL_083a: dup
+			IL_083b: ldc.i4.s 14
+			IL_083d: ldloc.s 15
+			IL_083f: stelem.ref
+			IL_0840: dup
+			IL_0841: ldc.i4.s 15
+			IL_0843: ldloc.s 16
+			IL_0845: stelem.ref
+			IL_0846: dup
+			IL_0847: ldc.i4.s 16
+			IL_0849: ldloc.s 17
+			IL_084b: stelem.ref
+			IL_084c: dup
+			IL_084d: ldc.i4.s 17
+			IL_084f: ldloc.s 18
+			IL_0851: stelem.ref
+			IL_0852: dup
+			IL_0853: ldc.i4.s 18
+			IL_0855: ldloc.s 19
+			IL_0857: stelem.ref
+			IL_0858: dup
+			IL_0859: ldc.i4.s 19
+			IL_085b: ldloc.s 20
+			IL_085d: stelem.ref
+			IL_085e: dup
+			IL_085f: ldc.i4.s 20
+			IL_0861: ldloc.s 21
+			IL_0863: stelem.ref
+			IL_0864: dup
+			IL_0865: ldc.i4.s 21
+			IL_0867: ldloc.s 22
+			IL_0869: stelem.ref
+			IL_086a: dup
+			IL_086b: ldc.i4.s 22
+			IL_086d: ldloc.s 23
+			IL_086f: stelem.ref
+			IL_0870: dup
+			IL_0871: ldc.i4.s 23
+			IL_0873: ldloc.s 24
+			IL_0875: stelem.ref
+			IL_0876: dup
+			IL_0877: ldc.i4.s 24
+			IL_0879: ldloc.s 25
+			IL_087b: stelem.ref
+			IL_087c: dup
+			IL_087d: ldc.i4.s 25
+			IL_087f: ldloc.s 26
+			IL_0881: stelem.ref
+			IL_0882: dup
+			IL_0883: ldc.i4.s 26
+			IL_0885: ldloc.s 27
+			IL_0887: stelem.ref
+			IL_0888: dup
+			IL_0889: ldc.i4.s 27
+			IL_088b: ldloc.s 28
+			IL_088d: stelem.ref
+			IL_088e: pop
+			IL_088f: ldloc.0
+			IL_0890: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0895: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_089a: ret
 
-			IL_0842: ldloc.0
-			IL_0843: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_0848: stloc.s 29
-			IL_084a: ldloc.s 29
-			IL_084c: stloc.s 11
-			IL_084e: ldloc.s 23
-			IL_0850: stloc.s 29
-			IL_0852: ldloc.s 29
-			IL_0854: stloc.s 13
+			IL_089b: ldloc.0
+			IL_089c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_08a1: stloc.s 34
+			IL_08a3: ldloc.s 34
+			IL_08a5: stloc.s 11
+			IL_08a7: ldloc.s 23
+			IL_08a9: stloc.s 34
+			IL_08ab: ldloc.s 34
+			IL_08ad: stloc.s 13
 
-			IL_0856: ldloc.s 12
-			IL_0858: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_085d: ldc.i4.0
-			IL_085e: ceq
-			IL_0860: stloc.s 30
-			IL_0862: ldloc.s 30
-			IL_0864: brfalse IL_08e0
+			IL_08af: ldloc.s 12
+			IL_08b1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_08b6: ldc.i4.0
+			IL_08b7: ceq
+			IL_08b9: stloc.s 31
+			IL_08bb: ldloc.s 31
+			IL_08bd: brfalse IL_0939
 
-			IL_0869: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
-			IL_086e: stloc.s 24
-			IL_0870: ldloc.1
-			IL_0871: ldstr "section"
-			IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_087b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0880: stloc.s 34
-			IL_0882: ldstr "Could not infer an element id for section '"
-			IL_0887: ldloc.s 34
-			IL_0889: call string [System.Runtime]System.String::Concat(string, string)
-			IL_088e: stloc.s 34
-			IL_0890: ldloc.s 34
-			IL_0892: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0897: call string [System.Runtime]System.String::Concat(string, string)
-			IL_089c: stloc.s 34
-			IL_089e: ldloc.s 34
-			IL_08a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_08a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_08aa: stloc.s 29
-			IL_08ac: ldloc.s 29
-			IL_08ae: stloc.s 25
-			IL_08b0: ldloc.0
-			IL_08b1: ldc.i4.m1
-			IL_08b2: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08b7: ldloc.0
-			IL_08b8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_08c2: ldarg.0
-			IL_08c3: ldc.i4.1
-			IL_08c4: newarr [System.Runtime]System.Object
-			IL_08c9: dup
-			IL_08ca: ldc.i4.0
-			IL_08cb: ldloc.s 25
-			IL_08cd: stelem.ref
-			IL_08ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_08d3: pop
-			IL_08d4: ldloc.0
-			IL_08d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08df: ret
+			IL_08c2: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope/Block_L291C18::.ctor()
+			IL_08c7: stloc.s 24
+			IL_08c9: ldloc.1
+			IL_08ca: ldstr "section"
+			IL_08cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_08d4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08d9: stloc.s 36
+			IL_08db: ldstr "Could not infer an element id for section '"
+			IL_08e0: ldloc.s 36
+			IL_08e2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08e7: stloc.s 36
+			IL_08e9: ldloc.s 36
+			IL_08eb: ldstr "'. Try passing --id sec-... explicitly."
+			IL_08f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_08f5: stloc.s 36
+			IL_08f7: ldloc.s 36
+			IL_08f9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_08fe: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0903: stloc.s 34
+			IL_0905: ldloc.s 34
+			IL_0907: stloc.s 25
+			IL_0909: ldloc.0
+			IL_090a: ldc.i4.m1
+			IL_090b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0910: ldloc.0
+			IL_0911: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0916: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_091b: ldarg.0
+			IL_091c: ldc.i4.1
+			IL_091d: newarr [System.Runtime]System.Object
+			IL_0922: dup
+			IL_0923: ldc.i4.0
+			IL_0924: ldloc.s 25
+			IL_0926: stelem.ref
+			IL_0927: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_092c: pop
+			IL_092d: ldloc.0
+			IL_092e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0933: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0938: ret
 
-			IL_08e0: ldarg.0
-			IL_08e1: ldc.i4.1
-			IL_08e2: ldelem.ref
-			IL_08e3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_08e8: ldnull
-			IL_08e9: ldloc.s 11
-			IL_08eb: ldloc.s 12
-			IL_08ed: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-			IL_08f2: stloc.s 29
-			IL_08f4: ldloc.s 29
-			IL_08f6: stloc.s 26
-			IL_08f8: ldarg.0
-			IL_08f9: ldc.i4.1
-			IL_08fa: ldelem.ref
-			IL_08fb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0900: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0905: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_090a: stloc.s 29
-			IL_090c: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
-			IL_0911: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0916: stloc.s 35
-			IL_0918: ldloc.s 35
-			IL_091a: ldstr "cwd"
-			IL_091f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0924: stloc.s 35
-			IL_0926: ldloc.s 29
-			IL_0928: ldstr "join"
-			IL_092d: ldloc.s 35
-			IL_092f: ldloc.1
-			IL_0930: ldstr "outFile"
-			IL_0935: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_093a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_093f: stloc.s 35
-			IL_0941: ldloc.s 35
-			IL_0943: stloc.s 27
-			IL_0945: ldloc.s 26
-			IL_0947: ldstr "html"
-			IL_094c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0951: stloc.s 35
-			IL_0953: ldloc.1
-			IL_0954: ldstr "section"
-			IL_0959: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_095e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0963: stloc.s 34
-			IL_0965: ldstr "ECMA-262 "
-			IL_096a: ldloc.s 34
-			IL_096c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0971: stloc.s 34
-			IL_0973: ldnull
-			IL_0974: ldloc.s 35
-			IL_0976: ldloc.s 34
-			IL_0978: ldloc.s 13
-			IL_097a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-			IL_097f: stloc.s 35
-			IL_0981: ldloc.s 35
-			IL_0983: stloc.s 28
-			IL_0985: ldarg.0
-			IL_0986: ldc.i4.1
-			IL_0987: ldelem.ref
-			IL_0988: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_098d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0992: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0997: stloc.s 35
-			IL_0999: ldloc.s 35
-			IL_099b: ldstr "writeFileSync"
-			IL_09a0: ldloc.s 27
-			IL_09a2: ldloc.s 28
-			IL_09a4: ldstr "utf8"
-			IL_09a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_09ae: pop
-			IL_09af: ldloc.1
-			IL_09b0: ldstr "section"
-			IL_09b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09bf: stloc.s 34
-			IL_09c1: ldstr "Extracted section "
-			IL_09c6: ldloc.s 34
-			IL_09c8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09cd: stloc.s 34
-			IL_09cf: ldloc.s 34
-			IL_09d1: ldstr " (id="
-			IL_09d6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09db: stloc.s 34
-			IL_09dd: ldloc.s 12
-			IL_09df: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09e4: stloc.s 33
-			IL_09e6: ldloc.s 34
-			IL_09e8: ldloc.s 33
-			IL_09ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09ef: stloc.s 33
-			IL_09f1: ldloc.s 33
-			IL_09f3: ldstr ", tag="
-			IL_09f8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09fd: stloc.s 33
-			IL_09ff: ldloc.s 26
-			IL_0a01: ldstr "tagName"
-			IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a0b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a10: stloc.s 34
-			IL_0a12: ldloc.s 33
-			IL_0a14: ldloc.s 34
-			IL_0a16: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a1b: stloc.s 34
-			IL_0a1d: ldloc.s 34
-			IL_0a1f: ldstr ") -> "
-			IL_0a24: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a29: stloc.s 34
-			IL_0a2b: ldloc.s 27
-			IL_0a2d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a32: stloc.s 33
-			IL_0a34: ldloc.s 34
-			IL_0a36: ldloc.s 33
-			IL_0a38: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a3d: stloc.s 33
-			IL_0a3f: ldnull
-			IL_0a40: ldloc.s 33
-			IL_0a42: ldloc.s 27
-			IL_0a44: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0a49: stloc.s 35
-			IL_0a4b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a50: ldloc.s 35
-			IL_0a52: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a57: pop
-			IL_0a58: ldarg.0
-			IL_0a59: ldc.i4.1
-			IL_0a5a: ldelem.ref
-			IL_0a5b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a60: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a65: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a6a: stloc.s 35
-			IL_0a6c: ldloc.s 35
-			IL_0a6e: ldstr "readFileSync"
-			IL_0a73: ldloc.s 27
-			IL_0a75: ldstr "utf8"
-			IL_0a7a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0a7f: stloc.s 35
-			IL_0a81: ldnull
-			IL_0a82: ldloc.s 35
-			IL_0a84: ldloc.s 27
-			IL_0a86: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-			IL_0a8b: stloc.s 35
-			IL_0a8d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a92: ldloc.s 35
-			IL_0a94: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0a99: pop
-			IL_0a9a: ldloc.0
-			IL_0a9b: ldc.i4.m1
-			IL_0a9c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0aa1: ldloc.0
-			IL_0aa2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0aa7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0aac: ldarg.0
-			IL_0aad: ldc.i4.1
-			IL_0aae: newarr [System.Runtime]System.Object
-			IL_0ab3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0ab8: pop
-			IL_0ab9: ldloc.0
-			IL_0aba: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0abf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0ac4: ret
+			IL_0939: ldarg.0
+			IL_093a: ldc.i4.1
+			IL_093b: ldelem.ref
+			IL_093c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0941: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0946: ldc.i4.1
+			IL_0947: newarr [System.Runtime]System.Object
+			IL_094c: dup
+			IL_094d: ldc.i4.0
+			IL_094e: ldarg.0
+			IL_094f: ldc.i4.1
+			IL_0950: ldelem.ref
+			IL_0951: stelem.ref
+			IL_0952: ldloc.s 11
+			IL_0954: ldloc.s 12
+			IL_0956: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_095b: stloc.s 34
+			IL_095d: ldloc.s 34
+			IL_095f: stloc.s 26
+			IL_0961: ldarg.0
+			IL_0962: ldc.i4.1
+			IL_0963: ldelem.ref
+			IL_0964: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0969: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_096e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0973: stloc.s 34
+			IL_0975: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Process [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_process()
+			IL_097a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_097f: stloc.s 29
+			IL_0981: ldloc.s 29
+			IL_0983: ldstr "cwd"
+			IL_0988: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_098d: stloc.s 29
+			IL_098f: ldloc.s 34
+			IL_0991: ldstr "join"
+			IL_0996: ldloc.s 29
+			IL_0998: ldloc.1
+			IL_0999: ldstr "outFile"
+			IL_099e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09a3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_09a8: stloc.s 29
+			IL_09aa: ldloc.s 29
+			IL_09ac: stloc.s 27
+			IL_09ae: ldarg.0
+			IL_09af: ldc.i4.1
+			IL_09b0: ldelem.ref
+			IL_09b1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_09b6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_09bb: stloc.s 29
+			IL_09bd: ldc.i4.1
+			IL_09be: newarr [System.Runtime]System.Object
+			IL_09c3: dup
+			IL_09c4: ldc.i4.0
+			IL_09c5: ldarg.0
+			IL_09c6: ldc.i4.1
+			IL_09c7: ldelem.ref
+			IL_09c8: stelem.ref
+			IL_09c9: stloc.s 30
+			IL_09cb: ldloc.s 26
+			IL_09cd: ldstr "html"
+			IL_09d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09d7: stloc.s 34
+			IL_09d9: ldloc.1
+			IL_09da: ldstr "section"
+			IL_09df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09e9: stloc.s 36
+			IL_09eb: ldstr "ECMA-262 "
+			IL_09f0: ldloc.s 36
+			IL_09f2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09f7: stloc.s 36
+			IL_09f9: ldloc.s 29
+			IL_09fb: ldloc.s 30
+			IL_09fd: ldloc.s 34
+			IL_09ff: ldloc.s 36
+			IL_0a01: ldloc.s 13
+			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0a08: stloc.s 34
+			IL_0a0a: ldloc.s 34
+			IL_0a0c: stloc.s 28
+			IL_0a0e: ldarg.0
+			IL_0a0f: ldc.i4.1
+			IL_0a10: ldelem.ref
+			IL_0a11: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a16: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0a1b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a20: stloc.s 34
+			IL_0a22: ldloc.s 34
+			IL_0a24: ldstr "writeFileSync"
+			IL_0a29: ldloc.s 27
+			IL_0a2b: ldloc.s 28
+			IL_0a2d: ldstr "utf8"
+			IL_0a32: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_0a37: pop
+			IL_0a38: ldarg.0
+			IL_0a39: ldc.i4.1
+			IL_0a3a: ldelem.ref
+			IL_0a3b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a40: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0a45: stloc.s 34
+			IL_0a47: ldc.i4.1
+			IL_0a48: newarr [System.Runtime]System.Object
+			IL_0a4d: dup
+			IL_0a4e: ldc.i4.0
+			IL_0a4f: ldarg.0
+			IL_0a50: ldc.i4.1
+			IL_0a51: ldelem.ref
+			IL_0a52: stelem.ref
+			IL_0a53: stloc.s 30
+			IL_0a55: ldloc.1
+			IL_0a56: ldstr "section"
+			IL_0a5b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a60: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a65: stloc.s 36
+			IL_0a67: ldstr "Extracted section "
+			IL_0a6c: ldloc.s 36
+			IL_0a6e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a73: stloc.s 36
+			IL_0a75: ldloc.s 36
+			IL_0a77: ldstr " (id="
+			IL_0a7c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a81: stloc.s 36
+			IL_0a83: ldloc.s 12
+			IL_0a85: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0a8a: stloc.s 35
+			IL_0a8c: ldloc.s 36
+			IL_0a8e: ldloc.s 35
+			IL_0a90: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a95: stloc.s 35
+			IL_0a97: ldloc.s 35
+			IL_0a99: ldstr ", tag="
+			IL_0a9e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0aa3: stloc.s 35
+			IL_0aa5: ldloc.s 26
+			IL_0aa7: ldstr "tagName"
+			IL_0aac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ab1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ab6: stloc.s 36
+			IL_0ab8: ldloc.s 35
+			IL_0aba: ldloc.s 36
+			IL_0abc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ac1: stloc.s 36
+			IL_0ac3: ldloc.s 36
+			IL_0ac5: ldstr ") -> "
+			IL_0aca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0acf: stloc.s 36
+			IL_0ad1: ldloc.s 27
+			IL_0ad3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ad8: stloc.s 35
+			IL_0ada: ldloc.s 36
+			IL_0adc: ldloc.s 35
+			IL_0ade: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae3: stloc.s 35
+			IL_0ae5: ldloc.s 34
+			IL_0ae7: ldloc.s 30
+			IL_0ae9: ldloc.s 35
+			IL_0aeb: ldloc.s 27
+			IL_0aed: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0af2: stloc.s 34
+			IL_0af4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0af9: ldloc.s 34
+			IL_0afb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b00: pop
+			IL_0b01: ldarg.0
+			IL_0b02: ldc.i4.1
+			IL_0b03: ldelem.ref
+			IL_0b04: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b09: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b0e: stloc.s 34
+			IL_0b10: ldc.i4.1
+			IL_0b11: newarr [System.Runtime]System.Object
+			IL_0b16: dup
+			IL_0b17: ldc.i4.0
+			IL_0b18: ldarg.0
+			IL_0b19: ldc.i4.1
+			IL_0b1a: ldelem.ref
+			IL_0b1b: stelem.ref
+			IL_0b1c: stloc.s 30
+			IL_0b1e: ldarg.0
+			IL_0b1f: ldc.i4.1
+			IL_0b20: ldelem.ref
+			IL_0b21: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b26: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b2b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0b30: stloc.s 29
+			IL_0b32: ldloc.s 29
+			IL_0b34: ldstr "readFileSync"
+			IL_0b39: ldloc.s 27
+			IL_0b3b: ldstr "utf8"
+			IL_0b40: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0b45: stloc.s 29
+			IL_0b47: ldloc.s 34
+			IL_0b49: ldloc.s 30
+			IL_0b4b: ldloc.s 29
+			IL_0b4d: ldloc.s 27
+			IL_0b4f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0b54: stloc.s 29
+			IL_0b56: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b5b: ldloc.s 29
+			IL_0b5d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0b62: pop
+			IL_0b63: ldloc.0
+			IL_0b64: ldc.i4.m1
+			IL_0b65: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0b6a: ldloc.0
+			IL_0b6b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b70: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0b75: ldarg.0
+			IL_0b76: ldc.i4.1
+			IL_0b77: newarr [System.Runtime]System.Object
+			IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0b81: pop
+			IL_0b82: ldloc.0
+			IL_0b83: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0b88: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0b8d: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli
@@ -5268,7 +5408,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x450d
+			// Method begins at RVA 0x4621
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -5292,7 +5432,7 @@
 			string __dirname
 		) cil managed 
 	{
-		// Method begins at RVA 0x20f0
+		// Method begins at RVA 0x20ec
 		// Header size: 12
 		// Code size: 551 (0x227)
 		.maxstack 8
@@ -5534,7 +5674,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x46d8
+		// Method begins at RVA 0x47ec
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35c2
+				// Method begins at RVA 0x371e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x22b4
+			// Method begins at RVA 0x22b0
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35cb
+				// Method begins at RVA 0x3727
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -107,7 +107,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22e8
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 55 (0x37)
 			.maxstack 8
@@ -157,7 +157,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35d4
+				// Method begins at RVA 0x3730
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -181,7 +181,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x232c
+			// Method begins at RVA 0x2328
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -224,7 +224,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35dd
+				// Method begins at RVA 0x3739
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -249,7 +249,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2368
+			// Method begins at RVA 0x2364
 			// Header size: 12
 			// Code size: 122 (0x7a)
 			.maxstack 8
@@ -331,7 +331,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35e6
+				// Method begins at RVA 0x3742
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,9 +358,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x23f0
+			// Method begins at RVA 0x23ec
 			// Header size: 12
-			// Code size: 253 (0xfd)
+			// Code size: 287 (0x11f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -369,7 +369,8 @@
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[5] bool,
-				[6] string
+				[6] object[],
+				[7] string
 			)
 
 			IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.Date::Construct()
@@ -413,58 +414,74 @@
 			IL_0070: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0075: stloc.s 5
 			IL_0077: ldloc.s 5
-			IL_0079: brfalse IL_00b1
+			IL_0079: brfalse IL_00c4
 
-			IL_007e: ldarg.2
-			IL_007f: ldstr "nodeVersionTarget"
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0089: stloc.3
-			IL_008a: ldnull
-			IL_008b: ldloc.3
-			IL_008c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-			IL_0091: stloc.3
-			IL_0092: ldloc.3
-			IL_0093: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0098: stloc.s 6
-			IL_009a: ldstr "Target: "
-			IL_009f: ldloc.s 6
-			IL_00a1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00a6: stloc.s 6
-			IL_00a8: ldloc.1
-			IL_00a9: ldloc.s 6
-			IL_00ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00b0: pop
+			IL_007e: ldarg.0
+			IL_007f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+			IL_0084: stloc.3
+			IL_0085: ldc.i4.1
+			IL_0086: newarr [System.Runtime]System.Object
+			IL_008b: dup
+			IL_008c: ldc.i4.0
+			IL_008d: ldarg.0
+			IL_008e: stelem.ref
+			IL_008f: stloc.s 6
+			IL_0091: ldloc.3
+			IL_0092: ldloc.s 6
+			IL_0094: ldarg.2
+			IL_0095: ldstr "nodeVersionTarget"
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a4: stloc.3
+			IL_00a5: ldloc.3
+			IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00ab: stloc.s 7
+			IL_00ad: ldstr "Target: "
+			IL_00b2: ldloc.s 7
+			IL_00b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b9: stloc.s 7
+			IL_00bb: ldloc.1
+			IL_00bc: ldloc.s 7
+			IL_00be: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00c3: pop
 
-			IL_00b1: ldnull
-			IL_00b2: ldloc.0
-			IL_00b3: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-			IL_00b8: stloc.3
-			IL_00b9: ldloc.3
-			IL_00ba: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00bf: stloc.s 6
-			IL_00c1: ldstr "Generated: "
-			IL_00c6: ldloc.s 6
-			IL_00c8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00cd: stloc.s 6
-			IL_00cf: ldloc.1
-			IL_00d0: ldloc.s 6
-			IL_00d2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00d7: pop
-			IL_00d8: ldloc.1
-			IL_00d9: ldstr ""
-			IL_00de: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00e3: pop
-			IL_00e4: ldloc.1
-			IL_00e5: ldc.i4.1
-			IL_00e6: newarr [System.Runtime]System.Object
-			IL_00eb: dup
-			IL_00ec: ldc.i4.0
-			IL_00ed: ldstr "\n"
-			IL_00f2: stelem.ref
-			IL_00f3: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_00f8: stloc.s 6
-			IL_00fa: ldloc.s 6
-			IL_00fc: ret
+			IL_00c4: ldarg.0
+			IL_00c5: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+			IL_00ca: ldc.i4.1
+			IL_00cb: newarr [System.Runtime]System.Object
+			IL_00d0: dup
+			IL_00d1: ldc.i4.0
+			IL_00d2: ldarg.0
+			IL_00d3: stelem.ref
+			IL_00d4: ldloc.0
+			IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00da: stloc.3
+			IL_00db: ldloc.3
+			IL_00dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00e1: stloc.s 7
+			IL_00e3: ldstr "Generated: "
+			IL_00e8: ldloc.s 7
+			IL_00ea: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ef: stloc.s 7
+			IL_00f1: ldloc.1
+			IL_00f2: ldloc.s 7
+			IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00f9: pop
+			IL_00fa: ldloc.1
+			IL_00fb: ldstr ""
+			IL_0100: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0105: pop
+			IL_0106: ldloc.1
+			IL_0107: ldc.i4.1
+			IL_0108: newarr [System.Runtime]System.Object
+			IL_010d: dup
+			IL_010e: ldc.i4.0
+			IL_010f: ldstr "\n"
+			IL_0114: stelem.ref
+			IL_0115: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_011a: stloc.s 7
+			IL_011c: ldloc.s 7
+			IL_011e: ret
 		} // end of method renderHeader::__js_call__
 
 	} // end of class renderHeader
@@ -490,7 +507,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x35f8
+					// Method begins at RVA 0x3754
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -515,28 +532,49 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3590
+				// Method begins at RVA 0x36cc
 				// Header size: 12
-				// Code size: 29 (0x1d)
+				// Code size: 61 (0x3d)
 				.maxstack 8
 				.locals init (
-					[0] object,
-					[1] string
+					[0] object[],
+					[1] object,
+					[2] string
 				)
 
-				IL_0000: ldnull
-				IL_0001: ldarg.2
-				IL_0002: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-				IL_0007: stloc.0
-				IL_0008: ldloc.0
-				IL_0009: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_000e: stloc.1
-				IL_000f: ldstr "- "
-				IL_0014: ldloc.1
-				IL_0015: call string [System.Runtime]System.String::Concat(string, string)
-				IL_001a: stloc.1
-				IL_001b: ldloc.1
-				IL_001c: ret
+				IL_0000: ldc.i4.2
+				IL_0001: newarr [System.Runtime]System.Object
+				IL_0006: dup
+				IL_0007: ldc.i4.0
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: stelem.ref
+				IL_000c: dup
+				IL_000d: ldc.i4.1
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: stelem.ref
+				IL_0012: stloc.0
+				IL_0013: ldarg.0
+				IL_0014: ldc.i4.0
+				IL_0015: ldelem.ref
+				IL_0016: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
+				IL_001b: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+				IL_0020: ldloc.0
+				IL_0021: ldarg.2
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0027: stloc.1
+				IL_0028: ldloc.1
+				IL_0029: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_002e: stloc.2
+				IL_002f: ldstr "- "
+				IL_0034: ldloc.2
+				IL_0035: call string [System.Runtime]System.String::Concat(string, string)
+				IL_003a: stloc.2
+				IL_003b: ldloc.2
+				IL_003c: ret
 			} // end of method ArrowFunction_L42C20::__js_call__
 
 		} // end of class ArrowFunction_L42C20
@@ -548,7 +586,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x35ef
+				// Method begins at RVA 0x374b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -575,80 +613,90 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x24fc
+			// Method begins at RVA 0x2518
 			// Header size: 12
-			// Code size: 158 (0x9e)
+			// Code size: 177 (0xb1)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/Scope,
 				[1] object,
-				[2] object,
-				[3] bool,
-				[4] object
+				[2] object[],
+				[3] object,
+				[4] bool,
+				[5] object
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/Scope::.ctor()
 			IL_0005: stloc.0
-			IL_0006: ldnull
-			IL_0007: ldarg.2
-			IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
-			IL_000d: stloc.2
-			IL_000e: ldloc.2
-			IL_000f: stloc.1
-			IL_0010: ldloc.1
-			IL_0011: ldstr "length"
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0020: ldc.i4.0
-			IL_0021: ceq
-			IL_0023: stloc.3
-			IL_0024: ldloc.3
-			IL_0025: brfalse IL_0030
+			IL_0006: ldc.i4.1
+			IL_0007: newarr [System.Runtime]System.Object
+			IL_000c: dup
+			IL_000d: ldc.i4.0
+			IL_000e: ldarg.0
+			IL_000f: stelem.ref
+			IL_0010: stloc.2
+			IL_0011: ldarg.0
+			IL_0012: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::asArray
+			IL_0017: ldloc.2
+			IL_0018: ldarg.2
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_001e: stloc.3
+			IL_001f: ldloc.3
+			IL_0020: stloc.1
+			IL_0021: ldloc.1
+			IL_0022: ldstr "length"
+			IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_002c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0031: ldc.i4.0
+			IL_0032: ceq
+			IL_0034: stloc.s 4
+			IL_0036: ldloc.s 4
+			IL_0038: brfalse IL_0043
 
-			IL_002a: ldstr ""
-			IL_002f: ret
+			IL_003d: ldstr ""
+			IL_0042: ret
 
-			IL_0030: ldloc.1
-			IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0036: stloc.2
-			IL_0037: ldnull
-			IL_0038: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20::__js_call__(object[], object, object)
-			IL_003e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
-			IL_0043: ldc.i4.2
-			IL_0044: newarr [System.Runtime]System.Object
-			IL_0049: dup
-			IL_004a: ldc.i4.0
-			IL_004b: ldarg.0
-			IL_004c: stelem.ref
-			IL_004d: dup
-			IL_004e: ldc.i4.1
-			IL_004f: ldloc.0
-			IL_0050: stelem.ref
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_005b: ldc.i4.1
-			IL_005c: conv.r8
-			IL_005d: ldstr ""
-			IL_0062: ldc.i4.0
-			IL_0063: ldc.i4.1
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_006e: stloc.s 4
-			IL_0070: ldloc.2
-			IL_0071: ldstr "map"
-			IL_0076: ldloc.s 4
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_007d: stloc.s 4
-			IL_007f: ldloc.s 4
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0086: stloc.s 4
-			IL_0088: ldloc.s 4
-			IL_008a: ldstr "join"
-			IL_008f: ldstr "\n"
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0099: stloc.s 4
-			IL_009b: ldloc.s 4
-			IL_009d: ret
+			IL_0043: ldloc.1
+			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0049: stloc.3
+			IL_004a: ldnull
+			IL_004b: ldftn object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/ArrowFunction_L42C20::__js_call__(object[], object, object)
+			IL_0051: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
+			IL_0056: ldc.i4.2
+			IL_0057: newarr [System.Runtime]System.Object
+			IL_005c: dup
+			IL_005d: ldc.i4.0
+			IL_005e: ldarg.0
+			IL_005f: stelem.ref
+			IL_0060: dup
+			IL_0061: ldc.i4.1
+			IL_0062: ldloc.0
+			IL_0063: stelem.ref
+			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0069: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_006e: ldc.i4.1
+			IL_006f: conv.r8
+			IL_0070: ldstr ""
+			IL_0075: ldc.i4.0
+			IL_0076: ldc.i4.1
+			IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0081: stloc.s 5
+			IL_0083: ldloc.3
+			IL_0084: ldstr "map"
+			IL_0089: ldloc.s 5
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0090: stloc.s 5
+			IL_0092: ldloc.s 5
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0099: stloc.s 5
+			IL_009b: ldloc.s 5
+			IL_009d: ldstr "join"
+			IL_00a2: ldstr "\n"
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00ac: stloc.s 5
+			IL_00ae: ldloc.s 5
+			IL_00b0: ret
 		} // end of method renderImplementation::__js_call__
 
 	} // end of class renderImplementation
@@ -664,7 +712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3601
+				// Method begins at RVA 0x375d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -688,7 +736,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3613
+					// Method begins at RVA 0x376f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -706,7 +754,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x360a
+				// Method begins at RVA 0x3766
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -733,9 +781,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x25a8
+			// Method begins at RVA 0x25d8
 			// Header size: 12
-			// Code size: 613 (0x265)
+			// Code size: 636 (0x27c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -755,7 +803,9 @@
 				[14] string,
 				[15] object,
 				[16] string,
-				[17] object
+				[17] object,
+				[18] object[],
+				[19] object
 			)
 
 			IL_0000: ldarg.2
@@ -826,7 +876,7 @@
 					IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_009e: stloc.s 7
 					IL_00a0: ldloc.s 7
-					IL_00a2: brtrue IL_0232
+					IL_00a2: brtrue IL_0249
 
 					IL_00a7: ldloc.s 12
 					IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -925,76 +975,87 @@
 					IL_01ba: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_01bf: stloc.s 7
 					IL_01c1: ldloc.s 7
-					IL_01c3: brfalse IL_01ee
+					IL_01c3: brfalse IL_0205
 
-					IL_01c8: ldloc.s 4
-					IL_01ca: ldstr "docs"
-					IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01d4: stloc.s 12
-					IL_01d6: ldnull
-					IL_01d7: ldloc.s 12
-					IL_01d9: ldstr "docs"
-					IL_01de: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
-					IL_01e3: stloc.s 12
-					IL_01e5: ldloc.s 12
-					IL_01e7: stloc.s 6
-					IL_01e9: br IL_01f5
+					IL_01c8: ldarg.0
+					IL_01c9: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
+					IL_01ce: stloc.s 12
+					IL_01d0: ldc.i4.1
+					IL_01d1: newarr [System.Runtime]System.Object
+					IL_01d6: dup
+					IL_01d7: ldc.i4.0
+					IL_01d8: ldarg.0
+					IL_01d9: stelem.ref
+					IL_01da: stloc.s 18
+					IL_01dc: ldloc.s 4
+					IL_01de: ldstr "docs"
+					IL_01e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01e8: stloc.s 19
+					IL_01ea: ldloc.s 12
+					IL_01ec: ldloc.s 18
+					IL_01ee: ldloc.s 19
+					IL_01f0: ldstr "docs"
+					IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+					IL_01fa: stloc.s 19
+					IL_01fc: ldloc.s 19
+					IL_01fe: stloc.s 6
+					IL_0200: br IL_020c
 
-					IL_01ee: ldstr ""
-					IL_01f3: stloc.s 6
+					IL_0205: ldstr ""
+					IL_020a: stloc.s 6
 
-					IL_01f5: ldloc.s 6
-					IL_01f7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_01fc: stloc.s 16
-					IL_01fe: ldloc.s 14
-					IL_0200: ldloc.s 16
-					IL_0202: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0207: stloc.s 16
-					IL_0209: ldloc.s 16
-					IL_020b: ldstr " |"
-					IL_0210: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0215: stloc.s 16
-					IL_0217: ldloc.0
-					IL_0218: ldloc.s 16
-					IL_021a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_021f: pop
-					IL_0220: br IL_008f
+					IL_020c: ldloc.s 6
+					IL_020e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0213: stloc.s 16
+					IL_0215: ldloc.s 14
+					IL_0217: ldloc.s 16
+					IL_0219: call string [System.Runtime]System.String::Concat(string, string)
+					IL_021e: stloc.s 16
+					IL_0220: ldloc.s 16
+					IL_0222: ldstr " |"
+					IL_0227: call string [System.Runtime]System.String::Concat(string, string)
+					IL_022c: stloc.s 16
+					IL_022e: ldloc.0
+					IL_022f: ldloc.s 16
+					IL_0231: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0236: pop
+					IL_0237: br IL_008f
 				// end loop
-				IL_0225: ldloc.1
-				IL_0226: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_022b: ldc.i4.1
-				IL_022c: stloc.3
-				IL_022d: leave IL_024c
+				IL_023c: ldloc.1
+				IL_023d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_0242: ldc.i4.1
+				IL_0243: stloc.3
+				IL_0244: leave IL_0263
 
-				IL_0232: ldc.i4.1
-				IL_0233: stloc.2
-				IL_0234: leave IL_024c
+				IL_0249: ldc.i4.1
+				IL_024a: stloc.2
+				IL_024b: leave IL_0263
 			} // end .try
 			finally
 			{
-				IL_0239: ldloc.2
-				IL_023a: brtrue IL_024b
+				IL_0250: ldloc.2
+				IL_0251: brtrue IL_0262
 
-				IL_023f: ldloc.3
-				IL_0240: brtrue IL_024b
+				IL_0256: ldloc.3
+				IL_0257: brtrue IL_0262
 
-				IL_0245: ldloc.1
-				IL_0246: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_025c: ldloc.1
+				IL_025d: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_024b: endfinally
+				IL_0262: endfinally
 			} // end handler
 
-			IL_024c: ldloc.0
-			IL_024d: ldc.i4.1
-			IL_024e: newarr [System.Runtime]System.Object
-			IL_0253: dup
-			IL_0254: ldc.i4.0
-			IL_0255: ldstr "\n"
-			IL_025a: stelem.ref
-			IL_025b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0260: stloc.s 16
-			IL_0262: ldloc.s 16
-			IL_0264: ret
+			IL_0263: ldloc.0
+			IL_0264: ldc.i4.1
+			IL_0265: newarr [System.Runtime]System.Object
+			IL_026a: dup
+			IL_026b: ldc.i4.0
+			IL_026c: ldstr "\n"
+			IL_0271: stelem.ref
+			IL_0272: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0277: stloc.s 16
+			IL_0279: ldloc.s 16
+			IL_027b: ret
 		} // end of method renderApisTable::__js_call__
 
 	} // end of class renderApisTable
@@ -1010,7 +1071,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x361c
+				// Method begins at RVA 0x3778
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1034,7 +1095,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x362e
+					// Method begins at RVA 0x378a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1058,7 +1119,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3640
+						// Method begins at RVA 0x379c
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1076,7 +1137,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3637
+					// Method begins at RVA 0x3793
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1094,7 +1155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3625
+				// Method begins at RVA 0x3781
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1121,9 +1182,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2838
+			// Method begins at RVA 0x287c
 			// Header size: 12
-			// Code size: 722 (0x2d2)
+			// Code size: 783 (0x30f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1148,9 +1209,11 @@
 				[19] object,
 				[20] object,
 				[21] object,
-				[22] object,
-				[23] string,
-				[24] string
+				[22] object[],
+				[23] object,
+				[24] object,
+				[25] string,
+				[26] string
 			)
 
 			IL_0000: ldc.i4.0
@@ -1187,7 +1250,7 @@
 					IL_003c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0041: stloc.s 15
 					IL_0043: ldloc.s 15
-					IL_0045: brtrue IL_029f
+					IL_0045: brtrue IL_02dc
 
 					IL_004a: ldloc.s 18
 					IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -1237,210 +1300,239 @@
 					IL_00cc: ldloc.s 15
 					IL_00ce: brfalse IL_00d8
 
-					IL_00d3: br IL_028d
+					IL_00d3: br IL_02ca
 
-					IL_00d8: ldloc.s 4
-					IL_00da: ldstr "name"
-					IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_00e4: stloc.s 18
-					IL_00e6: ldloc.s 18
-					IL_00e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00ed: stloc.s 15
-					IL_00ef: ldloc.s 15
-					IL_00f1: brtrue IL_0102
+					IL_00d8: ldarg.0
+					IL_00d9: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+					IL_00de: stloc.s 18
+					IL_00e0: ldc.i4.1
+					IL_00e1: newarr [System.Runtime]System.Object
+					IL_00e6: dup
+					IL_00e7: ldc.i4.0
+					IL_00e8: ldarg.0
+					IL_00e9: stelem.ref
+					IL_00ea: stloc.s 22
+					IL_00ec: ldloc.s 4
+					IL_00ee: ldstr "name"
+					IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_00f8: stloc.s 23
+					IL_00fa: ldloc.s 23
+					IL_00fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0101: stloc.s 15
+					IL_0103: ldloc.s 15
+					IL_0105: brtrue IL_0116
 
-					IL_00f6: ldstr ""
-					IL_00fb: stloc.s 22
-					IL_00fd: br IL_0106
+					IL_010a: ldstr ""
+					IL_010f: stloc.s 24
+					IL_0111: br IL_011a
 
-					IL_0102: ldloc.s 18
-					IL_0104: stloc.s 22
+					IL_0116: ldloc.s 23
+					IL_0118: stloc.s 24
 
-					IL_0106: ldnull
-					IL_0107: ldloc.s 22
-					IL_0109: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-					IL_010e: stloc.s 18
-					IL_0110: ldloc.s 18
-					IL_0112: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0117: stloc.s 23
-					IL_0119: ldstr "- "
-					IL_011e: ldloc.s 23
-					IL_0120: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0125: stloc.s 23
-					IL_0127: ldloc.0
-					IL_0128: ldloc.s 23
-					IL_012a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_012f: pop
-					IL_0130: ldloc.s 4
-					IL_0132: ldstr "tests"
-					IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_013c: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-					IL_0141: stloc.s 6
-					IL_0143: ldc.i4.0
-					IL_0144: stloc.s 7
-					IL_0146: ldc.i4.0
-					IL_0147: stloc.s 8
+					IL_011a: ldloc.s 18
+					IL_011c: ldloc.s 22
+					IL_011e: ldloc.s 24
+					IL_0120: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0125: stloc.s 18
+					IL_0127: ldloc.s 18
+					IL_0129: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_012e: stloc.s 25
+					IL_0130: ldstr "- "
+					IL_0135: ldloc.s 25
+					IL_0137: call string [System.Runtime]System.String::Concat(string, string)
+					IL_013c: stloc.s 25
+					IL_013e: ldloc.0
+					IL_013f: ldloc.s 25
+					IL_0141: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0146: pop
+					IL_0147: ldloc.s 4
+					IL_0149: ldstr "tests"
+					IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0153: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+					IL_0158: stloc.s 6
+					IL_015a: ldc.i4.0
+					IL_015b: stloc.s 7
+					IL_015d: ldc.i4.0
+					IL_015e: stloc.s 8
 					.try
 					{
-						// loop start (head: IL_0149)
-							IL_0149: ldloc.s 6
-							IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-							IL_0150: stloc.s 18
-							IL_0152: ldloc.s 18
-							IL_0154: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-							IL_0159: stloc.s 15
-							IL_015b: ldloc.s 15
-							IL_015d: brtrue IL_026f
+						// loop start (head: IL_0160)
+							IL_0160: ldloc.s 6
+							IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+							IL_0167: stloc.s 18
+							IL_0169: ldloc.s 18
+							IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+							IL_0170: stloc.s 15
+							IL_0172: ldloc.s 15
+							IL_0174: brtrue IL_02ac
 
-							IL_0162: ldloc.s 18
-							IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-							IL_0169: stloc.s 18
-							IL_016b: ldloc.s 18
-							IL_016d: stloc.s 9
-							IL_016f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/Scope_ForOf_L58C7/Scope_ForOf_L61C9/Block_L61C31::.ctor()
-							IL_0174: stloc.s 10
-							IL_0176: ldloc.s 9
-							IL_0178: ldstr "name"
-							IL_017d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0182: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_0187: stloc.s 15
-							IL_0189: ldloc.s 15
-							IL_018b: brfalse IL_01b1
+							IL_0179: ldloc.s 18
+							IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+							IL_0180: stloc.s 18
+							IL_0182: ldloc.s 18
+							IL_0184: stloc.s 9
+							IL_0186: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/Scope_ForOf_L58C7/Scope_ForOf_L61C9/Block_L61C31::.ctor()
+							IL_018b: stloc.s 10
+							IL_018d: ldloc.s 9
+							IL_018f: ldstr "name"
+							IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0199: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_019e: stloc.s 15
+							IL_01a0: ldloc.s 15
+							IL_01a2: brfalse IL_01db
 
-							IL_0190: ldloc.s 9
-							IL_0192: ldstr "name"
-							IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_019c: stloc.s 18
-							IL_019e: ldnull
-							IL_019f: ldloc.s 18
-							IL_01a1: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-							IL_01a6: stloc.s 18
-							IL_01a8: ldloc.s 18
-							IL_01aa: stloc.s 11
-							IL_01ac: br IL_01b8
+							IL_01a7: ldarg.0
+							IL_01a8: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_01ad: stloc.s 18
+							IL_01af: ldc.i4.1
+							IL_01b0: newarr [System.Runtime]System.Object
+							IL_01b5: dup
+							IL_01b6: ldc.i4.0
+							IL_01b7: ldarg.0
+							IL_01b8: stelem.ref
+							IL_01b9: stloc.s 22
+							IL_01bb: ldloc.s 18
+							IL_01bd: ldloc.s 22
+							IL_01bf: ldloc.s 9
+							IL_01c1: ldstr "name"
+							IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_01d0: stloc.s 18
+							IL_01d2: ldloc.s 18
+							IL_01d4: stloc.s 11
+							IL_01d6: br IL_01e2
 
-							IL_01b1: ldstr ""
-							IL_01b6: stloc.s 11
+							IL_01db: ldstr ""
+							IL_01e0: stloc.s 11
 
-							IL_01b8: ldloc.s 11
-							IL_01ba: stloc.s 12
-							IL_01bc: ldloc.s 9
-							IL_01be: ldstr "file"
-							IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_01c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_01cd: stloc.s 15
-							IL_01cf: ldloc.s 15
-							IL_01d1: brfalse IL_021c
+							IL_01e2: ldloc.s 11
+							IL_01e4: stloc.s 12
+							IL_01e6: ldloc.s 9
+							IL_01e8: ldstr "file"
+							IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_01f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_01f7: stloc.s 15
+							IL_01f9: ldloc.s 15
+							IL_01fb: brfalse IL_0259
 
-							IL_01d6: ldloc.s 9
-							IL_01d8: ldstr "file"
-							IL_01dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_01e2: stloc.s 18
-							IL_01e4: ldnull
-							IL_01e5: ldloc.s 18
-							IL_01e7: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-							IL_01ec: stloc.s 18
-							IL_01ee: ldloc.s 18
-							IL_01f0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_01f5: stloc.s 23
-							IL_01f7: ldstr " ("
-							IL_01fc: ldloc.s 23
-							IL_01fe: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0203: stloc.s 23
-							IL_0205: ldloc.s 23
-							IL_0207: ldstr ")"
-							IL_020c: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0211: stloc.s 23
-							IL_0213: ldloc.s 23
-							IL_0215: stloc.s 13
-							IL_0217: br IL_0223
+							IL_0200: ldarg.0
+							IL_0201: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_0206: stloc.s 18
+							IL_0208: ldc.i4.1
+							IL_0209: newarr [System.Runtime]System.Object
+							IL_020e: dup
+							IL_020f: ldc.i4.0
+							IL_0210: ldarg.0
+							IL_0211: stelem.ref
+							IL_0212: stloc.s 22
+							IL_0214: ldloc.s 18
+							IL_0216: ldloc.s 22
+							IL_0218: ldloc.s 9
+							IL_021a: ldstr "file"
+							IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_0229: stloc.s 18
+							IL_022b: ldloc.s 18
+							IL_022d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0232: stloc.s 25
+							IL_0234: ldstr " ("
+							IL_0239: ldloc.s 25
+							IL_023b: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0240: stloc.s 25
+							IL_0242: ldloc.s 25
+							IL_0244: ldstr ")"
+							IL_0249: call string [System.Runtime]System.String::Concat(string, string)
+							IL_024e: stloc.s 25
+							IL_0250: ldloc.s 25
+							IL_0252: stloc.s 13
+							IL_0254: br IL_0260
 
-							IL_021c: ldstr ""
-							IL_0221: stloc.s 13
+							IL_0259: ldstr ""
+							IL_025e: stloc.s 13
 
-							IL_0223: ldloc.s 13
-							IL_0225: stloc.s 14
-							IL_0227: ldloc.s 12
-							IL_0229: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_022e: stloc.s 23
-							IL_0230: ldstr "  - "
-							IL_0235: ldloc.s 23
-							IL_0237: call string [System.Runtime]System.String::Concat(string, string)
-							IL_023c: stloc.s 23
-							IL_023e: ldloc.s 14
-							IL_0240: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0245: stloc.s 24
-							IL_0247: ldloc.s 23
-							IL_0249: ldloc.s 24
-							IL_024b: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0250: stloc.s 24
-							IL_0252: ldloc.0
-							IL_0253: ldloc.s 24
-							IL_0255: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_025a: pop
-							IL_025b: br IL_0149
+							IL_0260: ldloc.s 13
+							IL_0262: stloc.s 14
+							IL_0264: ldloc.s 12
+							IL_0266: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_026b: stloc.s 25
+							IL_026d: ldstr "  - "
+							IL_0272: ldloc.s 25
+							IL_0274: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0279: stloc.s 25
+							IL_027b: ldloc.s 14
+							IL_027d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0282: stloc.s 26
+							IL_0284: ldloc.s 25
+							IL_0286: ldloc.s 26
+							IL_0288: call string [System.Runtime]System.String::Concat(string, string)
+							IL_028d: stloc.s 26
+							IL_028f: ldloc.0
+							IL_0290: ldloc.s 26
+							IL_0292: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_0297: pop
+							IL_0298: br IL_0160
 						// end loop
-						IL_0260: ldloc.s 6
-						IL_0262: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-						IL_0267: ldc.i4.1
-						IL_0268: stloc.s 8
-						IL_026a: leave IL_028d
+						IL_029d: ldloc.s 6
+						IL_029f: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+						IL_02a4: ldc.i4.1
+						IL_02a5: stloc.s 8
+						IL_02a7: leave IL_02ca
 
-						IL_026f: ldc.i4.1
-						IL_0270: stloc.s 7
-						IL_0272: leave IL_028d
+						IL_02ac: ldc.i4.1
+						IL_02ad: stloc.s 7
+						IL_02af: leave IL_02ca
 					} // end .try
 					finally
 					{
-						IL_0277: ldloc.s 7
-						IL_0279: brtrue IL_028c
+						IL_02b4: ldloc.s 7
+						IL_02b6: brtrue IL_02c9
 
-						IL_027e: ldloc.s 8
-						IL_0280: brtrue IL_028c
+						IL_02bb: ldloc.s 8
+						IL_02bd: brtrue IL_02c9
 
-						IL_0285: ldloc.s 6
-						IL_0287: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+						IL_02c2: ldloc.s 6
+						IL_02c4: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-						IL_028c: endfinally
+						IL_02c9: endfinally
 					} // end handler
 
-					IL_028d: br IL_0032
+					IL_02ca: br IL_0032
 				// end loop
-				IL_0292: ldloc.1
-				IL_0293: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0298: ldc.i4.1
-				IL_0299: stloc.3
-				IL_029a: leave IL_02b9
+				IL_02cf: ldloc.1
+				IL_02d0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02d5: ldc.i4.1
+				IL_02d6: stloc.3
+				IL_02d7: leave IL_02f6
 
-				IL_029f: ldc.i4.1
-				IL_02a0: stloc.2
-				IL_02a1: leave IL_02b9
+				IL_02dc: ldc.i4.1
+				IL_02dd: stloc.2
+				IL_02de: leave IL_02f6
 			} // end .try
 			finally
 			{
-				IL_02a6: ldloc.2
-				IL_02a7: brtrue IL_02b8
+				IL_02e3: ldloc.2
+				IL_02e4: brtrue IL_02f5
 
-				IL_02ac: ldloc.3
-				IL_02ad: brtrue IL_02b8
+				IL_02e9: ldloc.3
+				IL_02ea: brtrue IL_02f5
 
-				IL_02b2: ldloc.1
-				IL_02b3: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_02ef: ldloc.1
+				IL_02f0: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_02b8: endfinally
+				IL_02f5: endfinally
 			} // end handler
 
-			IL_02b9: ldloc.0
-			IL_02ba: ldc.i4.1
-			IL_02bb: newarr [System.Runtime]System.Object
-			IL_02c0: dup
-			IL_02c1: ldc.i4.0
-			IL_02c2: ldstr "\n"
-			IL_02c7: stelem.ref
-			IL_02c8: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_02cd: stloc.s 24
-			IL_02cf: ldloc.s 24
-			IL_02d1: ret
+			IL_02f6: ldloc.0
+			IL_02f7: ldc.i4.1
+			IL_02f8: newarr [System.Runtime]System.Object
+			IL_02fd: dup
+			IL_02fe: ldc.i4.0
+			IL_02ff: ldstr "\n"
+			IL_0304: stelem.ref
+			IL_0305: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_030a: stloc.s 26
+			IL_030c: ldloc.s 26
+			IL_030e: ret
 		} // end of method renderApiTests::__js_call__
 
 	} // end of class renderApiTests
@@ -1456,7 +1548,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3649
+				// Method begins at RVA 0x37a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1484,7 +1576,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3664
+						// Method begins at RVA 0x37c0
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1504,7 +1596,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x366d
+						// Method begins at RVA 0x37c9
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1524,7 +1616,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3676
+						// Method begins at RVA 0x37d2
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1542,7 +1634,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x365b
+					// Method begins at RVA 0x37b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1560,7 +1652,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3652
+				// Method begins at RVA 0x37ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1587,9 +1679,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2b4c
+			// Method begins at RVA 0x2bcc
 			// Header size: 12
-			// Code size: 715 (0x2cb)
+			// Code size: 780 (0x30c)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1609,8 +1701,10 @@
 				[14] object,
 				[15] string,
 				[16] string,
-				[17] object,
-				[18] object
+				[17] object[],
+				[18] object,
+				[19] object,
+				[20] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -1659,7 +1753,7 @@
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0068: stloc.s 12
 					IL_006a: ldloc.s 12
-					IL_006c: brtrue IL_0298
+					IL_006c: brtrue IL_02d9
 
 					IL_0071: ldloc.s 11
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -1704,189 +1798,222 @@
 					IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00fa: stloc.s 12
 					IL_00fc: ldloc.s 12
-					IL_00fe: brfalse IL_013c
+					IL_00fe: brfalse IL_014e
 
-					IL_0103: ldloc.s 4
-					IL_0105: ldstr "docs"
-					IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_010f: stloc.s 11
-					IL_0111: ldnull
-					IL_0112: ldloc.s 11
-					IL_0114: ldnull
-					IL_0115: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
-					IL_011a: stloc.s 11
-					IL_011c: ldloc.s 11
-					IL_011e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0123: stloc.s 16
-					IL_0125: ldstr "Docs: "
-					IL_012a: ldloc.s 16
-					IL_012c: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0131: stloc.s 16
-					IL_0133: ldloc.0
-					IL_0134: ldloc.s 16
-					IL_0136: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_013b: pop
+					IL_0103: ldarg.0
+					IL_0104: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
+					IL_0109: stloc.s 11
+					IL_010b: ldc.i4.1
+					IL_010c: newarr [System.Runtime]System.Object
+					IL_0111: dup
+					IL_0112: ldc.i4.0
+					IL_0113: ldarg.0
+					IL_0114: stelem.ref
+					IL_0115: stloc.s 17
+					IL_0117: ldloc.s 11
+					IL_0119: ldloc.s 17
+					IL_011b: ldloc.s 4
+					IL_011d: ldstr "docs"
+					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_012c: stloc.s 11
+					IL_012e: ldloc.s 11
+					IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0135: stloc.s 16
+					IL_0137: ldstr "Docs: "
+					IL_013c: ldloc.s 16
+					IL_013e: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0143: stloc.s 16
+					IL_0145: ldloc.0
+					IL_0146: ldloc.s 16
+					IL_0148: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_014d: pop
 
-					IL_013c: ldloc.s 4
-					IL_013e: ldstr "implementation"
-					IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_014d: stloc.s 12
-					IL_014f: ldloc.s 12
-					IL_0151: brfalse IL_0190
+					IL_014e: ldloc.s 4
+					IL_0150: ldstr "implementation"
+					IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_015f: stloc.s 12
+					IL_0161: ldloc.s 12
+					IL_0163: brfalse IL_01af
 
-					IL_0156: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L77C26::.ctor()
-					IL_015b: stloc.s 6
-					IL_015d: ldloc.0
-					IL_015e: ldstr "Implementation:"
-					IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0168: pop
-					IL_0169: ldloc.s 4
-					IL_016b: ldstr "implementation"
-					IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0175: stloc.s 11
-					IL_0177: ldarg.0
-					IL_0178: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_017d: ldnull
-					IL_017e: ldloc.s 11
-					IL_0180: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_0185: stloc.s 11
-					IL_0187: ldloc.0
-					IL_0188: ldloc.s 11
-					IL_018a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_018f: pop
+					IL_0168: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L77C26::.ctor()
+					IL_016d: stloc.s 6
+					IL_016f: ldloc.0
+					IL_0170: ldstr "Implementation:"
+					IL_0175: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_017a: pop
+					IL_017b: ldarg.0
+					IL_017c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
+					IL_0181: stloc.s 11
+					IL_0183: ldc.i4.1
+					IL_0184: newarr [System.Runtime]System.Object
+					IL_0189: dup
+					IL_018a: ldc.i4.0
+					IL_018b: ldarg.0
+					IL_018c: stelem.ref
+					IL_018d: stloc.s 17
+					IL_018f: ldloc.s 11
+					IL_0191: ldloc.s 17
+					IL_0193: ldloc.s 4
+					IL_0195: ldstr "implementation"
+					IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_01a4: stloc.s 11
+					IL_01a6: ldloc.0
+					IL_01a7: ldloc.s 11
+					IL_01a9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ae: pop
 
-					IL_0190: ldloc.0
-					IL_0191: ldstr ""
-					IL_0196: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_019b: pop
-					IL_019c: ldloc.s 4
-					IL_019e: ldstr "apis"
-					IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01a8: stloc.s 11
-					IL_01aa: ldloc.s 11
-					IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01b1: stloc.s 12
-					IL_01b3: ldloc.s 12
-					IL_01b5: brtrue IL_01c7
-
-					IL_01ba: ldc.i4.0
-					IL_01bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_01c0: stloc.s 17
-					IL_01c2: br IL_01cb
-
-					IL_01c7: ldloc.s 11
-					IL_01c9: stloc.s 17
-
+					IL_01af: ldloc.0
+					IL_01b0: ldstr ""
+					IL_01b5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ba: pop
+					IL_01bb: ldarg.0
+					IL_01bc: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApisTable
+					IL_01c1: stloc.s 11
+					IL_01c3: ldc.i4.1
+					IL_01c4: newarr [System.Runtime]System.Object
+					IL_01c9: dup
+					IL_01ca: ldc.i4.0
 					IL_01cb: ldarg.0
-					IL_01cc: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_01d1: ldnull
-					IL_01d2: ldloc.s 17
-					IL_01d4: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_01d9: stloc.s 11
-					IL_01db: ldloc.s 11
-					IL_01dd: stloc.s 7
-					IL_01df: ldloc.s 7
-					IL_01e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01e6: stloc.s 12
-					IL_01e8: ldloc.s 12
-					IL_01ea: brfalse IL_020b
+					IL_01cc: stelem.ref
+					IL_01cd: stloc.s 17
+					IL_01cf: ldloc.s 4
+					IL_01d1: ldstr "apis"
+					IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01db: stloc.s 18
+					IL_01dd: ldloc.s 18
+					IL_01df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01e4: stloc.s 12
+					IL_01e6: ldloc.s 12
+					IL_01e8: brtrue IL_01fa
 
-					IL_01ef: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L83C15::.ctor()
-					IL_01f4: stloc.s 8
-					IL_01f6: ldloc.0
-					IL_01f7: ldloc.s 7
-					IL_01f9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01fe: pop
-					IL_01ff: ldloc.0
-					IL_0200: ldstr ""
-					IL_0205: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_020a: pop
+					IL_01ed: ldc.i4.0
+					IL_01ee: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_01f3: stloc.s 19
+					IL_01f5: br IL_01fe
 
-					IL_020b: ldloc.s 4
-					IL_020d: ldstr "apis"
-					IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0217: stloc.s 11
-					IL_0219: ldloc.s 11
-					IL_021b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0220: stloc.s 12
-					IL_0222: ldloc.s 12
-					IL_0224: brtrue IL_0236
+					IL_01fa: ldloc.s 18
+					IL_01fc: stloc.s 19
 
-					IL_0229: ldc.i4.0
-					IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-					IL_022f: stloc.s 18
-					IL_0231: br IL_023a
+					IL_01fe: ldloc.s 11
+					IL_0200: ldloc.s 17
+					IL_0202: ldloc.s 19
+					IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0209: stloc.s 11
+					IL_020b: ldloc.s 11
+					IL_020d: stloc.s 7
+					IL_020f: ldloc.s 7
+					IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0216: stloc.s 12
+					IL_0218: ldloc.s 12
+					IL_021a: brfalse IL_023b
 
-					IL_0236: ldloc.s 11
-					IL_0238: stloc.s 18
+					IL_021f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L83C15::.ctor()
+					IL_0224: stloc.s 8
+					IL_0226: ldloc.0
+					IL_0227: ldloc.s 7
+					IL_0229: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_022e: pop
+					IL_022f: ldloc.0
+					IL_0230: ldstr ""
+					IL_0235: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_023a: pop
 
-					IL_023a: ldarg.0
-					IL_023b: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_0240: ldnull
-					IL_0241: ldloc.s 18
-					IL_0243: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_0248: stloc.s 11
-					IL_024a: ldloc.s 11
-					IL_024c: stloc.s 9
-					IL_024e: ldloc.s 9
-					IL_0250: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0255: stloc.s 12
-					IL_0257: ldloc.s 12
-					IL_0259: brfalse IL_0286
+					IL_023b: ldarg.0
+					IL_023c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderApiTests
+					IL_0241: stloc.s 11
+					IL_0243: ldc.i4.1
+					IL_0244: newarr [System.Runtime]System.Object
+					IL_0249: dup
+					IL_024a: ldc.i4.0
+					IL_024b: ldarg.0
+					IL_024c: stelem.ref
+					IL_024d: stloc.s 17
+					IL_024f: ldloc.s 4
+					IL_0251: ldstr "apis"
+					IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_025b: stloc.s 18
+					IL_025d: ldloc.s 18
+					IL_025f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0264: stloc.s 12
+					IL_0266: ldloc.s 12
+					IL_0268: brtrue IL_027a
 
-					IL_025e: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L88C15::.ctor()
-					IL_0263: stloc.s 10
-					IL_0265: ldloc.0
-					IL_0266: ldstr "Tests:"
-					IL_026b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0270: pop
-					IL_0271: ldloc.0
-					IL_0272: ldloc.s 9
-					IL_0274: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0279: pop
-					IL_027a: ldloc.0
-					IL_027b: ldstr ""
-					IL_0280: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0285: pop
+					IL_026d: ldc.i4.0
+					IL_026e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+					IL_0273: stloc.s 20
+					IL_0275: br IL_027e
 
-					IL_0286: br IL_0059
+					IL_027a: ldloc.s 18
+					IL_027c: stloc.s 20
+
+					IL_027e: ldloc.s 11
+					IL_0280: ldloc.s 17
+					IL_0282: ldloc.s 20
+					IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_0289: stloc.s 11
+					IL_028b: ldloc.s 11
+					IL_028d: stloc.s 9
+					IL_028f: ldloc.s 9
+					IL_0291: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0296: stloc.s 12
+					IL_0298: ldloc.s 12
+					IL_029a: brfalse IL_02c7
+
+					IL_029f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/Scope_ForOf_L74C7/Block_L74C36/Block_L88C15::.ctor()
+					IL_02a4: stloc.s 10
+					IL_02a6: ldloc.0
+					IL_02a7: ldstr "Tests:"
+					IL_02ac: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02b1: pop
+					IL_02b2: ldloc.0
+					IL_02b3: ldloc.s 9
+					IL_02b5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02ba: pop
+					IL_02bb: ldloc.0
+					IL_02bc: ldstr ""
+					IL_02c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_02c6: pop
+
+					IL_02c7: br IL_0059
 				// end loop
-				IL_028b: ldloc.1
-				IL_028c: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_0291: ldc.i4.1
-				IL_0292: stloc.3
-				IL_0293: leave IL_02b2
+				IL_02cc: ldloc.1
+				IL_02cd: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_02d2: ldc.i4.1
+				IL_02d3: stloc.3
+				IL_02d4: leave IL_02f3
 
-				IL_0298: ldc.i4.1
-				IL_0299: stloc.2
-				IL_029a: leave IL_02b2
+				IL_02d9: ldc.i4.1
+				IL_02da: stloc.2
+				IL_02db: leave IL_02f3
 			} // end .try
 			finally
 			{
-				IL_029f: ldloc.2
-				IL_02a0: brtrue IL_02b1
+				IL_02e0: ldloc.2
+				IL_02e1: brtrue IL_02f2
 
-				IL_02a5: ldloc.3
-				IL_02a6: brtrue IL_02b1
+				IL_02e6: ldloc.3
+				IL_02e7: brtrue IL_02f2
 
-				IL_02ab: ldloc.1
-				IL_02ac: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_02ec: ldloc.1
+				IL_02ed: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_02b1: endfinally
+				IL_02f2: endfinally
 			} // end handler
 
-			IL_02b2: ldloc.0
-			IL_02b3: ldc.i4.1
-			IL_02b4: newarr [System.Runtime]System.Object
-			IL_02b9: dup
-			IL_02ba: ldc.i4.0
-			IL_02bb: ldstr "\n"
-			IL_02c0: stelem.ref
-			IL_02c1: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_02c6: stloc.s 16
-			IL_02c8: ldloc.s 16
-			IL_02ca: ret
+			IL_02f3: ldloc.0
+			IL_02f4: ldc.i4.1
+			IL_02f5: newarr [System.Runtime]System.Object
+			IL_02fa: dup
+			IL_02fb: ldc.i4.0
+			IL_02fc: ldstr "\n"
+			IL_0301: stelem.ref
+			IL_0302: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0307: stloc.s 16
+			IL_0309: ldloc.s 16
+			IL_030b: ret
 		} // end of method renderModules::__js_call__
 
 	} // end of class renderModules
@@ -1902,7 +2029,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x367f
+				// Method begins at RVA 0x37db
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1930,7 +2057,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x369a
+						// Method begins at RVA 0x37f6
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1950,7 +2077,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x36a3
+						// Method begins at RVA 0x37ff
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1970,7 +2097,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x36ac
+						// Method begins at RVA 0x3808
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1994,7 +2121,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x36be
+							// Method begins at RVA 0x381a
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -2012,7 +2139,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x36b5
+						// Method begins at RVA 0x3811
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -2030,7 +2157,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3691
+					// Method begins at RVA 0x37ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2048,7 +2175,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3688
+				// Method begins at RVA 0x37e4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2075,9 +2202,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x2e40
+			// Method begins at RVA 0x2f00
 			// Header size: 12
-			// Code size: 992 (0x3e0)
+			// Code size: 1061 (0x425)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2104,7 +2231,8 @@
 				[21] object,
 				[22] string,
 				[23] string,
-				[24] object
+				[24] object[],
+				[25] object
 			)
 
 			IL_0000: ldc.i4.0
@@ -2153,7 +2281,7 @@
 					IL_0063: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
 					IL_0068: stloc.s 19
 					IL_006a: ldloc.s 19
-					IL_006c: brtrue IL_03ad
+					IL_006c: brtrue IL_03f2
 
 					IL_0071: ldloc.s 18
 					IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
@@ -2198,286 +2326,319 @@
 					IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_00fa: stloc.s 19
 					IL_00fc: ldloc.s 19
-					IL_00fe: brfalse IL_013c
+					IL_00fe: brfalse IL_014e
 
-					IL_0103: ldloc.s 4
-					IL_0105: ldstr "docs"
-					IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_010f: stloc.s 18
-					IL_0111: ldnull
-					IL_0112: ldloc.s 18
-					IL_0114: ldnull
-					IL_0115: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
-					IL_011a: stloc.s 18
-					IL_011c: ldloc.s 18
-					IL_011e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0123: stloc.s 23
-					IL_0125: ldstr "Docs: "
-					IL_012a: ldloc.s 23
-					IL_012c: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0131: stloc.s 23
-					IL_0133: ldloc.0
-					IL_0134: ldloc.s 23
-					IL_0136: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_013b: pop
+					IL_0103: ldarg.0
+					IL_0104: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::link
+					IL_0109: stloc.s 18
+					IL_010b: ldc.i4.1
+					IL_010c: newarr [System.Runtime]System.Object
+					IL_0111: dup
+					IL_0112: ldc.i4.0
+					IL_0113: ldarg.0
+					IL_0114: stelem.ref
+					IL_0115: stloc.s 24
+					IL_0117: ldloc.s 18
+					IL_0119: ldloc.s 24
+					IL_011b: ldloc.s 4
+					IL_011d: ldstr "docs"
+					IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_012c: stloc.s 18
+					IL_012e: ldloc.s 18
+					IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0135: stloc.s 23
+					IL_0137: ldstr "Docs: "
+					IL_013c: ldloc.s 23
+					IL_013e: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0143: stloc.s 23
+					IL_0145: ldloc.0
+					IL_0146: ldloc.s 23
+					IL_0148: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_014d: pop
 
-					IL_013c: ldloc.s 4
-					IL_013e: ldstr "implementation"
-					IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0148: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_014d: stloc.s 19
-					IL_014f: ldloc.s 19
-					IL_0151: brfalse IL_0190
+					IL_014e: ldloc.s 4
+					IL_0150: ldstr "implementation"
+					IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_015a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_015f: stloc.s 19
+					IL_0161: ldloc.s 19
+					IL_0163: brfalse IL_01af
 
-					IL_0156: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L104C26::.ctor()
-					IL_015b: stloc.s 6
-					IL_015d: ldloc.0
-					IL_015e: ldstr "Implementation:"
-					IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0168: pop
-					IL_0169: ldloc.s 4
-					IL_016b: ldstr "implementation"
-					IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0175: stloc.s 18
-					IL_0177: ldarg.0
-					IL_0178: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-					IL_017d: ldnull
-					IL_017e: ldloc.s 18
-					IL_0180: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-					IL_0185: stloc.s 18
-					IL_0187: ldloc.0
-					IL_0188: ldloc.s 18
-					IL_018a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_018f: pop
+					IL_0168: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L104C26::.ctor()
+					IL_016d: stloc.s 6
+					IL_016f: ldloc.0
+					IL_0170: ldstr "Implementation:"
+					IL_0175: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_017a: pop
+					IL_017b: ldarg.0
+					IL_017c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderImplementation
+					IL_0181: stloc.s 18
+					IL_0183: ldc.i4.1
+					IL_0184: newarr [System.Runtime]System.Object
+					IL_0189: dup
+					IL_018a: ldc.i4.0
+					IL_018b: ldarg.0
+					IL_018c: stelem.ref
+					IL_018d: stloc.s 24
+					IL_018f: ldloc.s 18
+					IL_0191: ldloc.s 24
+					IL_0193: ldloc.s 4
+					IL_0195: ldstr "implementation"
+					IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+					IL_01a4: stloc.s 18
+					IL_01a6: ldloc.0
+					IL_01a7: ldloc.s 18
+					IL_01a9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ae: pop
 
-					IL_0190: ldloc.s 4
-					IL_0192: ldstr "notes"
-					IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_019c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01a1: stloc.s 19
-					IL_01a3: ldloc.s 19
-					IL_01a5: brfalse IL_01d0
+					IL_01af: ldloc.s 4
+					IL_01b1: ldstr "notes"
+					IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_01c0: stloc.s 19
+					IL_01c2: ldloc.s 19
+					IL_01c4: brfalse IL_01ef
 
-					IL_01aa: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L108C17::.ctor()
-					IL_01af: stloc.s 7
-					IL_01b1: ldloc.0
-					IL_01b2: ldstr "Notes:"
-					IL_01b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01bc: pop
-					IL_01bd: ldloc.0
-					IL_01be: ldloc.s 4
-					IL_01c0: ldstr "notes"
-					IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01ca: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_01cf: pop
+					IL_01c9: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L108C17::.ctor()
+					IL_01ce: stloc.s 7
+					IL_01d0: ldloc.0
+					IL_01d1: ldstr "Notes:"
+					IL_01d6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01db: pop
+					IL_01dc: ldloc.0
+					IL_01dd: ldloc.s 4
+					IL_01df: ldstr "notes"
+					IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01e9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_01ee: pop
 
-					IL_01d0: ldloc.s 4
-					IL_01d2: ldstr "tests"
-					IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01dc: stloc.s 18
-					IL_01de: ldloc.s 18
-					IL_01e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_01e5: stloc.s 19
-					IL_01e7: ldloc.s 19
-					IL_01e9: brfalse IL_020b
+					IL_01ef: ldloc.s 4
+					IL_01f1: ldstr "tests"
+					IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_01fb: stloc.s 18
+					IL_01fd: ldloc.s 18
+					IL_01ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0204: stloc.s 19
+					IL_0206: ldloc.s 19
+					IL_0208: brfalse IL_022a
 
-					IL_01ee: ldloc.s 4
-					IL_01f0: ldstr "tests"
-					IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_01fa: ldstr "length"
-					IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_0204: stloc.s 24
-					IL_0206: br IL_020f
+					IL_020d: ldloc.s 4
+					IL_020f: ldstr "tests"
+					IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0219: ldstr "length"
+					IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_0223: stloc.s 25
+					IL_0225: br IL_022e
 
-					IL_020b: ldloc.s 18
-					IL_020d: stloc.s 24
+					IL_022a: ldloc.s 18
+					IL_022c: stloc.s 25
 
-					IL_020f: ldloc.s 24
-					IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0216: stloc.s 19
-					IL_0218: ldloc.s 19
-					IL_021a: brfalse IL_038f
+					IL_022e: ldloc.s 25
+					IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_0235: stloc.s 19
+					IL_0237: ldloc.s 19
+					IL_0239: brfalse IL_03d4
 
-					IL_021f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L112C35::.ctor()
-					IL_0224: stloc.s 8
-					IL_0226: ldloc.0
-					IL_0227: ldstr "Tests:"
-					IL_022c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_0231: pop
-					IL_0232: ldloc.s 4
-					IL_0234: ldstr "tests"
-					IL_0239: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-					IL_023e: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
-					IL_0243: stloc.s 9
-					IL_0245: ldc.i4.0
-					IL_0246: stloc.s 10
-					IL_0248: ldc.i4.0
-					IL_0249: stloc.s 11
+					IL_023e: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Block_L112C35::.ctor()
+					IL_0243: stloc.s 8
+					IL_0245: ldloc.0
+					IL_0246: ldstr "Tests:"
+					IL_024b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_0250: pop
+					IL_0251: ldloc.s 4
+					IL_0253: ldstr "tests"
+					IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+					IL_025d: call class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator [JavaScriptRuntime]JavaScriptRuntime.Object::GetIterator(object)
+					IL_0262: stloc.s 9
+					IL_0264: ldc.i4.0
+					IL_0265: stloc.s 10
+					IL_0267: ldc.i4.0
+					IL_0268: stloc.s 11
 					.try
 					{
-						// loop start (head: IL_024b)
-							IL_024b: ldloc.s 9
-							IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
-							IL_0252: stloc.s 18
-							IL_0254: ldloc.s 18
-							IL_0256: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
-							IL_025b: stloc.s 19
-							IL_025d: ldloc.s 19
-							IL_025f: brtrue IL_0371
+						// loop start (head: IL_026a)
+							IL_026a: ldloc.s 9
+							IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorNext(object)
+							IL_0271: stloc.s 18
+							IL_0273: ldloc.s 18
+							IL_0275: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultDone(object)
+							IL_027a: stloc.s 19
+							IL_027c: ldloc.s 19
+							IL_027e: brtrue IL_03b6
 
-							IL_0264: ldloc.s 18
-							IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
-							IL_026b: stloc.s 18
-							IL_026d: ldloc.s 18
-							IL_026f: stloc.s 12
-							IL_0271: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31::.ctor()
-							IL_0276: stloc.s 13
-							IL_0278: ldloc.s 12
-							IL_027a: ldstr "name"
-							IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_0284: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_0289: stloc.s 19
-							IL_028b: ldloc.s 19
-							IL_028d: brfalse IL_02b3
+							IL_0283: ldloc.s 18
+							IL_0285: call object [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorResultValue(object)
+							IL_028a: stloc.s 18
+							IL_028c: ldloc.s 18
+							IL_028e: stloc.s 12
+							IL_0290: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/Scope_ForOf_L101C7/Block_L101C36/Scope_ForOf_L114C11/Block_L114C31::.ctor()
+							IL_0295: stloc.s 13
+							IL_0297: ldloc.s 12
+							IL_0299: ldstr "name"
+							IL_029e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_02a8: stloc.s 19
+							IL_02aa: ldloc.s 19
+							IL_02ac: brfalse IL_02e5
 
-							IL_0292: ldloc.s 12
-							IL_0294: ldstr "name"
-							IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_029e: stloc.s 18
-							IL_02a0: ldnull
-							IL_02a1: ldloc.s 18
-							IL_02a3: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-							IL_02a8: stloc.s 18
-							IL_02aa: ldloc.s 18
-							IL_02ac: stloc.s 14
-							IL_02ae: br IL_02ba
+							IL_02b1: ldarg.0
+							IL_02b2: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_02b7: stloc.s 18
+							IL_02b9: ldc.i4.1
+							IL_02ba: newarr [System.Runtime]System.Object
+							IL_02bf: dup
+							IL_02c0: ldc.i4.0
+							IL_02c1: ldarg.0
+							IL_02c2: stelem.ref
+							IL_02c3: stloc.s 24
+							IL_02c5: ldloc.s 18
+							IL_02c7: ldloc.s 24
+							IL_02c9: ldloc.s 12
+							IL_02cb: ldstr "name"
+							IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_02da: stloc.s 18
+							IL_02dc: ldloc.s 18
+							IL_02de: stloc.s 14
+							IL_02e0: br IL_02ec
 
-							IL_02b3: ldstr ""
-							IL_02b8: stloc.s 14
+							IL_02e5: ldstr ""
+							IL_02ea: stloc.s 14
 
-							IL_02ba: ldloc.s 14
-							IL_02bc: stloc.s 15
-							IL_02be: ldloc.s 12
-							IL_02c0: ldstr "file"
-							IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-							IL_02cf: stloc.s 19
-							IL_02d1: ldloc.s 19
-							IL_02d3: brfalse IL_031e
+							IL_02ec: ldloc.s 14
+							IL_02ee: stloc.s 15
+							IL_02f0: ldloc.s 12
+							IL_02f2: ldstr "file"
+							IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_02fc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+							IL_0301: stloc.s 19
+							IL_0303: ldloc.s 19
+							IL_0305: brfalse IL_0363
 
-							IL_02d8: ldloc.s 12
-							IL_02da: ldstr "file"
-							IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-							IL_02e4: stloc.s 18
-							IL_02e6: ldnull
-							IL_02e7: ldloc.s 18
-							IL_02e9: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-							IL_02ee: stloc.s 18
-							IL_02f0: ldloc.s 18
-							IL_02f2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_02f7: stloc.s 23
-							IL_02f9: ldstr " ("
-							IL_02fe: ldloc.s 23
-							IL_0300: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0305: stloc.s 23
-							IL_0307: ldloc.s 23
-							IL_0309: ldstr ")"
-							IL_030e: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0313: stloc.s 23
-							IL_0315: ldloc.s 23
-							IL_0317: stloc.s 16
-							IL_0319: br IL_0325
+							IL_030a: ldarg.0
+							IL_030b: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fmtCode
+							IL_0310: stloc.s 18
+							IL_0312: ldc.i4.1
+							IL_0313: newarr [System.Runtime]System.Object
+							IL_0318: dup
+							IL_0319: ldc.i4.0
+							IL_031a: ldarg.0
+							IL_031b: stelem.ref
+							IL_031c: stloc.s 24
+							IL_031e: ldloc.s 18
+							IL_0320: ldloc.s 24
+							IL_0322: ldloc.s 12
+							IL_0324: ldstr "file"
+							IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+							IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+							IL_0333: stloc.s 18
+							IL_0335: ldloc.s 18
+							IL_0337: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_033c: stloc.s 23
+							IL_033e: ldstr " ("
+							IL_0343: ldloc.s 23
+							IL_0345: call string [System.Runtime]System.String::Concat(string, string)
+							IL_034a: stloc.s 23
+							IL_034c: ldloc.s 23
+							IL_034e: ldstr ")"
+							IL_0353: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0358: stloc.s 23
+							IL_035a: ldloc.s 23
+							IL_035c: stloc.s 16
+							IL_035e: br IL_036a
 
-							IL_031e: ldstr ""
-							IL_0323: stloc.s 16
+							IL_0363: ldstr ""
+							IL_0368: stloc.s 16
 
-							IL_0325: ldloc.s 16
-							IL_0327: stloc.s 17
-							IL_0329: ldloc.s 15
-							IL_032b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0330: stloc.s 23
-							IL_0332: ldstr "- "
-							IL_0337: ldloc.s 23
-							IL_0339: call string [System.Runtime]System.String::Concat(string, string)
-							IL_033e: stloc.s 23
-							IL_0340: ldloc.s 17
-							IL_0342: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-							IL_0347: stloc.s 22
-							IL_0349: ldloc.s 23
-							IL_034b: ldloc.s 22
-							IL_034d: call string [System.Runtime]System.String::Concat(string, string)
-							IL_0352: stloc.s 22
-							IL_0354: ldloc.0
-							IL_0355: ldloc.s 22
-							IL_0357: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-							IL_035c: pop
-							IL_035d: br IL_024b
+							IL_036a: ldloc.s 16
+							IL_036c: stloc.s 17
+							IL_036e: ldloc.s 15
+							IL_0370: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_0375: stloc.s 23
+							IL_0377: ldstr "- "
+							IL_037c: ldloc.s 23
+							IL_037e: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0383: stloc.s 23
+							IL_0385: ldloc.s 17
+							IL_0387: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+							IL_038c: stloc.s 22
+							IL_038e: ldloc.s 23
+							IL_0390: ldloc.s 22
+							IL_0392: call string [System.Runtime]System.String::Concat(string, string)
+							IL_0397: stloc.s 22
+							IL_0399: ldloc.0
+							IL_039a: ldloc.s 22
+							IL_039c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+							IL_03a1: pop
+							IL_03a2: br IL_026a
 						// end loop
-						IL_0362: ldloc.s 9
-						IL_0364: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-						IL_0369: ldc.i4.1
-						IL_036a: stloc.s 11
-						IL_036c: leave IL_038f
+						IL_03a7: ldloc.s 9
+						IL_03a9: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+						IL_03ae: ldc.i4.1
+						IL_03af: stloc.s 11
+						IL_03b1: leave IL_03d4
 
-						IL_0371: ldc.i4.1
-						IL_0372: stloc.s 10
-						IL_0374: leave IL_038f
+						IL_03b6: ldc.i4.1
+						IL_03b7: stloc.s 10
+						IL_03b9: leave IL_03d4
 					} // end .try
 					finally
 					{
-						IL_0379: ldloc.s 10
-						IL_037b: brtrue IL_038e
+						IL_03be: ldloc.s 10
+						IL_03c0: brtrue IL_03d3
 
-						IL_0380: ldloc.s 11
-						IL_0382: brtrue IL_038e
+						IL_03c5: ldloc.s 11
+						IL_03c7: brtrue IL_03d3
 
-						IL_0387: ldloc.s 9
-						IL_0389: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+						IL_03cc: ldloc.s 9
+						IL_03ce: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-						IL_038e: endfinally
+						IL_03d3: endfinally
 					} // end handler
 
-					IL_038f: ldloc.0
-					IL_0390: ldstr ""
-					IL_0395: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-					IL_039a: pop
-					IL_039b: br IL_0059
+					IL_03d4: ldloc.0
+					IL_03d5: ldstr ""
+					IL_03da: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+					IL_03df: pop
+					IL_03e0: br IL_0059
 				// end loop
-				IL_03a0: ldloc.1
-				IL_03a1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
-				IL_03a6: ldc.i4.1
-				IL_03a7: stloc.3
-				IL_03a8: leave IL_03c7
+				IL_03e5: ldloc.1
+				IL_03e6: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorClose(object)
+				IL_03eb: ldc.i4.1
+				IL_03ec: stloc.3
+				IL_03ed: leave IL_040c
 
-				IL_03ad: ldc.i4.1
-				IL_03ae: stloc.2
-				IL_03af: leave IL_03c7
+				IL_03f2: ldc.i4.1
+				IL_03f3: stloc.2
+				IL_03f4: leave IL_040c
 			} // end .try
 			finally
 			{
-				IL_03b4: ldloc.2
-				IL_03b5: brtrue IL_03c6
+				IL_03f9: ldloc.2
+				IL_03fa: brtrue IL_040b
 
-				IL_03ba: ldloc.3
-				IL_03bb: brtrue IL_03c6
+				IL_03ff: ldloc.3
+				IL_0400: brtrue IL_040b
 
-				IL_03c0: ldloc.1
-				IL_03c1: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
+				IL_0405: ldloc.1
+				IL_0406: call void [JavaScriptRuntime]JavaScriptRuntime.Object::IteratorCloseForThrowCompletion(object)
 
-				IL_03c6: endfinally
+				IL_040b: endfinally
 			} // end handler
 
-			IL_03c7: ldloc.0
-			IL_03c8: ldc.i4.1
-			IL_03c9: newarr [System.Runtime]System.Object
-			IL_03ce: dup
-			IL_03cf: ldc.i4.0
-			IL_03d0: ldstr "\n"
-			IL_03d5: stelem.ref
-			IL_03d6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_03db: stloc.s 22
-			IL_03dd: ldloc.s 22
-			IL_03df: ret
+			IL_040c: ldloc.0
+			IL_040d: ldc.i4.1
+			IL_040e: newarr [System.Runtime]System.Object
+			IL_0413: dup
+			IL_0414: ldc.i4.0
+			IL_0415: ldstr "\n"
+			IL_041a: stelem.ref
+			IL_041b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0420: stloc.s 22
+			IL_0422: ldloc.s 22
+			IL_0424: ret
 		} // end of method renderGlobals::__js_call__
 
 	} // end of class renderGlobals
@@ -2493,7 +2654,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36c7
+				// Method begins at RVA 0x3823
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2513,7 +2674,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36d0
+				// Method begins at RVA 0x382c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2537,7 +2698,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3260
+			// Method begins at RVA 0x3368
 			// Header size: 12
 			// Code size: 278 (0x116)
 			.maxstack 8
@@ -2690,7 +2851,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x36d9
+				// Method begins at RVA 0x3835
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2716,9 +2877,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 10 00 00 02
 			)
-			// Method begins at RVA 0x3394
+			// Method begins at RVA 0x349c
 			// Header size: 12
-			// Code size: 496 (0x1f0)
+			// Code size: 547 (0x223)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2812,121 +2973,148 @@
 			IL_00b2: ldloc.s 8
 			IL_00b4: stloc.2
 			IL_00b5: ldarg.0
-			IL_00b6: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_00bb: ldnull
-			IL_00bc: ldloc.1
-			IL_00bd: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_00c2: stloc.s 8
-			IL_00c4: ldloc.s 8
-			IL_00c6: stloc.3
-			IL_00c7: ldc.i4.0
-			IL_00c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00cd: stloc.s 4
-			IL_00cf: ldarg.0
-			IL_00d0: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_00d5: ldnull
-			IL_00d6: ldloc.3
-			IL_00d7: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_00dc: stloc.s 8
-			IL_00de: ldloc.s 4
-			IL_00e0: ldloc.s 8
-			IL_00e2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_00e7: pop
-			IL_00e8: ldarg.0
-			IL_00e9: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_00ee: ldnull
-			IL_00ef: ldloc.3
-			IL_00f0: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_00f5: stloc.s 8
-			IL_00f7: ldloc.s 4
-			IL_00f9: ldloc.s 8
-			IL_00fb: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0100: pop
-			IL_0101: ldarg.0
-			IL_0102: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-			IL_0107: ldnull
-			IL_0108: ldloc.3
-			IL_0109: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-			IL_010e: stloc.s 8
-			IL_0110: ldloc.s 4
-			IL_0112: ldloc.s 8
-			IL_0114: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0119: pop
-			IL_011a: ldnull
-			IL_011b: ldloc.3
-			IL_011c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
-			IL_0121: stloc.s 8
-			IL_0123: ldloc.s 8
-			IL_0125: stloc.s 5
-			IL_0127: ldloc.s 5
-			IL_0129: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_012e: stloc.s 10
-			IL_0130: ldloc.s 10
-			IL_0132: brfalse IL_0141
+			IL_00b6: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::readJson
+			IL_00bb: ldc.i4.1
+			IL_00bc: newarr [System.Runtime]System.Object
+			IL_00c1: dup
+			IL_00c2: ldc.i4.0
+			IL_00c3: ldarg.0
+			IL_00c4: stelem.ref
+			IL_00c5: ldloc.1
+			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00cb: stloc.s 8
+			IL_00cd: ldloc.s 8
+			IL_00cf: stloc.3
+			IL_00d0: ldc.i4.0
+			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d6: stloc.s 4
+			IL_00d8: ldarg.0
+			IL_00d9: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderHeader
+			IL_00de: ldc.i4.1
+			IL_00df: newarr [System.Runtime]System.Object
+			IL_00e4: dup
+			IL_00e5: ldc.i4.0
+			IL_00e6: ldarg.0
+			IL_00e7: stelem.ref
+			IL_00e8: ldloc.3
+			IL_00e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00ee: stloc.s 8
+			IL_00f0: ldloc.s 4
+			IL_00f2: ldloc.s 8
+			IL_00f4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_00f9: pop
+			IL_00fa: ldarg.0
+			IL_00fb: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderModules
+			IL_0100: ldc.i4.1
+			IL_0101: newarr [System.Runtime]System.Object
+			IL_0106: dup
+			IL_0107: ldc.i4.0
+			IL_0108: ldarg.0
+			IL_0109: stelem.ref
+			IL_010a: ldloc.3
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0110: stloc.s 8
+			IL_0112: ldloc.s 4
+			IL_0114: ldloc.s 8
+			IL_0116: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_011b: pop
+			IL_011c: ldarg.0
+			IL_011d: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderGlobals
+			IL_0122: ldc.i4.1
+			IL_0123: newarr [System.Runtime]System.Object
+			IL_0128: dup
+			IL_0129: ldc.i4.0
+			IL_012a: ldarg.0
+			IL_012b: stelem.ref
+			IL_012c: ldloc.3
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0132: stloc.s 8
+			IL_0134: ldloc.s 4
+			IL_0136: ldloc.s 8
+			IL_0138: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_013d: pop
+			IL_013e: ldarg.0
+			IL_013f: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::renderLimitations
+			IL_0144: ldc.i4.1
+			IL_0145: newarr [System.Runtime]System.Object
+			IL_014a: dup
+			IL_014b: ldc.i4.0
+			IL_014c: ldarg.0
+			IL_014d: stelem.ref
+			IL_014e: ldloc.3
+			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0154: stloc.s 8
+			IL_0156: ldloc.s 8
+			IL_0158: stloc.s 5
+			IL_015a: ldloc.s 5
+			IL_015c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0161: stloc.s 10
+			IL_0163: ldloc.s 10
+			IL_0165: brfalse IL_0174
 
-			IL_0137: ldloc.s 4
-			IL_0139: ldloc.s 5
-			IL_013b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0140: pop
+			IL_016a: ldloc.s 4
+			IL_016c: ldloc.s 5
+			IL_016e: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0173: pop
 
-			IL_0141: ldloc.s 4
-			IL_0143: ldc.i4.1
-			IL_0144: newarr [System.Runtime]System.Object
-			IL_0149: dup
-			IL_014a: ldc.i4.0
-			IL_014b: ldstr "\n\n"
-			IL_0150: stelem.ref
-			IL_0151: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0156: stloc.s 11
-			IL_0158: ldloc.s 11
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015f: stloc.s 8
-			IL_0161: ldstr "\\r?\\n"
-			IL_0166: ldstr "g"
-			IL_016b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0170: stloc.s 12
-			IL_0172: ldloc.s 8
-			IL_0174: ldstr "replace"
-			IL_0179: ldloc.s 12
-			IL_017b: ldstr "\n"
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_0185: stloc.s 8
-			IL_0187: ldloc.s 8
-			IL_0189: stloc.s 6
-			IL_018b: ldarg.0
-			IL_018c: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0196: stloc.s 8
-			IL_0198: ldloc.s 8
-			IL_019a: ldstr "writeFileSync"
-			IL_019f: ldloc.2
-			IL_01a0: ldloc.s 6
-			IL_01a2: ldstr "utf8"
-			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_01ac: pop
-			IL_01ad: ldarg.0
-			IL_01ae: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0174: ldloc.s 4
+			IL_0176: ldc.i4.1
+			IL_0177: newarr [System.Runtime]System.Object
+			IL_017c: dup
+			IL_017d: ldc.i4.0
+			IL_017e: ldstr "\n\n"
+			IL_0183: stelem.ref
+			IL_0184: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0189: stloc.s 11
+			IL_018b: ldloc.s 11
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0192: stloc.s 8
+			IL_0194: ldstr "\\r?\\n"
+			IL_0199: ldstr "g"
+			IL_019e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01a3: stloc.s 12
+			IL_01a5: ldloc.s 8
+			IL_01a7: ldstr "replace"
+			IL_01ac: ldloc.s 12
+			IL_01ae: ldstr "\n"
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
 			IL_01b8: stloc.s 8
 			IL_01ba: ldloc.s 8
-			IL_01bc: ldstr "relative"
-			IL_01c1: ldloc.0
-			IL_01c2: ldloc.2
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_01c8: stloc.s 8
-			IL_01ca: ldloc.s 8
-			IL_01cc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d1: stloc.s 11
-			IL_01d3: ldstr "Wrote "
-			IL_01d8: ldloc.s 11
-			IL_01da: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01df: stloc.s 11
-			IL_01e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01e6: ldloc.s 11
-			IL_01e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01ed: pop
-			IL_01ee: ldnull
-			IL_01ef: ret
+			IL_01bc: stloc.s 6
+			IL_01be: ldarg.0
+			IL_01bf: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::fs
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c9: stloc.s 8
+			IL_01cb: ldloc.s 8
+			IL_01cd: ldstr "writeFileSync"
+			IL_01d2: ldloc.2
+			IL_01d3: ldloc.s 6
+			IL_01d5: ldstr "utf8"
+			IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_01df: pop
+			IL_01e0: ldarg.0
+			IL_01e1: ldfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01eb: stloc.s 8
+			IL_01ed: ldloc.s 8
+			IL_01ef: ldstr "relative"
+			IL_01f4: ldloc.0
+			IL_01f5: ldloc.2
+			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_01fb: stloc.s 8
+			IL_01fd: ldloc.s 8
+			IL_01ff: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0204: stloc.s 11
+			IL_0206: ldstr "Wrote "
+			IL_020b: ldloc.s 11
+			IL_020d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0212: stloc.s 11
+			IL_0214: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0219: ldloc.s 11
+			IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0220: pop
+			IL_0221: ldnull
+			IL_0222: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -2969,7 +3157,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x35b9
+			// Method begins at RVA 0x3715
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2995,7 +3183,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 597 (0x255)
+		// Code size: 596 (0x254)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope,
@@ -3241,12 +3429,11 @@
 		IL_0240: ldloc.0
 		IL_0241: ldloc.2
 		IL_0242: stfld object Modules.Compile_Scripts_GenerateNodeSupportMd/Scope::path
-		IL_0247: ldloc.0
-		IL_0248: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_024d: ldnull
-		IL_024e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
-		IL_0253: pop
-		IL_0254: ret
+		IL_0247: ldloc.1
+		IL_0248: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0252: pop
+		IL_0253: ret
 	} // end of method Compile_Scripts_GenerateNodeSupportMd::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_GenerateNodeSupportMd
@@ -3258,7 +3445,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x36e2
+		// Method begins at RVA 0x383e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x301a
+					// Method begins at RVA 0x3026
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b42
+				// Method begins at RVA 0x2b4e
 				// Header size: 1
 				// Code size: 14 (0xe)
 				.maxstack 8
@@ -76,7 +76,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x302c
+						// Method begins at RVA 0x3038
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -100,7 +100,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2de0
+					// Method begins at RVA 0x2dec
 					// Header size: 12
 					// Code size: 131 (0x83)
 					.maxstack 8
@@ -171,7 +171,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3035
+						// Method begins at RVA 0x3041
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -195,7 +195,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2e70
+					// Method begins at RVA 0x2e7c
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -238,7 +238,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3023
+					// Method begins at RVA 0x302f
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -262,7 +262,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2b54
+				// Method begins at RVA 0x2b60
 				// Header size: 12
 				// Code size: 154 (0x9a)
 				.maxstack 8
@@ -365,7 +365,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3011
+				// Method begins at RVA 0x301d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -392,7 +392,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2894
+			// Method begins at RVA 0x28a0
 			// Header size: 12
 			// Code size: 176 (0xb0)
 			.maxstack 8
@@ -495,7 +495,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x303e
+				// Method begins at RVA 0x304a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -519,7 +519,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2950
+			// Method begins at RVA 0x295c
 			// Header size: 1
 			// Code size: 2 (0x2)
 			.maxstack 8
@@ -548,7 +548,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3047
+				// Method begins at RVA 0x3053
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -572,7 +572,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2954
+			// Method begins at RVA 0x2960
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -623,7 +623,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3062
+				// Method begins at RVA 0x306e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -647,7 +647,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x298c
+			// Method begins at RVA 0x2998
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -703,7 +703,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x3098
+							// Method begins at RVA 0x30a4
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -721,7 +721,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x308f
+						// Method begins at RVA 0x309b
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -745,7 +745,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2ebc
+					// Method begins at RVA 0x2ec8
 					// Header size: 12
 					// Code size: 110 (0x6e)
 					.maxstack 8
@@ -809,7 +809,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30a1
+						// Method begins at RVA 0x30ad
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -833,7 +833,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f38
+					// Method begins at RVA 0x2f44
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -876,7 +876,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3086
+					// Method begins at RVA 0x3092
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -900,7 +900,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bfc
+				// Method begins at RVA 0x2c08
 				// Header size: 12
 				// Code size: 146 (0x92)
 				.maxstack 8
@@ -1001,7 +1001,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x307d
+				// Method begins at RVA 0x3089
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1028,7 +1028,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x29c4
+			// Method begins at RVA 0x29d0
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -1097,7 +1097,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30aa
+				// Method begins at RVA 0x30b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1121,7 +1121,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2a24
+			// Method begins at RVA 0x2a30
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1173,7 +1173,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30d7
+						// Method begins at RVA 0x30e3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1191,7 +1191,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30ce
+					// Method begins at RVA 0x30da
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1215,7 +1215,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2c9c
+				// Method begins at RVA 0x2ca8
 				// Header size: 12
 				// Code size: 106 (0x6a)
 				.maxstack 8
@@ -1275,7 +1275,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30e0
+					// Method begins at RVA 0x30ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1299,7 +1299,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d14
+				// Method begins at RVA 0x2d20
 				// Header size: 12
 				// Code size: 64 (0x40)
 				.maxstack 8
@@ -1342,7 +1342,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30c5
+				// Method begins at RVA 0x30d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1368,7 +1368,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2a5c
+			// Method begins at RVA 0x2a68
 			// Header size: 12
 			// Code size: 130 (0x82)
 			.maxstack 8
@@ -1458,7 +1458,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x30fb
+						// Method begins at RVA 0x3107
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1481,7 +1481,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 00 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2f84
+					// Method begins at RVA 0x2f90
 					// Header size: 12
 					// Code size: 41 (0x29)
 					.maxstack 8
@@ -1525,7 +1525,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x3104
+						// Method begins at RVA 0x3110
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -1549,7 +1549,7 @@
 					.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 						01 00 02 00 00 00 00 00
 					)
-					// Method begins at RVA 0x2fbc
+					// Method begins at RVA 0x2fc8
 					// Header size: 12
 					// Code size: 64 (0x40)
 					.maxstack 8
@@ -1585,7 +1585,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x30f2
+					// Method begins at RVA 0x30fe
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1609,7 +1609,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2d60
+				// Method begins at RVA 0x2d6c
 				// Header size: 12
 				// Code size: 113 (0x71)
 				.maxstack 8
@@ -1689,7 +1689,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30e9
+				// Method begins at RVA 0x30f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1716,7 +1716,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 17 00 00 02
 			)
-			// Method begins at RVA 0x2aec
+			// Method begins at RVA 0x2af8
 			// Header size: 12
 			// Code size: 74 (0x4a)
 			.maxstack 8
@@ -1788,7 +1788,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3050
+				// Method begins at RVA 0x305c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1808,7 +1808,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3059
+				// Method begins at RVA 0x3065
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1828,7 +1828,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x306b
+				// Method begins at RVA 0x3077
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1848,7 +1848,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3074
+				// Method begins at RVA 0x3080
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1868,7 +1868,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30b3
+				// Method begins at RVA 0x30bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1888,7 +1888,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x30bc
+				// Method begins at RVA 0x30c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1908,7 +1908,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x310d
+				// Method begins at RVA 0x3119
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1928,7 +1928,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3116
+				// Method begins at RVA 0x3122
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1952,7 +1952,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3008
+			// Method begins at RVA 0x3014
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1978,7 +1978,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 2049 (0x801)
+		// Code size: 2064 (0x810)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
@@ -2017,9 +2017,10 @@
 			[33] class Modules.Iterator_Helper_Cleanup/Scope/Block_L129C16,
 			[34] object,
 			[35] object,
-			[36] object,
+			[36] object[],
 			[37] object,
-			[38] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[38] object,
+			[39] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
 		IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/Scope::.ctor()
@@ -2044,689 +2045,694 @@
 		IL_0030: stloc.s 35
 		IL_0032: ldloc.s 35
 		IL_0034: stloc.1
-		IL_0035: ldloc.0
-		IL_0036: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_003b: ldnull
-		IL_003c: ldc.r8 2
-		IL_0045: box [System.Runtime]System.Double
-		IL_004a: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_004f: stloc.s 35
-		IL_0051: ldloc.s 35
-		IL_0053: stloc.2
-		IL_0054: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005e: stloc.s 35
-		IL_0060: ldloc.s 35
-		IL_0062: ldstr "from"
-		IL_0067: ldloc.2
-		IL_0068: ldstr "iterable"
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0077: stloc.s 35
-		IL_0079: ldloc.s 35
-		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0080: stloc.s 35
-		IL_0082: ldnull
-		IL_0083: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56::__js_call__(object, object)
-		IL_0089: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_008e: ldc.i4.1
-		IL_008f: newarr [System.Runtime]System.Object
-		IL_0094: dup
-		IL_0095: ldc.i4.0
-		IL_0096: ldloc.0
-		IL_0097: stelem.ref
-		IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00a2: ldc.i4.1
-		IL_00a3: conv.r8
-		IL_00a4: ldstr ""
-		IL_00a9: ldc.i4.0
-		IL_00aa: ldc.i4.1
-		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00b5: stloc.s 36
-		IL_00b7: ldloc.s 35
-		IL_00b9: ldstr "map"
-		IL_00be: ldloc.s 36
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00c5: stloc.s 36
-		IL_00c7: ldloc.s 36
-		IL_00c9: stloc.3
-		IL_00ca: ldloc.3
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00d0: stloc.s 36
-		IL_00d2: ldloc.s 36
-		IL_00d4: ldstr "next"
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00de: pop
-		IL_00df: ldloc.3
-		IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e5: stloc.s 36
-		IL_00e7: ldloc.s 36
-		IL_00e9: ldstr "next"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00f3: pop
-		IL_00f4: ldloc.3
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00fa: stloc.s 36
-		IL_00fc: ldloc.s 36
-		IL_00fe: ldstr "next"
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0108: stloc.s 36
-		IL_010a: ldloc.s 36
-		IL_010c: ldstr "done"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0116: stloc.s 36
-		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011d: ldloc.s 36
-		IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0124: pop
-		IL_0125: ldloc.2
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_012b: stloc.s 36
-		IL_012d: ldloc.s 36
-		IL_012f: ldstr "getClosed"
-		IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0139: stloc.s 36
-		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0140: ldloc.s 36
-		IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0147: pop
-		IL_0148: ldloc.0
-		IL_0149: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_014e: ldnull
-		IL_014f: ldc.r8 2
-		IL_0158: box [System.Runtime]System.Double
-		IL_015d: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_0162: stloc.s 36
-		IL_0164: ldloc.s 36
-		IL_0166: stloc.s 4
-		IL_0168: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0172: stloc.s 36
-		IL_0174: ldloc.s 36
-		IL_0176: ldstr "from"
-		IL_017b: ldloc.s 4
-		IL_017d: ldstr "iterable"
-		IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_018c: stloc.s 36
-		IL_018e: ldloc.s 36
-		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0195: stloc.s 36
-		IL_0197: ldnull
-		IL_0198: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68::__js_call__(object, object)
-		IL_019e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_01a3: ldc.i4.1
-		IL_01a4: newarr [System.Runtime]System.Object
-		IL_01a9: dup
-		IL_01aa: ldc.i4.0
-		IL_01ab: ldloc.0
-		IL_01ac: stelem.ref
-		IL_01ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01b7: ldc.i4.1
-		IL_01b8: conv.r8
-		IL_01b9: ldstr ""
-		IL_01be: ldc.i4.0
-		IL_01bf: ldc.i4.1
-		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01ca: stloc.s 35
-		IL_01cc: ldloc.s 36
-		IL_01ce: ldstr "map"
-		IL_01d3: ldloc.s 35
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_01da: stloc.s 35
-		IL_01dc: ldloc.s 35
-		IL_01de: stloc.s 5
+		IL_0035: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003a: stloc.s 36
+		IL_003c: ldloc.1
+		IL_003d: ldloc.s 36
+		IL_003f: ldc.r8 2
+		IL_0048: box [System.Runtime]System.Double
+		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0052: stloc.s 35
+		IL_0054: ldloc.s 35
+		IL_0056: stloc.2
+		IL_0057: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0061: stloc.s 35
+		IL_0063: ldloc.s 35
+		IL_0065: ldstr "from"
+		IL_006a: ldloc.2
+		IL_006b: ldstr "iterable"
+		IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007a: stloc.s 35
+		IL_007c: ldloc.s 35
+		IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0083: stloc.s 35
+		IL_0085: ldnull
+		IL_0086: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L28C56::__js_call__(object, object)
+		IL_008c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0091: ldc.i4.1
+		IL_0092: newarr [System.Runtime]System.Object
+		IL_0097: dup
+		IL_0098: ldc.i4.0
+		IL_0099: ldloc.0
+		IL_009a: stelem.ref
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00a5: ldc.i4.1
+		IL_00a6: conv.r8
+		IL_00a7: ldstr ""
+		IL_00ac: ldc.i4.0
+		IL_00ad: ldc.i4.1
+		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_00b8: stloc.s 37
+		IL_00ba: ldloc.s 35
+		IL_00bc: ldstr "map"
+		IL_00c1: ldloc.s 37
+		IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00c8: stloc.s 37
+		IL_00ca: ldloc.s 37
+		IL_00cc: stloc.3
+		IL_00cd: ldloc.3
+		IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00d3: stloc.s 37
+		IL_00d5: ldloc.s 37
+		IL_00d7: ldstr "next"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00e1: pop
+		IL_00e2: ldloc.3
+		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e8: stloc.s 37
+		IL_00ea: ldloc.s 37
+		IL_00ec: ldstr "next"
+		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00f6: pop
+		IL_00f7: ldloc.3
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fd: stloc.s 37
+		IL_00ff: ldloc.s 37
+		IL_0101: ldstr "next"
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_010b: stloc.s 37
+		IL_010d: ldloc.s 37
+		IL_010f: ldstr "done"
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0119: stloc.s 37
+		IL_011b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0120: ldloc.s 37
+		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0127: pop
+		IL_0128: ldloc.2
+		IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012e: stloc.s 37
+		IL_0130: ldloc.s 37
+		IL_0132: ldstr "getClosed"
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_013c: stloc.s 37
+		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0143: ldloc.s 37
+		IL_0145: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014a: pop
+		IL_014b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0150: stloc.s 36
+		IL_0152: ldloc.1
+		IL_0153: ldloc.s 36
+		IL_0155: ldc.r8 2
+		IL_015e: box [System.Runtime]System.Double
+		IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0168: stloc.s 37
+		IL_016a: ldloc.s 37
+		IL_016c: stloc.s 4
+		IL_016e: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0178: stloc.s 37
+		IL_017a: ldloc.s 37
+		IL_017c: ldstr "from"
+		IL_0181: ldloc.s 4
+		IL_0183: ldstr "iterable"
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0192: stloc.s 37
+		IL_0194: ldloc.s 37
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_019b: stloc.s 37
+		IL_019d: ldnull
+		IL_019e: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L35C68::__js_call__(object, object)
+		IL_01a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_01a9: ldc.i4.1
+		IL_01aa: newarr [System.Runtime]System.Object
+		IL_01af: dup
+		IL_01b0: ldc.i4.0
+		IL_01b1: ldloc.0
+		IL_01b2: stelem.ref
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01bd: ldc.i4.1
+		IL_01be: conv.r8
+		IL_01bf: ldstr ""
+		IL_01c4: ldc.i4.0
+		IL_01c5: ldc.i4.1
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_01d0: stloc.s 35
+		IL_01d2: ldloc.s 37
+		IL_01d4: ldstr "map"
+		IL_01d9: ldloc.s 35
+		IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_01e0: stloc.s 35
+		IL_01e2: ldloc.s 35
+		IL_01e4: stloc.s 5
 		.try
 		{
-			IL_01e0: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L38C4::.ctor()
-			IL_01e5: stloc.s 6
-			IL_01e7: ldloc.s 5
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01ee: stloc.s 35
-			IL_01f0: ldloc.s 35
-			IL_01f2: ldstr "next"
-			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_01fc: pop
-			IL_01fd: leave IL_0244
+			IL_01e6: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L38C4::.ctor()
+			IL_01eb: stloc.s 6
+			IL_01ed: ldloc.s 5
+			IL_01ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f4: stloc.s 35
+			IL_01f6: ldloc.s 35
+			IL_01f8: ldstr "next"
+			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0202: pop
+			IL_0203: leave IL_024a
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0202: stloc.s 7
-			IL_0204: ldloc.s 7
-			IL_0206: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_020b: dup
-			IL_020c: brtrue IL_0222
+			IL_0208: stloc.s 7
+			IL_020a: ldloc.s 7
+			IL_020c: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0211: dup
+			IL_0212: brtrue IL_0228
 
-			IL_0211: pop
-			IL_0212: ldloc.s 7
-			IL_0214: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0219: dup
-			IL_021a: brtrue IL_022e
+			IL_0217: pop
+			IL_0218: ldloc.s 7
+			IL_021a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_021f: dup
+			IL_0220: brtrue IL_0234
 
-			IL_021f: pop
-			IL_0220: rethrow
+			IL_0225: pop
+			IL_0226: rethrow
 
-			IL_0222: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0227: stloc.s 8
-			IL_0229: br IL_0230
+			IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_022d: stloc.s 8
+			IL_022f: br IL_0236
 
-			IL_022e: stloc.s 8
+			IL_0234: stloc.s 8
 
-			IL_0230: ldloc.s 8
-			IL_0232: stloc.s 35
-			IL_0234: ldloc.s 35
-			IL_0236: stloc.s 9
-			IL_0238: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L40C16::.ctor()
-			IL_023d: stloc.s 10
-			IL_023f: leave IL_0244
+			IL_0236: ldloc.s 8
+			IL_0238: stloc.s 35
+			IL_023a: ldloc.s 35
+			IL_023c: stloc.s 9
+			IL_023e: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L40C16::.ctor()
+			IL_0243: stloc.s 10
+			IL_0245: leave IL_024a
 		} // end handler
 
-		IL_0244: ldloc.s 4
-		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024b: stloc.s 35
-		IL_024d: ldloc.s 35
-		IL_024f: ldstr "getClosed"
-		IL_0254: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0259: stloc.s 35
-		IL_025b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0260: ldloc.s 35
-		IL_0262: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0267: pop
-		IL_0268: ldloc.0
-		IL_0269: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_026e: ldnull
-		IL_026f: ldc.r8 2
-		IL_0278: box [System.Runtime]System.Double
-		IL_027d: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_0282: stloc.s 35
-		IL_0284: ldloc.s 35
-		IL_0286: stloc.s 11
-		IL_0288: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0292: stloc.s 35
-		IL_0294: ldloc.s 35
-		IL_0296: ldstr "from"
-		IL_029b: ldloc.s 11
-		IL_029d: ldstr "iterable"
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02ac: stloc.s 35
-		IL_02ae: ldloc.s 35
-		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_024a: ldloc.s 4
+		IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0251: stloc.s 35
+		IL_0253: ldloc.s 35
+		IL_0255: ldstr "getClosed"
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_025f: stloc.s 35
+		IL_0261: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0266: ldloc.s 35
+		IL_0268: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_026d: pop
+		IL_026e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0273: stloc.s 36
+		IL_0275: ldloc.1
+		IL_0276: ldloc.s 36
+		IL_0278: ldc.r8 2
+		IL_0281: box [System.Runtime]System.Double
+		IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_028b: stloc.s 35
+		IL_028d: ldloc.s 35
+		IL_028f: stloc.s 11
+		IL_0291: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_029b: stloc.s 35
+		IL_029d: ldloc.s 35
+		IL_029f: ldstr "from"
+		IL_02a4: ldloc.s 11
+		IL_02a6: ldstr "iterable"
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
 		IL_02b5: stloc.s 35
-		IL_02b7: ldnull
-		IL_02b8: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77::__js_call__(object, object)
-		IL_02be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_02c3: ldc.i4.1
-		IL_02c4: newarr [System.Runtime]System.Object
-		IL_02c9: dup
-		IL_02ca: ldc.i4.0
-		IL_02cb: ldloc.0
-		IL_02cc: stelem.ref
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02d7: ldc.i4.1
-		IL_02d8: conv.r8
-		IL_02d9: ldstr ""
-		IL_02de: ldc.i4.0
-		IL_02df: ldc.i4.1
-		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02ea: stloc.s 36
-		IL_02ec: ldloc.s 35
-		IL_02ee: ldstr "filter"
-		IL_02f3: ldloc.s 36
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_02fa: stloc.s 36
-		IL_02fc: ldloc.s 36
-		IL_02fe: stloc.s 12
+		IL_02b7: ldloc.s 35
+		IL_02b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02be: stloc.s 35
+		IL_02c0: ldnull
+		IL_02c1: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L45C77::__js_call__(object, object)
+		IL_02c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_02cc: ldc.i4.1
+		IL_02cd: newarr [System.Runtime]System.Object
+		IL_02d2: dup
+		IL_02d3: ldc.i4.0
+		IL_02d4: ldloc.0
+		IL_02d5: stelem.ref
+		IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02e0: ldc.i4.1
+		IL_02e1: conv.r8
+		IL_02e2: ldstr ""
+		IL_02e7: ldc.i4.0
+		IL_02e8: ldc.i4.1
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_02f3: stloc.s 37
+		IL_02f5: ldloc.s 35
+		IL_02f7: ldstr "filter"
+		IL_02fc: ldloc.s 37
+		IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0303: stloc.s 37
+		IL_0305: ldloc.s 37
+		IL_0307: stloc.s 12
 		.try
 		{
-			IL_0300: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L48C4::.ctor()
-			IL_0305: stloc.s 13
-			IL_0307: ldloc.s 12
-			IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_030e: stloc.s 36
-			IL_0310: ldloc.s 36
-			IL_0312: ldstr "next"
-			IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_031c: pop
-			IL_031d: leave IL_0364
+			IL_0309: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L48C4::.ctor()
+			IL_030e: stloc.s 13
+			IL_0310: ldloc.s 12
+			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0317: stloc.s 37
+			IL_0319: ldloc.s 37
+			IL_031b: ldstr "next"
+			IL_0320: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0325: pop
+			IL_0326: leave IL_036d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0322: stloc.s 14
-			IL_0324: ldloc.s 14
-			IL_0326: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_032b: dup
-			IL_032c: brtrue IL_0342
+			IL_032b: stloc.s 14
+			IL_032d: ldloc.s 14
+			IL_032f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0334: dup
+			IL_0335: brtrue IL_034b
 
-			IL_0331: pop
-			IL_0332: ldloc.s 14
-			IL_0334: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0339: dup
-			IL_033a: brtrue IL_034e
+			IL_033a: pop
+			IL_033b: ldloc.s 14
+			IL_033d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0342: dup
+			IL_0343: brtrue IL_0357
 
-			IL_033f: pop
-			IL_0340: rethrow
+			IL_0348: pop
+			IL_0349: rethrow
 
-			IL_0342: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0347: stloc.s 15
-			IL_0349: br IL_0350
+			IL_034b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0350: stloc.s 15
+			IL_0352: br IL_0359
 
-			IL_034e: stloc.s 15
+			IL_0357: stloc.s 15
 
-			IL_0350: ldloc.s 15
-			IL_0352: stloc.s 36
-			IL_0354: ldloc.s 36
-			IL_0356: stloc.s 16
-			IL_0358: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L50C16::.ctor()
-			IL_035d: stloc.s 17
-			IL_035f: leave IL_0364
+			IL_0359: ldloc.s 15
+			IL_035b: stloc.s 37
+			IL_035d: ldloc.s 37
+			IL_035f: stloc.s 16
+			IL_0361: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L50C16::.ctor()
+			IL_0366: stloc.s 17
+			IL_0368: leave IL_036d
 		} // end handler
 
-		IL_0364: ldloc.s 11
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_036b: stloc.s 36
-		IL_036d: ldloc.s 36
-		IL_036f: ldstr "getClosed"
-		IL_0374: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0379: stloc.s 36
-		IL_037b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0380: ldloc.s 36
-		IL_0382: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0387: pop
-		IL_0388: ldloc.0
-		IL_0389: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_038e: ldnull
-		IL_038f: ldc.r8 3
-		IL_0398: box [System.Runtime]System.Double
-		IL_039d: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_03a2: stloc.s 36
-		IL_03a4: ldloc.s 36
-		IL_03a6: stloc.s 18
-		IL_03a8: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b2: stloc.s 36
-		IL_03b4: ldloc.s 36
-		IL_03b6: ldstr "from"
-		IL_03bb: ldloc.s 18
-		IL_03bd: ldstr "iterable"
-		IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03cc: stloc.s 36
-		IL_03ce: ldloc.s 36
-		IL_03d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d5: stloc.s 36
-		IL_03d7: ldloc.s 36
-		IL_03d9: ldstr "take"
-		IL_03de: ldc.r8 0.0
-		IL_03e7: box [System.Runtime]System.Double
-		IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_03f1: stloc.s 36
-		IL_03f3: ldloc.s 36
-		IL_03f5: stloc.s 19
-		IL_03f7: ldloc.s 19
-		IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03fe: stloc.s 36
-		IL_0400: ldloc.s 36
-		IL_0402: ldstr "next"
-		IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_040c: stloc.s 36
-		IL_040e: ldloc.s 36
-		IL_0410: ldstr "done"
-		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_041a: stloc.s 36
-		IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0421: ldloc.s 36
-		IL_0423: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0428: pop
-		IL_0429: ldloc.s 18
-		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0430: stloc.s 36
-		IL_0432: ldloc.s 36
-		IL_0434: ldstr "getClosed"
-		IL_0439: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_043e: stloc.s 36
-		IL_0440: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0445: ldloc.s 36
-		IL_0447: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_044c: pop
-		IL_044d: ldloc.0
-		IL_044e: ldc.r8 0.0
-		IL_0457: box [System.Runtime]System.Double
-		IL_045c: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_0461: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_046b: stloc.s 36
-		IL_046d: ldloc.s 36
-		IL_046f: ldstr "from"
-		IL_0474: ldc.i4.1
-		IL_0475: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_047a: dup
-		IL_047b: ldc.r8 1
-		IL_0484: box [System.Runtime]System.Double
-		IL_0489: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0493: stloc.s 36
-		IL_0495: ldloc.s 36
-		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_049c: stloc.s 36
-		IL_049e: ldc.i4.1
-		IL_049f: newarr [System.Runtime]System.Object
-		IL_04a4: dup
-		IL_04a5: ldc.i4.0
-		IL_04a6: ldloc.0
-		IL_04a7: stelem.ref
-		IL_04a8: ldc.i4.0
-		IL_04a9: ldelem.ref
-		IL_04aa: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_04af: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_04b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_04ba: ldc.i4.1
-		IL_04bb: newarr [System.Runtime]System.Object
-		IL_04c0: dup
-		IL_04c1: ldc.i4.0
-		IL_04c2: ldloc.0
-		IL_04c3: stelem.ref
-		IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_04ce: ldc.i4.1
-		IL_04cf: conv.r8
-		IL_04d0: ldstr ""
-		IL_04d5: ldc.i4.0
-		IL_04d6: ldc.i4.1
-		IL_04d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04dc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_04e1: stloc.s 35
-		IL_04e3: ldloc.s 36
-		IL_04e5: ldstr "flatMap"
-		IL_04ea: ldloc.s 35
-		IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04f1: stloc.s 35
-		IL_04f3: ldloc.s 35
-		IL_04f5: stloc.s 20
-		IL_04f7: ldloc.s 20
-		IL_04f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04fe: stloc.s 35
-		IL_0500: ldloc.s 35
-		IL_0502: ldstr "next"
-		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_050c: pop
-		IL_050d: ldloc.s 20
-		IL_050f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0514: stloc.s 35
-		IL_0516: ldloc.s 35
-		IL_0518: ldstr "next"
-		IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0522: stloc.s 35
-		IL_0524: ldloc.s 35
-		IL_0526: ldstr "done"
-		IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0530: stloc.s 35
-		IL_0532: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0537: ldloc.s 35
-		IL_0539: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_053e: pop
-		IL_053f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0544: ldloc.0
-		IL_0545: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
-		IL_054a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_054f: pop
+		IL_036d: ldloc.s 11
+		IL_036f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0374: stloc.s 37
+		IL_0376: ldloc.s 37
+		IL_0378: ldstr "getClosed"
+		IL_037d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0382: stloc.s 37
+		IL_0384: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0389: ldloc.s 37
+		IL_038b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0390: pop
+		IL_0391: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0396: stloc.s 36
+		IL_0398: ldloc.1
+		IL_0399: ldloc.s 36
+		IL_039b: ldc.r8 3
+		IL_03a4: box [System.Runtime]System.Double
+		IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03ae: stloc.s 37
+		IL_03b0: ldloc.s 37
+		IL_03b2: stloc.s 18
+		IL_03b4: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03be: stloc.s 37
+		IL_03c0: ldloc.s 37
+		IL_03c2: ldstr "from"
+		IL_03c7: ldloc.s 18
+		IL_03c9: ldstr "iterable"
+		IL_03ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03d8: stloc.s 37
+		IL_03da: ldloc.s 37
+		IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e1: stloc.s 37
+		IL_03e3: ldloc.s 37
+		IL_03e5: ldstr "take"
+		IL_03ea: ldc.r8 0.0
+		IL_03f3: box [System.Runtime]System.Double
+		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_03fd: stloc.s 37
+		IL_03ff: ldloc.s 37
+		IL_0401: stloc.s 19
+		IL_0403: ldloc.s 19
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_040a: stloc.s 37
+		IL_040c: ldloc.s 37
+		IL_040e: ldstr "next"
+		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0418: stloc.s 37
+		IL_041a: ldloc.s 37
+		IL_041c: ldstr "done"
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0426: stloc.s 37
+		IL_0428: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_042d: ldloc.s 37
+		IL_042f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0434: pop
+		IL_0435: ldloc.s 18
+		IL_0437: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_043c: stloc.s 37
+		IL_043e: ldloc.s 37
+		IL_0440: ldstr "getClosed"
+		IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_044a: stloc.s 37
+		IL_044c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0451: ldloc.s 37
+		IL_0453: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0458: pop
+		IL_0459: ldloc.0
+		IL_045a: ldc.r8 0.0
+		IL_0463: box [System.Runtime]System.Double
+		IL_0468: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_046d: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0477: stloc.s 37
+		IL_0479: ldloc.s 37
+		IL_047b: ldstr "from"
+		IL_0480: ldc.i4.1
+		IL_0481: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0486: dup
+		IL_0487: ldc.r8 1
+		IL_0490: box [System.Runtime]System.Double
+		IL_0495: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_049a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_049f: stloc.s 37
+		IL_04a1: ldloc.s 37
+		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04a8: stloc.s 37
+		IL_04aa: ldc.i4.1
+		IL_04ab: newarr [System.Runtime]System.Object
+		IL_04b0: dup
+		IL_04b1: ldc.i4.0
+		IL_04b2: ldloc.0
+		IL_04b3: stelem.ref
+		IL_04b4: ldc.i4.0
+		IL_04b5: ldelem.ref
+		IL_04b6: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_04bb: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_04c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_04c6: ldc.i4.1
+		IL_04c7: newarr [System.Runtime]System.Object
+		IL_04cc: dup
+		IL_04cd: ldc.i4.0
+		IL_04ce: ldloc.0
+		IL_04cf: stelem.ref
+		IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_04da: ldc.i4.1
+		IL_04db: conv.r8
+		IL_04dc: ldstr ""
+		IL_04e1: ldc.i4.0
+		IL_04e2: ldc.i4.1
+		IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_04ed: stloc.s 35
+		IL_04ef: ldloc.s 37
+		IL_04f1: ldstr "flatMap"
+		IL_04f6: ldloc.s 35
+		IL_04f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04fd: stloc.s 35
+		IL_04ff: ldloc.s 35
+		IL_0501: stloc.s 20
+		IL_0503: ldloc.s 20
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_050a: stloc.s 35
+		IL_050c: ldloc.s 35
+		IL_050e: ldstr "next"
+		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0518: pop
+		IL_0519: ldloc.s 20
+		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0520: stloc.s 35
+		IL_0522: ldloc.s 35
+		IL_0524: ldstr "next"
+		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_052e: stloc.s 35
+		IL_0530: ldloc.s 35
+		IL_0532: ldstr "done"
+		IL_0537: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_053c: stloc.s 35
+		IL_053e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0543: ldloc.s 35
+		IL_0545: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_054a: pop
+		IL_054b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0550: ldloc.0
-		IL_0551: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0556: ldnull
-		IL_0557: ldc.r8 2
-		IL_0560: box [System.Runtime]System.Double
-		IL_0565: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_056a: stloc.s 35
-		IL_056c: ldloc.s 35
-		IL_056e: stloc.s 21
-		IL_0570: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_057a: stloc.s 35
-		IL_057c: ldloc.s 35
-		IL_057e: ldstr "from"
-		IL_0583: ldloc.s 21
-		IL_0585: ldstr "iterable"
-		IL_058a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0594: stloc.s 35
-		IL_0596: ldloc.s 35
-		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_059d: stloc.s 35
-		IL_059f: ldnull
-		IL_05a0: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74::__js_call__(object, object)
-		IL_05a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_05ab: ldc.i4.1
-		IL_05ac: newarr [System.Runtime]System.Object
-		IL_05b1: dup
-		IL_05b2: ldc.i4.0
-		IL_05b3: ldloc.0
-		IL_05b4: stelem.ref
-		IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_05ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_05bf: ldc.i4.1
-		IL_05c0: conv.r8
-		IL_05c1: ldstr ""
-		IL_05c6: ldc.i4.0
-		IL_05c7: ldc.i4.1
-		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_05d2: stloc.s 36
-		IL_05d4: ldloc.s 35
-		IL_05d6: ldstr "flatMap"
-		IL_05db: ldloc.s 36
-		IL_05dd: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_05e2: stloc.s 36
-		IL_05e4: ldloc.s 36
-		IL_05e6: stloc.s 22
+		IL_0551: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatInnerClosed
+		IL_0556: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_055b: pop
+		IL_055c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0561: stloc.s 36
+		IL_0563: ldloc.1
+		IL_0564: ldloc.s 36
+		IL_0566: ldc.r8 2
+		IL_056f: box [System.Runtime]System.Double
+		IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0579: stloc.s 35
+		IL_057b: ldloc.s 35
+		IL_057d: stloc.s 21
+		IL_057f: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0589: stloc.s 35
+		IL_058b: ldloc.s 35
+		IL_058d: ldstr "from"
+		IL_0592: ldloc.s 21
+		IL_0594: ldstr "iterable"
+		IL_0599: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05a3: stloc.s 35
+		IL_05a5: ldloc.s 35
+		IL_05a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05ac: stloc.s 35
+		IL_05ae: ldnull
+		IL_05af: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L84C74::__js_call__(object, object)
+		IL_05b5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_05ba: ldc.i4.1
+		IL_05bb: newarr [System.Runtime]System.Object
+		IL_05c0: dup
+		IL_05c1: ldc.i4.0
+		IL_05c2: ldloc.0
+		IL_05c3: stelem.ref
+		IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_05c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_05ce: ldc.i4.1
+		IL_05cf: conv.r8
+		IL_05d0: ldstr ""
+		IL_05d5: ldc.i4.0
+		IL_05d6: ldc.i4.1
+		IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_05dc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_05e1: stloc.s 37
+		IL_05e3: ldloc.s 35
+		IL_05e5: ldstr "flatMap"
+		IL_05ea: ldloc.s 37
+		IL_05ec: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_05f1: stloc.s 37
+		IL_05f3: ldloc.s 37
+		IL_05f5: stloc.s 22
 		.try
 		{
-			IL_05e8: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L87C4::.ctor()
-			IL_05ed: stloc.s 23
-			IL_05ef: ldloc.s 22
-			IL_05f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05f6: stloc.s 36
-			IL_05f8: ldloc.s 36
-			IL_05fa: ldstr "next"
-			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0604: pop
-			IL_0605: leave IL_064c
+			IL_05f7: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L87C4::.ctor()
+			IL_05fc: stloc.s 23
+			IL_05fe: ldloc.s 22
+			IL_0600: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0605: stloc.s 37
+			IL_0607: ldloc.s 37
+			IL_0609: ldstr "next"
+			IL_060e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0613: pop
+			IL_0614: leave IL_065b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_060a: stloc.s 24
-			IL_060c: ldloc.s 24
-			IL_060e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0613: dup
-			IL_0614: brtrue IL_062a
+			IL_0619: stloc.s 24
+			IL_061b: ldloc.s 24
+			IL_061d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0622: dup
+			IL_0623: brtrue IL_0639
 
-			IL_0619: pop
-			IL_061a: ldloc.s 24
-			IL_061c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0621: dup
-			IL_0622: brtrue IL_0636
+			IL_0628: pop
+			IL_0629: ldloc.s 24
+			IL_062b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0630: dup
+			IL_0631: brtrue IL_0645
 
-			IL_0627: pop
-			IL_0628: rethrow
+			IL_0636: pop
+			IL_0637: rethrow
 
-			IL_062a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_062f: stloc.s 25
-			IL_0631: br IL_0638
+			IL_0639: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_063e: stloc.s 25
+			IL_0640: br IL_0647
 
-			IL_0636: stloc.s 25
+			IL_0645: stloc.s 25
 
-			IL_0638: ldloc.s 25
-			IL_063a: stloc.s 36
-			IL_063c: ldloc.s 36
-			IL_063e: stloc.s 26
-			IL_0640: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L89C16::.ctor()
-			IL_0645: stloc.s 27
-			IL_0647: leave IL_064c
+			IL_0647: ldloc.s 25
+			IL_0649: stloc.s 37
+			IL_064b: ldloc.s 37
+			IL_064d: stloc.s 26
+			IL_064f: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L89C16::.ctor()
+			IL_0654: stloc.s 27
+			IL_0656: leave IL_065b
 		} // end handler
 
-		IL_064c: ldloc.s 21
-		IL_064e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0653: stloc.s 36
-		IL_0655: ldloc.s 36
-		IL_0657: ldstr "getClosed"
-		IL_065c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0661: stloc.s 36
-		IL_0663: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0668: ldloc.s 36
-		IL_066a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_066f: pop
-		IL_0670: ldloc.0
-		IL_0671: ldc.r8 0.0
-		IL_067a: box [System.Runtime]System.Double
-		IL_067f: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_0684: ldloc.0
-		IL_0685: ldc.r8 0.0
-		IL_068e: box [System.Runtime]System.Double
-		IL_0693: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_0698: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
-		IL_069d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06a2: stloc.s 36
-		IL_06a4: ldstr "iterator"
-		IL_06a9: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
-		IL_06ae: stloc.s 35
-		IL_06b0: ldc.i4.1
-		IL_06b1: newarr [System.Runtime]System.Object
-		IL_06b6: dup
-		IL_06b7: ldc.i4.0
-		IL_06b8: ldloc.0
-		IL_06b9: stelem.ref
-		IL_06ba: ldc.i4.0
-		IL_06bb: ldelem.ref
-		IL_06bc: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_06c1: ldftn object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
-		IL_06c7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_06cc: ldc.i4.0
-		IL_06cd: conv.r8
-		IL_06ce: ldstr ""
-		IL_06d3: ldc.i4.0
-		IL_06d4: ldc.i4.1
-		IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_06da: stloc.s 37
-		IL_06dc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_06e1: stloc.s 38
-		IL_06e3: ldloc.s 38
-		IL_06e5: ldloc.s 35
-		IL_06e7: ldloc.s 37
-		IL_06e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_06ee: pop
-		IL_06ef: ldloc.s 36
-		IL_06f1: ldstr "from"
+		IL_065b: ldloc.s 21
+		IL_065d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0662: stloc.s 37
+		IL_0664: ldloc.s 37
+		IL_0666: ldstr "getClosed"
+		IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0670: stloc.s 37
+		IL_0672: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0677: ldloc.s 37
+		IL_0679: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_067e: pop
+		IL_067f: ldloc.0
+		IL_0680: ldc.r8 0.0
+		IL_0689: box [System.Runtime]System.Double
+		IL_068e: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_0693: ldloc.0
+		IL_0694: ldc.r8 0.0
+		IL_069d: box [System.Runtime]System.Double
+		IL_06a2: stfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_06a7: call class [System.Runtime]System.Func`3<object[], object[], object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Iterator()
+		IL_06ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06b1: stloc.s 37
+		IL_06b3: ldstr "iterator"
+		IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::GetWellKnown(string)
+		IL_06bd: stloc.s 35
+		IL_06bf: ldc.i4.1
+		IL_06c0: newarr [System.Runtime]System.Object
+		IL_06c5: dup
+		IL_06c6: ldc.i4.0
+		IL_06c7: ldloc.0
+		IL_06c8: stelem.ref
+		IL_06c9: ldc.i4.0
+		IL_06ca: ldelem.ref
+		IL_06cb: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_06d0: ldftn object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
+		IL_06d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_06db: ldc.i4.0
+		IL_06dc: conv.r8
+		IL_06dd: ldstr ""
+		IL_06e2: ldc.i4.0
+		IL_06e3: ldc.i4.1
+		IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_06e9: stloc.s 38
+		IL_06eb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06f0: stloc.s 39
+		IL_06f2: ldloc.s 39
+		IL_06f4: ldloc.s 35
 		IL_06f6: ldloc.s 38
-		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_06fd: stloc.s 36
-		IL_06ff: ldloc.s 36
-		IL_0701: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0706: stloc.s 36
-		IL_0708: ldc.i4.1
-		IL_0709: newarr [System.Runtime]System.Object
-		IL_070e: dup
-		IL_070f: ldc.i4.0
-		IL_0710: ldloc.0
-		IL_0711: stelem.ref
-		IL_0712: ldc.i4.0
-		IL_0713: ldelem.ref
-		IL_0714: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0719: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_071f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0724: ldc.i4.1
-		IL_0725: newarr [System.Runtime]System.Object
-		IL_072a: dup
-		IL_072b: ldc.i4.0
-		IL_072c: ldloc.0
-		IL_072d: stelem.ref
-		IL_072e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0738: ldc.i4.1
-		IL_0739: conv.r8
-		IL_073a: ldstr ""
-		IL_073f: ldc.i4.0
-		IL_0740: ldc.i4.1
-		IL_0741: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0746: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_074b: stloc.s 37
-		IL_074d: ldloc.s 36
-		IL_074f: ldstr "flatMap"
-		IL_0754: ldloc.s 37
-		IL_0756: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_075b: stloc.s 37
-		IL_075d: ldloc.s 37
-		IL_075f: stloc.s 28
+		IL_06f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_06fd: pop
+		IL_06fe: ldloc.s 37
+		IL_0700: ldstr "from"
+		IL_0705: ldloc.s 39
+		IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_070c: stloc.s 37
+		IL_070e: ldloc.s 37
+		IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0715: stloc.s 37
+		IL_0717: ldc.i4.1
+		IL_0718: newarr [System.Runtime]System.Object
+		IL_071d: dup
+		IL_071e: ldc.i4.0
+		IL_071f: ldloc.0
+		IL_0720: stelem.ref
+		IL_0721: ldc.i4.0
+		IL_0722: ldelem.ref
+		IL_0723: castclass Modules.Iterator_Helper_Cleanup/Scope
+		IL_0728: ldftn object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+		IL_072e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0733: ldc.i4.1
+		IL_0734: newarr [System.Runtime]System.Object
+		IL_0739: dup
+		IL_073a: ldc.i4.0
+		IL_073b: ldloc.0
+		IL_073c: stelem.ref
+		IL_073d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0742: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0747: ldc.i4.1
+		IL_0748: conv.r8
+		IL_0749: ldstr ""
+		IL_074e: ldc.i4.0
+		IL_074f: ldc.i4.1
+		IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0755: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_075a: stloc.s 38
+		IL_075c: ldloc.s 37
+		IL_075e: ldstr "flatMap"
+		IL_0763: ldloc.s 38
+		IL_0765: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_076a: stloc.s 38
+		IL_076c: ldloc.s 38
+		IL_076e: stloc.s 28
 		.try
 		{
-			IL_0761: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L126C4::.ctor()
-			IL_0766: stloc.s 29
-			IL_0768: ldloc.s 28
-			IL_076a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_076f: stloc.s 37
-			IL_0771: ldloc.s 37
-			IL_0773: ldstr "next"
-			IL_0778: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_077d: pop
-			IL_077e: ldloc.s 28
-			IL_0780: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0785: stloc.s 37
-			IL_0787: ldloc.s 37
-			IL_0789: ldstr "next"
-			IL_078e: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0793: pop
-			IL_0794: leave IL_07db
+			IL_0770: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L126C4::.ctor()
+			IL_0775: stloc.s 29
+			IL_0777: ldloc.s 28
+			IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_077e: stloc.s 38
+			IL_0780: ldloc.s 38
+			IL_0782: ldstr "next"
+			IL_0787: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_078c: pop
+			IL_078d: ldloc.s 28
+			IL_078f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0794: stloc.s 38
+			IL_0796: ldloc.s 38
+			IL_0798: ldstr "next"
+			IL_079d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_07a2: pop
+			IL_07a3: leave IL_07ea
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0799: stloc.s 30
-			IL_079b: ldloc.s 30
-			IL_079d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_07a2: dup
-			IL_07a3: brtrue IL_07b9
+			IL_07a8: stloc.s 30
+			IL_07aa: ldloc.s 30
+			IL_07ac: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07b1: dup
+			IL_07b2: brtrue IL_07c8
 
-			IL_07a8: pop
-			IL_07a9: ldloc.s 30
-			IL_07ab: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_07b0: dup
-			IL_07b1: brtrue IL_07c5
+			IL_07b7: pop
+			IL_07b8: ldloc.s 30
+			IL_07ba: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07bf: dup
+			IL_07c0: brtrue IL_07d4
 
-			IL_07b6: pop
-			IL_07b7: rethrow
+			IL_07c5: pop
+			IL_07c6: rethrow
 
-			IL_07b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_07be: stloc.s 31
-			IL_07c0: br IL_07c7
+			IL_07c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07cd: stloc.s 31
+			IL_07cf: br IL_07d6
 
-			IL_07c5: stloc.s 31
+			IL_07d4: stloc.s 31
 
-			IL_07c7: ldloc.s 31
-			IL_07c9: stloc.s 37
-			IL_07cb: ldloc.s 37
-			IL_07cd: stloc.s 32
-			IL_07cf: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L129C16::.ctor()
-			IL_07d4: stloc.s 33
-			IL_07d6: leave IL_07db
+			IL_07d6: ldloc.s 31
+			IL_07d8: stloc.s 38
+			IL_07da: ldloc.s 38
+			IL_07dc: stloc.s 32
+			IL_07de: newobj instance void Modules.Iterator_Helper_Cleanup/Scope/Block_L129C16::.ctor()
+			IL_07e3: stloc.s 33
+			IL_07e5: leave IL_07ea
 		} // end handler
 
-		IL_07db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07e0: ldloc.0
-		IL_07e1: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
-		IL_07e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07eb: pop
-		IL_07ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07f1: ldloc.0
-		IL_07f2: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
-		IL_07f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_07fc: pop
-		IL_07fd: ldnull
-		IL_07fe: stloc.s 34
-		IL_0800: ret
+		IL_07ea: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_07ef: ldloc.0
+		IL_07f0: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowOuterClosed
+		IL_07f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_07fa: pop
+		IL_07fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0800: ldloc.0
+		IL_0801: ldfld object Modules.Iterator_Helper_Cleanup/Scope::flatThrowInnerClosed
+		IL_0806: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_080b: pop
+		IL_080c: ldnull
+		IL_080d: stloc.s 34
+		IL_080f: ret
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup
@@ -2738,7 +2744,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x311f
+		// Method begins at RVA 0x312b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216b
+				// Method begins at RVA 0x2177
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20ec
+			// Method begins at RVA 0x20f8
 			// Header size: 12
 			// Code size: 106 (0x6a)
 			.maxstack 8
@@ -112,7 +112,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2162
+			// Method begins at RVA 0x216e
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -138,7 +138,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 143 (0x8f)
+		// Code size: 153 (0x99)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Fround_SignedZero/Scope,
@@ -148,7 +148,8 @@
 			[4] object,
 			[5] float64,
 			[6] object,
-			[7] object
+			[7] object[],
+			[8] object
 		)
 
 		IL_0000: newobj instance void Modules.Math_Fround_SignedZero/Scope::.ctor()
@@ -186,18 +187,21 @@
 		IL_0068: ldloc.s 6
 		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_006f: pop
-		IL_0070: ldloc.3
-		IL_0071: box [System.Runtime]System.Double
-		IL_0076: stloc.s 7
-		IL_0078: ldnull
-		IL_0079: ldloc.3
-		IL_007a: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
-		IL_007f: stloc.s 4
-		IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0086: ldloc.s 4
-		IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008d: pop
-		IL_008e: ret
+		IL_0070: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0075: stloc.s 7
+		IL_0077: ldloc.3
+		IL_0078: box [System.Runtime]System.Double
+		IL_007d: stloc.s 8
+		IL_007f: ldloc.1
+		IL_0080: ldloc.s 7
+		IL_0082: ldloc.s 8
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0089: stloc.s 4
+		IL_008b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0090: ldloc.s 4
+		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0097: pop
+		IL_0098: ret
 	} // end of method Math_Fround_SignedZero::__js_module_init__
 
 } // end of class Modules.Math_Fround_SignedZero
@@ -209,7 +213,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2174
+		// Method begins at RVA 0x2180
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2257
+				// Method begins at RVA 0x2263
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 106 (0x6a)
 			.maxstack 8
@@ -112,7 +112,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x224e
+			// Method begins at RVA 0x225a
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -138,7 +138,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 380 (0x17c)
+		// Code size: 389 (0x185)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Imul_Clz32_Basics/Scope,
@@ -153,8 +153,9 @@
 			[9] float64,
 			[10] object,
 			[11] object,
-			[12] object,
-			[13] object
+			[12] object[],
+			[13] object,
+			[14] object
 		)
 
 		IL_0000: newobj instance void Modules.Math_Imul_Clz32_Basics/Scope::.ctor()
@@ -233,37 +234,40 @@
 		IL_0118: ldstr " "
 		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
 		IL_0122: stloc.s 11
-		IL_0124: ldloc.s 4
-		IL_0126: box [System.Runtime]System.Double
-		IL_012b: stloc.s 10
-		IL_012d: ldnull
-		IL_012e: ldloc.s 4
-		IL_0130: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
-		IL_0135: stloc.s 8
-		IL_0137: ldloc.s 11
-		IL_0139: ldloc.s 8
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_0140: stloc.s 11
-		IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0147: ldloc.s 11
-		IL_0149: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_014e: pop
-		IL_014f: ldloc.s 5
-		IL_0151: box [System.Runtime]System.Double
-		IL_0156: stloc.s 10
-		IL_0158: ldloc.s 6
+		IL_0124: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0129: stloc.s 12
+		IL_012b: ldloc.s 4
+		IL_012d: box [System.Runtime]System.Double
+		IL_0132: stloc.s 10
+		IL_0134: ldloc.1
+		IL_0135: ldloc.s 12
+		IL_0137: ldloc.s 10
+		IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_013e: stloc.s 8
+		IL_0140: ldloc.s 11
+		IL_0142: ldloc.s 8
+		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_0149: stloc.s 11
+		IL_014b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0150: ldloc.s 11
+		IL_0152: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0157: pop
+		IL_0158: ldloc.s 5
 		IL_015a: box [System.Runtime]System.Double
-		IL_015f: stloc.s 12
-		IL_0161: ldloc.s 7
+		IL_015f: stloc.s 10
+		IL_0161: ldloc.s 6
 		IL_0163: box [System.Runtime]System.Double
 		IL_0168: stloc.s 13
-		IL_016a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_016f: ldloc.s 10
-		IL_0171: ldloc.s 12
-		IL_0173: ldloc.s 13
-		IL_0175: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_017a: pop
-		IL_017b: ret
+		IL_016a: ldloc.s 7
+		IL_016c: box [System.Runtime]System.Double
+		IL_0171: stloc.s 14
+		IL_0173: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0178: ldloc.s 10
+		IL_017a: ldloc.s 13
+		IL_017c: ldloc.s 14
+		IL_017e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0183: pop
+		IL_0184: ret
 	} // end of method Math_Imul_Clz32_Basics::__js_module_init__
 
 } // end of class Modules.Math_Imul_Clz32_Basics
@@ -275,7 +279,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2260
+		// Method begins at RVA 0x226c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -29,7 +29,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28e0
+					// Method begins at RVA 0x28f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -100,7 +100,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28e9
+					// Method begins at RVA 0x2901
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -171,7 +171,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28f2
+					// Method begins at RVA 0x290a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -252,7 +252,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x28fb
+					// Method begins at RVA 0x2913
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -279,7 +279,7 @@
 				)
 				// Method begins at RVA 0x2740
 				// Header size: 12
-				// Code size: 200 (0xc8)
+				// Code size: 222 (0xde)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -355,11 +355,25 @@
 				IL_00b8: ldc.i4.0
 				IL_00b9: ldelem.ref
 				IL_00ba: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-				IL_00bf: ldnull
-				IL_00c0: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-				IL_00c5: pop
-				IL_00c6: ldnull
-				IL_00c7: ret
+				IL_00bf: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
+				IL_00c4: ldc.i4.2
+				IL_00c5: newarr [System.Runtime]System.Object
+				IL_00ca: dup
+				IL_00cb: ldc.i4.0
+				IL_00cc: ldarg.0
+				IL_00cd: ldc.i4.0
+				IL_00ce: ldelem.ref
+				IL_00cf: stelem.ref
+				IL_00d0: dup
+				IL_00d1: ldc.i4.1
+				IL_00d2: ldarg.0
+				IL_00d3: ldc.i4.1
+				IL_00d4: ldelem.ref
+				IL_00d5: stelem.ref
+				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_00db: pop
+				IL_00dc: ldnull
+				IL_00dd: ret
 			} // end of method ArrowFunction_L31C23::__js_call__
 
 		} // end of class ArrowFunction_L31C23
@@ -382,7 +396,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28d7
+				// Method begins at RVA 0x28ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -683,7 +697,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x290d
+					// Method begins at RVA 0x2925
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -708,7 +722,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2814
+				// Method begins at RVA 0x282c
 				// Header size: 12
 				// Code size: 82 (0x52)
 				.maxstack 8
@@ -764,7 +778,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2916
+					// Method begins at RVA 0x292e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -788,7 +802,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2872
+				// Method begins at RVA 0x288a
 				// Header size: 1
 				// Code size: 19 (0x13)
 				.maxstack 8
@@ -818,7 +832,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2904
+				// Method begins at RVA 0x291c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1015,7 +1029,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x28ce
+				// Method begins at RVA 0x28e6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1038,7 +1052,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x28c5
+			// Method begins at RVA 0x28dd
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1064,7 +1078,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 158 (0x9e)
+		// Code size: 157 (0x9d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Silent/Scope,
@@ -1133,12 +1147,11 @@
 		IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
 		IL_008f: pop
 
-		IL_0090: ldloc.0
-		IL_0091: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-		IL_0096: ldnull
-		IL_0097: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-		IL_009c: pop
-		IL_009d: ret
+		IL_0090: ldloc.1
+		IL_0091: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_009b: pop
+		IL_009c: ret
 	} // end of method Require_ChildProcess_Fork_Silent::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Silent
@@ -1166,7 +1179,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x293a
+					// Method begins at RVA 0x2952
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1187,7 +1200,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2931
+				// Method begins at RVA 0x2949
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1211,7 +1224,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2888
+			// Method begins at RVA 0x28a0
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -1255,7 +1268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2928
+				// Method begins at RVA 0x2940
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1273,7 +1286,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x291f
+			// Method begins at RVA 0x2937
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1409,7 +1422,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2943
+		// Method begins at RVA 0x295b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Require_Crypto_ErrorPaths
+﻿// IL code: Require_Crypto_ErrorPaths
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3bfb
+					// Method begins at RVA 0x3d2b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3c04
+					// Method begins at RVA 0x3d34
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3bf2
+				// Method begins at RVA 0x3d22
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27dc
+			// Method begins at RVA 0x2880
 			// Header size: 12
 			// Code size: 226 (0xe2)
 			.maxstack 8
@@ -203,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c0d
+				// Method begins at RVA 0x3d3d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -229,7 +229,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x28dc
+			// Method begins at RVA 0x2980
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -264,7 +264,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c16
+				// Method begins at RVA 0x3d46
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -290,7 +290,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2910
+			// Method begins at RVA 0x29b4
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -324,7 +324,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c1f
+				// Method begins at RVA 0x3d4f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -350,7 +350,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x293c
+			// Method begins at RVA 0x29e0
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -386,7 +386,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c28
+				// Method begins at RVA 0x3d58
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -412,7 +412,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2978
+			// Method begins at RVA 0x2a1c
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -447,7 +447,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c31
+				// Method begins at RVA 0x3d61
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -473,7 +473,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x29a8
+			// Method begins at RVA 0x2a4c
 			// Header size: 12
 			// Code size: 37 (0x25)
 			.maxstack 8
@@ -509,7 +509,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c3a
+				// Method begins at RVA 0x3d6a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -535,7 +535,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x29dc
+			// Method begins at RVA 0x2a80
 			// Header size: 12
 			// Code size: 45 (0x2d)
 			.maxstack 8
@@ -571,7 +571,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c43
+				// Method begins at RVA 0x3d73
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -597,7 +597,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a18
+			// Method begins at RVA 0x2abc
 			// Header size: 12
 			// Code size: 82 (0x52)
 			.maxstack 8
@@ -650,7 +650,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c4c
+				// Method begins at RVA 0x3d7c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -676,7 +676,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2a78
+			// Method begins at RVA 0x2b1c
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -733,7 +733,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c55
+				// Method begins at RVA 0x3d85
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -759,7 +759,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2ae0
+			// Method begins at RVA 0x2b84
 			// Header size: 12
 			// Code size: 99 (0x63)
 			.maxstack 8
@@ -817,7 +817,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c5e
+				// Method begins at RVA 0x3d8e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -843,7 +843,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2b50
+			// Method begins at RVA 0x2bf4
 			// Header size: 12
 			// Code size: 91 (0x5b)
 			.maxstack 8
@@ -901,7 +901,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c67
+				// Method begins at RVA 0x3d97
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -927,7 +927,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2bb8
+			// Method begins at RVA 0x2c5c
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -983,7 +983,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c70
+				// Method begins at RVA 0x3da0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1009,7 +1009,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c18
+			// Method begins at RVA 0x2cbc
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1066,7 +1066,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c79
+				// Method begins at RVA 0x3da9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1092,7 +1092,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2c80
+			// Method begins at RVA 0x2d24
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1149,7 +1149,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c82
+				// Method begins at RVA 0x3db2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1175,7 +1175,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2ce8
+			// Method begins at RVA 0x2d8c
 			// Header size: 12
 			// Code size: 90 (0x5a)
 			.maxstack 8
@@ -1232,7 +1232,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c8b
+				// Method begins at RVA 0x3dbb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1258,7 +1258,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2d50
+			// Method begins at RVA 0x2df4
 			// Header size: 12
 			// Code size: 93 (0x5d)
 			.maxstack 8
@@ -1319,7 +1319,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c94
+				// Method begins at RVA 0x3dc4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1345,7 +1345,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2dbc
+			// Method begins at RVA 0x2e60
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -1379,7 +1379,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3c9d
+				// Method begins at RVA 0x3dcd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1405,7 +1405,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2de8
+			// Method begins at RVA 0x2e8c
 			// Header size: 12
 			// Code size: 41 (0x29)
 			.maxstack 8
@@ -1441,7 +1441,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3ca6
+				// Method begins at RVA 0x3dd6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1467,7 +1467,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2e20
+			// Method begins at RVA 0x2ec4
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -1501,7 +1501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3caf
+				// Method begins at RVA 0x3ddf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1527,7 +1527,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 24 00 00 02
 			)
-			// Method begins at RVA 0x2e4c
+			// Method begins at RVA 0x2ef0
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -1575,7 +1575,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3cc1
+					// Method begins at RVA 0x3df1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1595,7 +1595,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3cca
+					// Method begins at RVA 0x3dfa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1619,7 +1619,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cb8
+				// Method begins at RVA 0x3de8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1645,7 +1645,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2e80
+			// Method begins at RVA 0x2f24
 			// Header size: 12
 			// Code size: 486 (0x1e6)
 			.maxstack 8
@@ -1872,7 +1872,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3cdc
+					// Method begins at RVA 0x3e0c
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1896,7 +1896,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x36f8
+				// Method begins at RVA 0x3828
 				// Header size: 12
 				// Code size: 50 (0x32)
 				.maxstack 8
@@ -1938,7 +1938,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3ce5
+					// Method begins at RVA 0x3e15
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1962,7 +1962,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3738
+				// Method begins at RVA 0x3868
 				// Header size: 12
 				// Code size: 135 (0x87)
 				.maxstack 8
@@ -2043,7 +2043,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3cee
+					// Method begins at RVA 0x3e1e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2067,7 +2067,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x37cc
+				// Method begins at RVA 0x38fc
 				// Header size: 12
 				// Code size: 126 (0x7e)
 				.maxstack 9
@@ -2141,7 +2141,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3cf7
+					// Method begins at RVA 0x3e27
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2165,7 +2165,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3858
+				// Method begins at RVA 0x3988
 				// Header size: 12
 				// Code size: 124 (0x7c)
 				.maxstack 8
@@ -2243,7 +2243,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d00
+					// Method begins at RVA 0x3e30
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2267,7 +2267,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x38e0
+				// Method begins at RVA 0x3a10
 				// Header size: 12
 				// Code size: 135 (0x87)
 				.maxstack 8
@@ -2348,7 +2348,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d09
+					// Method begins at RVA 0x3e39
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2372,7 +2372,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3974
+				// Method begins at RVA 0x3aa4
 				// Header size: 12
 				// Code size: 135 (0x87)
 				.maxstack 8
@@ -2453,7 +2453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d12
+					// Method begins at RVA 0x3e42
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2477,7 +2477,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3a08
+				// Method begins at RVA 0x3b38
 				// Header size: 12
 				// Code size: 144 (0x90)
 				.maxstack 8
@@ -2559,7 +2559,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d1b
+					// Method begins at RVA 0x3e4b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2583,7 +2583,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3aa4
+				// Method begins at RVA 0x3bd4
 				// Header size: 12
 				// Code size: 155 (0x9b)
 				.maxstack 8
@@ -2668,7 +2668,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d24
+					// Method begins at RVA 0x3e54
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2692,7 +2692,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3b4c
+				// Method begins at RVA 0x3c7c
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2742,7 +2742,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3d2d
+					// Method begins at RVA 0x3e5d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -2766,7 +2766,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x3b9c
+				// Method begins at RVA 0x3ccc
 				// Header size: 12
 				// Code size: 65 (0x41)
 				.maxstack 8
@@ -2844,7 +2844,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3cd3
+				// Method begins at RVA 0x3e03
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -2868,16 +2868,16 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x3074
+			// Method begins at RVA 0x3118
 			// Header size: 12
-			// Code size: 1635 (0x663)
+			// Code size: 1775 (0x6ef)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope,
-				[1] object,
-				[2] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[4] object[]
+				[1] object[],
+				[2] object,
+				[3] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
 			IL_0000: ldarg.0
@@ -2912,7 +2912,7 @@
 
 			IL_0048: ldloc.0
 			IL_0049: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_004e: switch (IL_0083, IL_011f, IL_019b, IL_0217, IL_0293, IL_030f, IL_038b, IL_0407, IL_0483, IL_052e, IL_05b3, IL_0631)
+			IL_004e: switch (IL_0083, IL_012d, IL_01b7, IL_0241, IL_02cb, IL_0355, IL_03df, IL_0469, IL_04f3, IL_059e, IL_0631, IL_06bd)
 
 			IL_0083: ldloc.0
 			IL_0084: ldarg.0
@@ -2925,626 +2925,624 @@
 			IL_009b: ldstr "subtle"
 			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_00a5: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_00aa: ldnull
-			IL_00ab: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
-			IL_00b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_00b6: ldc.i4.2
-			IL_00b7: newarr [System.Runtime]System.Object
-			IL_00bc: dup
-			IL_00bd: ldc.i4.0
-			IL_00be: ldarg.0
-			IL_00bf: ldc.i4.1
-			IL_00c0: ldelem.ref
-			IL_00c1: stelem.ref
-			IL_00c2: dup
-			IL_00c3: ldc.i4.1
-			IL_00c4: ldloc.0
-			IL_00c5: stelem.ref
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_00d0: ldc.i4.0
-			IL_00d1: conv.r8
-			IL_00d2: ldstr ""
-			IL_00d7: ldc.i4.0
-			IL_00d8: ldc.i4.1
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_00e3: stloc.1
-			IL_00e4: ldc.i4.1
-			IL_00e5: newarr [System.Runtime]System.Object
-			IL_00ea: dup
-			IL_00eb: ldc.i4.0
-			IL_00ec: ldarg.0
-			IL_00ed: ldc.i4.1
-			IL_00ee: ldelem.ref
-			IL_00ef: stelem.ref
-			IL_00f0: ldnull
-			IL_00f1: ldstr "subtle digest unsupported"
-			IL_00f6: ldloc.1
-			IL_00f7: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_00fc: stloc.1
-			IL_00fd: ldloc.0
-			IL_00fe: ldc.i4.1
-			IL_00ff: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0104: ldloc.0
-			IL_0105: ldloc.1
-			IL_0106: ldarg.0
-			IL_0107: ldc.i4.1
-			IL_0108: ldloc.0
-			IL_0109: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_010e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0113: ldloc.0
-			IL_0114: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0119: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_011e: ret
+			IL_00aa: ldc.i4.1
+			IL_00ab: newarr [System.Runtime]System.Object
+			IL_00b0: dup
+			IL_00b1: ldc.i4.0
+			IL_00b2: ldarg.0
+			IL_00b3: ldc.i4.1
+			IL_00b4: ldelem.ref
+			IL_00b5: stelem.ref
+			IL_00b6: stloc.1
+			IL_00b7: ldnull
+			IL_00b8: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L56C56::__js_call__(object[], object)
+			IL_00be: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_00c3: ldc.i4.2
+			IL_00c4: newarr [System.Runtime]System.Object
+			IL_00c9: dup
+			IL_00ca: ldc.i4.0
+			IL_00cb: ldarg.0
+			IL_00cc: ldc.i4.1
+			IL_00cd: ldelem.ref
+			IL_00ce: stelem.ref
+			IL_00cf: dup
+			IL_00d0: ldc.i4.1
+			IL_00d1: ldloc.0
+			IL_00d2: stelem.ref
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_00dd: ldc.i4.0
+			IL_00de: conv.r8
+			IL_00df: ldstr ""
+			IL_00e4: ldc.i4.0
+			IL_00e5: ldc.i4.1
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_00f0: stloc.2
+			IL_00f1: ldarg.0
+			IL_00f2: ldc.i4.1
+			IL_00f3: ldelem.ref
+			IL_00f4: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_00f9: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_00fe: ldloc.1
+			IL_00ff: ldstr "subtle digest unsupported"
+			IL_0104: ldloc.2
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_010a: stloc.2
+			IL_010b: ldloc.0
+			IL_010c: ldc.i4.1
+			IL_010d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0112: ldloc.0
+			IL_0113: ldloc.2
+			IL_0114: ldarg.0
+			IL_0115: ldc.i4.1
+			IL_0116: ldloc.0
+			IL_0117: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0121: ldloc.0
+			IL_0122: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0127: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_012c: ret
 
-			IL_011f: ldloc.0
-			IL_0120: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
-			IL_0125: pop
-			IL_0126: ldnull
-			IL_0127: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
-			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0132: ldc.i4.2
-			IL_0133: newarr [System.Runtime]System.Object
-			IL_0138: dup
-			IL_0139: ldc.i4.0
-			IL_013a: ldarg.0
-			IL_013b: ldc.i4.1
-			IL_013c: ldelem.ref
-			IL_013d: stelem.ref
-			IL_013e: dup
-			IL_013f: ldc.i4.1
-			IL_0140: ldloc.0
-			IL_0141: stelem.ref
-			IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_014c: ldc.i4.0
-			IL_014d: conv.r8
-			IL_014e: ldstr ""
-			IL_0153: ldc.i4.0
-			IL_0154: ldc.i4.1
-			IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_015f: stloc.1
-			IL_0160: ldc.i4.1
-			IL_0161: newarr [System.Runtime]System.Object
-			IL_0166: dup
+			IL_012d: ldloc.0
+			IL_012e: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited1
+			IL_0133: pop
+			IL_0134: ldc.i4.1
+			IL_0135: newarr [System.Runtime]System.Object
+			IL_013a: dup
+			IL_013b: ldc.i4.0
+			IL_013c: ldarg.0
+			IL_013d: ldc.i4.1
+			IL_013e: ldelem.ref
+			IL_013f: stelem.ref
+			IL_0140: stloc.1
+			IL_0141: ldnull
+			IL_0142: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L57C51::__js_call__(object[], object)
+			IL_0148: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_014d: ldc.i4.2
+			IL_014e: newarr [System.Runtime]System.Object
+			IL_0153: dup
+			IL_0154: ldc.i4.0
+			IL_0155: ldarg.0
+			IL_0156: ldc.i4.1
+			IL_0157: ldelem.ref
+			IL_0158: stelem.ref
+			IL_0159: dup
+			IL_015a: ldc.i4.1
+			IL_015b: ldloc.0
+			IL_015c: stelem.ref
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 			IL_0167: ldc.i4.0
-			IL_0168: ldarg.0
-			IL_0169: ldc.i4.1
-			IL_016a: ldelem.ref
-			IL_016b: stelem.ref
-			IL_016c: ldnull
-			IL_016d: ldstr "subtle import format"
-			IL_0172: ldloc.1
-			IL_0173: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_0178: stloc.1
-			IL_0179: ldloc.0
-			IL_017a: ldc.i4.2
-			IL_017b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0180: ldloc.0
-			IL_0181: ldloc.1
-			IL_0182: ldarg.0
-			IL_0183: ldc.i4.2
-			IL_0184: ldloc.0
-			IL_0185: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_018a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_018f: ldloc.0
-			IL_0190: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0195: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_019a: ret
+			IL_0168: conv.r8
+			IL_0169: ldstr ""
+			IL_016e: ldc.i4.0
+			IL_016f: ldc.i4.1
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_017a: stloc.2
+			IL_017b: ldarg.0
+			IL_017c: ldc.i4.1
+			IL_017d: ldelem.ref
+			IL_017e: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0183: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0188: ldloc.1
+			IL_0189: ldstr "subtle import format"
+			IL_018e: ldloc.2
+			IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0194: stloc.2
+			IL_0195: ldloc.0
+			IL_0196: ldc.i4.2
+			IL_0197: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_019c: ldloc.0
+			IL_019d: ldloc.2
+			IL_019e: ldarg.0
+			IL_019f: ldc.i4.2
+			IL_01a0: ldloc.0
+			IL_01a1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_01a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01ab: ldloc.0
+			IL_01ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01b1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01b6: ret
 
-			IL_019b: ldloc.0
-			IL_019c: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
-			IL_01a1: pop
-			IL_01a2: ldnull
-			IL_01a3: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
-			IL_01a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_01ae: ldc.i4.2
-			IL_01af: newarr [System.Runtime]System.Object
-			IL_01b4: dup
-			IL_01b5: ldc.i4.0
-			IL_01b6: ldarg.0
-			IL_01b7: ldc.i4.1
-			IL_01b8: ldelem.ref
-			IL_01b9: stelem.ref
-			IL_01ba: dup
-			IL_01bb: ldc.i4.1
-			IL_01bc: ldloc.0
-			IL_01bd: stelem.ref
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_01c8: ldc.i4.0
-			IL_01c9: conv.r8
-			IL_01ca: ldstr ""
-			IL_01cf: ldc.i4.0
-			IL_01d0: ldc.i4.1
-			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_01d6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_01db: stloc.1
-			IL_01dc: ldc.i4.1
-			IL_01dd: newarr [System.Runtime]System.Object
-			IL_01e2: dup
-			IL_01e3: ldc.i4.0
-			IL_01e4: ldarg.0
-			IL_01e5: ldc.i4.1
-			IL_01e6: ldelem.ref
-			IL_01e7: stelem.ref
-			IL_01e8: ldnull
-			IL_01e9: ldstr "subtle import key data"
-			IL_01ee: ldloc.1
-			IL_01ef: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_01f4: stloc.1
-			IL_01f5: ldloc.0
-			IL_01f6: ldc.i4.3
-			IL_01f7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_01fc: ldloc.0
-			IL_01fd: ldloc.1
-			IL_01fe: ldarg.0
-			IL_01ff: ldc.i4.3
-			IL_0200: ldloc.0
-			IL_0201: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0206: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_020b: ldloc.0
-			IL_020c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0211: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0216: ret
+			IL_01b7: ldloc.0
+			IL_01b8: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited2
+			IL_01bd: pop
+			IL_01be: ldc.i4.1
+			IL_01bf: newarr [System.Runtime]System.Object
+			IL_01c4: dup
+			IL_01c5: ldc.i4.0
+			IL_01c6: ldarg.0
+			IL_01c7: ldc.i4.1
+			IL_01c8: ldelem.ref
+			IL_01c9: stelem.ref
+			IL_01ca: stloc.1
+			IL_01cb: ldnull
+			IL_01cc: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L63C53::__js_call__(object[], object)
+			IL_01d2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_01d7: ldc.i4.2
+			IL_01d8: newarr [System.Runtime]System.Object
+			IL_01dd: dup
+			IL_01de: ldc.i4.0
+			IL_01df: ldarg.0
+			IL_01e0: ldc.i4.1
+			IL_01e1: ldelem.ref
+			IL_01e2: stelem.ref
+			IL_01e3: dup
+			IL_01e4: ldc.i4.1
+			IL_01e5: ldloc.0
+			IL_01e6: stelem.ref
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_01f1: ldc.i4.0
+			IL_01f2: conv.r8
+			IL_01f3: ldstr ""
+			IL_01f8: ldc.i4.0
+			IL_01f9: ldc.i4.1
+			IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0204: stloc.2
+			IL_0205: ldarg.0
+			IL_0206: ldc.i4.1
+			IL_0207: ldelem.ref
+			IL_0208: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_020d: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0212: ldloc.1
+			IL_0213: ldstr "subtle import key data"
+			IL_0218: ldloc.2
+			IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_021e: stloc.2
+			IL_021f: ldloc.0
+			IL_0220: ldc.i4.3
+			IL_0221: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0226: ldloc.0
+			IL_0227: ldloc.2
+			IL_0228: ldarg.0
+			IL_0229: ldc.i4.3
+			IL_022a: ldloc.0
+			IL_022b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0230: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0235: ldloc.0
+			IL_0236: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_023b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0240: ret
 
-			IL_0217: ldloc.0
-			IL_0218: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
-			IL_021d: pop
-			IL_021e: ldnull
-			IL_021f: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
-			IL_0225: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_022a: ldc.i4.2
-			IL_022b: newarr [System.Runtime]System.Object
-			IL_0230: dup
-			IL_0231: ldc.i4.0
-			IL_0232: ldarg.0
-			IL_0233: ldc.i4.1
-			IL_0234: ldelem.ref
-			IL_0235: stelem.ref
-			IL_0236: dup
-			IL_0237: ldc.i4.1
-			IL_0238: ldloc.0
-			IL_0239: stelem.ref
-			IL_023a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0244: ldc.i4.0
-			IL_0245: conv.r8
-			IL_0246: ldstr ""
-			IL_024b: ldc.i4.0
-			IL_024c: ldc.i4.1
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0257: stloc.1
-			IL_0258: ldc.i4.1
-			IL_0259: newarr [System.Runtime]System.Object
-			IL_025e: dup
-			IL_025f: ldc.i4.0
-			IL_0260: ldarg.0
-			IL_0261: ldc.i4.1
-			IL_0262: ldelem.ref
-			IL_0263: stelem.ref
-			IL_0264: ldnull
-			IL_0265: ldstr "subtle import empty usages"
-			IL_026a: ldloc.1
-			IL_026b: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_0270: stloc.1
-			IL_0271: ldloc.0
-			IL_0272: ldc.i4.4
-			IL_0273: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0278: ldloc.0
-			IL_0279: ldloc.1
-			IL_027a: ldarg.0
-			IL_027b: ldc.i4.4
-			IL_027c: ldloc.0
-			IL_027d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0282: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0287: ldloc.0
-			IL_0288: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_028d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0292: ret
-
-			IL_0293: ldloc.0
-			IL_0294: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
-			IL_0299: pop
-			IL_029a: ldnull
-			IL_029b: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
-			IL_02a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_02a6: ldc.i4.2
-			IL_02a7: newarr [System.Runtime]System.Object
-			IL_02ac: dup
-			IL_02ad: ldc.i4.0
-			IL_02ae: ldarg.0
-			IL_02af: ldc.i4.1
-			IL_02b0: ldelem.ref
-			IL_02b1: stelem.ref
-			IL_02b2: dup
-			IL_02b3: ldc.i4.1
+			IL_0241: ldloc.0
+			IL_0242: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited3
+			IL_0247: pop
+			IL_0248: ldc.i4.1
+			IL_0249: newarr [System.Runtime]System.Object
+			IL_024e: dup
+			IL_024f: ldc.i4.0
+			IL_0250: ldarg.0
+			IL_0251: ldc.i4.1
+			IL_0252: ldelem.ref
+			IL_0253: stelem.ref
+			IL_0254: stloc.1
+			IL_0255: ldnull
+			IL_0256: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L69C57::__js_call__(object[], object)
+			IL_025c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0261: ldc.i4.2
+			IL_0262: newarr [System.Runtime]System.Object
+			IL_0267: dup
+			IL_0268: ldc.i4.0
+			IL_0269: ldarg.0
+			IL_026a: ldc.i4.1
+			IL_026b: ldelem.ref
+			IL_026c: stelem.ref
+			IL_026d: dup
+			IL_026e: ldc.i4.1
+			IL_026f: ldloc.0
+			IL_0270: stelem.ref
+			IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_027b: ldc.i4.0
+			IL_027c: conv.r8
+			IL_027d: ldstr ""
+			IL_0282: ldc.i4.0
+			IL_0283: ldc.i4.1
+			IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_028e: stloc.2
+			IL_028f: ldarg.0
+			IL_0290: ldc.i4.1
+			IL_0291: ldelem.ref
+			IL_0292: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0297: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_029c: ldloc.1
+			IL_029d: ldstr "subtle import empty usages"
+			IL_02a2: ldloc.2
+			IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_02a8: stloc.2
+			IL_02a9: ldloc.0
+			IL_02aa: ldc.i4.4
+			IL_02ab: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_02b0: ldloc.0
+			IL_02b1: ldloc.2
+			IL_02b2: ldarg.0
+			IL_02b3: ldc.i4.4
 			IL_02b4: ldloc.0
-			IL_02b5: stelem.ref
-			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_02c0: ldc.i4.0
-			IL_02c1: conv.r8
-			IL_02c2: ldstr ""
-			IL_02c7: ldc.i4.0
-			IL_02c8: ldc.i4.1
-			IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_02d3: stloc.1
-			IL_02d4: ldc.i4.1
-			IL_02d5: newarr [System.Runtime]System.Object
-			IL_02da: dup
-			IL_02db: ldc.i4.0
-			IL_02dc: ldarg.0
-			IL_02dd: ldc.i4.1
-			IL_02de: ldelem.ref
-			IL_02df: stelem.ref
-			IL_02e0: ldnull
-			IL_02e1: ldstr "subtle import invalid usage enum"
-			IL_02e6: ldloc.1
-			IL_02e7: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_02ec: stloc.1
-			IL_02ed: ldloc.0
-			IL_02ee: ldc.i4.5
-			IL_02ef: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_02f4: ldloc.0
-			IL_02f5: ldloc.1
-			IL_02f6: ldarg.0
-			IL_02f7: ldc.i4.5
-			IL_02f8: ldloc.0
-			IL_02f9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_02fe: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0303: ldloc.0
-			IL_0304: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0309: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_030e: ret
+			IL_02b5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_02ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_02bf: ldloc.0
+			IL_02c0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02c5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02ca: ret
 
-			IL_030f: ldloc.0
-			IL_0310: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
-			IL_0315: pop
-			IL_0316: ldnull
-			IL_0317: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
-			IL_031d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0322: ldc.i4.2
-			IL_0323: newarr [System.Runtime]System.Object
-			IL_0328: dup
-			IL_0329: ldc.i4.0
-			IL_032a: ldarg.0
-			IL_032b: ldc.i4.1
-			IL_032c: ldelem.ref
-			IL_032d: stelem.ref
-			IL_032e: dup
-			IL_032f: ldc.i4.1
-			IL_0330: ldloc.0
-			IL_0331: stelem.ref
-			IL_0332: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_033c: ldc.i4.0
-			IL_033d: conv.r8
-			IL_033e: ldstr ""
-			IL_0343: ldc.i4.0
-			IL_0344: ldc.i4.1
-			IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_034f: stloc.1
-			IL_0350: ldc.i4.1
-			IL_0351: newarr [System.Runtime]System.Object
-			IL_0356: dup
-			IL_0357: ldc.i4.0
-			IL_0358: ldarg.0
-			IL_0359: ldc.i4.1
-			IL_035a: ldelem.ref
-			IL_035b: stelem.ref
-			IL_035c: ldnull
-			IL_035d: ldstr "subtle import unsupported usage"
-			IL_0362: ldloc.1
-			IL_0363: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+			IL_02cb: ldloc.0
+			IL_02cc: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited4
+			IL_02d1: pop
+			IL_02d2: ldc.i4.1
+			IL_02d3: newarr [System.Runtime]System.Object
+			IL_02d8: dup
+			IL_02d9: ldc.i4.0
+			IL_02da: ldarg.0
+			IL_02db: ldc.i4.1
+			IL_02dc: ldelem.ref
+			IL_02dd: stelem.ref
+			IL_02de: stloc.1
+			IL_02df: ldnull
+			IL_02e0: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L75C63::__js_call__(object[], object)
+			IL_02e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_02eb: ldc.i4.2
+			IL_02ec: newarr [System.Runtime]System.Object
+			IL_02f1: dup
+			IL_02f2: ldc.i4.0
+			IL_02f3: ldarg.0
+			IL_02f4: ldc.i4.1
+			IL_02f5: ldelem.ref
+			IL_02f6: stelem.ref
+			IL_02f7: dup
+			IL_02f8: ldc.i4.1
+			IL_02f9: ldloc.0
+			IL_02fa: stelem.ref
+			IL_02fb: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0300: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0305: ldc.i4.0
+			IL_0306: conv.r8
+			IL_0307: ldstr ""
+			IL_030c: ldc.i4.0
+			IL_030d: ldc.i4.1
+			IL_030e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0313: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_0318: stloc.2
+			IL_0319: ldarg.0
+			IL_031a: ldc.i4.1
+			IL_031b: ldelem.ref
+			IL_031c: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0321: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0326: ldloc.1
+			IL_0327: ldstr "subtle import invalid usage enum"
+			IL_032c: ldloc.2
+			IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0332: stloc.2
+			IL_0333: ldloc.0
+			IL_0334: ldc.i4.5
+			IL_0335: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_033a: ldloc.0
+			IL_033b: ldloc.2
+			IL_033c: ldarg.0
+			IL_033d: ldc.i4.5
+			IL_033e: ldloc.0
+			IL_033f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0349: ldloc.0
+			IL_034a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_034f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0354: ret
+
+			IL_0355: ldloc.0
+			IL_0356: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited5
+			IL_035b: pop
+			IL_035c: ldc.i4.1
+			IL_035d: newarr [System.Runtime]System.Object
+			IL_0362: dup
+			IL_0363: ldc.i4.0
+			IL_0364: ldarg.0
+			IL_0365: ldc.i4.1
+			IL_0366: ldelem.ref
+			IL_0367: stelem.ref
 			IL_0368: stloc.1
-			IL_0369: ldloc.0
-			IL_036a: ldc.i4.6
-			IL_036b: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0370: ldloc.0
-			IL_0371: ldloc.1
-			IL_0372: ldarg.0
-			IL_0373: ldc.i4.6
-			IL_0374: ldloc.0
-			IL_0375: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_037a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_037f: ldloc.0
-			IL_0380: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0385: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_038a: ret
+			IL_0369: ldnull
+			IL_036a: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L81C62::__js_call__(object[], object)
+			IL_0370: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0375: ldc.i4.2
+			IL_0376: newarr [System.Runtime]System.Object
+			IL_037b: dup
+			IL_037c: ldc.i4.0
+			IL_037d: ldarg.0
+			IL_037e: ldc.i4.1
+			IL_037f: ldelem.ref
+			IL_0380: stelem.ref
+			IL_0381: dup
+			IL_0382: ldc.i4.1
+			IL_0383: ldloc.0
+			IL_0384: stelem.ref
+			IL_0385: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_038f: ldc.i4.0
+			IL_0390: conv.r8
+			IL_0391: ldstr ""
+			IL_0396: ldc.i4.0
+			IL_0397: ldc.i4.1
+			IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_03a2: stloc.2
+			IL_03a3: ldarg.0
+			IL_03a4: ldc.i4.1
+			IL_03a5: ldelem.ref
+			IL_03a6: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_03ab: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_03b0: ldloc.1
+			IL_03b1: ldstr "subtle import unsupported usage"
+			IL_03b6: ldloc.2
+			IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03bc: stloc.2
+			IL_03bd: ldloc.0
+			IL_03be: ldc.i4.6
+			IL_03bf: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_03c4: ldloc.0
+			IL_03c5: ldloc.2
+			IL_03c6: ldarg.0
+			IL_03c7: ldc.i4.6
+			IL_03c8: ldloc.0
+			IL_03c9: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_03ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_03d3: ldloc.0
+			IL_03d4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_03d9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_03de: ret
 
-			IL_038b: ldloc.0
-			IL_038c: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
-			IL_0391: pop
-			IL_0392: ldnull
-			IL_0393: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
-			IL_0399: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_039e: ldc.i4.2
-			IL_039f: newarr [System.Runtime]System.Object
-			IL_03a4: dup
-			IL_03a5: ldc.i4.0
-			IL_03a6: ldarg.0
-			IL_03a7: ldc.i4.1
-			IL_03a8: ldelem.ref
-			IL_03a9: stelem.ref
-			IL_03aa: dup
-			IL_03ab: ldc.i4.1
-			IL_03ac: ldloc.0
-			IL_03ad: stelem.ref
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_03b8: ldc.i4.0
-			IL_03b9: conv.r8
-			IL_03ba: ldstr ""
-			IL_03bf: ldc.i4.0
-			IL_03c0: ldc.i4.1
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_03cb: stloc.1
-			IL_03cc: ldc.i4.1
-			IL_03cd: newarr [System.Runtime]System.Object
-			IL_03d2: dup
-			IL_03d3: ldc.i4.0
-			IL_03d4: ldarg.0
-			IL_03d5: ldc.i4.1
-			IL_03d6: ldelem.ref
-			IL_03d7: stelem.ref
-			IL_03d8: ldnull
-			IL_03d9: ldstr "subtle import zero key"
-			IL_03de: ldloc.1
-			IL_03df: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_03e4: stloc.1
-			IL_03e5: ldloc.0
-			IL_03e6: ldc.i4.7
-			IL_03e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03ec: ldloc.0
-			IL_03ed: ldloc.1
+			IL_03df: ldloc.0
+			IL_03e0: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited6
+			IL_03e5: pop
+			IL_03e6: ldc.i4.1
+			IL_03e7: newarr [System.Runtime]System.Object
+			IL_03ec: dup
+			IL_03ed: ldc.i4.0
 			IL_03ee: ldarg.0
-			IL_03ef: ldc.i4.7
-			IL_03f0: ldloc.0
-			IL_03f1: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_03fb: ldloc.0
-			IL_03fc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0401: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0406: ret
-
-			IL_0407: ldloc.0
-			IL_0408: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
-			IL_040d: pop
-			IL_040e: ldnull
-			IL_040f: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
-			IL_0415: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_041a: ldc.i4.2
-			IL_041b: newarr [System.Runtime]System.Object
-			IL_0420: dup
-			IL_0421: ldc.i4.0
-			IL_0422: ldarg.0
-			IL_0423: ldc.i4.1
-			IL_0424: ldelem.ref
-			IL_0425: stelem.ref
-			IL_0426: dup
-			IL_0427: ldc.i4.1
-			IL_0428: ldloc.0
-			IL_0429: stelem.ref
-			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_042f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0434: ldc.i4.0
-			IL_0435: conv.r8
-			IL_0436: ldstr ""
-			IL_043b: ldc.i4.0
-			IL_043c: ldc.i4.1
-			IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0447: stloc.1
-			IL_0448: ldc.i4.1
-			IL_0449: newarr [System.Runtime]System.Object
-			IL_044e: dup
-			IL_044f: ldc.i4.0
+			IL_03ef: ldc.i4.1
+			IL_03f0: ldelem.ref
+			IL_03f1: stelem.ref
+			IL_03f2: stloc.1
+			IL_03f3: ldnull
+			IL_03f4: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L87C53::__js_call__(object[], object)
+			IL_03fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_03ff: ldc.i4.2
+			IL_0400: newarr [System.Runtime]System.Object
+			IL_0405: dup
+			IL_0406: ldc.i4.0
+			IL_0407: ldarg.0
+			IL_0408: ldc.i4.1
+			IL_0409: ldelem.ref
+			IL_040a: stelem.ref
+			IL_040b: dup
+			IL_040c: ldc.i4.1
+			IL_040d: ldloc.0
+			IL_040e: stelem.ref
+			IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_0419: ldc.i4.0
+			IL_041a: conv.r8
+			IL_041b: ldstr ""
+			IL_0420: ldc.i4.0
+			IL_0421: ldc.i4.1
+			IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_042c: stloc.2
+			IL_042d: ldarg.0
+			IL_042e: ldc.i4.1
+			IL_042f: ldelem.ref
+			IL_0430: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0435: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_043a: ldloc.1
+			IL_043b: ldstr "subtle import zero key"
+			IL_0440: ldloc.2
+			IL_0441: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0446: stloc.2
+			IL_0447: ldloc.0
+			IL_0448: ldc.i4.7
+			IL_0449: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_044e: ldloc.0
+			IL_044f: ldloc.2
 			IL_0450: ldarg.0
-			IL_0451: ldc.i4.1
-			IL_0452: ldelem.ref
-			IL_0453: stelem.ref
-			IL_0454: ldnull
-			IL_0455: ldstr "subtle import length mismatch"
-			IL_045a: ldloc.1
-			IL_045b: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_0460: stloc.1
-			IL_0461: ldloc.0
-			IL_0462: ldc.i4.8
-			IL_0463: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0468: ldloc.0
-			IL_0469: ldloc.1
-			IL_046a: ldarg.0
-			IL_046b: ldc.i4.8
-			IL_046c: ldloc.0
-			IL_046d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0472: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0477: ldloc.0
-			IL_0478: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_047d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0482: ret
+			IL_0451: ldc.i4.7
+			IL_0452: ldloc.0
+			IL_0453: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0458: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_045d: ldloc.0
+			IL_045e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0463: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0468: ret
 
-			IL_0483: ldloc.0
-			IL_0484: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
-			IL_0489: pop
-			IL_048a: ldloc.0
-			IL_048b: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
-			IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0495: stloc.1
-			IL_0496: ldstr "key"
-			IL_049b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_04a0: stloc.2
-			IL_04a1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04a6: dup
-			IL_04a7: ldstr "name"
-			IL_04ac: ldstr "HMAC"
-			IL_04b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04b6: dup
-			IL_04b7: ldstr "hash"
-			IL_04bc: ldstr "SHA-256"
-			IL_04c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04c6: stloc.3
-			IL_04c7: ldc.i4.5
-			IL_04c8: newarr [System.Runtime]System.Object
-			IL_04cd: dup
-			IL_04ce: ldc.i4.0
-			IL_04cf: ldstr "raw"
-			IL_04d4: stelem.ref
-			IL_04d5: dup
-			IL_04d6: ldc.i4.1
-			IL_04d7: ldloc.2
-			IL_04d8: stelem.ref
-			IL_04d9: dup
-			IL_04da: ldc.i4.2
-			IL_04db: ldloc.3
-			IL_04dc: stelem.ref
-			IL_04dd: dup
-			IL_04de: ldc.i4.3
-			IL_04df: ldc.i4.0
-			IL_04e0: box [System.Runtime]System.Boolean
-			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.4
-			IL_04e8: ldc.i4.1
-			IL_04e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_04ee: dup
-			IL_04ef: ldstr "verify"
-			IL_04f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04f9: stelem.ref
-			IL_04fa: stloc.s 4
-			IL_04fc: ldloc.1
-			IL_04fd: ldstr "importKey"
-			IL_0502: ldloc.s 4
-			IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-			IL_0509: stloc.1
-			IL_050a: ldloc.0
-			IL_050b: ldc.i4.s 9
-			IL_050d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0512: ldloc.0
-			IL_0513: ldloc.1
-			IL_0514: ldarg.0
-			IL_0515: ldc.i4.s 9
-			IL_0517: ldloc.0
-			IL_0518: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_051d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_0522: ldloc.0
-			IL_0523: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0528: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_052d: ret
+			IL_0469: ldloc.0
+			IL_046a: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited7
+			IL_046f: pop
+			IL_0470: ldc.i4.1
+			IL_0471: newarr [System.Runtime]System.Object
+			IL_0476: dup
+			IL_0477: ldc.i4.0
+			IL_0478: ldarg.0
+			IL_0479: ldc.i4.1
+			IL_047a: ldelem.ref
+			IL_047b: stelem.ref
+			IL_047c: stloc.1
+			IL_047d: ldnull
+			IL_047e: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L93C60::__js_call__(object[], object)
+			IL_0484: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0489: ldc.i4.2
+			IL_048a: newarr [System.Runtime]System.Object
+			IL_048f: dup
+			IL_0490: ldc.i4.0
+			IL_0491: ldarg.0
+			IL_0492: ldc.i4.1
+			IL_0493: ldelem.ref
+			IL_0494: stelem.ref
+			IL_0495: dup
+			IL_0496: ldc.i4.1
+			IL_0497: ldloc.0
+			IL_0498: stelem.ref
+			IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_04a3: ldc.i4.0
+			IL_04a4: conv.r8
+			IL_04a5: ldstr ""
+			IL_04aa: ldc.i4.0
+			IL_04ab: ldc.i4.1
+			IL_04ac: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_04b1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_04b6: stloc.2
+			IL_04b7: ldarg.0
+			IL_04b8: ldc.i4.1
+			IL_04b9: ldelem.ref
+			IL_04ba: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_04bf: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_04c4: ldloc.1
+			IL_04c5: ldstr "subtle import length mismatch"
+			IL_04ca: ldloc.2
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04d0: stloc.2
+			IL_04d1: ldloc.0
+			IL_04d2: ldc.i4.8
+			IL_04d3: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_04d8: ldloc.0
+			IL_04d9: ldloc.2
+			IL_04da: ldarg.0
+			IL_04db: ldc.i4.8
+			IL_04dc: ldloc.0
+			IL_04dd: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_04e2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_04e7: ldloc.0
+			IL_04e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04f2: ret
 
-			IL_052e: ldloc.0
-			IL_052f: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
-			IL_0534: stloc.1
-			IL_0535: ldloc.0
-			IL_0536: ldloc.1
-			IL_0537: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
-			IL_053c: ldnull
-			IL_053d: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
-			IL_0543: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_0548: ldc.i4.2
-			IL_0549: newarr [System.Runtime]System.Object
-			IL_054e: dup
-			IL_054f: ldc.i4.0
-			IL_0550: ldarg.0
-			IL_0551: ldc.i4.1
-			IL_0552: ldelem.ref
-			IL_0553: stelem.ref
-			IL_0554: dup
-			IL_0555: ldc.i4.1
-			IL_0556: ldloc.0
+			IL_04f3: ldloc.0
+			IL_04f4: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited8
+			IL_04f9: pop
+			IL_04fa: ldloc.0
+			IL_04fb: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::subtle
+			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0505: stloc.2
+			IL_0506: ldstr "key"
+			IL_050b: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_0510: stloc.3
+			IL_0511: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0516: dup
+			IL_0517: ldstr "name"
+			IL_051c: ldstr "HMAC"
+			IL_0521: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0526: dup
+			IL_0527: ldstr "hash"
+			IL_052c: ldstr "SHA-256"
+			IL_0531: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0536: stloc.s 4
+			IL_0538: ldc.i4.5
+			IL_0539: newarr [System.Runtime]System.Object
+			IL_053e: dup
+			IL_053f: ldc.i4.0
+			IL_0540: ldstr "raw"
+			IL_0545: stelem.ref
+			IL_0546: dup
+			IL_0547: ldc.i4.1
+			IL_0548: ldloc.3
+			IL_0549: stelem.ref
+			IL_054a: dup
+			IL_054b: ldc.i4.2
+			IL_054c: ldloc.s 4
+			IL_054e: stelem.ref
+			IL_054f: dup
+			IL_0550: ldc.i4.3
+			IL_0551: ldc.i4.0
+			IL_0552: box [System.Runtime]System.Boolean
 			IL_0557: stelem.ref
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_0562: ldc.i4.0
-			IL_0563: conv.r8
-			IL_0564: ldstr ""
-			IL_0569: ldc.i4.0
-			IL_056a: ldc.i4.1
-			IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_0575: stloc.1
-			IL_0576: ldc.i4.1
-			IL_0577: newarr [System.Runtime]System.Object
-			IL_057c: dup
-			IL_057d: ldc.i4.0
-			IL_057e: ldarg.0
-			IL_057f: ldc.i4.1
-			IL_0580: ldelem.ref
-			IL_0581: stelem.ref
-			IL_0582: ldnull
-			IL_0583: ldstr "subtle sign algorithm"
-			IL_0588: ldloc.1
-			IL_0589: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_058e: stloc.1
-			IL_058f: ldloc.0
-			IL_0590: ldc.i4.s 10
-			IL_0592: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0597: ldloc.0
-			IL_0598: ldloc.1
-			IL_0599: ldarg.0
-			IL_059a: ldc.i4.s 10
-			IL_059c: ldloc.0
-			IL_059d: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
-			IL_05a7: ldloc.0
-			IL_05a8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05ad: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05b2: ret
+			IL_0558: dup
+			IL_0559: ldc.i4.4
+			IL_055a: ldc.i4.1
+			IL_055b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0560: dup
+			IL_0561: ldstr "verify"
+			IL_0566: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_056b: stelem.ref
+			IL_056c: stloc.1
+			IL_056d: ldloc.2
+			IL_056e: ldstr "importKey"
+			IL_0573: ldloc.1
+			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+			IL_0579: stloc.2
+			IL_057a: ldloc.0
+			IL_057b: ldc.i4.s 9
+			IL_057d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0582: ldloc.0
+			IL_0583: ldloc.2
+			IL_0584: ldarg.0
+			IL_0585: ldc.i4.s 9
+			IL_0587: ldloc.0
+			IL_0588: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_058d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0592: ldloc.0
+			IL_0593: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0598: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_059d: ret
 
-			IL_05b3: ldloc.0
-			IL_05b4: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
-			IL_05b9: pop
-			IL_05ba: ldnull
-			IL_05bb: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
-			IL_05c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
-			IL_05c6: ldc.i4.2
-			IL_05c7: newarr [System.Runtime]System.Object
-			IL_05cc: dup
-			IL_05cd: ldc.i4.0
-			IL_05ce: ldarg.0
-			IL_05cf: ldc.i4.1
-			IL_05d0: ldelem.ref
-			IL_05d1: stelem.ref
-			IL_05d2: dup
-			IL_05d3: ldc.i4.1
-			IL_05d4: ldloc.0
-			IL_05d5: stelem.ref
-			IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-			IL_05e0: ldc.i4.0
-			IL_05e1: conv.r8
-			IL_05e2: ldstr ""
-			IL_05e7: ldc.i4.0
-			IL_05e8: ldc.i4.1
-			IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-			IL_05f3: stloc.1
+			IL_059e: ldloc.0
+			IL_059f: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited9
+			IL_05a4: stloc.2
+			IL_05a5: ldloc.0
+			IL_05a6: ldloc.2
+			IL_05a7: stfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::verifyOnlyKey
+			IL_05ac: ldc.i4.1
+			IL_05ad: newarr [System.Runtime]System.Object
+			IL_05b2: dup
+			IL_05b3: ldc.i4.0
+			IL_05b4: ldarg.0
+			IL_05b5: ldc.i4.1
+			IL_05b6: ldelem.ref
+			IL_05b7: stelem.ref
+			IL_05b8: stloc.1
+			IL_05b9: ldnull
+			IL_05ba: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L107C52::__js_call__(object[], object)
+			IL_05c0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_05c5: ldc.i4.2
+			IL_05c6: newarr [System.Runtime]System.Object
+			IL_05cb: dup
+			IL_05cc: ldc.i4.0
+			IL_05cd: ldarg.0
+			IL_05ce: ldc.i4.1
+			IL_05cf: ldelem.ref
+			IL_05d0: stelem.ref
+			IL_05d1: dup
+			IL_05d2: ldc.i4.1
+			IL_05d3: ldloc.0
+			IL_05d4: stelem.ref
+			IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_05da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_05df: ldc.i4.0
+			IL_05e0: conv.r8
+			IL_05e1: ldstr ""
+			IL_05e6: ldc.i4.0
+			IL_05e7: ldc.i4.1
+			IL_05e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_05f2: stloc.2
+			IL_05f3: ldarg.0
 			IL_05f4: ldc.i4.1
-			IL_05f5: newarr [System.Runtime]System.Object
-			IL_05fa: dup
-			IL_05fb: ldc.i4.0
-			IL_05fc: ldarg.0
-			IL_05fd: ldc.i4.1
-			IL_05fe: ldelem.ref
-			IL_05ff: stelem.ref
-			IL_0600: ldnull
-			IL_0601: ldstr "subtle sign usage"
-			IL_0606: ldloc.1
-			IL_0607: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-			IL_060c: stloc.1
+			IL_05f5: ldelem.ref
+			IL_05f6: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_05fb: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_0600: ldloc.1
+			IL_0601: ldstr "subtle sign algorithm"
+			IL_0606: ldloc.2
+			IL_0607: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_060c: stloc.2
 			IL_060d: ldloc.0
-			IL_060e: ldc.i4.s 11
+			IL_060e: ldc.i4.s 10
 			IL_0610: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0615: ldloc.0
-			IL_0616: ldloc.1
+			IL_0616: ldloc.2
 			IL_0617: ldarg.0
-			IL_0618: ldc.i4.s 11
+			IL_0618: ldc.i4.s 10
 			IL_061a: ldloc.0
 			IL_061b: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
 			IL_0620: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
@@ -3554,23 +3552,85 @@
 			IL_0630: ret
 
 			IL_0631: ldloc.0
-			IL_0632: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
+			IL_0632: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited10
 			IL_0637: pop
-			IL_0638: ldloc.0
-			IL_0639: ldc.i4.m1
-			IL_063a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_063f: ldloc.0
-			IL_0640: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0645: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_064a: ldarg.0
-			IL_064b: ldc.i4.1
-			IL_064c: newarr [System.Runtime]System.Object
-			IL_0651: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0656: pop
-			IL_0657: ldloc.0
-			IL_0658: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_065d: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0662: ret
+			IL_0638: ldc.i4.1
+			IL_0639: newarr [System.Runtime]System.Object
+			IL_063e: dup
+			IL_063f: ldc.i4.0
+			IL_0640: ldarg.0
+			IL_0641: ldc.i4.1
+			IL_0642: ldelem.ref
+			IL_0643: stelem.ref
+			IL_0644: stloc.1
+			IL_0645: ldnull
+			IL_0646: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/ArrowFunction_L108C48::__js_call__(object[], object)
+			IL_064c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
+			IL_0651: ldc.i4.2
+			IL_0652: newarr [System.Runtime]System.Object
+			IL_0657: dup
+			IL_0658: ldc.i4.0
+			IL_0659: ldarg.0
+			IL_065a: ldc.i4.1
+			IL_065b: ldelem.ref
+			IL_065c: stelem.ref
+			IL_065d: dup
+			IL_065e: ldc.i4.1
+			IL_065f: ldloc.0
+			IL_0660: stelem.ref
+			IL_0661: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+			IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+			IL_066b: ldc.i4.0
+			IL_066c: conv.r8
+			IL_066d: ldstr ""
+			IL_0672: ldc.i4.0
+			IL_0673: ldc.i4.1
+			IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_0679: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+			IL_067e: stloc.2
+			IL_067f: ldarg.0
+			IL_0680: ldc.i4.1
+			IL_0681: ldelem.ref
+			IL_0682: castclass Modules.Require_Crypto_ErrorPaths/Scope
+			IL_0687: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::logPromiseError
+			IL_068c: ldloc.1
+			IL_068d: ldstr "subtle sign usage"
+			IL_0692: ldloc.2
+			IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0698: stloc.2
+			IL_0699: ldloc.0
+			IL_069a: ldc.i4.s 11
+			IL_069c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06a1: ldloc.0
+			IL_06a2: ldloc.2
+			IL_06a3: ldarg.0
+			IL_06a4: ldc.i4.s 11
+			IL_06a6: ldloc.0
+			IL_06a7: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06ac: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_06b1: ldloc.0
+			IL_06b2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06b7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06bc: ret
+
+			IL_06bd: ldloc.0
+			IL_06be: ldfld object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/Scope::_awaited11
+			IL_06c3: pop
+			IL_06c4: ldloc.0
+			IL_06c5: ldc.i4.m1
+			IL_06c6: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06cb: ldloc.0
+			IL_06cc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_06d6: ldarg.0
+			IL_06d7: ldc.i4.1
+			IL_06d8: newarr [System.Runtime]System.Object
+			IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_06e2: pop
+			IL_06e3: ldloc.0
+			IL_06e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06e9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06ee: ret
 		} // end of method runWebCryptoErrors::__js_call__
 
 	} // end of class runWebCryptoErrors
@@ -3586,7 +3646,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3d36
+				// Method begins at RVA 0x3e66
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -3609,7 +3669,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x36e3
+			// Method begins at RVA 0x3813
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -3651,7 +3711,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x3be9
+			// Method begins at RVA 0x3d19
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -3677,14 +3737,15 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1918 (0x77e)
+		// Code size: 2084 (0x824)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_ErrorPaths/Scope,
 			[1] object,
 			[2] object,
 			[3] object,
-			[4] object
+			[4] object[],
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Crypto_ErrorPaths/Scope::.ctor()
@@ -3743,699 +3804,751 @@
 		IL_0080: ldloc.0
 		IL_0081: ldloc.3
 		IL_0082: stfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_0087: ldc.i4.1
-		IL_0088: newarr [System.Runtime]System.Object
-		IL_008d: dup
-		IL_008e: ldc.i4.0
-		IL_008f: ldloc.0
-		IL_0090: stelem.ref
-		IL_0091: ldc.i4.0
-		IL_0092: ldelem.ref
-		IL_0093: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0098: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_009e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00a3: ldc.i4.1
-		IL_00a4: newarr [System.Runtime]System.Object
-		IL_00a9: dup
-		IL_00aa: ldc.i4.0
-		IL_00ab: ldloc.0
-		IL_00ac: stelem.ref
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_00b7: ldc.i4.0
-		IL_00b8: conv.r8
-		IL_00b9: ldstr ""
+		IL_0087: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_008c: stloc.s 4
+		IL_008e: ldc.i4.1
+		IL_008f: newarr [System.Runtime]System.Object
+		IL_0094: dup
+		IL_0095: ldc.i4.0
+		IL_0096: ldloc.0
+		IL_0097: stelem.ref
+		IL_0098: ldc.i4.0
+		IL_0099: ldelem.ref
+		IL_009a: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_009f: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_00a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00aa: ldc.i4.1
+		IL_00ab: newarr [System.Runtime]System.Object
+		IL_00b0: dup
+		IL_00b1: ldc.i4.0
+		IL_00b2: ldloc.0
+		IL_00b3: stelem.ref
+		IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_00be: ldc.i4.0
-		IL_00bf: ldc.i4.1
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00ca: stloc.3
-		IL_00cb: ldnull
-		IL_00cc: ldstr "algorithm type"
-		IL_00d1: ldloc.3
-		IL_00d2: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_00d7: pop
-		IL_00d8: ldc.i4.1
-		IL_00d9: newarr [System.Runtime]System.Object
-		IL_00de: dup
-		IL_00df: ldc.i4.0
-		IL_00e0: ldloc.0
-		IL_00e1: stelem.ref
-		IL_00e2: ldc.i4.0
-		IL_00e3: ldelem.ref
-		IL_00e4: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_00e9: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00f4: ldc.i4.1
-		IL_00f5: newarr [System.Runtime]System.Object
-		IL_00fa: dup
-		IL_00fb: ldc.i4.0
-		IL_00fc: ldloc.0
-		IL_00fd: stelem.ref
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0108: ldc.i4.0
-		IL_0109: conv.r8
-		IL_010a: ldstr ""
-		IL_010f: ldc.i4.0
-		IL_0110: ldc.i4.1
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_011b: stloc.3
-		IL_011c: ldnull
-		IL_011d: ldstr "algorithm unsupported"
-		IL_0122: ldloc.3
-		IL_0123: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0128: pop
-		IL_0129: ldc.i4.1
-		IL_012a: newarr [System.Runtime]System.Object
-		IL_012f: dup
-		IL_0130: ldc.i4.0
-		IL_0131: ldloc.0
-		IL_0132: stelem.ref
-		IL_0133: ldc.i4.0
-		IL_0134: ldelem.ref
-		IL_0135: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_013a: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_0140: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0145: ldc.i4.1
-		IL_0146: newarr [System.Runtime]System.Object
-		IL_014b: dup
+		IL_00bf: conv.r8
+		IL_00c0: ldstr ""
+		IL_00c5: ldc.i4.0
+		IL_00c6: ldc.i4.1
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_00d1: stloc.3
+		IL_00d2: ldloc.1
+		IL_00d3: ldloc.s 4
+		IL_00d5: ldstr "algorithm type"
+		IL_00da: ldloc.3
+		IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00e0: pop
+		IL_00e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00e6: stloc.s 4
+		IL_00e8: ldc.i4.1
+		IL_00e9: newarr [System.Runtime]System.Object
+		IL_00ee: dup
+		IL_00ef: ldc.i4.0
+		IL_00f0: ldloc.0
+		IL_00f1: stelem.ref
+		IL_00f2: ldc.i4.0
+		IL_00f3: ldelem.ref
+		IL_00f4: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_00f9: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L17C35::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_00ff: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0104: ldc.i4.1
+		IL_0105: newarr [System.Runtime]System.Object
+		IL_010a: dup
+		IL_010b: ldc.i4.0
+		IL_010c: ldloc.0
+		IL_010d: stelem.ref
+		IL_010e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0118: ldc.i4.0
+		IL_0119: conv.r8
+		IL_011a: ldstr ""
+		IL_011f: ldc.i4.0
+		IL_0120: ldc.i4.1
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_012b: stloc.3
+		IL_012c: ldloc.1
+		IL_012d: ldloc.s 4
+		IL_012f: ldstr "algorithm unsupported"
+		IL_0134: ldloc.3
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_013a: pop
+		IL_013b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0140: stloc.s 4
+		IL_0142: ldc.i4.1
+		IL_0143: newarr [System.Runtime]System.Object
+		IL_0148: dup
+		IL_0149: ldc.i4.0
+		IL_014a: ldloc.0
+		IL_014b: stelem.ref
 		IL_014c: ldc.i4.0
-		IL_014d: ldloc.0
-		IL_014e: stelem.ref
-		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0159: ldc.i4.0
-		IL_015a: conv.r8
-		IL_015b: ldstr ""
-		IL_0160: ldc.i4.0
-		IL_0161: ldc.i4.1
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_016c: stloc.3
-		IL_016d: ldnull
-		IL_016e: ldstr "hmac algorithm type"
-		IL_0173: ldloc.3
-		IL_0174: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0179: pop
+		IL_014d: ldelem.ref
+		IL_014e: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0153: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L18C33::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0159: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_015e: ldc.i4.1
+		IL_015f: newarr [System.Runtime]System.Object
+		IL_0164: dup
+		IL_0165: ldc.i4.0
+		IL_0166: ldloc.0
+		IL_0167: stelem.ref
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0172: ldc.i4.0
+		IL_0173: conv.r8
+		IL_0174: ldstr ""
+		IL_0179: ldc.i4.0
 		IL_017a: ldc.i4.1
-		IL_017b: newarr [System.Runtime]System.Object
-		IL_0180: dup
-		IL_0181: ldc.i4.0
-		IL_0182: ldloc.0
-		IL_0183: stelem.ref
-		IL_0184: ldc.i4.0
-		IL_0185: ldelem.ref
-		IL_0186: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_018b: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0196: ldc.i4.1
-		IL_0197: newarr [System.Runtime]System.Object
-		IL_019c: dup
-		IL_019d: ldc.i4.0
-		IL_019e: ldloc.0
-		IL_019f: stelem.ref
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01aa: ldc.i4.0
-		IL_01ab: conv.r8
-		IL_01ac: ldstr ""
-		IL_01b1: ldc.i4.0
-		IL_01b2: ldc.i4.1
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01bd: stloc.3
-		IL_01be: ldnull
-		IL_01bf: ldstr "hmac algorithm unsupported"
-		IL_01c4: ldloc.3
-		IL_01c5: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_01ca: pop
-		IL_01cb: ldc.i4.1
-		IL_01cc: newarr [System.Runtime]System.Object
-		IL_01d1: dup
-		IL_01d2: ldc.i4.0
-		IL_01d3: ldloc.0
-		IL_01d4: stelem.ref
-		IL_01d5: ldc.i4.0
-		IL_01d6: ldelem.ref
-		IL_01d7: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_01dc: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_01e2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01e7: ldc.i4.1
-		IL_01e8: newarr [System.Runtime]System.Object
-		IL_01ed: dup
-		IL_01ee: ldc.i4.0
-		IL_01ef: ldloc.0
-		IL_01f0: stelem.ref
-		IL_01f1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01fb: ldc.i4.0
-		IL_01fc: conv.r8
-		IL_01fd: ldstr ""
-		IL_0202: ldc.i4.0
-		IL_0203: ldc.i4.1
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_020e: stloc.3
-		IL_020f: ldnull
-		IL_0210: ldstr "hmac key null"
-		IL_0215: ldloc.3
-		IL_0216: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_021b: pop
-		IL_021c: ldc.i4.1
-		IL_021d: newarr [System.Runtime]System.Object
-		IL_0222: dup
-		IL_0223: ldc.i4.0
-		IL_0224: ldloc.0
-		IL_0225: stelem.ref
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0185: stloc.3
+		IL_0186: ldloc.1
+		IL_0187: ldloc.s 4
+		IL_0189: ldstr "hmac algorithm type"
+		IL_018e: ldloc.3
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0194: pop
+		IL_0195: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_019a: stloc.s 4
+		IL_019c: ldc.i4.1
+		IL_019d: newarr [System.Runtime]System.Object
+		IL_01a2: dup
+		IL_01a3: ldc.i4.0
+		IL_01a4: ldloc.0
+		IL_01a5: stelem.ref
+		IL_01a6: ldc.i4.0
+		IL_01a7: ldelem.ref
+		IL_01a8: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_01ad: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L19C40::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_01b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01b8: ldc.i4.1
+		IL_01b9: newarr [System.Runtime]System.Object
+		IL_01be: dup
+		IL_01bf: ldc.i4.0
+		IL_01c0: ldloc.0
+		IL_01c1: stelem.ref
+		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01cc: ldc.i4.0
+		IL_01cd: conv.r8
+		IL_01ce: ldstr ""
+		IL_01d3: ldc.i4.0
+		IL_01d4: ldc.i4.1
+		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_01df: stloc.3
+		IL_01e0: ldloc.1
+		IL_01e1: ldloc.s 4
+		IL_01e3: ldstr "hmac algorithm unsupported"
+		IL_01e8: ldloc.3
+		IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01ee: pop
+		IL_01ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f4: stloc.s 4
+		IL_01f6: ldc.i4.1
+		IL_01f7: newarr [System.Runtime]System.Object
+		IL_01fc: dup
+		IL_01fd: ldc.i4.0
+		IL_01fe: ldloc.0
+		IL_01ff: stelem.ref
+		IL_0200: ldc.i4.0
+		IL_0201: ldelem.ref
+		IL_0202: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0207: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L20C27::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_020d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0212: ldc.i4.1
+		IL_0213: newarr [System.Runtime]System.Object
+		IL_0218: dup
+		IL_0219: ldc.i4.0
+		IL_021a: ldloc.0
+		IL_021b: stelem.ref
+		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_0226: ldc.i4.0
-		IL_0227: ldelem.ref
-		IL_0228: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_022d: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_0233: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0238: ldc.i4.1
-		IL_0239: newarr [System.Runtime]System.Object
-		IL_023e: dup
-		IL_023f: ldc.i4.0
-		IL_0240: ldloc.0
-		IL_0241: stelem.ref
-		IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_024c: ldc.i4.0
-		IL_024d: conv.r8
-		IL_024e: ldstr ""
-		IL_0253: ldc.i4.0
-		IL_0254: ldc.i4.1
-		IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_025f: stloc.3
-		IL_0260: ldnull
-		IL_0261: ldstr "hmac key number"
-		IL_0266: ldloc.3
-		IL_0267: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_026c: pop
-		IL_026d: ldc.i4.1
-		IL_026e: newarr [System.Runtime]System.Object
-		IL_0273: dup
-		IL_0274: ldc.i4.0
-		IL_0275: ldloc.0
-		IL_0276: stelem.ref
-		IL_0277: ldc.i4.0
-		IL_0278: ldelem.ref
-		IL_0279: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_027e: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_0284: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0289: ldc.i4.1
-		IL_028a: newarr [System.Runtime]System.Object
-		IL_028f: dup
-		IL_0290: ldc.i4.0
-		IL_0291: ldloc.0
-		IL_0292: stelem.ref
-		IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_029d: ldc.i4.0
-		IL_029e: conv.r8
-		IL_029f: ldstr ""
-		IL_02a4: ldc.i4.0
-		IL_02a5: ldc.i4.1
-		IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02b0: stloc.3
-		IL_02b1: ldnull
-		IL_02b2: ldstr "pbkdf2 digest missing"
-		IL_02b7: ldloc.3
-		IL_02b8: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_02bd: pop
-		IL_02be: ldc.i4.1
-		IL_02bf: newarr [System.Runtime]System.Object
-		IL_02c4: dup
-		IL_02c5: ldc.i4.0
-		IL_02c6: ldloc.0
-		IL_02c7: stelem.ref
-		IL_02c8: ldc.i4.0
-		IL_02c9: ldelem.ref
-		IL_02ca: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_02cf: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_02d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02da: ldc.i4.1
-		IL_02db: newarr [System.Runtime]System.Object
-		IL_02e0: dup
+		IL_0227: conv.r8
+		IL_0228: ldstr ""
+		IL_022d: ldc.i4.0
+		IL_022e: ldc.i4.1
+		IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0239: stloc.3
+		IL_023a: ldloc.1
+		IL_023b: ldloc.s 4
+		IL_023d: ldstr "hmac key null"
+		IL_0242: ldloc.3
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0248: pop
+		IL_0249: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_024e: stloc.s 4
+		IL_0250: ldc.i4.1
+		IL_0251: newarr [System.Runtime]System.Object
+		IL_0256: dup
+		IL_0257: ldc.i4.0
+		IL_0258: ldloc.0
+		IL_0259: stelem.ref
+		IL_025a: ldc.i4.0
+		IL_025b: ldelem.ref
+		IL_025c: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0261: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L21C29::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0267: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_026c: ldc.i4.1
+		IL_026d: newarr [System.Runtime]System.Object
+		IL_0272: dup
+		IL_0273: ldc.i4.0
+		IL_0274: ldloc.0
+		IL_0275: stelem.ref
+		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0280: ldc.i4.0
+		IL_0281: conv.r8
+		IL_0282: ldstr ""
+		IL_0287: ldc.i4.0
+		IL_0288: ldc.i4.1
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0293: stloc.3
+		IL_0294: ldloc.1
+		IL_0295: ldloc.s 4
+		IL_0297: ldstr "hmac key number"
+		IL_029c: ldloc.3
+		IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02a2: pop
+		IL_02a3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02a8: stloc.s 4
+		IL_02aa: ldc.i4.1
+		IL_02ab: newarr [System.Runtime]System.Object
+		IL_02b0: dup
+		IL_02b1: ldc.i4.0
+		IL_02b2: ldloc.0
+		IL_02b3: stelem.ref
+		IL_02b4: ldc.i4.0
+		IL_02b5: ldelem.ref
+		IL_02b6: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_02bb: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L22C35::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_02c1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02c6: ldc.i4.1
+		IL_02c7: newarr [System.Runtime]System.Object
+		IL_02cc: dup
+		IL_02cd: ldc.i4.0
+		IL_02ce: ldloc.0
+		IL_02cf: stelem.ref
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02da: ldc.i4.0
+		IL_02db: conv.r8
+		IL_02dc: ldstr ""
 		IL_02e1: ldc.i4.0
-		IL_02e2: ldloc.0
-		IL_02e3: stelem.ref
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02ee: ldc.i4.0
-		IL_02ef: conv.r8
-		IL_02f0: ldstr ""
-		IL_02f5: ldc.i4.0
-		IL_02f6: ldc.i4.1
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0301: stloc.3
-		IL_0302: ldnull
-		IL_0303: ldstr "pbkdf2 digest unsupported"
-		IL_0308: ldloc.3
-		IL_0309: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_030e: pop
-		IL_030f: ldc.i4.1
-		IL_0310: newarr [System.Runtime]System.Object
-		IL_0315: dup
-		IL_0316: ldc.i4.0
-		IL_0317: ldloc.0
-		IL_0318: stelem.ref
-		IL_0319: ldc.i4.0
-		IL_031a: ldelem.ref
-		IL_031b: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0320: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_0326: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_032b: ldc.i4.1
-		IL_032c: newarr [System.Runtime]System.Object
-		IL_0331: dup
-		IL_0332: ldc.i4.0
-		IL_0333: ldloc.0
-		IL_0334: stelem.ref
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_033a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_033f: ldc.i4.0
-		IL_0340: conv.r8
-		IL_0341: ldstr ""
-		IL_0346: ldc.i4.0
-		IL_0347: ldc.i4.1
-		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_034d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0352: stloc.3
-		IL_0353: ldnull
-		IL_0354: ldstr "pbkdf2 password number"
-		IL_0359: ldloc.3
-		IL_035a: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_035f: pop
-		IL_0360: ldc.i4.1
-		IL_0361: newarr [System.Runtime]System.Object
-		IL_0366: dup
-		IL_0367: ldc.i4.0
-		IL_0368: ldloc.0
-		IL_0369: stelem.ref
-		IL_036a: ldc.i4.0
-		IL_036b: ldelem.ref
-		IL_036c: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0371: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_0377: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_037c: ldc.i4.1
-		IL_037d: newarr [System.Runtime]System.Object
-		IL_0382: dup
-		IL_0383: ldc.i4.0
-		IL_0384: ldloc.0
-		IL_0385: stelem.ref
-		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0390: ldc.i4.0
-		IL_0391: conv.r8
-		IL_0392: ldstr ""
-		IL_0397: ldc.i4.0
-		IL_0398: ldc.i4.1
-		IL_0399: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_03a3: stloc.3
-		IL_03a4: ldnull
-		IL_03a5: ldstr "pbkdf2 salt null"
+		IL_02e2: ldc.i4.1
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_02ed: stloc.3
+		IL_02ee: ldloc.1
+		IL_02ef: ldloc.s 4
+		IL_02f1: ldstr "pbkdf2 digest missing"
+		IL_02f6: ldloc.3
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02fc: pop
+		IL_02fd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0302: stloc.s 4
+		IL_0304: ldc.i4.1
+		IL_0305: newarr [System.Runtime]System.Object
+		IL_030a: dup
+		IL_030b: ldc.i4.0
+		IL_030c: ldloc.0
+		IL_030d: stelem.ref
+		IL_030e: ldc.i4.0
+		IL_030f: ldelem.ref
+		IL_0310: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0315: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L23C39::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_031b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0320: ldc.i4.1
+		IL_0321: newarr [System.Runtime]System.Object
+		IL_0326: dup
+		IL_0327: ldc.i4.0
+		IL_0328: ldloc.0
+		IL_0329: stelem.ref
+		IL_032a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0334: ldc.i4.0
+		IL_0335: conv.r8
+		IL_0336: ldstr ""
+		IL_033b: ldc.i4.0
+		IL_033c: ldc.i4.1
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0347: stloc.3
+		IL_0348: ldloc.1
+		IL_0349: ldloc.s 4
+		IL_034b: ldstr "pbkdf2 digest unsupported"
+		IL_0350: ldloc.3
+		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0356: pop
+		IL_0357: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_035c: stloc.s 4
+		IL_035e: ldc.i4.1
+		IL_035f: newarr [System.Runtime]System.Object
+		IL_0364: dup
+		IL_0365: ldc.i4.0
+		IL_0366: ldloc.0
+		IL_0367: stelem.ref
+		IL_0368: ldc.i4.0
+		IL_0369: ldelem.ref
+		IL_036a: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_036f: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L24C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0375: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_037a: ldc.i4.1
+		IL_037b: newarr [System.Runtime]System.Object
+		IL_0380: dup
+		IL_0381: ldc.i4.0
+		IL_0382: ldloc.0
+		IL_0383: stelem.ref
+		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_038e: ldc.i4.0
+		IL_038f: conv.r8
+		IL_0390: ldstr ""
+		IL_0395: ldc.i4.0
+		IL_0396: ldc.i4.1
+		IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_03a1: stloc.3
+		IL_03a2: ldloc.1
+		IL_03a3: ldloc.s 4
+		IL_03a5: ldstr "pbkdf2 password number"
 		IL_03aa: ldloc.3
-		IL_03ab: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 		IL_03b0: pop
-		IL_03b1: ldc.i4.1
-		IL_03b2: newarr [System.Runtime]System.Object
-		IL_03b7: dup
-		IL_03b8: ldc.i4.0
-		IL_03b9: ldloc.0
-		IL_03ba: stelem.ref
-		IL_03bb: ldc.i4.0
-		IL_03bc: ldelem.ref
-		IL_03bd: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_03c2: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_03c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_03cd: ldc.i4.1
-		IL_03ce: newarr [System.Runtime]System.Object
-		IL_03d3: dup
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldloc.0
-		IL_03d6: stelem.ref
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_03e1: ldc.i4.0
-		IL_03e2: conv.r8
-		IL_03e3: ldstr ""
+		IL_03b1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03b6: stloc.s 4
+		IL_03b8: ldc.i4.1
+		IL_03b9: newarr [System.Runtime]System.Object
+		IL_03be: dup
+		IL_03bf: ldc.i4.0
+		IL_03c0: ldloc.0
+		IL_03c1: stelem.ref
+		IL_03c2: ldc.i4.0
+		IL_03c3: ldelem.ref
+		IL_03c4: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_03c9: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L25C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_03cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_03d4: ldc.i4.1
+		IL_03d5: newarr [System.Runtime]System.Object
+		IL_03da: dup
+		IL_03db: ldc.i4.0
+		IL_03dc: ldloc.0
+		IL_03dd: stelem.ref
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_03e8: ldc.i4.0
-		IL_03e9: ldc.i4.1
-		IL_03ea: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_03f4: stloc.3
-		IL_03f5: ldnull
-		IL_03f6: ldstr "pbkdf2 iterations type"
-		IL_03fb: ldloc.3
-		IL_03fc: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0401: pop
-		IL_0402: ldc.i4.1
-		IL_0403: newarr [System.Runtime]System.Object
-		IL_0408: dup
-		IL_0409: ldc.i4.0
-		IL_040a: ldloc.0
-		IL_040b: stelem.ref
-		IL_040c: ldc.i4.0
-		IL_040d: ldelem.ref
-		IL_040e: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0413: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_0419: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_041e: ldc.i4.1
-		IL_041f: newarr [System.Runtime]System.Object
-		IL_0424: dup
-		IL_0425: ldc.i4.0
-		IL_0426: ldloc.0
-		IL_0427: stelem.ref
-		IL_0428: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0432: ldc.i4.0
-		IL_0433: conv.r8
-		IL_0434: ldstr ""
-		IL_0439: ldc.i4.0
-		IL_043a: ldc.i4.1
-		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0445: stloc.3
-		IL_0446: ldnull
-		IL_0447: ldstr "pbkdf2 iterations float"
-		IL_044c: ldloc.3
-		IL_044d: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0452: pop
-		IL_0453: ldc.i4.1
-		IL_0454: newarr [System.Runtime]System.Object
-		IL_0459: dup
-		IL_045a: ldc.i4.0
-		IL_045b: ldloc.0
-		IL_045c: stelem.ref
-		IL_045d: ldc.i4.0
-		IL_045e: ldelem.ref
-		IL_045f: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0464: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_046a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_046f: ldc.i4.1
-		IL_0470: newarr [System.Runtime]System.Object
-		IL_0475: dup
+		IL_03e9: conv.r8
+		IL_03ea: ldstr ""
+		IL_03ef: ldc.i4.0
+		IL_03f0: ldc.i4.1
+		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03f6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_03fb: stloc.3
+		IL_03fc: ldloc.1
+		IL_03fd: ldloc.s 4
+		IL_03ff: ldstr "pbkdf2 salt null"
+		IL_0404: ldloc.3
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_040a: pop
+		IL_040b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0410: stloc.s 4
+		IL_0412: ldc.i4.1
+		IL_0413: newarr [System.Runtime]System.Object
+		IL_0418: dup
+		IL_0419: ldc.i4.0
+		IL_041a: ldloc.0
+		IL_041b: stelem.ref
+		IL_041c: ldc.i4.0
+		IL_041d: ldelem.ref
+		IL_041e: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0423: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L26C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0429: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_042e: ldc.i4.1
+		IL_042f: newarr [System.Runtime]System.Object
+		IL_0434: dup
+		IL_0435: ldc.i4.0
+		IL_0436: ldloc.0
+		IL_0437: stelem.ref
+		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_043d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0442: ldc.i4.0
+		IL_0443: conv.r8
+		IL_0444: ldstr ""
+		IL_0449: ldc.i4.0
+		IL_044a: ldc.i4.1
+		IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0450: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0455: stloc.3
+		IL_0456: ldloc.1
+		IL_0457: ldloc.s 4
+		IL_0459: ldstr "pbkdf2 iterations type"
+		IL_045e: ldloc.3
+		IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0464: pop
+		IL_0465: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_046a: stloc.s 4
+		IL_046c: ldc.i4.1
+		IL_046d: newarr [System.Runtime]System.Object
+		IL_0472: dup
+		IL_0473: ldc.i4.0
+		IL_0474: ldloc.0
+		IL_0475: stelem.ref
 		IL_0476: ldc.i4.0
-		IL_0477: ldloc.0
-		IL_0478: stelem.ref
-		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0483: ldc.i4.0
-		IL_0484: conv.r8
-		IL_0485: ldstr ""
-		IL_048a: ldc.i4.0
-		IL_048b: ldc.i4.1
-		IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0496: stloc.3
-		IL_0497: ldnull
-		IL_0498: ldstr "pbkdf2 iterations zero"
-		IL_049d: ldloc.3
-		IL_049e: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_04a3: pop
+		IL_0477: ldelem.ref
+		IL_0478: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_047d: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L27C37::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0483: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0488: ldc.i4.1
+		IL_0489: newarr [System.Runtime]System.Object
+		IL_048e: dup
+		IL_048f: ldc.i4.0
+		IL_0490: ldloc.0
+		IL_0491: stelem.ref
+		IL_0492: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_049c: ldc.i4.0
+		IL_049d: conv.r8
+		IL_049e: ldstr ""
+		IL_04a3: ldc.i4.0
 		IL_04a4: ldc.i4.1
-		IL_04a5: newarr [System.Runtime]System.Object
-		IL_04aa: dup
-		IL_04ab: ldc.i4.0
-		IL_04ac: ldloc.0
-		IL_04ad: stelem.ref
-		IL_04ae: ldc.i4.0
-		IL_04af: ldelem.ref
-		IL_04b0: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_04b5: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_04bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_04c0: ldc.i4.1
-		IL_04c1: newarr [System.Runtime]System.Object
-		IL_04c6: dup
-		IL_04c7: ldc.i4.0
-		IL_04c8: ldloc.0
-		IL_04c9: stelem.ref
-		IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_04cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_04d4: ldc.i4.0
-		IL_04d5: conv.r8
-		IL_04d6: ldstr ""
-		IL_04db: ldc.i4.0
-		IL_04dc: ldc.i4.1
-		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04e2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_04e7: stloc.3
-		IL_04e8: ldnull
-		IL_04e9: ldstr "pbkdf2 keylen float"
-		IL_04ee: ldloc.3
-		IL_04ef: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_04f4: pop
-		IL_04f5: ldc.i4.1
-		IL_04f6: newarr [System.Runtime]System.Object
-		IL_04fb: dup
-		IL_04fc: ldc.i4.0
-		IL_04fd: ldloc.0
-		IL_04fe: stelem.ref
-		IL_04ff: ldc.i4.0
-		IL_0500: ldelem.ref
-		IL_0501: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0506: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_050c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0511: ldc.i4.1
-		IL_0512: newarr [System.Runtime]System.Object
-		IL_0517: dup
-		IL_0518: ldc.i4.0
-		IL_0519: ldloc.0
-		IL_051a: stelem.ref
-		IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0520: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0525: ldc.i4.0
-		IL_0526: conv.r8
-		IL_0527: ldstr ""
-		IL_052c: ldc.i4.0
-		IL_052d: ldc.i4.1
-		IL_052e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0538: stloc.3
-		IL_0539: ldnull
-		IL_053a: ldstr "pbkdf2 keylen negative"
-		IL_053f: ldloc.3
-		IL_0540: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0545: pop
-		IL_0546: ldc.i4.1
-		IL_0547: newarr [System.Runtime]System.Object
-		IL_054c: dup
-		IL_054d: ldc.i4.0
-		IL_054e: ldloc.0
-		IL_054f: stelem.ref
+		IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_04af: stloc.3
+		IL_04b0: ldloc.1
+		IL_04b1: ldloc.s 4
+		IL_04b3: ldstr "pbkdf2 iterations float"
+		IL_04b8: ldloc.3
+		IL_04b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04be: pop
+		IL_04bf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04c4: stloc.s 4
+		IL_04c6: ldc.i4.1
+		IL_04c7: newarr [System.Runtime]System.Object
+		IL_04cc: dup
+		IL_04cd: ldc.i4.0
+		IL_04ce: ldloc.0
+		IL_04cf: stelem.ref
+		IL_04d0: ldc.i4.0
+		IL_04d1: ldelem.ref
+		IL_04d2: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_04d7: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L28C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_04dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_04e2: ldc.i4.1
+		IL_04e3: newarr [System.Runtime]System.Object
+		IL_04e8: dup
+		IL_04e9: ldc.i4.0
+		IL_04ea: ldloc.0
+		IL_04eb: stelem.ref
+		IL_04ec: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_04f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_04f6: ldc.i4.0
+		IL_04f7: conv.r8
+		IL_04f8: ldstr ""
+		IL_04fd: ldc.i4.0
+		IL_04fe: ldc.i4.1
+		IL_04ff: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0509: stloc.3
+		IL_050a: ldloc.1
+		IL_050b: ldloc.s 4
+		IL_050d: ldstr "pbkdf2 iterations zero"
+		IL_0512: ldloc.3
+		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0518: pop
+		IL_0519: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_051e: stloc.s 4
+		IL_0520: ldc.i4.1
+		IL_0521: newarr [System.Runtime]System.Object
+		IL_0526: dup
+		IL_0527: ldc.i4.0
+		IL_0528: ldloc.0
+		IL_0529: stelem.ref
+		IL_052a: ldc.i4.0
+		IL_052b: ldelem.ref
+		IL_052c: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0531: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0537: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_053c: ldc.i4.1
+		IL_053d: newarr [System.Runtime]System.Object
+		IL_0542: dup
+		IL_0543: ldc.i4.0
+		IL_0544: ldloc.0
+		IL_0545: stelem.ref
+		IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_0550: ldc.i4.0
-		IL_0551: ldelem.ref
-		IL_0552: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0557: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_055d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0562: ldc.i4.1
-		IL_0563: newarr [System.Runtime]System.Object
-		IL_0568: dup
-		IL_0569: ldc.i4.0
-		IL_056a: ldloc.0
-		IL_056b: stelem.ref
-		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0576: ldc.i4.0
-		IL_0577: conv.r8
-		IL_0578: ldstr ""
-		IL_057d: ldc.i4.0
-		IL_057e: ldc.i4.1
-		IL_057f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0584: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0589: stloc.3
-		IL_058a: ldnull
-		IL_058b: ldstr "random size type"
-		IL_0590: ldloc.3
-		IL_0591: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0596: pop
-		IL_0597: ldc.i4.1
-		IL_0598: newarr [System.Runtime]System.Object
-		IL_059d: dup
-		IL_059e: ldc.i4.0
-		IL_059f: ldloc.0
-		IL_05a0: stelem.ref
-		IL_05a1: ldc.i4.0
-		IL_05a2: ldelem.ref
-		IL_05a3: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_05a8: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_05ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_05b3: ldc.i4.1
-		IL_05b4: newarr [System.Runtime]System.Object
-		IL_05b9: dup
-		IL_05ba: ldc.i4.0
-		IL_05bb: ldloc.0
-		IL_05bc: stelem.ref
-		IL_05bd: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_05c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_05c7: ldc.i4.0
-		IL_05c8: conv.r8
-		IL_05c9: ldstr ""
-		IL_05ce: ldc.i4.0
-		IL_05cf: ldc.i4.1
-		IL_05d0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05d5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_05da: stloc.3
-		IL_05db: ldnull
-		IL_05dc: ldstr "random size negative"
-		IL_05e1: ldloc.3
-		IL_05e2: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_05e7: pop
-		IL_05e8: ldloc.0
-		IL_05e9: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_05ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05f3: stloc.3
-		IL_05f4: ldloc.3
-		IL_05f5: ldstr "createHash"
-		IL_05fa: ldstr "sha256"
-		IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0604: stloc.3
-		IL_0605: ldloc.0
-		IL_0606: ldloc.3
-		IL_0607: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_060c: ldloc.0
-		IL_060d: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0551: conv.r8
+		IL_0552: ldstr ""
+		IL_0557: ldc.i4.0
+		IL_0558: ldc.i4.1
+		IL_0559: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_055e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0563: stloc.3
+		IL_0564: ldloc.1
+		IL_0565: ldloc.s 4
+		IL_0567: ldstr "pbkdf2 keylen float"
+		IL_056c: ldloc.3
+		IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0572: pop
+		IL_0573: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0578: stloc.s 4
+		IL_057a: ldc.i4.1
+		IL_057b: newarr [System.Runtime]System.Object
+		IL_0580: dup
+		IL_0581: ldc.i4.0
+		IL_0582: ldloc.0
+		IL_0583: stelem.ref
+		IL_0584: ldc.i4.0
+		IL_0585: ldelem.ref
+		IL_0586: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_058b: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L30C36::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0591: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0596: ldc.i4.1
+		IL_0597: newarr [System.Runtime]System.Object
+		IL_059c: dup
+		IL_059d: ldc.i4.0
+		IL_059e: ldloc.0
+		IL_059f: stelem.ref
+		IL_05a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_05aa: ldc.i4.0
+		IL_05ab: conv.r8
+		IL_05ac: ldstr ""
+		IL_05b1: ldc.i4.0
+		IL_05b2: ldc.i4.1
+		IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_05b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_05bd: stloc.3
+		IL_05be: ldloc.1
+		IL_05bf: ldloc.s 4
+		IL_05c1: ldstr "pbkdf2 keylen negative"
+		IL_05c6: ldloc.3
+		IL_05c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_05cc: pop
+		IL_05cd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05d2: stloc.s 4
+		IL_05d4: ldc.i4.1
+		IL_05d5: newarr [System.Runtime]System.Object
+		IL_05da: dup
+		IL_05db: ldc.i4.0
+		IL_05dc: ldloc.0
+		IL_05dd: stelem.ref
+		IL_05de: ldc.i4.0
+		IL_05df: ldelem.ref
+		IL_05e0: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_05e5: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L31C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_05eb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_05f0: ldc.i4.1
+		IL_05f1: newarr [System.Runtime]System.Object
+		IL_05f6: dup
+		IL_05f7: ldc.i4.0
+		IL_05f8: ldloc.0
+		IL_05f9: stelem.ref
+		IL_05fa: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0604: ldc.i4.0
+		IL_0605: conv.r8
+		IL_0606: ldstr ""
+		IL_060b: ldc.i4.0
+		IL_060c: ldc.i4.1
+		IL_060d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
 		IL_0617: stloc.3
-		IL_0618: ldloc.3
-		IL_0619: ldstr "update"
-		IL_061e: ldstr "abc"
-		IL_0623: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0628: pop
-		IL_0629: ldloc.0
-		IL_062a: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
-		IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0634: stloc.3
-		IL_0635: ldloc.3
-		IL_0636: ldstr "digest"
-		IL_063b: ldstr "hex"
-		IL_0640: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0645: stloc.3
-		IL_0646: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_064b: ldstr "digest first:"
-		IL_0650: ldloc.3
-		IL_0651: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0656: pop
-		IL_0657: ldc.i4.1
-		IL_0658: newarr [System.Runtime]System.Object
-		IL_065d: dup
+		IL_0618: ldloc.1
+		IL_0619: ldloc.s 4
+		IL_061b: ldstr "random size type"
+		IL_0620: ldloc.3
+		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0626: pop
+		IL_0627: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_062c: stloc.s 4
+		IL_062e: ldc.i4.1
+		IL_062f: newarr [System.Runtime]System.Object
+		IL_0634: dup
+		IL_0635: ldc.i4.0
+		IL_0636: ldloc.0
+		IL_0637: stelem.ref
+		IL_0638: ldc.i4.0
+		IL_0639: ldelem.ref
+		IL_063a: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_063f: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L32C34::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0645: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_064a: ldc.i4.1
+		IL_064b: newarr [System.Runtime]System.Object
+		IL_0650: dup
+		IL_0651: ldc.i4.0
+		IL_0652: ldloc.0
+		IL_0653: stelem.ref
+		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0659: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_065e: ldc.i4.0
-		IL_065f: ldloc.0
-		IL_0660: stelem.ref
-		IL_0661: ldc.i4.0
-		IL_0662: ldelem.ref
-		IL_0663: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_0668: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_066e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0673: ldc.i4.1
-		IL_0674: newarr [System.Runtime]System.Object
-		IL_0679: dup
-		IL_067a: ldc.i4.0
-		IL_067b: ldloc.0
-		IL_067c: stelem.ref
-		IL_067d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0687: ldc.i4.0
-		IL_0688: conv.r8
-		IL_0689: ldstr ""
-		IL_068e: ldc.i4.0
-		IL_068f: ldc.i4.1
-		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_069a: stloc.3
-		IL_069b: ldnull
-		IL_069c: ldstr "digest twice"
-		IL_06a1: ldloc.3
-		IL_06a2: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_06a7: pop
-		IL_06a8: ldloc.0
-		IL_06a9: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
-		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06b3: stloc.3
-		IL_06b4: ldloc.3
-		IL_06b5: ldstr "createHmac"
-		IL_06ba: ldstr "sha256"
-		IL_06bf: ldstr "key"
-		IL_06c4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_06c9: stloc.3
-		IL_06ca: ldloc.0
-		IL_06cb: ldloc.3
-		IL_06cc: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
-		IL_06d1: ldc.i4.1
-		IL_06d2: newarr [System.Runtime]System.Object
-		IL_06d7: dup
-		IL_06d8: ldc.i4.0
-		IL_06d9: ldloc.0
-		IL_06da: stelem.ref
-		IL_06db: ldc.i4.0
-		IL_06dc: ldelem.ref
-		IL_06dd: castclass Modules.Require_Crypto_ErrorPaths/Scope
-		IL_06e2: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
-		IL_06e8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_06ed: ldc.i4.1
-		IL_06ee: newarr [System.Runtime]System.Object
-		IL_06f3: dup
-		IL_06f4: ldc.i4.0
-		IL_06f5: ldloc.0
-		IL_06f6: stelem.ref
-		IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_06fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_065f: conv.r8
+		IL_0660: ldstr ""
+		IL_0665: ldc.i4.0
+		IL_0666: ldc.i4.1
+		IL_0667: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_066c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0671: stloc.3
+		IL_0672: ldloc.1
+		IL_0673: ldloc.s 4
+		IL_0675: ldstr "random size negative"
+		IL_067a: ldloc.3
+		IL_067b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0680: pop
+		IL_0681: ldloc.0
+		IL_0682: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_068c: stloc.3
+		IL_068d: ldloc.3
+		IL_068e: ldstr "createHash"
+		IL_0693: ldstr "sha256"
+		IL_0698: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_069d: stloc.3
+		IL_069e: ldloc.0
+		IL_069f: ldloc.3
+		IL_06a0: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_06a5: ldloc.0
+		IL_06a6: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06b0: stloc.3
+		IL_06b1: ldloc.3
+		IL_06b2: ldstr "update"
+		IL_06b7: ldstr "abc"
+		IL_06bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_06c1: pop
+		IL_06c2: ldloc.0
+		IL_06c3: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::hash
+		IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06cd: stloc.3
+		IL_06ce: ldloc.3
+		IL_06cf: ldstr "digest"
+		IL_06d4: ldstr "hex"
+		IL_06d9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_06de: stloc.3
+		IL_06df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06e4: ldstr "digest first:"
+		IL_06e9: ldloc.3
+		IL_06ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06ef: pop
+		IL_06f0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06f5: stloc.s 4
+		IL_06f7: ldc.i4.1
+		IL_06f8: newarr [System.Runtime]System.Object
+		IL_06fd: dup
+		IL_06fe: ldc.i4.0
+		IL_06ff: ldloc.0
+		IL_0700: stelem.ref
 		IL_0701: ldc.i4.0
-		IL_0702: conv.r8
-		IL_0703: ldstr ""
-		IL_0708: ldc.i4.0
-		IL_0709: ldc.i4.1
-		IL_070a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_070f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0714: stloc.3
-		IL_0715: ldnull
-		IL_0716: ldstr "hmac update type"
-		IL_071b: ldloc.3
-		IL_071c: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0721: pop
-		IL_0722: ldc.i4.1
-		IL_0723: newarr [System.Runtime]System.Object
-		IL_0728: dup
-		IL_0729: ldc.i4.0
-		IL_072a: ldloc.0
-		IL_072b: stelem.ref
-		IL_072c: ldnull
-		IL_072d: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
-		IL_0732: stloc.3
-		IL_0733: ldloc.3
-		IL_0734: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0739: stloc.3
-		IL_073a: ldnull
-		IL_073b: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27::__js_call__(object)
-		IL_0741: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0746: ldc.i4.1
-		IL_0747: newarr [System.Runtime]System.Object
-		IL_074c: dup
-		IL_074d: ldc.i4.0
-		IL_074e: ldloc.0
-		IL_074f: stelem.ref
-		IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0755: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_075a: ldc.i4.0
-		IL_075b: conv.r8
-		IL_075c: ldstr ""
-		IL_0761: ldc.i4.0
-		IL_0762: ldc.i4.1
-		IL_0763: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0768: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_076d: stloc.s 4
-		IL_076f: ldloc.3
-		IL_0770: ldstr "then"
-		IL_0775: ldloc.s 4
-		IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_077c: pop
-		IL_077d: ret
+		IL_0702: ldelem.ref
+		IL_0703: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_0708: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L37C26::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_070e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0713: ldc.i4.1
+		IL_0714: newarr [System.Runtime]System.Object
+		IL_0719: dup
+		IL_071a: ldc.i4.0
+		IL_071b: ldloc.0
+		IL_071c: stelem.ref
+		IL_071d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0722: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0727: ldc.i4.0
+		IL_0728: conv.r8
+		IL_0729: ldstr ""
+		IL_072e: ldc.i4.0
+		IL_072f: ldc.i4.1
+		IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0735: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_073a: stloc.3
+		IL_073b: ldloc.1
+		IL_073c: ldloc.s 4
+		IL_073e: ldstr "digest twice"
+		IL_0743: ldloc.3
+		IL_0744: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0749: pop
+		IL_074a: ldloc.0
+		IL_074b: ldfld object Modules.Require_Crypto_ErrorPaths/Scope::crypto
+		IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0755: stloc.3
+		IL_0756: ldloc.3
+		IL_0757: ldstr "createHmac"
+		IL_075c: ldstr "sha256"
+		IL_0761: ldstr "key"
+		IL_0766: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_076b: stloc.3
+		IL_076c: ldloc.0
+		IL_076d: ldloc.3
+		IL_076e: stfld object Modules.Require_Crypto_ErrorPaths/Scope::hmac
+		IL_0773: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0778: stloc.s 4
+		IL_077a: ldc.i4.1
+		IL_077b: newarr [System.Runtime]System.Object
+		IL_0780: dup
+		IL_0781: ldc.i4.0
+		IL_0782: ldloc.0
+		IL_0783: stelem.ref
+		IL_0784: ldc.i4.0
+		IL_0785: ldelem.ref
+		IL_0786: castclass Modules.Require_Crypto_ErrorPaths/Scope
+		IL_078b: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L40C30::__js_call__(class Modules.Require_Crypto_ErrorPaths/Scope, object)
+		IL_0791: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0796: ldc.i4.1
+		IL_0797: newarr [System.Runtime]System.Object
+		IL_079c: dup
+		IL_079d: ldc.i4.0
+		IL_079e: ldloc.0
+		IL_079f: stelem.ref
+		IL_07a0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_07a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_07aa: ldc.i4.0
+		IL_07ab: conv.r8
+		IL_07ac: ldstr ""
+		IL_07b1: ldc.i4.0
+		IL_07b2: ldc.i4.1
+		IL_07b3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_07bd: stloc.3
+		IL_07be: ldloc.1
+		IL_07bf: ldloc.s 4
+		IL_07c1: ldstr "hmac update type"
+		IL_07c6: ldloc.3
+		IL_07c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_07cc: pop
+		IL_07cd: ldloc.2
+		IL_07ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_07d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_07d8: stloc.3
+		IL_07d9: ldloc.3
+		IL_07da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_07df: stloc.3
+		IL_07e0: ldnull
+		IL_07e1: ldftn object Modules.Require_Crypto_ErrorPaths/ArrowFunction_L111C27::__js_call__(object)
+		IL_07e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_07ec: ldc.i4.1
+		IL_07ed: newarr [System.Runtime]System.Object
+		IL_07f2: dup
+		IL_07f3: ldc.i4.0
+		IL_07f4: ldloc.0
+		IL_07f5: stelem.ref
+		IL_07f6: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0800: ldc.i4.0
+		IL_0801: conv.r8
+		IL_0802: ldstr ""
+		IL_0807: ldc.i4.0
+		IL_0808: ldc.i4.1
+		IL_0809: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_080e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0813: stloc.s 5
+		IL_0815: ldloc.3
+		IL_0816: ldstr "then"
+		IL_081b: ldloc.s 5
+		IL_081d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0822: pop
+		IL_0823: ret
 	} // end of method Require_Crypto_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Crypto_ErrorPaths
@@ -4447,7 +4560,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x3d3f
+		// Method begins at RVA 0x3e6f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Require_Crypto_WebCrypto_Subtle
+﻿// IL code: Require_Crypto_WebCrypto_Subtle
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -69,7 +69,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29ac
+				// Method begins at RVA 0x29a4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -93,7 +93,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20f8
+			// Method begins at RVA 0x20f0
 			// Header size: 12
 			// Code size: 2188 (0x88c)
 			.maxstack 8
@@ -1025,7 +1025,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29b5
+				// Method begins at RVA 0x29ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1048,7 +1048,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2990
+			// Method begins at RVA 0x2988
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -1079,7 +1079,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x29a3
+			// Method begins at RVA 0x299b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1105,7 +1105,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 153 (0x99)
+		// Code size: 148 (0x94)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_WebCrypto_Subtle/Scope,
@@ -1140,43 +1140,38 @@
 		IL_0038: ldloc.0
 		IL_0039: ldloc.2
 		IL_003a: stfld object Modules.Require_Crypto_WebCrypto_Subtle/Scope::crypto
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: ldnull
-		IL_004a: call object Modules.Require_Crypto_WebCrypto_Subtle/run::__js_call__(object[], object)
-		IL_004f: stloc.2
-		IL_0050: ldloc.2
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0056: stloc.2
-		IL_0057: ldnull
-		IL_0058: ldftn object Modules.Require_Crypto_WebCrypto_Subtle/ArrowFunction_L39C12::__js_call__(object)
-		IL_005e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0063: ldc.i4.1
-		IL_0064: newarr [System.Runtime]System.Object
-		IL_0069: dup
-		IL_006a: ldc.i4.0
-		IL_006b: ldloc.0
-		IL_006c: stelem.ref
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0077: ldc.i4.0
-		IL_0078: conv.r8
-		IL_0079: ldstr ""
-		IL_007e: ldc.i4.0
-		IL_007f: ldc.i4.1
-		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_008a: stloc.3
-		IL_008b: ldloc.2
-		IL_008c: ldstr "then"
-		IL_0091: ldloc.3
-		IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0097: pop
-		IL_0098: ret
+		IL_003f: ldloc.1
+		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004a: stloc.2
+		IL_004b: ldloc.2
+		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0051: stloc.2
+		IL_0052: ldnull
+		IL_0053: ldftn object Modules.Require_Crypto_WebCrypto_Subtle/ArrowFunction_L39C12::__js_call__(object)
+		IL_0059: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_005e: ldc.i4.1
+		IL_005f: newarr [System.Runtime]System.Object
+		IL_0064: dup
+		IL_0065: ldc.i4.0
+		IL_0066: ldloc.0
+		IL_0067: stelem.ref
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0072: ldc.i4.0
+		IL_0073: conv.r8
+		IL_0074: ldstr ""
+		IL_0079: ldc.i4.0
+		IL_007a: ldc.i4.1
+		IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0085: stloc.3
+		IL_0086: ldloc.2
+		IL_0087: ldstr "then"
+		IL_008c: ldloc.3
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0092: pop
+		IL_0093: ret
 	} // end of method Require_Crypto_WebCrypto_Subtle::__js_module_init__
 
 } // end of class Modules.Require_Crypto_WebCrypto_Subtle
@@ -1188,7 +1183,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29be
+		// Method begins at RVA 0x29b6
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Events_AsyncHelpers_On_Once
+﻿// IL code: Events_AsyncHelpers_On_Once
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fa8
+				// Method begins at RVA 0x2fa4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fc3
+						// Method begins at RVA 0x2fbf
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fba
+					// Method begins at RVA 0x2fb6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fb1
+				// Method begins at RVA 0x2fad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21d4
 			// Header size: 12
 			// Code size: 1189 (0x4a5)
 			.maxstack 8
@@ -650,7 +650,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fde
+						// Method begins at RVA 0x2fda
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -674,7 +674,7 @@
 						.method public hidebysig specialname rtspecialname 
 							instance void .ctor () cil managed 
 						{
-							// Method begins at RVA 0x2ff0
+							// Method begins at RVA 0x2fec
 							// Header size: 1
 							// Code size: 8 (0x8)
 							.maxstack 8
@@ -692,7 +692,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2fe7
+						// Method begins at RVA 0x2fe3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -712,7 +712,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2ff9
+						// Method begins at RVA 0x2ff5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -736,7 +736,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2fd5
+					// Method begins at RVA 0x2fd1
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -760,7 +760,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2bf0
+				// Method begins at RVA 0x2bec
 				// Header size: 12
 				// Code size: 931 (0x3a3)
 				.maxstack 8
@@ -1202,7 +1202,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2fcc
+				// Method begins at RVA 0x2fc8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1226,7 +1226,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x268c
+			// Method begins at RVA 0x2688
 			// Header size: 12
 			// Code size: 417 (0x1a1)
 			.maxstack 8
@@ -1440,7 +1440,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3002
+				// Method begins at RVA 0x2ffe
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1464,7 +1464,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x283c
+			// Method begins at RVA 0x2838
 			// Header size: 12
 			// Code size: 431 (0x1af)
 			.maxstack 8
@@ -1668,7 +1668,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x3014
+					// Method begins at RVA 0x3010
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1688,7 +1688,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x301d
+					// Method begins at RVA 0x3019
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -1712,7 +1712,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x300b
+				// Method begins at RVA 0x3007
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1736,7 +1736,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x29f8
+			// Method begins at RVA 0x29f4
 			// Header size: 12
 			// Code size: 470 (0x1d6)
 			.maxstack 8
@@ -1956,7 +1956,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x3026
+				// Method begins at RVA 0x3022
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1979,7 +1979,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2bda
+			// Method begins at RVA 0x2bd6
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -2023,7 +2023,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2f9f
+			// Method begins at RVA 0x2f9b
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -2049,7 +2049,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 379 (0x17b)
+		// Code size: 374 (0x176)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_AsyncHelpers_On_Once/Scope,
@@ -2144,67 +2144,62 @@
 		IL_00c3: ldstr "EventEmitter"
 		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00cd: stfld object Modules.Events_AsyncHelpers_On_Once/Scope::EventEmitter
-		IL_00d2: ldc.i4.1
-		IL_00d3: newarr [System.Runtime]System.Object
-		IL_00d8: dup
-		IL_00d9: ldc.i4.0
-		IL_00da: ldloc.0
-		IL_00db: stelem.ref
-		IL_00dc: ldnull
-		IL_00dd: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
-		IL_00e2: stloc.s 5
-		IL_00e4: ldloc.s 5
-		IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00eb: stloc.s 5
-		IL_00ed: ldloc.s 5
-		IL_00ef: ldstr "then"
-		IL_00f4: ldloc.2
-		IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_00fa: stloc.s 5
-		IL_00fc: ldloc.s 5
-		IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0103: stloc.s 5
-		IL_0105: ldloc.s 5
-		IL_0107: ldstr "then"
-		IL_010c: ldloc.3
-		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0112: stloc.s 5
-		IL_0114: ldloc.s 5
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_011b: stloc.s 5
-		IL_011d: ldloc.s 5
-		IL_011f: ldstr "then"
-		IL_0124: ldloc.s 4
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_012b: stloc.s 5
-		IL_012d: ldloc.s 5
-		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0134: stloc.s 5
-		IL_0136: ldnull
-		IL_0137: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
-		IL_013d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0142: ldc.i4.1
-		IL_0143: newarr [System.Runtime]System.Object
-		IL_0148: dup
-		IL_0149: ldc.i4.0
-		IL_014a: ldloc.0
-		IL_014b: stelem.ref
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0156: ldc.i4.0
-		IL_0157: conv.r8
-		IL_0158: ldstr ""
-		IL_015d: ldc.i4.0
-		IL_015e: ldc.i4.1
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0169: stloc.s 6
-		IL_016b: ldloc.s 5
-		IL_016d: ldstr "then"
-		IL_0172: ldloc.s 6
-		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0179: pop
-		IL_017a: ret
+		IL_00d2: ldloc.1
+		IL_00d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00dd: stloc.s 5
+		IL_00df: ldloc.s 5
+		IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e6: stloc.s 5
+		IL_00e8: ldloc.s 5
+		IL_00ea: ldstr "then"
+		IL_00ef: ldloc.2
+		IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_00f5: stloc.s 5
+		IL_00f7: ldloc.s 5
+		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00fe: stloc.s 5
+		IL_0100: ldloc.s 5
+		IL_0102: ldstr "then"
+		IL_0107: ldloc.3
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010d: stloc.s 5
+		IL_010f: ldloc.s 5
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.s 5
+		IL_0118: ldloc.s 5
+		IL_011a: ldstr "then"
+		IL_011f: ldloc.s 4
+		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0126: stloc.s 5
+		IL_0128: ldloc.s 5
+		IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_012f: stloc.s 5
+		IL_0131: ldnull
+		IL_0132: ldftn object Modules.Events_AsyncHelpers_On_Once/ArrowFunction_L74C9::__js_call__(object)
+		IL_0138: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_013d: ldc.i4.1
+		IL_013e: newarr [System.Runtime]System.Object
+		IL_0143: dup
+		IL_0144: ldc.i4.0
+		IL_0145: ldloc.0
+		IL_0146: stelem.ref
+		IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0151: ldc.i4.0
+		IL_0152: conv.r8
+		IL_0153: ldstr ""
+		IL_0158: ldc.i4.0
+		IL_0159: ldc.i4.1
+		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0164: stloc.s 6
+		IL_0166: ldloc.s 5
+		IL_0168: ldstr "then"
+		IL_016d: ldloc.s 6
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0174: pop
+		IL_0175: ret
 	} // end of method Events_AsyncHelpers_On_Once::__js_module_init__
 
 } // end of class Modules.Events_AsyncHelpers_On_Once
@@ -2216,7 +2211,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x302f
+		// Method begins at RVA 0x302b
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -112,13 +112,14 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 137 (0x89)
+		// Code size: 140 (0x8c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Join_NestedFunction/Scope,
 			[1] object,
 			[2] object,
-			[3] object
+			[3] object,
+			[4] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Require_Path_Join_NestedFunction/Scope::.ctor()
@@ -150,29 +151,30 @@
 		IL_003f: ldloc.0
 		IL_0040: ldloc.3
 		IL_0041: stfld object Modules.Require_Path_Join_NestedFunction/Scope::path
-		IL_0046: ldloc.0
-		IL_0047: castclass Modules.Require_Path_Join_NestedFunction/Scope
-		IL_004c: ldnull
-		IL_004d: ldstr "a"
-		IL_0052: ldstr "b"
-		IL_0057: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
-		IL_005c: stloc.3
-		IL_005d: ldloc.3
-		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0063: stloc.3
-		IL_0064: ldloc.3
-		IL_0065: ldstr "replace"
-		IL_006a: ldstr "\\"
-		IL_006f: ldstr "/"
-		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-		IL_0079: stloc.3
-		IL_007a: ldloc.3
-		IL_007b: stloc.2
-		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0081: ldloc.2
-		IL_0082: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0087: pop
-		IL_0088: ret
+		IL_0046: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004b: stloc.s 4
+		IL_004d: ldloc.1
+		IL_004e: ldloc.s 4
+		IL_0050: ldstr "a"
+		IL_0055: ldstr "b"
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_005f: stloc.3
+		IL_0060: ldloc.3
+		IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0066: stloc.3
+		IL_0067: ldloc.3
+		IL_0068: ldstr "replace"
+		IL_006d: ldstr "\\"
+		IL_0072: ldstr "/"
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+		IL_007c: stloc.3
+		IL_007d: ldloc.3
+		IL_007e: stloc.2
+		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0084: ldloc.2
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008a: pop
+		IL_008b: ret
 	} // end of method Require_Path_Join_NestedFunction::__js_module_init__
 
 } // end of class Modules.Require_Path_Join_NestedFunction

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2937
+					// Method begins at RVA 0x2993
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x291c
+				// Method begins at RVA 0x2978
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x292e
+				// Method begins at RVA 0x298a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -90,7 +90,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2124
+			// Method begins at RVA 0x2120
 			// Header size: 12
 			// Code size: 101 (0x65)
 			.maxstack 8
@@ -155,7 +155,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2940
+				// Method begins at RVA 0x299c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -181,7 +181,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2198
+			// Method begins at RVA 0x2194
 			// Header size: 12
 			// Code size: 52 (0x34)
 			.maxstack 8
@@ -228,7 +228,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x295b
+					// Method begins at RVA 0x29b7
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -251,7 +251,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x291f
+				// Method begins at RVA 0x297b
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -273,7 +273,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2976
+					// Method begins at RVA 0x29d2
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -296,7 +296,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2922
+				// Method begins at RVA 0x297e
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -333,7 +333,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2952
+					// Method begins at RVA 0x29ae
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -353,7 +353,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2964
+					// Method begins at RVA 0x29c0
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -373,7 +373,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x296d
+					// Method begins at RVA 0x29c9
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -393,7 +393,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x297f
+					// Method begins at RVA 0x29db
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -413,7 +413,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2988
+					// Method begins at RVA 0x29e4
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -433,7 +433,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2991
+					// Method begins at RVA 0x29ed
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -453,7 +453,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x299a
+					// Method begins at RVA 0x29f6
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -473,7 +473,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29a3
+					// Method begins at RVA 0x29ff
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -501,7 +501,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2949
+				// Method begins at RVA 0x29a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -525,9 +525,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21d4
 			// Header size: 12
-			// Code size: 1818 (0x71a)
+			// Code size: 1914 (0x77a)
 			.maxstack 10
 			.locals init (
 				[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope,
@@ -690,7 +690,7 @@
 
 			IL_00ff: ldloc.0
 			IL_0100: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0105: switch (IL_011e, IL_049d, IL_0481, IL_0664, IL_0648)
+			IL_0105: switch (IL_011e, IL_04dd, IL_04c1, IL_06c4, IL_06a8)
 			.try
 			{
 				IL_011e: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L17C6::.ctor()
@@ -706,616 +706,664 @@
 				IL_0139: ldc.i4.1
 				IL_013a: ldelem.ref
 				IL_013b: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0140: ldnull
-				IL_0141: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_0146: stloc.s 21
-				IL_0148: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_014d: dup
-				IL_014e: ldstr "signal"
-				IL_0153: ldc.i4.0
-				IL_0154: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-				IL_0159: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_015e: stloc.s 22
-				IL_0160: ldnull
-				IL_0161: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-				IL_0167: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_016c: ldc.i4.0
-				IL_016d: conv.r8
-				IL_016e: ldstr ""
-				IL_0173: ldc.i4.0
-				IL_0174: ldc.i4.1
-				IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_017a: stloc.s 23
-				IL_017c: ldloc.s 20
-				IL_017e: ldstr "finished"
-				IL_0183: ldloc.s 21
-				IL_0185: ldloc.s 22
-				IL_0187: ldloc.s 23
-				IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-				IL_018e: pop
-				IL_018f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0194: ldstr "callback-finished:ok"
-				IL_0199: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0140: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_0145: ldc.i4.1
+				IL_0146: newarr [System.Runtime]System.Object
+				IL_014b: dup
+				IL_014c: ldc.i4.0
+				IL_014d: ldarg.0
+				IL_014e: ldc.i4.1
+				IL_014f: ldelem.ref
+				IL_0150: stelem.ref
+				IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0156: stloc.s 21
+				IL_0158: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_015d: dup
+				IL_015e: ldstr "signal"
+				IL_0163: ldc.i4.0
+				IL_0164: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+				IL_0169: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_016e: stloc.s 22
+				IL_0170: ldnull
+				IL_0171: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+				IL_0177: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_017c: ldc.i4.0
+				IL_017d: conv.r8
+				IL_017e: ldstr ""
+				IL_0183: ldc.i4.0
+				IL_0184: ldc.i4.1
+				IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_018a: stloc.s 23
+				IL_018c: ldloc.s 20
+				IL_018e: ldstr "finished"
+				IL_0193: ldloc.s 21
+				IL_0195: ldloc.s 22
+				IL_0197: ldloc.s 23
+				IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
 				IL_019e: pop
-				IL_019f: leave IL_023f
+				IL_019f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_01a4: ldstr "callback-finished:ok"
+				IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_01ae: pop
+				IL_01af: leave IL_024f
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_01a4: stloc.2
-				IL_01a5: ldloc.2
-				IL_01a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_01ab: dup
-				IL_01ac: brtrue IL_01c1
+				IL_01b4: stloc.2
+				IL_01b5: ldloc.2
+				IL_01b6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_01bb: dup
+				IL_01bc: brtrue IL_01d1
 
-				IL_01b1: pop
-				IL_01b2: ldloc.2
-				IL_01b3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_01b8: dup
-				IL_01b9: brtrue IL_01cc
+				IL_01c1: pop
+				IL_01c2: ldloc.2
+				IL_01c3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_01c8: dup
+				IL_01c9: brtrue IL_01dc
 
-				IL_01be: pop
-				IL_01bf: rethrow
+				IL_01ce: pop
+				IL_01cf: rethrow
 
-				IL_01c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_01c6: stloc.3
-				IL_01c7: br IL_01cd
+				IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_01d6: stloc.3
+				IL_01d7: br IL_01dd
 
-				IL_01cc: stloc.3
+				IL_01dc: stloc.3
 
-				IL_01cd: ldloc.3
-				IL_01ce: stloc.s 23
-				IL_01d0: ldloc.s 23
-				IL_01d2: stloc.s 4
-				IL_01d4: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
-				IL_01d9: stloc.s 5
-				IL_01db: ldstr "callback-finished:"
-				IL_01e0: ldloc.s 4
-				IL_01e2: ldstr "name"
-				IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01f1: stloc.s 24
-				IL_01f3: ldloc.s 24
-				IL_01f5: ldstr ":"
-				IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_01ff: stloc.s 24
-				IL_0201: ldloc.s 24
-				IL_0203: ldloc.s 4
-				IL_0205: ldstr "code"
-				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0214: stloc.s 24
-				IL_0216: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_021b: ldloc.s 24
-				IL_021d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0222: pop
-				IL_0223: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0228: ldloc.s 4
-				IL_022a: ldstr "message"
-				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0234: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0239: pop
-				IL_023a: leave IL_023f
+				IL_01dd: ldloc.3
+				IL_01de: stloc.s 23
+				IL_01e0: ldloc.s 23
+				IL_01e2: stloc.s 4
+				IL_01e4: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L20C18::.ctor()
+				IL_01e9: stloc.s 5
+				IL_01eb: ldstr "callback-finished:"
+				IL_01f0: ldloc.s 4
+				IL_01f2: ldstr "name"
+				IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0201: stloc.s 24
+				IL_0203: ldloc.s 24
+				IL_0205: ldstr ":"
+				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_020f: stloc.s 24
+				IL_0211: ldloc.s 24
+				IL_0213: ldloc.s 4
+				IL_0215: ldstr "code"
+				IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0224: stloc.s 24
+				IL_0226: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_022b: ldloc.s 24
+				IL_022d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0232: pop
+				IL_0233: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0238: ldloc.s 4
+				IL_023a: ldstr "message"
+				IL_023f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0244: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0249: pop
+				IL_024a: leave IL_024f
 			} // end handler
 			.try
 			{
-				IL_023f: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
-				IL_0244: stloc.s 6
-				IL_0246: ldarg.0
-				IL_0247: ldc.i4.1
-				IL_0248: ldelem.ref
-				IL_0249: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_024e: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
-				IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0258: stloc.s 23
-				IL_025a: ldarg.0
-				IL_025b: ldc.i4.1
-				IL_025c: ldelem.ref
-				IL_025d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0262: ldnull
-				IL_0263: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_0268: stloc.s 21
+				IL_024f: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L25C6::.ctor()
+				IL_0254: stloc.s 6
+				IL_0256: ldarg.0
+				IL_0257: ldc.i4.1
+				IL_0258: ldelem.ref
+				IL_0259: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_025e: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::'stream'
+				IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0268: stloc.s 23
 				IL_026a: ldarg.0
 				IL_026b: ldc.i4.1
 				IL_026c: ldelem.ref
 				IL_026d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-				IL_0272: ldnull
-				IL_0273: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-				IL_0278: stloc.s 20
-				IL_027a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_027f: dup
-				IL_0280: ldstr "signal"
-				IL_0285: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_028a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_028f: stloc.s 22
-				IL_0291: ldnull
-				IL_0292: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-				IL_0298: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-				IL_029d: ldc.i4.0
-				IL_029e: conv.r8
-				IL_029f: ldstr ""
-				IL_02a4: ldc.i4.0
-				IL_02a5: ldc.i4.1
-				IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-				IL_02ab: stloc.s 25
-				IL_02ad: ldc.i4.4
-				IL_02ae: newarr [System.Runtime]System.Object
-				IL_02b3: dup
-				IL_02b4: ldc.i4.0
-				IL_02b5: ldloc.s 21
-				IL_02b7: stelem.ref
-				IL_02b8: dup
-				IL_02b9: ldc.i4.1
-				IL_02ba: ldloc.s 20
-				IL_02bc: stelem.ref
-				IL_02bd: dup
-				IL_02be: ldc.i4.2
-				IL_02bf: ldloc.s 22
-				IL_02c1: stelem.ref
-				IL_02c2: dup
-				IL_02c3: ldc.i4.3
-				IL_02c4: ldloc.s 25
-				IL_02c6: stelem.ref
-				IL_02c7: stloc.s 26
-				IL_02c9: ldloc.s 23
-				IL_02cb: ldstr "pipeline"
-				IL_02d0: ldloc.s 26
-				IL_02d2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
-				IL_02d7: pop
-				IL_02d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_02dd: ldstr "callback-pipeline:ok"
-				IL_02e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_02e7: pop
-				IL_02e8: leave IL_038e
+				IL_0272: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+				IL_0277: ldc.i4.1
+				IL_0278: newarr [System.Runtime]System.Object
+				IL_027d: dup
+				IL_027e: ldc.i4.0
+				IL_027f: ldarg.0
+				IL_0280: ldc.i4.1
+				IL_0281: ldelem.ref
+				IL_0282: stelem.ref
+				IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0288: stloc.s 21
+				IL_028a: ldarg.0
+				IL_028b: ldc.i4.1
+				IL_028c: ldelem.ref
+				IL_028d: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+				IL_0292: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+				IL_0297: ldc.i4.1
+				IL_0298: newarr [System.Runtime]System.Object
+				IL_029d: dup
+				IL_029e: ldc.i4.0
+				IL_029f: ldarg.0
+				IL_02a0: ldc.i4.1
+				IL_02a1: ldelem.ref
+				IL_02a2: stelem.ref
+				IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_02a8: stloc.s 20
+				IL_02aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_02af: dup
+				IL_02b0: ldstr "signal"
+				IL_02b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_02ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_02bf: stloc.s 22
+				IL_02c1: ldnull
+				IL_02c2: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+				IL_02c8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+				IL_02cd: ldc.i4.0
+				IL_02ce: conv.r8
+				IL_02cf: ldstr ""
+				IL_02d4: ldc.i4.0
+				IL_02d5: ldc.i4.1
+				IL_02d6: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+				IL_02db: stloc.s 25
+				IL_02dd: ldc.i4.4
+				IL_02de: newarr [System.Runtime]System.Object
+				IL_02e3: dup
+				IL_02e4: ldc.i4.0
+				IL_02e5: ldloc.s 21
+				IL_02e7: stelem.ref
+				IL_02e8: dup
+				IL_02e9: ldc.i4.1
+				IL_02ea: ldloc.s 20
+				IL_02ec: stelem.ref
+				IL_02ed: dup
+				IL_02ee: ldc.i4.2
+				IL_02ef: ldloc.s 22
+				IL_02f1: stelem.ref
+				IL_02f2: dup
+				IL_02f3: ldc.i4.3
+				IL_02f4: ldloc.s 25
+				IL_02f6: stelem.ref
+				IL_02f7: stloc.s 26
+				IL_02f9: ldloc.s 23
+				IL_02fb: ldstr "pipeline"
+				IL_0300: ldloc.s 26
+				IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember(object, string, object[])
+				IL_0307: pop
+				IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_030d: ldstr "callback-pipeline:ok"
+				IL_0312: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_0317: pop
+				IL_0318: leave IL_03be
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_02ed: stloc.s 7
-				IL_02ef: ldloc.s 7
-				IL_02f1: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_02f6: dup
-				IL_02f7: brtrue IL_030d
+				IL_031d: stloc.s 7
+				IL_031f: ldloc.s 7
+				IL_0321: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_0326: dup
+				IL_0327: brtrue IL_033d
 
-				IL_02fc: pop
-				IL_02fd: ldloc.s 7
-				IL_02ff: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0304: dup
-				IL_0305: brtrue IL_0319
+				IL_032c: pop
+				IL_032d: ldloc.s 7
+				IL_032f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_0334: dup
+				IL_0335: brtrue IL_0349
 
-				IL_030a: pop
-				IL_030b: rethrow
+				IL_033a: pop
+				IL_033b: rethrow
 
-				IL_030d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_0312: stloc.s 8
-				IL_0314: br IL_031b
+				IL_033d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_0342: stloc.s 8
+				IL_0344: br IL_034b
 
-				IL_0319: stloc.s 8
+				IL_0349: stloc.s 8
 
-				IL_031b: ldloc.s 8
-				IL_031d: stloc.s 23
-				IL_031f: ldloc.s 23
-				IL_0321: stloc.s 9
-				IL_0323: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
-				IL_0328: stloc.s 10
-				IL_032a: ldstr "callback-pipeline:"
-				IL_032f: ldloc.s 9
-				IL_0331: ldstr "name"
-				IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0340: stloc.s 24
-				IL_0342: ldloc.s 24
-				IL_0344: ldstr ":"
-				IL_0349: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_034e: stloc.s 24
-				IL_0350: ldloc.s 24
-				IL_0352: ldloc.s 9
-				IL_0354: ldstr "code"
-				IL_0359: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0363: stloc.s 24
-				IL_0365: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_036a: ldloc.s 24
-				IL_036c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0371: pop
-				IL_0372: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0377: ldloc.s 9
-				IL_0379: ldstr "message"
-				IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0383: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0388: pop
-				IL_0389: leave IL_038e
+				IL_034b: ldloc.s 8
+				IL_034d: stloc.s 23
+				IL_034f: ldloc.s 23
+				IL_0351: stloc.s 9
+				IL_0353: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L28C18::.ctor()
+				IL_0358: stloc.s 10
+				IL_035a: ldstr "callback-pipeline:"
+				IL_035f: ldloc.s 9
+				IL_0361: ldstr "name"
+				IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_036b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0370: stloc.s 24
+				IL_0372: ldloc.s 24
+				IL_0374: ldstr ":"
+				IL_0379: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_037e: stloc.s 24
+				IL_0380: ldloc.s 24
+				IL_0382: ldloc.s 9
+				IL_0384: ldstr "code"
+				IL_0389: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_038e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0393: stloc.s 24
+				IL_0395: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_039a: ldloc.s 24
+				IL_039c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_03a1: pop
+				IL_03a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_03a7: ldloc.s 9
+				IL_03a9: ldstr "message"
+				IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_03b8: pop
+				IL_03b9: leave IL_03be
 			} // end handler
 
-			IL_038e: ldloc.0
-			IL_038f: ldc.i4.0
-			IL_0390: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0395: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_039a: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
-			IL_039f: stloc.s 11
-			IL_03a1: ldarg.0
-			IL_03a2: ldc.i4.1
-			IL_03a3: ldelem.ref
-			IL_03a4: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_03a9: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03b3: stloc.s 23
-			IL_03b5: ldarg.0
-			IL_03b6: ldc.i4.1
-			IL_03b7: ldelem.ref
-			IL_03b8: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_03bd: ldnull
-			IL_03be: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_03c3: stloc.s 25
-			IL_03c5: ldloc.s 23
-			IL_03c7: ldstr "finished"
-			IL_03cc: ldloc.s 25
-			IL_03ce: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03d3: dup
-			IL_03d4: ldstr "signal"
-			IL_03d9: ldc.i4.0
-			IL_03da: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_03df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03e4: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_03e9: stloc.s 25
-			IL_03eb: ldloc.0
-			IL_03ec: ldc.i4.2
-			IL_03ed: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_03f2: ldloc.0
-			IL_03f3: ldloc.s 25
-			IL_03f5: ldarg.0
-			IL_03f6: ldc.i4.1
-			IL_03f7: ldloc.0
-			IL_03f8: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_03fd: ldc.i4.1
-			IL_03fe: ldstr "_pendingException"
-			IL_0403: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_0408: ldloc.0
-			IL_0409: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_040e: dup
-			IL_040f: ldc.i4.0
-			IL_0410: ldloc.1
-			IL_0411: stelem.ref
-			IL_0412: dup
-			IL_0413: ldc.i4.1
-			IL_0414: ldloc.2
-			IL_0415: stelem.ref
-			IL_0416: dup
-			IL_0417: ldc.i4.2
-			IL_0418: ldloc.3
-			IL_0419: stelem.ref
-			IL_041a: dup
-			IL_041b: ldc.i4.3
-			IL_041c: ldloc.s 4
-			IL_041e: stelem.ref
-			IL_041f: dup
-			IL_0420: ldc.i4.4
-			IL_0421: ldloc.s 5
-			IL_0423: stelem.ref
-			IL_0424: dup
-			IL_0425: ldc.i4.5
-			IL_0426: ldloc.s 6
-			IL_0428: stelem.ref
-			IL_0429: dup
-			IL_042a: ldc.i4.6
-			IL_042b: ldloc.s 7
-			IL_042d: stelem.ref
-			IL_042e: dup
-			IL_042f: ldc.i4.7
-			IL_0430: ldloc.s 8
-			IL_0432: stelem.ref
-			IL_0433: dup
-			IL_0434: ldc.i4.8
-			IL_0435: ldloc.s 9
-			IL_0437: stelem.ref
-			IL_0438: dup
-			IL_0439: ldc.i4.s 9
-			IL_043b: ldloc.s 10
-			IL_043d: stelem.ref
-			IL_043e: dup
-			IL_043f: ldc.i4.s 10
-			IL_0441: ldloc.s 11
-			IL_0443: stelem.ref
-			IL_0444: dup
-			IL_0445: ldc.i4.s 11
-			IL_0447: ldloc.s 12
-			IL_0449: stelem.ref
-			IL_044a: dup
-			IL_044b: ldc.i4.s 12
-			IL_044d: ldloc.s 13
-			IL_044f: stelem.ref
-			IL_0450: dup
-			IL_0451: ldc.i4.s 13
-			IL_0453: ldloc.s 14
+			IL_03be: ldloc.0
+			IL_03bf: ldc.i4.0
+			IL_03c0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03c5: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_03ca: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L33C6::.ctor()
+			IL_03cf: stloc.s 11
+			IL_03d1: ldarg.0
+			IL_03d2: ldc.i4.1
+			IL_03d3: ldelem.ref
+			IL_03d4: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_03d9: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03e3: stloc.s 23
+			IL_03e5: ldarg.0
+			IL_03e6: ldc.i4.1
+			IL_03e7: ldelem.ref
+			IL_03e8: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_03ed: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_03f2: ldc.i4.1
+			IL_03f3: newarr [System.Runtime]System.Object
+			IL_03f8: dup
+			IL_03f9: ldc.i4.0
+			IL_03fa: ldarg.0
+			IL_03fb: ldc.i4.1
+			IL_03fc: ldelem.ref
+			IL_03fd: stelem.ref
+			IL_03fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0403: stloc.s 25
+			IL_0405: ldloc.s 23
+			IL_0407: ldstr "finished"
+			IL_040c: ldloc.s 25
+			IL_040e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0413: dup
+			IL_0414: ldstr "signal"
+			IL_0419: ldc.i4.0
+			IL_041a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_041f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0424: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0429: stloc.s 25
+			IL_042b: ldloc.0
+			IL_042c: ldc.i4.2
+			IL_042d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0432: ldloc.0
+			IL_0433: ldloc.s 25
+			IL_0435: ldarg.0
+			IL_0436: ldc.i4.1
+			IL_0437: ldloc.0
+			IL_0438: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_043d: ldc.i4.1
+			IL_043e: ldstr "_pendingException"
+			IL_0443: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_0448: ldloc.0
+			IL_0449: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_044e: dup
+			IL_044f: ldc.i4.0
+			IL_0450: ldloc.1
+			IL_0451: stelem.ref
+			IL_0452: dup
+			IL_0453: ldc.i4.1
+			IL_0454: ldloc.2
 			IL_0455: stelem.ref
 			IL_0456: dup
-			IL_0457: ldc.i4.s 14
-			IL_0459: ldloc.s 15
-			IL_045b: stelem.ref
-			IL_045c: dup
-			IL_045d: ldc.i4.s 15
-			IL_045f: ldloc.s 16
-			IL_0461: stelem.ref
-			IL_0462: dup
-			IL_0463: ldc.i4.s 16
-			IL_0465: ldloc.s 17
-			IL_0467: stelem.ref
-			IL_0468: dup
-			IL_0469: ldc.i4.s 17
-			IL_046b: ldloc.s 18
+			IL_0457: ldc.i4.2
+			IL_0458: ldloc.3
+			IL_0459: stelem.ref
+			IL_045a: dup
+			IL_045b: ldc.i4.3
+			IL_045c: ldloc.s 4
+			IL_045e: stelem.ref
+			IL_045f: dup
+			IL_0460: ldc.i4.4
+			IL_0461: ldloc.s 5
+			IL_0463: stelem.ref
+			IL_0464: dup
+			IL_0465: ldc.i4.5
+			IL_0466: ldloc.s 6
+			IL_0468: stelem.ref
+			IL_0469: dup
+			IL_046a: ldc.i4.6
+			IL_046b: ldloc.s 7
 			IL_046d: stelem.ref
 			IL_046e: dup
-			IL_046f: ldc.i4.s 18
-			IL_0471: ldloc.s 19
-			IL_0473: stelem.ref
-			IL_0474: pop
-			IL_0475: ldloc.0
-			IL_0476: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_047b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0480: ret
+			IL_046f: ldc.i4.7
+			IL_0470: ldloc.s 8
+			IL_0472: stelem.ref
+			IL_0473: dup
+			IL_0474: ldc.i4.8
+			IL_0475: ldloc.s 9
+			IL_0477: stelem.ref
+			IL_0478: dup
+			IL_0479: ldc.i4.s 9
+			IL_047b: ldloc.s 10
+			IL_047d: stelem.ref
+			IL_047e: dup
+			IL_047f: ldc.i4.s 10
+			IL_0481: ldloc.s 11
+			IL_0483: stelem.ref
+			IL_0484: dup
+			IL_0485: ldc.i4.s 11
+			IL_0487: ldloc.s 12
+			IL_0489: stelem.ref
+			IL_048a: dup
+			IL_048b: ldc.i4.s 12
+			IL_048d: ldloc.s 13
+			IL_048f: stelem.ref
+			IL_0490: dup
+			IL_0491: ldc.i4.s 13
+			IL_0493: ldloc.s 14
+			IL_0495: stelem.ref
+			IL_0496: dup
+			IL_0497: ldc.i4.s 14
+			IL_0499: ldloc.s 15
+			IL_049b: stelem.ref
+			IL_049c: dup
+			IL_049d: ldc.i4.s 15
+			IL_049f: ldloc.s 16
+			IL_04a1: stelem.ref
+			IL_04a2: dup
+			IL_04a3: ldc.i4.s 16
+			IL_04a5: ldloc.s 17
+			IL_04a7: stelem.ref
+			IL_04a8: dup
+			IL_04a9: ldc.i4.s 17
+			IL_04ab: ldloc.s 18
+			IL_04ad: stelem.ref
+			IL_04ae: dup
+			IL_04af: ldc.i4.s 18
+			IL_04b1: ldloc.s 19
+			IL_04b3: stelem.ref
+			IL_04b4: pop
+			IL_04b5: ldloc.0
+			IL_04b6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_04bb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_04c0: ret
 
-			IL_0481: ldloc.0
-			IL_0482: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
-			IL_0487: pop
-			IL_0488: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_048d: ldstr "promise-finished:ok"
-			IL_0492: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0497: pop
-			IL_0498: br IL_0520
+			IL_04c1: ldloc.0
+			IL_04c2: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited1
+			IL_04c7: pop
+			IL_04c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04cd: ldstr "promise-finished:ok"
+			IL_04d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04d7: pop
+			IL_04d8: br IL_0560
 
-			IL_049d: ldloc.0
-			IL_049e: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04a3: stloc.s 25
-			IL_04a5: ldloc.0
-			IL_04a6: ldc.i4.0
-			IL_04a7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_04ac: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_04b1: ldloc.s 25
-			IL_04b3: stloc.s 12
-			IL_04b5: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
-			IL_04ba: stloc.s 13
-			IL_04bc: ldstr "promise-finished:"
-			IL_04c1: ldloc.s 12
-			IL_04c3: ldstr "name"
-			IL_04c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04d2: stloc.s 24
-			IL_04d4: ldloc.s 24
-			IL_04d6: ldstr ":"
-			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04e0: stloc.s 24
-			IL_04e2: ldloc.s 24
-			IL_04e4: ldloc.s 12
-			IL_04e6: ldstr "code"
-			IL_04eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04f5: stloc.s 24
-			IL_04f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04fc: ldloc.s 24
-			IL_04fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0503: pop
-			IL_0504: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0509: ldloc.s 12
-			IL_050b: ldstr "message"
-			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0515: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_051a: pop
-			IL_051b: br IL_0520
+			IL_04dd: ldloc.0
+			IL_04de: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04e3: stloc.s 25
+			IL_04e5: ldloc.0
+			IL_04e6: ldc.i4.0
+			IL_04e7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_04ec: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_04f1: ldloc.s 25
+			IL_04f3: stloc.s 12
+			IL_04f5: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L36C18::.ctor()
+			IL_04fa: stloc.s 13
+			IL_04fc: ldstr "promise-finished:"
+			IL_0501: ldloc.s 12
+			IL_0503: ldstr "name"
+			IL_0508: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_050d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0512: stloc.s 24
+			IL_0514: ldloc.s 24
+			IL_0516: ldstr ":"
+			IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0520: stloc.s 24
+			IL_0522: ldloc.s 24
+			IL_0524: ldloc.s 12
+			IL_0526: ldstr "code"
+			IL_052b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0530: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0535: stloc.s 24
+			IL_0537: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_053c: ldloc.s 24
+			IL_053e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0543: pop
+			IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0549: ldloc.s 12
+			IL_054b: ldstr "message"
+			IL_0550: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0555: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_055a: pop
+			IL_055b: br IL_0560
 
-			IL_0520: ldloc.0
-			IL_0521: ldc.i4.0
-			IL_0522: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0527: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_052c: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
-			IL_0531: stloc.s 14
-			IL_0533: ldarg.0
-			IL_0534: ldc.i4.1
-			IL_0535: ldelem.ref
-			IL_0536: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_053b: ldnull
-			IL_053c: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_0541: stloc.s 25
-			IL_0543: ldloc.s 25
-			IL_0545: stloc.s 15
-			IL_0547: ldarg.0
-			IL_0548: ldc.i4.1
-			IL_0549: ldelem.ref
-			IL_054a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_054f: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0559: stloc.s 25
-			IL_055b: ldarg.0
-			IL_055c: ldc.i4.1
-			IL_055d: ldelem.ref
-			IL_055e: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-			IL_0563: ldnull
-			IL_0564: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-			IL_0569: stloc.s 23
-			IL_056b: ldloc.s 25
-			IL_056d: ldstr "pipeline"
-			IL_0572: ldloc.s 15
-			IL_0574: ldloc.s 23
-			IL_0576: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_057b: dup
-			IL_057c: ldstr "signal"
-			IL_0581: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0586: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_058b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_0590: stloc.s 23
-			IL_0592: ldloc.s 23
-			IL_0594: stloc.s 16
-			IL_0596: ldloc.s 15
-			IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_059d: stloc.s 23
-			IL_059f: ldloc.s 23
-			IL_05a1: ldstr "push"
-			IL_05a6: ldc.i4.0
-			IL_05a7: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_05ac: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_05b1: pop
-			IL_05b2: ldloc.0
-			IL_05b3: ldc.i4.4
-			IL_05b4: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05b9: ldloc.0
-			IL_05ba: ldloc.s 16
-			IL_05bc: ldarg.0
-			IL_05bd: ldc.i4.2
-			IL_05be: ldloc.0
-			IL_05bf: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_05c4: ldc.i4.3
-			IL_05c5: ldstr "_pendingException"
-			IL_05ca: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
-			IL_05cf: ldloc.0
-			IL_05d0: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_05d5: dup
-			IL_05d6: ldc.i4.0
-			IL_05d7: ldloc.1
-			IL_05d8: stelem.ref
-			IL_05d9: dup
-			IL_05da: ldc.i4.1
-			IL_05db: ldloc.2
-			IL_05dc: stelem.ref
-			IL_05dd: dup
-			IL_05de: ldc.i4.2
-			IL_05df: ldloc.3
-			IL_05e0: stelem.ref
-			IL_05e1: dup
-			IL_05e2: ldc.i4.3
-			IL_05e3: ldloc.s 4
-			IL_05e5: stelem.ref
-			IL_05e6: dup
-			IL_05e7: ldc.i4.4
-			IL_05e8: ldloc.s 5
-			IL_05ea: stelem.ref
-			IL_05eb: dup
-			IL_05ec: ldc.i4.5
-			IL_05ed: ldloc.s 6
-			IL_05ef: stelem.ref
-			IL_05f0: dup
-			IL_05f1: ldc.i4.6
-			IL_05f2: ldloc.s 7
-			IL_05f4: stelem.ref
-			IL_05f5: dup
-			IL_05f6: ldc.i4.7
-			IL_05f7: ldloc.s 8
-			IL_05f9: stelem.ref
-			IL_05fa: dup
-			IL_05fb: ldc.i4.8
-			IL_05fc: ldloc.s 9
-			IL_05fe: stelem.ref
-			IL_05ff: dup
-			IL_0600: ldc.i4.s 9
-			IL_0602: ldloc.s 10
-			IL_0604: stelem.ref
-			IL_0605: dup
-			IL_0606: ldc.i4.s 10
-			IL_0608: ldloc.s 11
-			IL_060a: stelem.ref
-			IL_060b: dup
-			IL_060c: ldc.i4.s 11
-			IL_060e: ldloc.s 12
-			IL_0610: stelem.ref
-			IL_0611: dup
-			IL_0612: ldc.i4.s 12
-			IL_0614: ldloc.s 13
-			IL_0616: stelem.ref
-			IL_0617: dup
-			IL_0618: ldc.i4.s 13
-			IL_061a: ldloc.s 14
-			IL_061c: stelem.ref
-			IL_061d: dup
-			IL_061e: ldc.i4.s 14
-			IL_0620: ldloc.s 15
-			IL_0622: stelem.ref
-			IL_0623: dup
-			IL_0624: ldc.i4.s 15
-			IL_0626: ldloc.s 16
-			IL_0628: stelem.ref
-			IL_0629: dup
-			IL_062a: ldc.i4.s 16
-			IL_062c: ldloc.s 17
-			IL_062e: stelem.ref
-			IL_062f: dup
-			IL_0630: ldc.i4.s 17
-			IL_0632: ldloc.s 18
-			IL_0634: stelem.ref
+			IL_0560: ldloc.0
+			IL_0561: ldc.i4.0
+			IL_0562: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0567: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_056c: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L41C6::.ctor()
+			IL_0571: stloc.s 14
+			IL_0573: ldarg.0
+			IL_0574: ldc.i4.1
+			IL_0575: ldelem.ref
+			IL_0576: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_057b: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createReadable
+			IL_0580: ldc.i4.1
+			IL_0581: newarr [System.Runtime]System.Object
+			IL_0586: dup
+			IL_0587: ldc.i4.0
+			IL_0588: ldarg.0
+			IL_0589: ldc.i4.1
+			IL_058a: ldelem.ref
+			IL_058b: stelem.ref
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0591: stloc.s 25
+			IL_0593: ldloc.s 25
+			IL_0595: stloc.s 15
+			IL_0597: ldarg.0
+			IL_0598: ldc.i4.1
+			IL_0599: ldelem.ref
+			IL_059a: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_059f: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
+			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05a9: stloc.s 25
+			IL_05ab: ldarg.0
+			IL_05ac: ldc.i4.1
+			IL_05ad: ldelem.ref
+			IL_05ae: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
+			IL_05b3: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::createWritable
+			IL_05b8: ldc.i4.1
+			IL_05b9: newarr [System.Runtime]System.Object
+			IL_05be: dup
+			IL_05bf: ldc.i4.0
+			IL_05c0: ldarg.0
+			IL_05c1: ldc.i4.1
+			IL_05c2: ldelem.ref
+			IL_05c3: stelem.ref
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_05c9: stloc.s 23
+			IL_05cb: ldloc.s 25
+			IL_05cd: ldstr "pipeline"
+			IL_05d2: ldloc.s 15
+			IL_05d4: ldloc.s 23
+			IL_05d6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05db: dup
+			IL_05dc: ldstr "signal"
+			IL_05e1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_05f0: stloc.s 23
+			IL_05f2: ldloc.s 23
+			IL_05f4: stloc.s 16
+			IL_05f6: ldloc.s 15
+			IL_05f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05fd: stloc.s 23
+			IL_05ff: ldloc.s 23
+			IL_0601: ldstr "push"
+			IL_0606: ldc.i4.0
+			IL_0607: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_060c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0611: pop
+			IL_0612: ldloc.0
+			IL_0613: ldc.i4.4
+			IL_0614: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0619: ldloc.0
+			IL_061a: ldloc.s 16
+			IL_061c: ldarg.0
+			IL_061d: ldc.i4.2
+			IL_061e: ldloc.0
+			IL_061f: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0624: ldc.i4.3
+			IL_0625: ldstr "_pendingException"
+			IL_062a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationWithRejectResumeTyped(object, object[], int32, object, int32, string)
+			IL_062f: ldloc.0
+			IL_0630: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0635: dup
-			IL_0636: ldc.i4.s 18
-			IL_0638: ldloc.s 19
-			IL_063a: stelem.ref
-			IL_063b: pop
-			IL_063c: ldloc.0
-			IL_063d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0642: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0647: ret
+			IL_0636: ldc.i4.0
+			IL_0637: ldloc.1
+			IL_0638: stelem.ref
+			IL_0639: dup
+			IL_063a: ldc.i4.1
+			IL_063b: ldloc.2
+			IL_063c: stelem.ref
+			IL_063d: dup
+			IL_063e: ldc.i4.2
+			IL_063f: ldloc.3
+			IL_0640: stelem.ref
+			IL_0641: dup
+			IL_0642: ldc.i4.3
+			IL_0643: ldloc.s 4
+			IL_0645: stelem.ref
+			IL_0646: dup
+			IL_0647: ldc.i4.4
+			IL_0648: ldloc.s 5
+			IL_064a: stelem.ref
+			IL_064b: dup
+			IL_064c: ldc.i4.5
+			IL_064d: ldloc.s 6
+			IL_064f: stelem.ref
+			IL_0650: dup
+			IL_0651: ldc.i4.6
+			IL_0652: ldloc.s 7
+			IL_0654: stelem.ref
+			IL_0655: dup
+			IL_0656: ldc.i4.7
+			IL_0657: ldloc.s 8
+			IL_0659: stelem.ref
+			IL_065a: dup
+			IL_065b: ldc.i4.8
+			IL_065c: ldloc.s 9
+			IL_065e: stelem.ref
+			IL_065f: dup
+			IL_0660: ldc.i4.s 9
+			IL_0662: ldloc.s 10
+			IL_0664: stelem.ref
+			IL_0665: dup
+			IL_0666: ldc.i4.s 10
+			IL_0668: ldloc.s 11
+			IL_066a: stelem.ref
+			IL_066b: dup
+			IL_066c: ldc.i4.s 11
+			IL_066e: ldloc.s 12
+			IL_0670: stelem.ref
+			IL_0671: dup
+			IL_0672: ldc.i4.s 12
+			IL_0674: ldloc.s 13
+			IL_0676: stelem.ref
+			IL_0677: dup
+			IL_0678: ldc.i4.s 13
+			IL_067a: ldloc.s 14
+			IL_067c: stelem.ref
+			IL_067d: dup
+			IL_067e: ldc.i4.s 14
+			IL_0680: ldloc.s 15
+			IL_0682: stelem.ref
+			IL_0683: dup
+			IL_0684: ldc.i4.s 15
+			IL_0686: ldloc.s 16
+			IL_0688: stelem.ref
+			IL_0689: dup
+			IL_068a: ldc.i4.s 16
+			IL_068c: ldloc.s 17
+			IL_068e: stelem.ref
+			IL_068f: dup
+			IL_0690: ldc.i4.s 17
+			IL_0692: ldloc.s 18
+			IL_0694: stelem.ref
+			IL_0695: dup
+			IL_0696: ldc.i4.s 18
+			IL_0698: ldloc.s 19
+			IL_069a: stelem.ref
+			IL_069b: pop
+			IL_069c: ldloc.0
+			IL_069d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_06a2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_06a7: ret
 
-			IL_0648: ldloc.0
-			IL_0649: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
-			IL_064e: pop
-			IL_064f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0654: ldstr "promise-pipeline:ok"
-			IL_0659: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_065e: pop
-			IL_065f: br IL_06e7
+			IL_06a8: ldloc.0
+			IL_06a9: ldfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope::_awaited2
+			IL_06ae: pop
+			IL_06af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06b4: ldstr "promise-pipeline:ok"
+			IL_06b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06be: pop
+			IL_06bf: br IL_0747
 
-			IL_0664: ldloc.0
-			IL_0665: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_066a: stloc.s 23
-			IL_066c: ldloc.0
-			IL_066d: ldc.i4.0
-			IL_066e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0673: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
-			IL_0678: ldloc.s 23
-			IL_067a: stloc.s 17
-			IL_067c: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
-			IL_0681: stloc.s 18
-			IL_0683: ldstr "promise-pipeline:"
-			IL_0688: ldloc.s 17
-			IL_068a: ldstr "name"
-			IL_068f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0694: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0699: stloc.s 24
-			IL_069b: ldloc.s 24
-			IL_069d: ldstr ":"
-			IL_06a2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06a7: stloc.s 24
-			IL_06a9: ldloc.s 24
-			IL_06ab: ldloc.s 17
-			IL_06ad: ldstr "code"
-			IL_06b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_06bc: stloc.s 24
-			IL_06be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06c3: ldloc.s 24
-			IL_06c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06ca: pop
-			IL_06cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06d0: ldloc.s 17
-			IL_06d2: ldstr "message"
-			IL_06d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06e1: pop
-			IL_06e2: br IL_06e7
+			IL_06c4: ldloc.0
+			IL_06c5: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_06ca: stloc.s 23
+			IL_06cc: ldloc.0
+			IL_06cd: ldc.i4.0
+			IL_06ce: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_06d3: stfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_pendingException
+			IL_06d8: ldloc.s 23
+			IL_06da: stloc.s 17
+			IL_06dc: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/Scope/Block_L47C18::.ctor()
+			IL_06e1: stloc.s 18
+			IL_06e3: ldstr "promise-pipeline:"
+			IL_06e8: ldloc.s 17
+			IL_06ea: ldstr "name"
+			IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06f4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_06f9: stloc.s 24
+			IL_06fb: ldloc.s 24
+			IL_06fd: ldstr ":"
+			IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0707: stloc.s 24
+			IL_0709: ldloc.s 24
+			IL_070b: ldloc.s 17
+			IL_070d: ldstr "code"
+			IL_0712: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_071c: stloc.s 24
+			IL_071e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0723: ldloc.s 24
+			IL_0725: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_072a: pop
+			IL_072b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0730: ldloc.s 17
+			IL_0732: ldstr "message"
+			IL_0737: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_073c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0741: pop
+			IL_0742: br IL_0747
 
-			IL_06e7: ldnull
-			IL_06e8: stloc.s 19
-			IL_06ea: ldloc.0
-			IL_06eb: ldc.i4.m1
-			IL_06ec: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06f1: ldloc.0
-			IL_06f2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_06f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_06fc: ldarg.0
-			IL_06fd: ldc.i4.1
-			IL_06fe: newarr [System.Runtime]System.Object
-			IL_0703: dup
-			IL_0704: ldc.i4.0
-			IL_0705: ldloc.s 19
-			IL_0707: stelem.ref
-			IL_0708: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_070d: pop
-			IL_070e: ldloc.0
-			IL_070f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0714: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0719: ret
+			IL_0747: ldnull
+			IL_0748: stloc.s 19
+			IL_074a: ldloc.0
+			IL_074b: ldc.i4.m1
+			IL_074c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0751: ldloc.0
+			IL_0752: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0757: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_075c: ldarg.0
+			IL_075d: ldc.i4.1
+			IL_075e: newarr [System.Runtime]System.Object
+			IL_0763: dup
+			IL_0764: ldc.i4.0
+			IL_0765: ldloc.s 19
+			IL_0767: stelem.ref
+			IL_0768: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_076d: pop
+			IL_076e: ldloc.0
+			IL_076f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0774: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0779: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -1345,7 +1393,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2925
+			// Method begins at RVA 0x2981
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1371,7 +1419,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 200 (0xc8)
+		// Code size: 195 (0xc3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope,
@@ -1454,16 +1502,11 @@
 		IL_00af: ldloc.0
 		IL_00b0: ldloc.2
 		IL_00b1: stfld object Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope::streamPromises
-		IL_00b6: ldc.i4.1
-		IL_00b7: newarr [System.Runtime]System.Object
-		IL_00bc: dup
-		IL_00bd: ldc.i4.0
-		IL_00be: ldloc.0
-		IL_00bf: stelem.ref
-		IL_00c0: ldnull
-		IL_00c1: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main::__js_call__(object[], object)
-		IL_00c6: pop
-		IL_00c7: ret
+		IL_00b6: ldloc.1
+		IL_00b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00c1: pop
+		IL_00c2: ret
 	} // end of method Stream_Helper_Signal_Requires_AbortSignal::__js_module_init__
 
 } // end of class Modules.Stream_Helper_Signal_Requires_AbortSignal
@@ -1475,7 +1518,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x29ac
+		// Method begins at RVA 0x2a08
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Stream_Promises_Finished_Basic
+﻿// IL code: Stream_Promises_Finished_Basic
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2295
+					// Method begins at RVA 0x2291
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2280
+				// Method begins at RVA 0x227c
 				// Header size: 1
 				// Code size: 2 (0x2)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x228c
+				// Method begins at RVA 0x2288
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -97,7 +97,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 436 (0x1b4)
 			.maxstack 8
@@ -302,7 +302,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2283
+			// Method begins at RVA 0x227f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -328,7 +328,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 100 (0x64)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Promises_Finished_Basic/Scope,
@@ -369,16 +369,11 @@
 		IL_004b: ldloc.0
 		IL_004c: ldloc.2
 		IL_004d: stfld object Modules.Stream_Promises_Finished_Basic/Scope::streamPromises
-		IL_0052: ldc.i4.1
-		IL_0053: newarr [System.Runtime]System.Object
-		IL_0058: dup
-		IL_0059: ldc.i4.0
-		IL_005a: ldloc.0
-		IL_005b: stelem.ref
-		IL_005c: ldnull
-		IL_005d: call object Modules.Stream_Promises_Finished_Basic/main::__js_call__(object[], object)
-		IL_0062: pop
-		IL_0063: ret
+		IL_0052: ldloc.1
+		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005d: pop
+		IL_005e: ret
 	} // end of method Stream_Promises_Finished_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Promises_Finished_Basic
@@ -390,7 +385,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x229e
+		// Method begins at RVA 0x229a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Stream_Promises_Pipeline_ObjectMode
+﻿// IL code: Stream_Promises_Pipeline_ObjectMode
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x24fc
+					// Method begins at RVA 0x24f8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -47,7 +47,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2468
+				// Method begins at RVA 0x2464
 				// Header size: 12
 				// Code size: 70 (0x46)
 				.maxstack 8
@@ -94,7 +94,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2505
+					// Method begins at RVA 0x2501
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -119,7 +119,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24bc
+				// Method begins at RVA 0x24b8
 				// Header size: 12
 				// Code size: 34 (0x22)
 				.maxstack 8
@@ -161,7 +161,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x24f3
+				// Method begins at RVA 0x24ef
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -185,7 +185,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20c0
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 922 (0x39a)
 			.maxstack 8
@@ -572,7 +572,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x24ea
+			// Method begins at RVA 0x24e6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -598,7 +598,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 100 (0x64)
+		// Code size: 95 (0x5f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Promises_Pipeline_ObjectMode/Scope,
@@ -639,16 +639,11 @@
 		IL_004b: ldloc.0
 		IL_004c: ldloc.2
 		IL_004d: stfld object Modules.Stream_Promises_Pipeline_ObjectMode/Scope::streamPromises
-		IL_0052: ldc.i4.1
-		IL_0053: newarr [System.Runtime]System.Object
-		IL_0058: dup
-		IL_0059: ldc.i4.0
-		IL_005a: ldloc.0
-		IL_005b: stelem.ref
-		IL_005c: ldnull
-		IL_005d: call object Modules.Stream_Promises_Pipeline_ObjectMode/main::__js_call__(object[], object)
-		IL_0062: pop
-		IL_0063: ret
+		IL_0052: ldloc.1
+		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_005d: pop
+		IL_005e: ret
 	} // end of method Stream_Promises_Pipeline_ObjectMode::__js_module_init__
 
 } // end of class Modules.Stream_Promises_Pipeline_ObjectMode
@@ -660,7 +655,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x250e
+		// Method begins at RVA 0x250a
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x256c
+						// Method begins at RVA 0x25c1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2563
+					// Method begins at RVA 0x25b8
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2400
+				// Method begins at RVA 0x2428
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x257e
+						// Method begins at RVA 0x25d3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2575
+					// Method begins at RVA 0x25ca
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2438
+				// Method begins at RVA 0x2460
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2590
+						// Method begins at RVA 0x25e5
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2587
+					// Method begins at RVA 0x25dc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -279,7 +279,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24bc
+				// Method begins at RVA 0x24e4
 				// Header size: 12
 				// Code size: 107 (0x6b)
 				.maxstack 8
@@ -348,7 +348,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x255a
+				// Method begins at RVA 0x25af
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -374,7 +374,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x21ec
+			// Method begins at RVA 0x21f0
 			// Header size: 12
 			// Code size: 186 (0xba)
 			.maxstack 8
@@ -471,7 +471,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2599
+				// Method begins at RVA 0x25ee
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -495,7 +495,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x22b4
+			// Method begins at RVA 0x22b8
 			// Header size: 12
 			// Code size: 68 (0x44)
 			.maxstack 8
@@ -535,7 +535,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25a2
+				// Method begins at RVA 0x25f7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -558,7 +558,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2304
+			// Method begins at RVA 0x2308
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -584,7 +584,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25ab
+				// Method begins at RVA 0x2600
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -611,17 +611,29 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2317
-			// Header size: 1
-			// Code size: 10 (0xa)
+			// Method begins at RVA 0x231c
+			// Header size: 12
+			// Code size: 27 (0x1b)
 			.maxstack 8
+			.locals init (
+				[0] object[]
+			)
 
-			IL_0000: ldnull
-			IL_0001: ldarg.2
-			IL_0002: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
-			IL_0007: pop
-			IL_0008: ldnull
-			IL_0009: ret
+			IL_0000: ldc.i4.1
+			IL_0001: newarr [System.Runtime]System.Object
+			IL_0006: dup
+			IL_0007: ldc.i4.0
+			IL_0008: ldarg.0
+			IL_0009: stelem.ref
+			IL_000a: stloc.0
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
+			IL_0011: ldloc.0
+			IL_0012: ldarg.2
+			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0018: pop
+			IL_0019: ldnull
+			IL_001a: ret
 		} // end of method FunctionExpression_L45C9::__js_call__
 
 	} // end of class FunctionExpression_L45C9
@@ -641,7 +653,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25bd
+					// Method begins at RVA 0x2612
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -664,7 +676,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2533
+				// Method begins at RVA 0x255b
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -690,7 +702,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x25c6
+					// Method begins at RVA 0x261b
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -715,17 +727,40 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2546
-				// Header size: 1
-				// Code size: 10 (0xa)
+				// Method begins at RVA 0x2570
+				// Header size: 12
+				// Code size: 42 (0x2a)
 				.maxstack 8
+				.locals init (
+					[0] object[]
+				)
 
-				IL_0000: ldnull
-				IL_0001: ldarg.2
-				IL_0002: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
-				IL_0007: pop
-				IL_0008: ldnull
-				IL_0009: ret
+				IL_0000: ldc.i4.2
+				IL_0001: newarr [System.Runtime]System.Object
+				IL_0006: dup
+				IL_0007: ldc.i4.0
+				IL_0008: ldarg.0
+				IL_0009: ldc.i4.0
+				IL_000a: ldelem.ref
+				IL_000b: stelem.ref
+				IL_000c: dup
+				IL_000d: ldc.i4.1
+				IL_000e: ldarg.0
+				IL_000f: ldc.i4.1
+				IL_0010: ldelem.ref
+				IL_0011: stelem.ref
+				IL_0012: stloc.0
+				IL_0013: ldarg.0
+				IL_0014: ldc.i4.0
+				IL_0015: ldelem.ref
+				IL_0016: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+				IL_001b: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::logAbort
+				IL_0020: ldloc.0
+				IL_0021: ldarg.2
+				IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0027: pop
+				IL_0028: ldnull
+				IL_0029: ret
 			} // end of method FunctionExpression_L56C13::__js_call__
 
 		} // end of class FunctionExpression_L56C13
@@ -737,7 +772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x25b4
+				// Method begins at RVA 0x2609
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -763,9 +798,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
-			// Method begins at RVA 0x2324
+			// Method begins at RVA 0x2344
 			// Header size: 12
-			// Code size: 205 (0xcd)
+			// Code size: 214 (0xd6)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope,
@@ -777,82 +812,87 @@
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldarg.0
-			IL_0007: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-			IL_000c: ldnull
-			IL_000d: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-			IL_0012: stloc.2
-			IL_0013: ldloc.2
-			IL_0014: stloc.1
-			IL_0015: ldloc.1
-			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0007: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::createController
+			IL_000c: ldc.i4.1
+			IL_000d: newarr [System.Runtime]System.Object
+			IL_0012: dup
+			IL_0013: ldc.i4.0
+			IL_0014: ldarg.0
+			IL_0015: stelem.ref
+			IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_001b: stloc.2
 			IL_001c: ldloc.2
-			IL_001d: ldstr "abort"
-			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0027: pop
-			IL_0028: ldarg.0
-			IL_0029: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0033: stloc.2
-			IL_0034: ldloc.2
-			IL_0035: ldstr "setImmediate"
-			IL_003a: ldstr "immediate-value"
-			IL_003f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0044: dup
-			IL_0045: ldstr "signal"
-			IL_004a: ldloc.1
-			IL_004b: ldstr "signal"
-			IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0055: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
-			IL_005f: stloc.2
-			IL_0060: ldloc.2
-			IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0066: stloc.2
-			IL_0067: ldnull
-			IL_0068: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
-			IL_006e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_0073: ldc.i4.0
-			IL_0074: conv.r8
-			IL_0075: ldstr ""
-			IL_007a: ldc.i4.0
-			IL_007b: ldc.i4.1
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0081: stloc.3
-			IL_0082: ldloc.2
-			IL_0083: ldstr "then"
-			IL_0088: ldloc.3
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_008e: stloc.3
-			IL_008f: ldloc.3
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0095: stloc.3
-			IL_0096: ldc.i4.2
-			IL_0097: newarr [System.Runtime]System.Object
-			IL_009c: dup
-			IL_009d: ldc.i4.0
-			IL_009e: ldarg.0
-			IL_009f: stelem.ref
-			IL_00a0: dup
-			IL_00a1: ldc.i4.1
-			IL_00a2: ldloc.0
-			IL_00a3: stelem.ref
-			IL_00a4: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
-			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_00af: ldc.i4.1
-			IL_00b0: conv.r8
-			IL_00b1: ldstr ""
-			IL_00b6: ldc.i4.0
-			IL_00b7: ldc.i4.1
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_00bd: stloc.2
-			IL_00be: ldloc.3
-			IL_00bf: ldstr "catch"
-			IL_00c4: ldloc.2
-			IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_00ca: stloc.2
-			IL_00cb: ldloc.2
-			IL_00cc: ret
+			IL_001d: stloc.1
+			IL_001e: ldloc.1
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0024: stloc.2
+			IL_0025: ldloc.2
+			IL_0026: ldstr "abort"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0030: pop
+			IL_0031: ldarg.0
+			IL_0032: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003c: stloc.2
+			IL_003d: ldloc.2
+			IL_003e: ldstr "setImmediate"
+			IL_0043: ldstr "immediate-value"
+			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_004d: dup
+			IL_004e: ldstr "signal"
+			IL_0053: ldloc.1
+			IL_0054: ldstr "signal"
+			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_005e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember2(object, string, object, object)
+			IL_0068: stloc.2
+			IL_0069: ldloc.2
+			IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006f: stloc.2
+			IL_0070: ldnull
+			IL_0071: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
+			IL_0077: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_007c: ldc.i4.0
+			IL_007d: conv.r8
+			IL_007e: ldstr ""
+			IL_0083: ldc.i4.0
+			IL_0084: ldc.i4.1
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_008a: stloc.3
+			IL_008b: ldloc.2
+			IL_008c: ldstr "then"
+			IL_0091: ldloc.3
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0097: stloc.3
+			IL_0098: ldloc.3
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009e: stloc.3
+			IL_009f: ldc.i4.2
+			IL_00a0: newarr [System.Runtime]System.Object
+			IL_00a5: dup
+			IL_00a6: ldc.i4.0
+			IL_00a7: ldarg.0
+			IL_00a8: stelem.ref
+			IL_00a9: dup
+			IL_00aa: ldc.i4.1
+			IL_00ab: ldloc.0
+			IL_00ac: stelem.ref
+			IL_00ad: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
+			IL_00b3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_00b8: ldc.i4.1
+			IL_00b9: conv.r8
+			IL_00ba: ldstr ""
+			IL_00bf: ldc.i4.0
+			IL_00c0: ldc.i4.1
+			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+			IL_00c6: stloc.2
+			IL_00c7: ldloc.3
+			IL_00c8: ldstr "catch"
+			IL_00cd: ldloc.2
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_00d3: stloc.2
+			IL_00d4: ldloc.2
+			IL_00d5: ret
 		} // end of method FunctionExpression_L48C8::__js_call__
 
 	} // end of class FunctionExpression_L48C8
@@ -878,7 +918,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2551
+			// Method begins at RVA 0x25a6
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -904,7 +944,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 397 (0x18d)
+		// Code size: 401 (0x191)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope,
@@ -958,110 +998,110 @@
 		IL_0067: ldloc.3
 		IL_0068: stfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
 		IL_006d: ldloc.0
-		IL_006e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0073: ldnull
-		IL_0074: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_0079: stloc.3
-		IL_007a: ldloc.3
-		IL_007b: stloc.1
-		IL_007c: ldloc.0
-		IL_007d: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
-		IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0087: stloc.3
-		IL_0088: ldloc.3
-		IL_0089: ldstr "setTimeout"
-		IL_008e: ldc.r8 0.0
-		IL_0097: box [System.Runtime]System.Double
-		IL_009c: ldstr "timeout-value"
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00a6: dup
-		IL_00a7: ldstr "signal"
-		IL_00ac: ldloc.1
-		IL_00ad: ldstr "signal"
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-		IL_00c1: stloc.3
-		IL_00c2: ldloc.3
-		IL_00c3: stloc.2
-		IL_00c4: ldloc.1
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ca: stloc.3
-		IL_00cb: ldloc.3
-		IL_00cc: ldstr "abort"
-		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00d6: pop
-		IL_00d7: ldloc.2
-		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00dd: stloc.3
-		IL_00de: ldnull
-		IL_00df: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
-		IL_00e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00ea: ldc.i4.0
-		IL_00eb: conv.r8
-		IL_00ec: ldstr ""
-		IL_00f1: ldc.i4.0
-		IL_00f2: ldc.i4.1
-		IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00f8: stloc.s 4
-		IL_00fa: ldloc.3
-		IL_00fb: ldstr "then"
-		IL_0100: ldloc.s 4
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0107: stloc.s 4
-		IL_0109: ldloc.s 4
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0110: stloc.s 4
-		IL_0112: ldc.i4.1
-		IL_0113: newarr [System.Runtime]System.Object
-		IL_0118: dup
-		IL_0119: ldc.i4.0
-		IL_011a: ldloc.0
-		IL_011b: stelem.ref
-		IL_011c: ldc.i4.0
-		IL_011d: ldelem.ref
-		IL_011e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0123: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
-		IL_0129: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_012e: ldc.i4.1
-		IL_012f: conv.r8
-		IL_0130: ldstr ""
-		IL_0135: ldc.i4.0
-		IL_0136: ldc.i4.1
-		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_013c: stloc.3
-		IL_013d: ldloc.s 4
-		IL_013f: ldstr "catch"
-		IL_0144: ldloc.3
-		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_014a: stloc.3
-		IL_014b: ldloc.3
-		IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0151: stloc.3
-		IL_0152: ldc.i4.1
-		IL_0153: newarr [System.Runtime]System.Object
-		IL_0158: dup
-		IL_0159: ldc.i4.0
-		IL_015a: ldloc.0
-		IL_015b: stelem.ref
-		IL_015c: ldc.i4.0
-		IL_015d: ldelem.ref
-		IL_015e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0163: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_016e: ldc.i4.0
-		IL_016f: conv.r8
-		IL_0170: ldstr ""
-		IL_0175: ldc.i4.0
-		IL_0176: ldc.i4.1
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_017c: stloc.s 4
-		IL_017e: ldloc.3
-		IL_017f: ldstr "then"
-		IL_0184: ldloc.s 4
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_018b: pop
-		IL_018c: ret
+		IL_006e: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::createController
+		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_007d: stloc.3
+		IL_007e: ldloc.3
+		IL_007f: stloc.1
+		IL_0080: ldloc.0
+		IL_0081: ldfld object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::timersPromises
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_008b: stloc.3
+		IL_008c: ldloc.3
+		IL_008d: ldstr "setTimeout"
+		IL_0092: ldc.r8 0.0
+		IL_009b: box [System.Runtime]System.Double
+		IL_00a0: ldstr "timeout-value"
+		IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00aa: dup
+		IL_00ab: ldstr "signal"
+		IL_00b0: ldloc.1
+		IL_00b1: ldstr "signal"
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+		IL_00c5: stloc.3
+		IL_00c6: ldloc.3
+		IL_00c7: stloc.2
+		IL_00c8: ldloc.1
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ce: stloc.3
+		IL_00cf: ldloc.3
+		IL_00d0: ldstr "abort"
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00da: pop
+		IL_00db: ldloc.2
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00e1: stloc.3
+		IL_00e2: ldnull
+		IL_00e3: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
+		IL_00e9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ee: ldc.i4.0
+		IL_00ef: conv.r8
+		IL_00f0: ldstr ""
+		IL_00f5: ldc.i4.0
+		IL_00f6: ldc.i4.1
+		IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00fc: stloc.s 4
+		IL_00fe: ldloc.3
+		IL_00ff: ldstr "then"
+		IL_0104: ldloc.s 4
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_010b: stloc.s 4
+		IL_010d: ldloc.s 4
+		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0114: stloc.s 4
+		IL_0116: ldc.i4.1
+		IL_0117: newarr [System.Runtime]System.Object
+		IL_011c: dup
+		IL_011d: ldc.i4.0
+		IL_011e: ldloc.0
+		IL_011f: stelem.ref
+		IL_0120: ldc.i4.0
+		IL_0121: ldelem.ref
+		IL_0122: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0127: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
+		IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0132: ldc.i4.1
+		IL_0133: conv.r8
+		IL_0134: ldstr ""
+		IL_0139: ldc.i4.0
+		IL_013a: ldc.i4.1
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0140: stloc.3
+		IL_0141: ldloc.s 4
+		IL_0143: ldstr "catch"
+		IL_0148: ldloc.3
+		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_014e: stloc.3
+		IL_014f: ldloc.3
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0155: stloc.3
+		IL_0156: ldc.i4.1
+		IL_0157: newarr [System.Runtime]System.Object
+		IL_015c: dup
+		IL_015d: ldc.i4.0
+		IL_015e: ldloc.0
+		IL_015f: stelem.ref
+		IL_0160: ldc.i4.0
+		IL_0161: ldelem.ref
+		IL_0162: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
+		IL_0167: ldftn object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+		IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0172: ldc.i4.0
+		IL_0173: conv.r8
+		IL_0174: ldstr ""
+		IL_0179: ldc.i4.0
+		IL_017a: ldc.i4.1
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0180: stloc.s 4
+		IL_0182: ldloc.3
+		IL_0183: ldstr "then"
+		IL_0188: ldloc.s 4
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_018f: pop
+		IL_0190: ret
 	} // end of method TimersPromises_Abort_RejectsSupportedOneShotApis::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis
@@ -1073,7 +1113,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x25cf
+		// Method begins at RVA 0x2624
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TimersPromises_SetImmediate_AwaitsValue
+﻿// IL code: TimersPromises_SetImmediate_AwaitsValue
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21c9
+				// Method begins at RVA 0x21c5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,7 +53,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a8
+			// Method begins at RVA 0x20a4
 			// Header size: 12
 			// Code size: 268 (0x10c)
 			.maxstack 8
@@ -192,7 +192,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c0
+			// Method begins at RVA 0x21bc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -218,12 +218,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 75 (0x4b)
+		// Code size: 72 (0x48)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetImmediate_AwaitsValue/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_SetImmediate_AwaitsValue/Scope::.ctor()
@@ -245,21 +246,18 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldarg.1
-		IL_002d: ldstr "node:timers/promises"
-		IL_0032: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0037: stloc.2
-		IL_0038: ldc.i4.1
-		IL_0039: newarr [System.Runtime]System.Object
-		IL_003e: dup
-		IL_003f: ldc.i4.0
-		IL_0040: ldloc.0
-		IL_0041: stelem.ref
-		IL_0042: ldnull
-		IL_0043: ldloc.2
-		IL_0044: call object Modules.TimersPromises_SetImmediate_AwaitsValue/main::__js_call__(object[], object, object)
-		IL_0049: pop
-		IL_004a: ret
+		IL_002c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0031: stloc.3
+		IL_0032: ldarg.1
+		IL_0033: ldstr "node:timers/promises"
+		IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_003d: stloc.2
+		IL_003e: ldloc.1
+		IL_003f: ldloc.3
+		IL_0040: ldloc.2
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0046: pop
+		IL_0047: ret
 	} // end of method TimersPromises_SetImmediate_AwaitsValue::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetImmediate_AwaitsValue
@@ -271,7 +269,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21d2
+		// Method begins at RVA 0x21ce
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -26,7 +26,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2683
+						// Method begins at RVA 0x268f
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -44,7 +44,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x267a
+					// Method begins at RVA 0x2686
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -69,7 +69,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2478
+				// Method begins at RVA 0x2484
 				// Header size: 12
 				// Code size: 44 (0x2c)
 				.maxstack 8
@@ -115,7 +115,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x2695
+						// Method begins at RVA 0x26a1
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -133,7 +133,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x268c
+					// Method begins at RVA 0x2698
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -158,7 +158,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x24b0
+				// Method begins at RVA 0x24bc
 				// Header size: 12
 				// Code size: 117 (0x75)
 				.maxstack 8
@@ -237,7 +237,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x26a7
+						// Method begins at RVA 0x26b3
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -255,7 +255,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x269e
+					// Method begins at RVA 0x26aa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -280,7 +280,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2534
+				// Method begins at RVA 0x2540
 				// Header size: 12
 				// Code size: 133 (0x85)
 				.maxstack 8
@@ -359,7 +359,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2671
+				// Method begins at RVA 0x267d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -385,7 +385,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 0a 00 00 02
 			)
-			// Method begins at RVA 0x20e0
+			// Method begins at RVA 0x20dc
 			// Header size: 12
 			// Code size: 203 (0xcb)
 			.maxstack 8
@@ -491,7 +491,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26b9
+					// Method begins at RVA 0x26c5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -514,7 +514,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25c5
+				// Method begins at RVA 0x25d1
 				// Header size: 1
 				// Code size: 18 (0x12)
 				.maxstack 8
@@ -540,7 +540,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x26c2
+					// Method begins at RVA 0x26ce
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -564,7 +564,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x25d8
+				// Method begins at RVA 0x25e4
 				// Header size: 12
 				// Code size: 132 (0x84)
 				.maxstack 8
@@ -631,7 +631,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x26b0
+				// Method begins at RVA 0x26bc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -655,9 +655,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21b8
+			// Method begins at RVA 0x21b4
 			// Header size: 12
-			// Code size: 690 (0x2b2)
+			// Code size: 706 (0x2c2)
 			.maxstack 9
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope,
@@ -730,218 +730,226 @@
 
 			IL_0077: ldloc.0
 			IL_0078: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_007d: switch (IL_008e, IL_0145, IL_01b7)
+			IL_007d: switch (IL_008e, IL_0155, IL_01c7)
 
 			IL_008e: ldarg.0
 			IL_008f: ldc.i4.1
 			IL_0090: ldelem.ref
 			IL_0091: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_0096: ldnull
-			IL_0097: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
-			IL_009c: stloc.s 5
-			IL_009e: ldloc.s 5
-			IL_00a0: stloc.1
-			IL_00a1: ldarg.0
-			IL_00a2: ldc.i4.1
-			IL_00a3: ldelem.ref
-			IL_00a4: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-			IL_00a9: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-			IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b3: stloc.s 5
-			IL_00b5: ldloc.s 5
-			IL_00b7: ldstr "setInterval"
-			IL_00bc: ldc.r8 0.0
-			IL_00c5: box [System.Runtime]System.Double
-			IL_00ca: ldstr "tick"
-			IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00d4: dup
-			IL_00d5: ldstr "signal"
-			IL_00da: ldloc.1
-			IL_00db: ldstr "signal"
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
-			IL_00ef: stloc.s 5
-			IL_00f1: ldloc.s 5
-			IL_00f3: stloc.2
-			IL_00f4: ldloc.2
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fa: stloc.s 5
-			IL_00fc: ldloc.s 5
-			IL_00fe: ldstr "next"
-			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0108: stloc.s 5
-			IL_010a: ldloc.0
-			IL_010b: ldc.i4.1
-			IL_010c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0111: ldloc.0
-			IL_0112: ldloc.s 5
-			IL_0114: ldarg.0
-			IL_0115: ldc.i4.1
-			IL_0116: ldloc.0
-			IL_0117: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_011c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0096: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::createController
+			IL_009b: ldc.i4.1
+			IL_009c: newarr [System.Runtime]System.Object
+			IL_00a1: dup
+			IL_00a2: ldc.i4.0
+			IL_00a3: ldarg.0
+			IL_00a4: ldc.i4.1
+			IL_00a5: ldelem.ref
+			IL_00a6: stelem.ref
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00ac: stloc.s 5
+			IL_00ae: ldloc.s 5
+			IL_00b0: stloc.1
+			IL_00b1: ldarg.0
+			IL_00b2: ldc.i4.1
+			IL_00b3: ldelem.ref
+			IL_00b4: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
+			IL_00b9: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
+			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c3: stloc.s 5
+			IL_00c5: ldloc.s 5
+			IL_00c7: ldstr "setInterval"
+			IL_00cc: ldc.r8 0.0
+			IL_00d5: box [System.Runtime]System.Double
+			IL_00da: ldstr "tick"
+			IL_00df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_00e4: dup
+			IL_00e5: ldstr "signal"
+			IL_00ea: ldloc.1
+			IL_00eb: ldstr "signal"
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember3(object, string, object, object, object)
+			IL_00ff: stloc.s 5
+			IL_0101: ldloc.s 5
+			IL_0103: stloc.2
+			IL_0104: ldloc.2
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010a: stloc.s 5
+			IL_010c: ldloc.s 5
+			IL_010e: ldstr "next"
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0118: stloc.s 5
+			IL_011a: ldloc.0
+			IL_011b: ldc.i4.1
+			IL_011c: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0121: ldloc.0
-			IL_0122: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0127: dup
-			IL_0128: ldc.i4.0
-			IL_0129: ldloc.1
-			IL_012a: stelem.ref
-			IL_012b: dup
-			IL_012c: ldc.i4.1
-			IL_012d: ldloc.2
-			IL_012e: stelem.ref
-			IL_012f: dup
-			IL_0130: ldc.i4.2
-			IL_0131: ldloc.3
-			IL_0132: stelem.ref
-			IL_0133: dup
-			IL_0134: ldc.i4.3
-			IL_0135: ldloc.s 4
-			IL_0137: stelem.ref
-			IL_0138: pop
-			IL_0139: ldloc.0
-			IL_013a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_013f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0144: ret
+			IL_0122: ldloc.s 5
+			IL_0124: ldarg.0
+			IL_0125: ldc.i4.1
+			IL_0126: ldloc.0
+			IL_0127: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_012c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0131: ldloc.0
+			IL_0132: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0137: dup
+			IL_0138: ldc.i4.0
+			IL_0139: ldloc.1
+			IL_013a: stelem.ref
+			IL_013b: dup
+			IL_013c: ldc.i4.1
+			IL_013d: ldloc.2
+			IL_013e: stelem.ref
+			IL_013f: dup
+			IL_0140: ldc.i4.2
+			IL_0141: ldloc.3
+			IL_0142: stelem.ref
+			IL_0143: dup
+			IL_0144: ldc.i4.3
+			IL_0145: ldloc.s 4
+			IL_0147: stelem.ref
+			IL_0148: pop
+			IL_0149: ldloc.0
+			IL_014a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_014f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0154: ret
 
-			IL_0145: ldloc.0
-			IL_0146: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
-			IL_014b: stloc.s 5
-			IL_014d: ldloc.s 5
-			IL_014f: stloc.3
-			IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0155: ldloc.3
-			IL_0156: ldstr "value"
-			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0165: pop
-			IL_0166: ldloc.2
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016c: stloc.s 5
-			IL_016e: ldloc.s 5
-			IL_0170: ldstr "next"
-			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_017a: stloc.s 5
-			IL_017c: ldloc.0
-			IL_017d: ldc.i4.2
-			IL_017e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0183: ldloc.0
-			IL_0184: ldloc.s 5
-			IL_0186: ldarg.0
-			IL_0187: ldc.i4.2
-			IL_0188: ldloc.0
-			IL_0189: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_018e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_0155: ldloc.0
+			IL_0156: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited1
+			IL_015b: stloc.s 5
+			IL_015d: ldloc.s 5
+			IL_015f: stloc.3
+			IL_0160: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0165: ldloc.3
+			IL_0166: ldstr "value"
+			IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0175: pop
+			IL_0176: ldloc.2
+			IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_017c: stloc.s 5
+			IL_017e: ldloc.s 5
+			IL_0180: ldstr "next"
+			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_018a: stloc.s 5
+			IL_018c: ldloc.0
+			IL_018d: ldc.i4.2
+			IL_018e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
 			IL_0193: ldloc.0
-			IL_0194: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0199: dup
-			IL_019a: ldc.i4.0
-			IL_019b: ldloc.1
-			IL_019c: stelem.ref
-			IL_019d: dup
-			IL_019e: ldc.i4.1
-			IL_019f: ldloc.2
-			IL_01a0: stelem.ref
-			IL_01a1: dup
-			IL_01a2: ldc.i4.2
-			IL_01a3: ldloc.3
-			IL_01a4: stelem.ref
-			IL_01a5: dup
-			IL_01a6: ldc.i4.3
-			IL_01a7: ldloc.s 4
-			IL_01a9: stelem.ref
-			IL_01aa: pop
-			IL_01ab: ldloc.0
-			IL_01ac: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_01b1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_01b6: ret
+			IL_0194: ldloc.s 5
+			IL_0196: ldarg.0
+			IL_0197: ldc.i4.2
+			IL_0198: ldloc.0
+			IL_0199: ldfld object [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_019e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, object)
+			IL_01a3: ldloc.0
+			IL_01a4: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_01a9: dup
+			IL_01aa: ldc.i4.0
+			IL_01ab: ldloc.1
+			IL_01ac: stelem.ref
+			IL_01ad: dup
+			IL_01ae: ldc.i4.1
+			IL_01af: ldloc.2
+			IL_01b0: stelem.ref
+			IL_01b1: dup
+			IL_01b2: ldc.i4.2
+			IL_01b3: ldloc.3
+			IL_01b4: stelem.ref
+			IL_01b5: dup
+			IL_01b6: ldc.i4.3
+			IL_01b7: ldloc.s 4
+			IL_01b9: stelem.ref
+			IL_01ba: pop
+			IL_01bb: ldloc.0
+			IL_01bc: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_01c1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_01c6: ret
 
-			IL_01b7: ldloc.0
-			IL_01b8: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
-			IL_01bd: stloc.s 5
-			IL_01bf: ldloc.s 5
-			IL_01c1: stloc.s 4
-			IL_01c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01c8: ldloc.s 4
-			IL_01ca: ldstr "value"
-			IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01d9: pop
-			IL_01da: ldloc.1
-			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e0: stloc.s 5
-			IL_01e2: ldstr "boom-reason"
-			IL_01e7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01f1: stloc.s 6
-			IL_01f3: ldloc.s 5
-			IL_01f5: ldstr "abort"
-			IL_01fa: ldloc.s 6
-			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_0201: pop
-			IL_0202: ldloc.2
-			IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0208: stloc.s 6
+			IL_01c7: ldloc.0
+			IL_01c8: ldfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/Scope::_awaited2
+			IL_01cd: stloc.s 5
+			IL_01cf: ldloc.s 5
+			IL_01d1: stloc.s 4
+			IL_01d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01d8: ldloc.s 4
+			IL_01da: ldstr "value"
+			IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01e9: pop
+			IL_01ea: ldloc.1
+			IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01f0: stloc.s 5
+			IL_01f2: ldstr "boom-reason"
+			IL_01f7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0201: stloc.s 6
+			IL_0203: ldloc.s 5
+			IL_0205: ldstr "abort"
 			IL_020a: ldloc.s 6
-			IL_020c: ldstr "next"
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-			IL_0216: stloc.s 6
-			IL_0218: ldloc.s 6
-			IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_021f: stloc.s 6
-			IL_0221: ldnull
-			IL_0222: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-			IL_0228: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-			IL_022d: ldc.i4.0
-			IL_022e: conv.r8
-			IL_022f: ldstr ""
-			IL_0234: ldc.i4.0
-			IL_0235: ldc.i4.1
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_023b: stloc.s 5
-			IL_023d: ldloc.s 6
-			IL_023f: ldstr "then"
-			IL_0244: ldloc.s 5
-			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0211: pop
+			IL_0212: ldloc.2
+			IL_0213: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0218: stloc.s 6
+			IL_021a: ldloc.s 6
+			IL_021c: ldstr "next"
+			IL_0221: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+			IL_0226: stloc.s 6
+			IL_0228: ldloc.s 6
+			IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_022f: stloc.s 6
+			IL_0231: ldnull
+			IL_0232: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+			IL_0238: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+			IL_023d: ldc.i4.0
+			IL_023e: conv.r8
+			IL_023f: ldstr ""
+			IL_0244: ldc.i4.0
+			IL_0245: ldc.i4.1
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_024b: stloc.s 5
-			IL_024d: ldloc.s 5
-			IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0254: stloc.s 5
-			IL_0256: ldnull
-			IL_0257: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-			IL_025d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-			IL_0262: ldc.i4.1
-			IL_0263: conv.r8
-			IL_0264: ldstr ""
-			IL_0269: ldc.i4.0
-			IL_026a: ldc.i4.1
-			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-			IL_0270: stloc.s 6
-			IL_0272: ldloc.s 5
-			IL_0274: ldstr "catch"
-			IL_0279: ldloc.s 6
-			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_024d: ldloc.s 6
+			IL_024f: ldstr "then"
+			IL_0254: ldloc.s 5
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_025b: stloc.s 5
+			IL_025d: ldloc.s 5
+			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0264: stloc.s 5
+			IL_0266: ldnull
+			IL_0267: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+			IL_026d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+			IL_0272: ldc.i4.1
+			IL_0273: conv.r8
+			IL_0274: ldstr ""
+			IL_0279: ldc.i4.0
+			IL_027a: ldc.i4.1
+			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
 			IL_0280: stloc.s 6
-			IL_0282: ldloc.0
-			IL_0283: ldc.i4.m1
-			IL_0284: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0289: ldloc.0
-			IL_028a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_028f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0294: ldarg.0
-			IL_0295: ldc.i4.1
-			IL_0296: newarr [System.Runtime]System.Object
-			IL_029b: dup
-			IL_029c: ldc.i4.0
-			IL_029d: ldloc.s 6
-			IL_029f: stelem.ref
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_02a5: pop
-			IL_02a6: ldloc.0
-			IL_02a7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_02ac: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_02b1: ret
+			IL_0282: ldloc.s 5
+			IL_0284: ldstr "catch"
+			IL_0289: ldloc.s 6
+			IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_0290: stloc.s 6
+			IL_0292: ldloc.0
+			IL_0293: ldc.i4.m1
+			IL_0294: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0299: ldloc.0
+			IL_029a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_029f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_02a4: ldarg.0
+			IL_02a5: ldc.i4.1
+			IL_02a6: newarr [System.Runtime]System.Object
+			IL_02ab: dup
+			IL_02ac: ldc.i4.0
+			IL_02ad: ldloc.s 6
+			IL_02af: stelem.ref
+			IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_02b5: pop
+			IL_02b6: ldloc.0
+			IL_02b7: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_02bc: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_02c1: ret
 		} // end of method main::__js_call__
 
 	} // end of class main
@@ -966,7 +974,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2668
+			// Method begins at RVA 0x2674
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -992,7 +1000,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 131 (0x83)
+		// Code size: 126 (0x7e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope,
@@ -1047,16 +1055,11 @@
 		IL_006a: ldloc.0
 		IL_006b: ldloc.2
 		IL_006c: stfld object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope::timersPromises
-		IL_0071: ldc.i4.1
-		IL_0072: newarr [System.Runtime]System.Object
-		IL_0077: dup
-		IL_0078: ldc.i4.0
-		IL_0079: ldloc.0
-		IL_007a: stelem.ref
-		IL_007b: ldnull
-		IL_007c: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main::__js_call__(object[], object)
-		IL_0081: pop
-		IL_0082: ret
+		IL_0071: ldloc.1
+		IL_0072: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_007c: pop
+		IL_007d: ret
 	} // end of method TimersPromises_SetInterval_Abort_RejectsActiveIterator::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator
@@ -1068,7 +1071,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x26cb
+		// Method begins at RVA 0x26d7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TimersPromises_SetInterval_Backpressure_And_Return
+﻿// IL code: TimersPromises_SetInterval_Backpressure_And_Return
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -49,7 +49,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2581
+				// Method begins at RVA 0x2579
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -73,7 +73,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20b0
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 1212 (0x4bc)
 			.maxstack 8
@@ -645,7 +645,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2578
+			// Method begins at RVA 0x2570
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -671,7 +671,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 81 (0x51)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope,
@@ -705,16 +705,11 @@
 		IL_0038: ldloc.0
 		IL_0039: ldloc.2
 		IL_003a: stfld object Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope::timersPromises
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: ldnull
-		IL_004a: call object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main::__js_call__(object[], object)
-		IL_004f: pop
-		IL_0050: ret
+		IL_003f: ldloc.1
+		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method TimersPromises_SetInterval_Backpressure_And_Return::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_Backpressure_And_Return
@@ -726,7 +721,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x258a
+		// Method begins at RVA 0x2582
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
+﻿// IL code: TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2483
+				// Method begins at RVA 0x247b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -56,7 +56,7 @@
 					.method public hidebysig specialname rtspecialname 
 						instance void .ctor () cil managed 
 					{
-						// Method begins at RVA 0x249e
+						// Method begins at RVA 0x2496
 						// Header size: 1
 						// Code size: 8 (0x8)
 						.maxstack 8
@@ -74,7 +74,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2495
+					// Method begins at RVA 0x248d
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -92,7 +92,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x248c
+				// Method begins at RVA 0x2484
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -116,7 +116,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20b0
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 958 (0x3be)
 			.maxstack 8
@@ -561,7 +561,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x247a
+			// Method begins at RVA 0x2472
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -587,7 +587,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 81 (0x51)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope,
@@ -621,16 +621,11 @@
 		IL_0038: ldloc.0
 		IL_0039: ldloc.2
 		IL_003a: stfld object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope::timersPromises
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: ldnull
-		IL_004a: call object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main::__js_call__(object[], object)
-		IL_004f: pop
-		IL_0050: ret
+		IL_003f: ldloc.1
+		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
@@ -642,7 +637,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24a7
+		// Method begins at RVA 0x249f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TimersPromises_SetInterval_InfinityDelay_ClampsToTick
+﻿// IL code: TimersPromises_SetInterval_InfinityDelay_ClampsToTick
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -33,7 +33,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22a6
+				// Method begins at RVA 0x229e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -57,7 +57,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20b0
+			// Method begins at RVA 0x20a8
 			// Header size: 12
 			// Code size: 481 (0x1e1)
 			.maxstack 8
@@ -286,7 +286,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x229d
+			// Method begins at RVA 0x2295
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -312,7 +312,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 81 (0x51)
+		// Code size: 76 (0x4c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope,
@@ -346,16 +346,11 @@
 		IL_0038: ldloc.0
 		IL_0039: ldloc.2
 		IL_003a: stfld object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope::timersPromises
-		IL_003f: ldc.i4.1
-		IL_0040: newarr [System.Runtime]System.Object
-		IL_0045: dup
-		IL_0046: ldc.i4.0
-		IL_0047: ldloc.0
-		IL_0048: stelem.ref
-		IL_0049: ldnull
-		IL_004a: call object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main::__js_call__(object[], object)
-		IL_004f: pop
-		IL_0050: ret
+		IL_003f: ldloc.1
+		IL_0040: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004a: pop
+		IL_004b: ret
 	} // end of method TimersPromises_SetInterval_InfinityDelay_ClampsToTick::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick
@@ -367,7 +362,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22af
+		// Method begins at RVA 0x22a7
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetTimeout_AwaitsValue.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetTimeout_AwaitsValue.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TimersPromises_SetTimeout_AwaitsValue
+﻿// IL code: TimersPromises_SetTimeout_AwaitsValue
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -28,7 +28,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21d7
+				// Method begins at RVA 0x21d3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -53,7 +53,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 02 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a8
+			// Method begins at RVA 0x20a4
 			// Header size: 12
 			// Code size: 282 (0x11a)
 			.maxstack 8
@@ -194,7 +194,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21ce
+			// Method begins at RVA 0x21ca
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -220,12 +220,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 75 (0x4b)
+		// Code size: 72 (0x48)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetTimeout_AwaitsValue/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_SetTimeout_AwaitsValue/Scope::.ctor()
@@ -247,21 +248,18 @@
 		IL_0029: stloc.2
 		IL_002a: ldloc.2
 		IL_002b: stloc.1
-		IL_002c: ldarg.1
-		IL_002d: ldstr "node:timers/promises"
-		IL_0032: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
-		IL_0037: stloc.2
-		IL_0038: ldc.i4.1
-		IL_0039: newarr [System.Runtime]System.Object
-		IL_003e: dup
-		IL_003f: ldc.i4.0
-		IL_0040: ldloc.0
-		IL_0041: stelem.ref
-		IL_0042: ldnull
-		IL_0043: ldloc.2
-		IL_0044: call object Modules.TimersPromises_SetTimeout_AwaitsValue/main::__js_call__(object[], object, object)
-		IL_0049: pop
-		IL_004a: ret
+		IL_002c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0031: stloc.3
+		IL_0032: ldarg.1
+		IL_0033: ldstr "node:timers/promises"
+		IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.CommonJS.RequireDelegate::Invoke(object)
+		IL_003d: stloc.2
+		IL_003e: ldloc.1
+		IL_003f: ldloc.3
+		IL_0040: ldloc.2
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0046: pop
+		IL_0047: ret
 	} // end of method TimersPromises_SetTimeout_AwaitsValue::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetTimeout_AwaitsValue
@@ -273,7 +271,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21e0
+		// Method begins at RVA 0x21dc
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Require_Zlib_ErrorPaths
+﻿// IL code: Require_Zlib_ErrorPaths
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2712
+					// Method begins at RVA 0x273e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x271b
+					// Method begins at RVA 0x2747
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2709
+				// Method begins at RVA 0x2735
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -85,7 +85,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2490
+			// Method begins at RVA 0x24bc
 			// Header size: 12
 			// Code size: 226 (0xe2)
 			.maxstack 8
@@ -203,7 +203,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2724
+				// Method begins at RVA 0x2750
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -229,7 +229,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2590
+			// Method begins at RVA 0x25bc
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -268,7 +268,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x272d
+				// Method begins at RVA 0x2759
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -294,7 +294,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x25d4
+			// Method begins at RVA 0x2600
 			// Header size: 12
 			// Code size: 81 (0x51)
 			.maxstack 8
@@ -343,7 +343,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2736
+				// Method begins at RVA 0x2762
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -369,7 +369,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2634
+			// Method begins at RVA 0x2660
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -408,7 +408,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x273f
+				// Method begins at RVA 0x276b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -434,7 +434,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x2678
+			// Method begins at RVA 0x26a4
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -473,7 +473,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2748
+				// Method begins at RVA 0x2774
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -499,7 +499,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 09 00 00 02
 			)
-			// Method begins at RVA 0x26bc
+			// Method begins at RVA 0x26e8
 			// Header size: 12
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -543,7 +543,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2751
+				// Method begins at RVA 0x277d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -563,7 +563,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x275a
+				// Method begins at RVA 0x2786
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -585,7 +585,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2700
+			// Method begins at RVA 0x272c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -611,7 +611,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1058 (0x422)
+		// Code size: 1103 (0x44f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
@@ -624,12 +624,13 @@
 			[7] object,
 			[8] object,
 			[9] object,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
-			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[12] bool,
-			[13] object,
+			[10] object[],
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[13] bool,
 			[14] object,
-			[15] object
+			[15] object,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope::.ctor()
@@ -726,276 +727,291 @@
 		IL_013b: ldloc.s 8
 		IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 		IL_0142: pop
-		IL_0143: ldc.i4.1
-		IL_0144: newarr [System.Runtime]System.Object
-		IL_0149: dup
-		IL_014a: ldc.i4.0
-		IL_014b: ldloc.0
-		IL_014c: stelem.ref
-		IL_014d: ldc.i4.0
-		IL_014e: ldelem.ref
-		IL_014f: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_0154: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_015a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_015f: ldc.i4.1
-		IL_0160: newarr [System.Runtime]System.Object
-		IL_0165: dup
-		IL_0166: ldc.i4.0
-		IL_0167: ldloc.0
-		IL_0168: stelem.ref
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0173: ldc.i4.0
-		IL_0174: conv.r8
-		IL_0175: ldstr ""
+		IL_0143: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0148: stloc.s 10
+		IL_014a: ldc.i4.1
+		IL_014b: newarr [System.Runtime]System.Object
+		IL_0150: dup
+		IL_0151: ldc.i4.0
+		IL_0152: ldloc.0
+		IL_0153: stelem.ref
+		IL_0154: ldc.i4.0
+		IL_0155: ldelem.ref
+		IL_0156: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_015b: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L25C37::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0161: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0166: ldc.i4.1
+		IL_0167: newarr [System.Runtime]System.Object
+		IL_016c: dup
+		IL_016d: ldc.i4.0
+		IL_016e: ldloc.0
+		IL_016f: stelem.ref
+		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
 		IL_017a: ldc.i4.0
-		IL_017b: ldc.i4.1
-		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0186: stloc.s 8
-		IL_0188: ldnull
-		IL_0189: ldstr "gzip unsupported option"
-		IL_018e: ldloc.s 8
-		IL_0190: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_0195: pop
-		IL_0196: ldc.i4.1
-		IL_0197: newarr [System.Runtime]System.Object
-		IL_019c: dup
-		IL_019d: ldc.i4.0
-		IL_019e: ldloc.0
-		IL_019f: stelem.ref
-		IL_01a0: ldc.i4.0
-		IL_01a1: ldelem.ref
-		IL_01a2: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_01a7: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_01ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01b2: ldc.i4.1
-		IL_01b3: newarr [System.Runtime]System.Object
-		IL_01b8: dup
-		IL_01b9: ldc.i4.0
-		IL_01ba: ldloc.0
-		IL_01bb: stelem.ref
-		IL_01bc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_01c6: ldc.i4.0
-		IL_01c7: conv.r8
-		IL_01c8: ldstr ""
-		IL_01cd: ldc.i4.0
-		IL_01ce: ldc.i4.1
-		IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_01d9: stloc.s 8
-		IL_01db: ldnull
-		IL_01dc: ldstr "gunzip unsupported option"
-		IL_01e1: ldloc.s 8
-		IL_01e3: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_01e8: pop
-		IL_01e9: ldc.i4.1
-		IL_01ea: newarr [System.Runtime]System.Object
-		IL_01ef: dup
-		IL_01f0: ldc.i4.0
-		IL_01f1: ldloc.0
-		IL_01f2: stelem.ref
-		IL_01f3: ldc.i4.0
-		IL_01f4: ldelem.ref
-		IL_01f5: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_01fa: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_0200: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0205: ldc.i4.1
-		IL_0206: newarr [System.Runtime]System.Object
-		IL_020b: dup
+		IL_017b: conv.r8
+		IL_017c: ldstr ""
+		IL_0181: ldc.i4.0
+		IL_0182: ldc.i4.1
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_018d: stloc.s 8
+		IL_018f: ldloc.1
+		IL_0190: ldloc.s 10
+		IL_0192: ldstr "gzip unsupported option"
+		IL_0197: ldloc.s 8
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_019e: pop
+		IL_019f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01a4: stloc.s 10
+		IL_01a6: ldc.i4.1
+		IL_01a7: newarr [System.Runtime]System.Object
+		IL_01ac: dup
+		IL_01ad: ldc.i4.0
+		IL_01ae: ldloc.0
+		IL_01af: stelem.ref
+		IL_01b0: ldc.i4.0
+		IL_01b1: ldelem.ref
+		IL_01b2: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_01b7: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L26C39::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_01bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01c2: ldc.i4.1
+		IL_01c3: newarr [System.Runtime]System.Object
+		IL_01c8: dup
+		IL_01c9: ldc.i4.0
+		IL_01ca: ldloc.0
+		IL_01cb: stelem.ref
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_01d6: ldc.i4.0
+		IL_01d7: conv.r8
+		IL_01d8: ldstr ""
+		IL_01dd: ldc.i4.0
+		IL_01de: ldc.i4.1
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_01e9: stloc.s 8
+		IL_01eb: ldloc.1
+		IL_01ec: ldloc.s 10
+		IL_01ee: ldstr "gunzip unsupported option"
+		IL_01f3: ldloc.s 8
+		IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01fa: pop
+		IL_01fb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0200: stloc.s 10
+		IL_0202: ldc.i4.1
+		IL_0203: newarr [System.Runtime]System.Object
+		IL_0208: dup
+		IL_0209: ldc.i4.0
+		IL_020a: ldloc.0
+		IL_020b: stelem.ref
 		IL_020c: ldc.i4.0
-		IL_020d: ldloc.0
-		IL_020e: stelem.ref
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0219: ldc.i4.0
-		IL_021a: conv.r8
-		IL_021b: ldstr ""
-		IL_0220: ldc.i4.0
-		IL_0221: ldc.i4.1
-		IL_0222: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_022c: stloc.s 8
-		IL_022e: ldnull
-		IL_022f: ldstr "gzip bad level"
-		IL_0234: ldloc.s 8
-		IL_0236: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_023b: pop
-		IL_023c: ldc.i4.1
-		IL_023d: newarr [System.Runtime]System.Object
-		IL_0242: dup
-		IL_0243: ldc.i4.0
-		IL_0244: ldloc.0
-		IL_0245: stelem.ref
-		IL_0246: ldc.i4.0
-		IL_0247: ldelem.ref
-		IL_0248: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_024d: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_0253: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0258: ldc.i4.1
-		IL_0259: newarr [System.Runtime]System.Object
-		IL_025e: dup
-		IL_025f: ldc.i4.0
-		IL_0260: ldloc.0
-		IL_0261: stelem.ref
-		IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_026c: ldc.i4.0
-		IL_026d: conv.r8
-		IL_026e: ldstr ""
-		IL_0273: ldc.i4.0
-		IL_0274: ldc.i4.1
-		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_027f: stloc.s 8
-		IL_0281: ldnull
-		IL_0282: ldstr "gzip NaN level"
-		IL_0287: ldloc.s 8
-		IL_0289: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_028e: pop
-		IL_028f: ldc.i4.1
-		IL_0290: newarr [System.Runtime]System.Object
-		IL_0295: dup
-		IL_0296: ldc.i4.0
-		IL_0297: ldloc.0
-		IL_0298: stelem.ref
-		IL_0299: ldc.i4.0
-		IL_029a: ldelem.ref
-		IL_029b: castclass Modules.Require_Zlib_ErrorPaths/Scope
-		IL_02a0: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
-		IL_02a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02ab: ldc.i4.1
-		IL_02ac: newarr [System.Runtime]System.Object
-		IL_02b1: dup
-		IL_02b2: ldc.i4.0
-		IL_02b3: ldloc.0
-		IL_02b4: stelem.ref
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_02bf: ldc.i4.0
-		IL_02c0: conv.r8
-		IL_02c1: ldstr ""
-		IL_02c6: ldc.i4.0
-		IL_02c7: ldc.i4.1
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_02d2: stloc.s 8
-		IL_02d4: ldnull
-		IL_02d5: ldstr "gzip Infinity level"
-		IL_02da: ldloc.s 8
-		IL_02dc: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, object, object)
-		IL_02e1: pop
+		IL_020d: ldelem.ref
+		IL_020e: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_0213: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L27C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0219: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_021e: ldc.i4.1
+		IL_021f: newarr [System.Runtime]System.Object
+		IL_0224: dup
+		IL_0225: ldc.i4.0
+		IL_0226: ldloc.0
+		IL_0227: stelem.ref
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0232: ldc.i4.0
+		IL_0233: conv.r8
+		IL_0234: ldstr ""
+		IL_0239: ldc.i4.0
+		IL_023a: ldc.i4.1
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0240: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0245: stloc.s 8
+		IL_0247: ldloc.1
+		IL_0248: ldloc.s 10
+		IL_024a: ldstr "gzip bad level"
+		IL_024f: ldloc.s 8
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0256: pop
+		IL_0257: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_025c: stloc.s 10
+		IL_025e: ldc.i4.1
+		IL_025f: newarr [System.Runtime]System.Object
+		IL_0264: dup
+		IL_0265: ldc.i4.0
+		IL_0266: ldloc.0
+		IL_0267: stelem.ref
+		IL_0268: ldc.i4.0
+		IL_0269: ldelem.ref
+		IL_026a: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_026f: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L28C28::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_0275: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_027a: ldc.i4.1
+		IL_027b: newarr [System.Runtime]System.Object
+		IL_0280: dup
+		IL_0281: ldc.i4.0
+		IL_0282: ldloc.0
+		IL_0283: stelem.ref
+		IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_028e: ldc.i4.0
+		IL_028f: conv.r8
+		IL_0290: ldstr ""
+		IL_0295: ldc.i4.0
+		IL_0296: ldc.i4.1
+		IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_02a1: stloc.s 8
+		IL_02a3: ldloc.1
+		IL_02a4: ldloc.s 10
+		IL_02a6: ldstr "gzip NaN level"
+		IL_02ab: ldloc.s 8
+		IL_02ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02b2: pop
+		IL_02b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02b8: stloc.s 10
+		IL_02ba: ldc.i4.1
+		IL_02bb: newarr [System.Runtime]System.Object
+		IL_02c0: dup
+		IL_02c1: ldc.i4.0
+		IL_02c2: ldloc.0
+		IL_02c3: stelem.ref
+		IL_02c4: ldc.i4.0
+		IL_02c5: ldelem.ref
+		IL_02c6: castclass Modules.Require_Zlib_ErrorPaths/Scope
+		IL_02cb: ldftn object Modules.Require_Zlib_ErrorPaths/ArrowFunction_L29C33::__js_call__(class Modules.Require_Zlib_ErrorPaths/Scope, object)
+		IL_02d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02d6: ldc.i4.1
+		IL_02d7: newarr [System.Runtime]System.Object
+		IL_02dc: dup
+		IL_02dd: ldc.i4.0
+		IL_02de: ldloc.0
+		IL_02df: stelem.ref
+		IL_02e0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_02e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_02ea: ldc.i4.0
+		IL_02eb: conv.r8
+		IL_02ec: ldstr ""
+		IL_02f1: ldc.i4.0
+		IL_02f2: ldc.i4.1
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_02fd: stloc.s 8
+		IL_02ff: ldloc.1
+		IL_0300: ldloc.s 10
+		IL_0302: ldstr "gzip Infinity level"
+		IL_0307: ldloc.s 8
+		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_030e: pop
 		.try
 		{
-			IL_02e2: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L31C4::.ctor()
-			IL_02e7: stloc.2
-			IL_02e8: ldloc.0
-			IL_02e9: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02f3: stloc.s 8
-			IL_02f5: ldstr "not gzip"
-			IL_02fa: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
-			IL_02ff: stloc.s 10
-			IL_0301: ldloc.s 8
-			IL_0303: ldstr "gunzipSync"
-			IL_0308: ldloc.s 10
-			IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-			IL_030f: pop
-			IL_0310: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0315: ldstr "gunzip invalid data threw:"
-			IL_031a: ldc.i4.0
-			IL_031b: box [System.Runtime]System.Boolean
-			IL_0320: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0325: pop
-			IL_0326: leave IL_041e
+			IL_030f: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L31C4::.ctor()
+			IL_0314: stloc.2
+			IL_0315: ldloc.0
+			IL_0316: ldfld object Modules.Require_Zlib_ErrorPaths/Scope::zlib
+			IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0320: stloc.s 8
+			IL_0322: ldstr "not gzip"
+			IL_0327: call class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer::from(object)
+			IL_032c: stloc.s 11
+			IL_032e: ldloc.s 8
+			IL_0330: ldstr "gunzipSync"
+			IL_0335: ldloc.s 11
+			IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+			IL_033c: pop
+			IL_033d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0342: ldstr "gunzip invalid data threw:"
+			IL_0347: ldc.i4.0
+			IL_0348: box [System.Runtime]System.Boolean
+			IL_034d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0352: pop
+			IL_0353: leave IL_044b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_032b: stloc.3
-			IL_032c: ldloc.3
-			IL_032d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0332: dup
-			IL_0333: brtrue IL_0348
+			IL_0358: stloc.3
+			IL_0359: ldloc.3
+			IL_035a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_035f: dup
+			IL_0360: brtrue IL_0375
 
-			IL_0338: pop
-			IL_0339: ldloc.3
-			IL_033a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_033f: dup
-			IL_0340: brtrue IL_0354
+			IL_0365: pop
+			IL_0366: ldloc.3
+			IL_0367: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_036c: dup
+			IL_036d: brtrue IL_0381
 
-			IL_0345: pop
-			IL_0346: rethrow
+			IL_0372: pop
+			IL_0373: rethrow
 
-			IL_0348: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_034d: stloc.s 4
-			IL_034f: br IL_0356
+			IL_0375: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_037a: stloc.s 4
+			IL_037c: br IL_0383
 
-			IL_0354: stloc.s 4
+			IL_0381: stloc.s 4
 
-			IL_0356: ldloc.s 4
-			IL_0358: stloc.s 8
-			IL_035a: ldloc.s 8
-			IL_035c: stloc.s 5
-			IL_035e: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L34C16::.ctor()
-			IL_0363: stloc.s 6
-			IL_0365: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_036a: ldstr "gunzip invalid data threw:"
-			IL_036f: ldc.i4.1
-			IL_0370: box [System.Runtime]System.Boolean
-			IL_0375: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_037a: pop
-			IL_037b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0380: ldstr "gunzip invalid data name:"
-			IL_0385: ldloc.s 5
-			IL_0387: ldstr "name"
-			IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0391: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0396: pop
-			IL_0397: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_039c: stloc.s 11
-			IL_039e: ldloc.s 5
-			IL_03a0: ldstr "message"
-			IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03aa: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-			IL_03af: ldstr "string"
-			IL_03b4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_03b9: stloc.s 12
-			IL_03bb: ldloc.s 12
-			IL_03bd: box [System.Runtime]System.Boolean
-			IL_03c2: stloc.s 13
-			IL_03c4: ldloc.s 13
-			IL_03c6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03cb: stloc.s 12
-			IL_03cd: ldloc.s 12
-			IL_03cf: brfalse IL_0406
+			IL_0383: ldloc.s 4
+			IL_0385: stloc.s 8
+			IL_0387: ldloc.s 8
+			IL_0389: stloc.s 5
+			IL_038b: newobj instance void Modules.Require_Zlib_ErrorPaths/Scope/Block_L34C16::.ctor()
+			IL_0390: stloc.s 6
+			IL_0392: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0397: ldstr "gunzip invalid data threw:"
+			IL_039c: ldc.i4.1
+			IL_039d: box [System.Runtime]System.Boolean
+			IL_03a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_03a7: pop
+			IL_03a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ad: ldstr "gunzip invalid data name:"
+			IL_03b2: ldloc.s 5
+			IL_03b4: ldstr "name"
+			IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_03c3: pop
+			IL_03c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03c9: stloc.s 12
+			IL_03cb: ldloc.s 5
+			IL_03cd: ldstr "message"
+			IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03d7: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_03dc: ldstr "string"
+			IL_03e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_03e6: stloc.s 13
+			IL_03e8: ldloc.s 13
+			IL_03ea: box [System.Runtime]System.Boolean
+			IL_03ef: stloc.s 14
+			IL_03f1: ldloc.s 14
+			IL_03f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03f8: stloc.s 13
+			IL_03fa: ldloc.s 13
+			IL_03fc: brfalse IL_0433
 
-			IL_03d4: ldloc.s 5
-			IL_03d6: ldstr "message"
-			IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e0: ldstr "length"
-			IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_03ef: ldc.r8 0.0
-			IL_03f8: cgt
-			IL_03fa: box [System.Runtime]System.Boolean
-			IL_03ff: stloc.s 15
-			IL_0401: br IL_040a
+			IL_0401: ldloc.s 5
+			IL_0403: ldstr "message"
+			IL_0408: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_040d: ldstr "length"
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0417: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_041c: ldc.r8 0.0
+			IL_0425: cgt
+			IL_0427: box [System.Runtime]System.Boolean
+			IL_042c: stloc.s 16
+			IL_042e: br IL_0437
 
-			IL_0406: ldloc.s 13
-			IL_0408: stloc.s 15
+			IL_0433: ldloc.s 14
+			IL_0435: stloc.s 16
 
-			IL_040a: ldloc.s 11
-			IL_040c: ldstr "gunzip invalid data message length > 0:"
-			IL_0411: ldloc.s 15
-			IL_0413: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0418: pop
-			IL_0419: leave IL_041e
+			IL_0437: ldloc.s 12
+			IL_0439: ldstr "gunzip invalid data message length > 0:"
+			IL_043e: ldloc.s 16
+			IL_0440: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0445: pop
+			IL_0446: leave IL_044b
 		} // end handler
 
-		IL_041e: ldnull
-		IL_041f: stloc.s 7
-		IL_0421: ret
+		IL_044b: ldnull
+		IL_044c: stloc.s 7
+		IL_044e: ret
 	} // end of method Require_Zlib_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Zlib_ErrorPaths
@@ -1007,7 +1023,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2763
+		// Method begins at RVA 0x278f
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222f
+				// Method begins at RVA 0x222b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x2188
+			// Method begins at RVA 0x2184
 			// Header size: 12
 			// Code size: 30 (0x1e)
 			.maxstack 8
@@ -77,7 +77,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2238
+				// Method begins at RVA 0x2234
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -103,7 +103,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21b4
+			// Method begins at RVA 0x21b0
 			// Header size: 12
 			// Code size: 39 (0x27)
 			.maxstack 8
@@ -137,7 +137,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2241
+				// Method begins at RVA 0x223d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -163,7 +163,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 06 00 00 02
 			)
-			// Method begins at RVA 0x21e8
+			// Method begins at RVA 0x21e4
 			// Header size: 12
 			// Code size: 50 (0x32)
 			.maxstack 8
@@ -207,7 +207,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2226
+			// Method begins at RVA 0x2222
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -233,7 +233,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 297 (0x129)
+		// Code size: 294 (0x126)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope,
@@ -311,52 +311,49 @@
 		IL_0093: ldloc.0
 		IL_0094: ldstr ""
 		IL_0099: stfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-		IL_009e: ldloc.0
-		IL_009f: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_00a4: ldnull
-		IL_00a5: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_00aa: stloc.s 5
-		IL_00ac: ldloc.0
-		IL_00ad: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_00b2: ldnull
-		IL_00b3: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_00b8: stloc.s 6
-		IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00bf: stloc.s 7
-		IL_00c1: ldloc.s 7
-		IL_00c3: ldloc.s 5
-		IL_00c5: ldloc.s 6
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
-		IL_00cc: pop
-		IL_00cd: ldloc.0
-		IL_00ce: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_00d3: ldnull
-		IL_00d4: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_00d9: stloc.s 6
-		IL_00db: ldloc.s 7
-		IL_00dd: ldloc.s 6
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SpreadIntoObjectLiteral(object, object)
-		IL_00e4: pop
-		IL_00e5: ldloc.s 7
-		IL_00e7: stloc.s 4
-		IL_00e9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ee: ldloc.0
-		IL_00ef: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
-		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f9: pop
-		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ff: ldloc.s 4
-		IL_0101: ldstr "k"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0110: pop
-		IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0116: ldloc.s 4
-		IL_0118: ldstr "a"
-		IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0122: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0127: pop
-		IL_0128: ret
+		IL_009e: ldloc.1
+		IL_009f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00a9: stloc.s 5
+		IL_00ab: ldloc.2
+		IL_00ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00b6: stloc.s 6
+		IL_00b8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00bd: stloc.s 7
+		IL_00bf: ldloc.s 7
+		IL_00c1: ldloc.s 5
+		IL_00c3: ldloc.s 6
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
+		IL_00ca: pop
+		IL_00cb: ldloc.3
+		IL_00cc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00d6: stloc.s 6
+		IL_00d8: ldloc.s 7
+		IL_00da: ldloc.s 6
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::SpreadIntoObjectLiteral(object, object)
+		IL_00e1: pop
+		IL_00e2: ldloc.s 7
+		IL_00e4: stloc.s 4
+		IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00eb: ldloc.0
+		IL_00ec: ldfld object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope::log
+		IL_00f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f6: pop
+		IL_00f7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fc: ldloc.s 4
+		IL_00fe: ldstr "k"
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0108: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010d: pop
+		IL_010e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0113: ldloc.s 4
+		IL_0115: ldstr "a"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0124: pop
+		IL_0125: ret
 	} // end of method ObjectLiteral_ComputedKey_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ComputedKey_EvaluationOrder
@@ -368,7 +365,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x224a
+		// Method begins at RVA 0x2246
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x216f
+				// Method begins at RVA 0x216e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x212d
+			// Method begins at RVA 0x212c
 			// Header size: 1
 			// Code size: 56 (0x38)
 			.maxstack 8
@@ -79,7 +79,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2166
+			// Method begins at RVA 0x2165
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -105,7 +105,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 209 (0xd1)
+		// Code size: 208 (0xd0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InlinePropertyInit/Scope,
@@ -163,16 +163,15 @@
 		IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 		IL_00b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_00b6: pop
-		IL_00b7: ldloc.0
-		IL_00b8: castclass Modules.ObjectLiteral_InlinePropertyInit/Scope
-		IL_00bd: ldnull
-		IL_00be: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
-		IL_00c3: stloc.2
-		IL_00c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c9: ldloc.2
-		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00cf: pop
-		IL_00d0: ret
+		IL_00b7: ldloc.1
+		IL_00b8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00c2: stloc.2
+		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c8: ldloc.2
+		IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ce: pop
+		IL_00cf: ret
 	} // end of method ObjectLiteral_InlinePropertyInit::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InlinePropertyInit
@@ -184,7 +183,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2178
+		// Method begins at RVA 0x2177
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x275b
+					// Method begins at RVA 0x2777
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2764
+					// Method begins at RVA 0x2780
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2752
+				// Method begins at RVA 0x276e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x246c
+			// Method begins at RVA 0x2488
 			// Header size: 12
 			// Code size: 181 (0xb5)
 			.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x276d
+				// Method begins at RVA 0x2789
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -223,7 +223,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2540
+			// Method begins at RVA 0x255c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -247,7 +247,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2776
+				// Method begins at RVA 0x2792
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -273,7 +273,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2549
+			// Method begins at RVA 0x2565
 			// Header size: 1
 			// Code size: 17 (0x11)
 			.maxstack 8
@@ -302,60 +302,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x277f
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
-
-		// Methods
-		.method public hidebysig static 
-			object __js_call__ (
-				class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope scope,
-				object newTarget
-			) cil managed 
-		{
-			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
-				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
-				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
-				74 61 54 6f 6b 65 6e 11 00 00 02
-			)
-			// Method begins at RVA 0x255b
-			// Header size: 1
-			// Code size: 27 (0x1b)
-			.maxstack 8
-
-			IL_0000: ldarg.0
-			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
-			IL_0006: ldstr "proxy"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0010: ldstr "a"
-			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_001a: ret
-		} // end of method FunctionExpression_L28C16::__js_call__
-
-	} // end of class FunctionExpression_L28C16
-
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L29C16
-		extends [System.Runtime]System.Object
-	{
-		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Method begins at RVA 0x2788
+				// Method begins at RVA 0x279b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -382,6 +329,59 @@
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
 			// Method begins at RVA 0x2577
+			// Header size: 1
+			// Code size: 27 (0x1b)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::revocable
+			IL_0006: ldstr "proxy"
+			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0010: ldstr "a"
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_001a: ret
+		} // end of method FunctionExpression_L28C16::__js_call__
+
+	} // end of class FunctionExpression_L28C16
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L29C16
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27a4
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 11 00 00 02
+			)
+			// Method begins at RVA 0x2593
 			// Header size: 1
 			// Code size: 43 (0x2b)
 			.maxstack 8
@@ -412,7 +412,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2791
+				// Method begins at RVA 0x27ad
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -438,7 +438,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x25a4
+			// Method begins at RVA 0x25c0
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -474,7 +474,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x279a
+				// Method begins at RVA 0x27b6
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -500,7 +500,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x25d4
+			// Method begins at RVA 0x25f0
 			// Header size: 12
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -536,7 +536,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27a3
+				// Method begins at RVA 0x27bf
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -562,7 +562,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2604
+			// Method begins at RVA 0x2620
 			// Header size: 12
 			// Code size: 48 (0x30)
 			.maxstack 8
@@ -601,7 +601,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27ac
+				// Method begins at RVA 0x27c8
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -627,7 +627,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2640
+			// Method begins at RVA 0x265c
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -658,7 +658,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27b5
+				// Method begins at RVA 0x27d1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -684,7 +684,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x2664
+			// Method begins at RVA 0x2680
 			// Header size: 12
 			// Code size: 32 (0x20)
 			.maxstack 8
@@ -719,7 +719,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27be
+				// Method begins at RVA 0x27da
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -743,7 +743,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2690
+			// Method begins at RVA 0x26ac
 			// Header size: 12
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -772,7 +772,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27c7
+				// Method begins at RVA 0x27e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -798,7 +798,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x26b0
+			// Method begins at RVA 0x26cc
 			// Header size: 12
 			// Code size: 40 (0x28)
 			.maxstack 8
@@ -839,7 +839,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d0
+				// Method begins at RVA 0x27ec
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -863,7 +863,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x26e4
+			// Method begins at RVA 0x2700
 			// Header size: 12
 			// Code size: 28 (0x1c)
 			.maxstack 8
@@ -899,7 +899,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x27d9
+				// Method begins at RVA 0x27f5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -925,7 +925,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 11 00 00 02
 			)
-			// Method begins at RVA 0x270c
+			// Method begins at RVA 0x2728
 			// Header size: 12
 			// Code size: 49 (0x31)
 			.maxstack 8
@@ -976,7 +976,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2749
+			// Method begins at RVA 0x2765
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1002,7 +1002,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1038 (0x40e)
+		// Code size: 1065 (0x429)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope,
@@ -1010,7 +1010,8 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
 			[4] object,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] object[]
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1111,282 +1112,291 @@
 		IL_012a: ldstr "revoke"
 		IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
 		IL_0134: pop
-		IL_0135: ldc.i4.1
-		IL_0136: newarr [System.Runtime]System.Object
-		IL_013b: dup
-		IL_013c: ldc.i4.0
-		IL_013d: ldloc.0
-		IL_013e: stelem.ref
-		IL_013f: ldc.i4.0
-		IL_0140: ldelem.ref
-		IL_0141: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0146: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_014c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0151: ldc.i4.0
-		IL_0152: conv.r8
-		IL_0153: ldstr ""
+		IL_0135: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_013a: stloc.s 6
+		IL_013c: ldc.i4.1
+		IL_013d: newarr [System.Runtime]System.Object
+		IL_0142: dup
+		IL_0143: ldc.i4.0
+		IL_0144: ldloc.0
+		IL_0145: stelem.ref
+		IL_0146: ldc.i4.0
+		IL_0147: ldelem.ref
+		IL_0148: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_014d: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0153: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_0158: ldc.i4.0
-		IL_0159: ldc.i4.1
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_015f: stloc.s 4
-		IL_0161: ldloc.0
-		IL_0162: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0167: ldnull
-		IL_0168: ldstr "get"
-		IL_016d: ldloc.s 4
-		IL_016f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0174: pop
-		IL_0175: ldc.i4.1
-		IL_0176: newarr [System.Runtime]System.Object
-		IL_017b: dup
-		IL_017c: ldc.i4.0
-		IL_017d: ldloc.0
-		IL_017e: stelem.ref
-		IL_017f: ldc.i4.0
-		IL_0180: ldelem.ref
-		IL_0181: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0186: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_018c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0191: ldc.i4.0
-		IL_0192: conv.r8
-		IL_0193: ldstr ""
-		IL_0198: ldc.i4.0
-		IL_0199: ldc.i4.1
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_019f: stloc.s 4
-		IL_01a1: ldloc.0
-		IL_01a2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01a7: ldnull
-		IL_01a8: ldstr "set"
-		IL_01ad: ldloc.s 4
-		IL_01af: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_01b4: pop
-		IL_01b5: ldc.i4.1
-		IL_01b6: newarr [System.Runtime]System.Object
-		IL_01bb: dup
-		IL_01bc: ldc.i4.0
-		IL_01bd: ldloc.0
-		IL_01be: stelem.ref
-		IL_01bf: ldc.i4.0
-		IL_01c0: ldelem.ref
-		IL_01c1: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01c6: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_01cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01d1: ldc.i4.0
-		IL_01d2: conv.r8
-		IL_01d3: ldstr ""
-		IL_01d8: ldc.i4.0
-		IL_01d9: ldc.i4.1
-		IL_01da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01df: stloc.s 4
-		IL_01e1: ldloc.0
-		IL_01e2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01e7: ldnull
-		IL_01e8: ldstr "has"
-		IL_01ed: ldloc.s 4
-		IL_01ef: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_01f4: pop
-		IL_01f5: ldc.i4.1
-		IL_01f6: newarr [System.Runtime]System.Object
-		IL_01fb: dup
-		IL_01fc: ldc.i4.0
-		IL_01fd: ldloc.0
-		IL_01fe: stelem.ref
-		IL_01ff: ldc.i4.0
-		IL_0200: ldelem.ref
-		IL_0201: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0206: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_020c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0211: ldc.i4.0
-		IL_0212: conv.r8
-		IL_0213: ldstr ""
-		IL_0218: ldc.i4.0
-		IL_0219: ldc.i4.1
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_021f: stloc.s 4
-		IL_0221: ldloc.0
-		IL_0222: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0227: ldnull
-		IL_0228: ldstr "delete"
-		IL_022d: ldloc.s 4
-		IL_022f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0234: pop
-		IL_0235: ldc.i4.1
-		IL_0236: newarr [System.Runtime]System.Object
-		IL_023b: dup
-		IL_023c: ldc.i4.0
-		IL_023d: ldloc.0
-		IL_023e: stelem.ref
-		IL_023f: ldc.i4.0
-		IL_0240: ldelem.ref
-		IL_0241: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0246: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_024c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0251: ldc.i4.0
-		IL_0252: conv.r8
-		IL_0253: ldstr ""
-		IL_0258: ldc.i4.0
-		IL_0259: ldc.i4.1
-		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_025f: stloc.s 4
-		IL_0261: ldloc.0
-		IL_0262: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0267: ldnull
-		IL_0268: ldstr "keys"
-		IL_026d: ldloc.s 4
-		IL_026f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0274: pop
-		IL_0275: ldc.i4.1
-		IL_0276: newarr [System.Runtime]System.Object
-		IL_027b: dup
-		IL_027c: ldc.i4.0
-		IL_027d: ldloc.0
-		IL_027e: stelem.ref
-		IL_027f: ldc.i4.0
-		IL_0280: ldelem.ref
-		IL_0281: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0286: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_028c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0291: ldc.i4.0
-		IL_0292: conv.r8
-		IL_0293: ldstr ""
-		IL_0298: ldc.i4.0
-		IL_0299: ldc.i4.1
-		IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_029f: stloc.s 4
-		IL_02a1: ldloc.0
-		IL_02a2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02a7: ldnull
-		IL_02a8: ldstr "getPrototypeOf"
-		IL_02ad: ldloc.s 4
-		IL_02af: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_02b4: pop
-		IL_02b5: ldc.i4.1
-		IL_02b6: newarr [System.Runtime]System.Object
-		IL_02bb: dup
-		IL_02bc: ldc.i4.0
-		IL_02bd: ldloc.0
-		IL_02be: stelem.ref
-		IL_02bf: ldc.i4.0
-		IL_02c0: ldelem.ref
-		IL_02c1: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02c6: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_02cc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02d1: ldc.i4.0
-		IL_02d2: conv.r8
-		IL_02d3: ldstr ""
+		IL_0159: conv.r8
+		IL_015a: ldstr ""
+		IL_015f: ldc.i4.0
+		IL_0160: ldc.i4.1
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0166: stloc.s 4
+		IL_0168: ldloc.1
+		IL_0169: ldloc.s 6
+		IL_016b: ldstr "get"
+		IL_0170: ldloc.s 4
+		IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0177: pop
+		IL_0178: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017d: stloc.s 6
+		IL_017f: ldc.i4.1
+		IL_0180: newarr [System.Runtime]System.Object
+		IL_0185: dup
+		IL_0186: ldc.i4.0
+		IL_0187: ldloc.0
+		IL_0188: stelem.ref
+		IL_0189: ldc.i4.0
+		IL_018a: ldelem.ref
+		IL_018b: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0190: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0196: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_019b: ldc.i4.0
+		IL_019c: conv.r8
+		IL_019d: ldstr ""
+		IL_01a2: ldc.i4.0
+		IL_01a3: ldc.i4.1
+		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01a9: stloc.s 4
+		IL_01ab: ldloc.1
+		IL_01ac: ldloc.s 6
+		IL_01ae: ldstr "set"
+		IL_01b3: ldloc.s 4
+		IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01ba: pop
+		IL_01bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01c0: stloc.s 6
+		IL_01c2: ldc.i4.1
+		IL_01c3: newarr [System.Runtime]System.Object
+		IL_01c8: dup
+		IL_01c9: ldc.i4.0
+		IL_01ca: ldloc.0
+		IL_01cb: stelem.ref
+		IL_01cc: ldc.i4.0
+		IL_01cd: ldelem.ref
+		IL_01ce: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_01d3: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_01d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01de: ldc.i4.0
+		IL_01df: conv.r8
+		IL_01e0: ldstr ""
+		IL_01e5: ldc.i4.0
+		IL_01e6: ldc.i4.1
+		IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01ec: stloc.s 4
+		IL_01ee: ldloc.1
+		IL_01ef: ldloc.s 6
+		IL_01f1: ldstr "has"
+		IL_01f6: ldloc.s 4
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01fd: pop
+		IL_01fe: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0203: stloc.s 6
+		IL_0205: ldc.i4.1
+		IL_0206: newarr [System.Runtime]System.Object
+		IL_020b: dup
+		IL_020c: ldc.i4.0
+		IL_020d: ldloc.0
+		IL_020e: stelem.ref
+		IL_020f: ldc.i4.0
+		IL_0210: ldelem.ref
+		IL_0211: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0216: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_021c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0221: ldc.i4.0
+		IL_0222: conv.r8
+		IL_0223: ldstr ""
+		IL_0228: ldc.i4.0
+		IL_0229: ldc.i4.1
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_022f: stloc.s 4
+		IL_0231: ldloc.1
+		IL_0232: ldloc.s 6
+		IL_0234: ldstr "delete"
+		IL_0239: ldloc.s 4
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0240: pop
+		IL_0241: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0246: stloc.s 6
+		IL_0248: ldc.i4.1
+		IL_0249: newarr [System.Runtime]System.Object
+		IL_024e: dup
+		IL_024f: ldc.i4.0
+		IL_0250: ldloc.0
+		IL_0251: stelem.ref
+		IL_0252: ldc.i4.0
+		IL_0253: ldelem.ref
+		IL_0254: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_0259: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_025f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0264: ldc.i4.0
+		IL_0265: conv.r8
+		IL_0266: ldstr ""
+		IL_026b: ldc.i4.0
+		IL_026c: ldc.i4.1
+		IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0272: stloc.s 4
+		IL_0274: ldloc.1
+		IL_0275: ldloc.s 6
+		IL_0277: ldstr "keys"
+		IL_027c: ldloc.s 4
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0283: pop
+		IL_0284: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0289: stloc.s 6
+		IL_028b: ldc.i4.1
+		IL_028c: newarr [System.Runtime]System.Object
+		IL_0291: dup
+		IL_0292: ldc.i4.0
+		IL_0293: ldloc.0
+		IL_0294: stelem.ref
+		IL_0295: ldc.i4.0
+		IL_0296: ldelem.ref
+		IL_0297: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_029c: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_02a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02a7: ldc.i4.0
+		IL_02a8: conv.r8
+		IL_02a9: ldstr ""
+		IL_02ae: ldc.i4.0
+		IL_02af: ldc.i4.1
+		IL_02b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02b5: stloc.s 4
+		IL_02b7: ldloc.1
+		IL_02b8: ldloc.s 6
+		IL_02ba: ldstr "getPrototypeOf"
+		IL_02bf: ldloc.s 4
+		IL_02c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02c6: pop
+		IL_02c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02cc: stloc.s 6
+		IL_02ce: ldc.i4.1
+		IL_02cf: newarr [System.Runtime]System.Object
+		IL_02d4: dup
+		IL_02d5: ldc.i4.0
+		IL_02d6: ldloc.0
+		IL_02d7: stelem.ref
 		IL_02d8: ldc.i4.0
-		IL_02d9: ldc.i4.1
-		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02df: stloc.s 4
-		IL_02e1: ldloc.0
-		IL_02e2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02e7: ldnull
-		IL_02e8: ldstr "setPrototypeOf"
-		IL_02ed: ldloc.s 4
-		IL_02ef: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_02f4: pop
-		IL_02f5: ldnull
-		IL_02f6: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
-		IL_02fc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_0301: ldc.i4.1
-		IL_0302: conv.r8
-		IL_0303: ldstr ""
-		IL_0308: ldc.i4.0
-		IL_0309: ldc.i4.1
-		IL_030a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_030f: stloc.s 4
-		IL_0311: ldloc.s 4
-		IL_0313: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_031d: stloc.s 4
-		IL_031f: ldloc.0
-		IL_0320: ldloc.s 4
-		IL_0322: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_0327: ldloc.0
-		IL_0328: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
-		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02d9: ldelem.ref
+		IL_02da: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_02df: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_02e5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02ea: ldc.i4.0
+		IL_02eb: conv.r8
+		IL_02ec: ldstr ""
+		IL_02f1: ldc.i4.0
+		IL_02f2: ldc.i4.1
+		IL_02f3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02f8: stloc.s 4
+		IL_02fa: ldloc.1
+		IL_02fb: ldloc.s 6
+		IL_02fd: ldstr "setPrototypeOf"
+		IL_0302: ldloc.s 4
+		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0309: pop
+		IL_030a: ldnull
+		IL_030b: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
+		IL_0311: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_0316: ldc.i4.1
+		IL_0317: conv.r8
+		IL_0318: ldstr ""
+		IL_031d: ldc.i4.0
+		IL_031e: ldc.i4.1
+		IL_031f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0324: stloc.s 4
+		IL_0326: ldloc.s 4
+		IL_0328: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
 		IL_0332: stloc.s 4
-		IL_0334: ldloc.s 4
-		IL_0336: ldstr "revoke"
-		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0340: pop
-		IL_0341: ldc.i4.1
-		IL_0342: newarr [System.Runtime]System.Object
-		IL_0347: dup
-		IL_0348: ldc.i4.0
-		IL_0349: ldloc.0
-		IL_034a: stelem.ref
-		IL_034b: ldc.i4.0
-		IL_034c: ldelem.ref
-		IL_034d: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0352: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0358: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_035d: ldc.i4.0
-		IL_035e: conv.r8
-		IL_035f: ldstr ""
+		IL_0334: ldloc.0
+		IL_0335: ldloc.s 4
+		IL_0337: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_033c: ldloc.0
+		IL_033d: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::callable
+		IL_0342: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0347: stloc.s 4
+		IL_0349: ldloc.s 4
+		IL_034b: ldstr "revoke"
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0355: pop
+		IL_0356: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_035b: stloc.s 6
+		IL_035d: ldc.i4.1
+		IL_035e: newarr [System.Runtime]System.Object
+		IL_0363: dup
 		IL_0364: ldc.i4.0
-		IL_0365: ldc.i4.1
-		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_036b: stloc.s 4
-		IL_036d: ldloc.0
-		IL_036e: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0373: ldnull
-		IL_0374: ldstr "call"
-		IL_0379: ldloc.s 4
-		IL_037b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_0380: pop
-		IL_0381: ldnull
-		IL_0382: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
-		IL_0388: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
-		IL_038d: ldc.i4.1
-		IL_038e: conv.r8
-		IL_038f: ldstr "C"
-		IL_0394: ldc.i4.1
-		IL_0395: ldc.i4.1
-		IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_039b: stloc.s 4
-		IL_039d: ldloc.s 4
-		IL_039f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03a4: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
-		IL_03a9: stloc.s 4
-		IL_03ab: ldloc.0
-		IL_03ac: ldloc.s 4
-		IL_03ae: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_03b3: ldloc.0
-		IL_03b4: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
-		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03be: stloc.s 4
-		IL_03c0: ldloc.s 4
-		IL_03c2: ldstr "revoke"
-		IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_03cc: pop
-		IL_03cd: ldc.i4.1
-		IL_03ce: newarr [System.Runtime]System.Object
-		IL_03d3: dup
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldloc.0
-		IL_03d6: stelem.ref
-		IL_03d7: ldc.i4.0
-		IL_03d8: ldelem.ref
-		IL_03d9: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_03de: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_03e4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_03e9: ldc.i4.0
-		IL_03ea: conv.r8
-		IL_03eb: ldstr ""
-		IL_03f0: ldc.i4.0
-		IL_03f1: ldc.i4.1
-		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03f7: stloc.s 4
-		IL_03f9: ldloc.0
-		IL_03fa: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_03ff: ldnull
-		IL_0400: ldstr "construct"
-		IL_0405: ldloc.s 4
-		IL_0407: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, object, object)
-		IL_040c: pop
-		IL_040d: ret
+		IL_0365: ldloc.0
+		IL_0366: stelem.ref
+		IL_0367: ldc.i4.0
+		IL_0368: ldelem.ref
+		IL_0369: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_036e: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0374: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0379: ldc.i4.0
+		IL_037a: conv.r8
+		IL_037b: ldstr ""
+		IL_0380: ldc.i4.0
+		IL_0381: ldc.i4.1
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0387: stloc.s 4
+		IL_0389: ldloc.1
+		IL_038a: ldloc.s 6
+		IL_038c: ldstr "call"
+		IL_0391: ldloc.s 4
+		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0398: pop
+		IL_0399: ldnull
+		IL_039a: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
+		IL_03a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes1::.ctor(object, native int)
+		IL_03a5: ldc.i4.1
+		IL_03a6: conv.r8
+		IL_03a7: ldstr "C"
+		IL_03ac: ldc.i4.1
+		IL_03ad: ldc.i4.1
+		IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03b3: stloc.s 4
+		IL_03b5: ldloc.s 4
+		IL_03b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.Proxy::revocable(object, object)
+		IL_03c1: stloc.s 4
+		IL_03c3: ldloc.0
+		IL_03c4: ldloc.s 4
+		IL_03c6: stfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_03cb: ldloc.0
+		IL_03cc: ldfld object Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope::constructible
+		IL_03d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d6: stloc.s 4
+		IL_03d8: ldloc.s 4
+		IL_03da: ldstr "revoke"
+		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_03e4: pop
+		IL_03e5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03ea: stloc.s 6
+		IL_03ec: ldc.i4.1
+		IL_03ed: newarr [System.Runtime]System.Object
+		IL_03f2: dup
+		IL_03f3: ldc.i4.0
+		IL_03f4: ldloc.0
+		IL_03f5: stelem.ref
+		IL_03f6: ldc.i4.0
+		IL_03f7: ldelem.ref
+		IL_03f8: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
+		IL_03fd: ldftn object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+		IL_0403: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0408: ldc.i4.0
+		IL_0409: conv.r8
+		IL_040a: ldstr ""
+		IL_040f: ldc.i4.0
+		IL_0410: ldc.i4.1
+		IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0416: stloc.s 4
+		IL_0418: ldloc.1
+		IL_0419: ldloc.s 6
+		IL_041b: ldstr "construct"
+		IL_0420: ldloc.s 4
+		IL_0422: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0427: pop
+		IL_0428: ret
 	} // end of method Proxy_Revocable_ThrowsAfterRevoke::__js_module_init__
 
 } // end of class Modules.Proxy_Revocable_ThrowsAfterRevoke
@@ -1398,7 +1408,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x27e2
+		// Method begins at RVA 0x27fe
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29ac
+					// Method begins at RVA 0x29cc
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x29b5
+					// Method begins at RVA 0x29d5
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29a3
+				// Method begins at RVA 0x29c3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2638
+			// Method begins at RVA 0x2658
 			// Header size: 12
 			// Code size: 181 (0xb5)
 			.maxstack 8
@@ -198,7 +198,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29be
+				// Method begins at RVA 0x29de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -221,7 +221,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x270c
+			// Method begins at RVA 0x272c
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -251,7 +251,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29c7
+				// Method begins at RVA 0x29e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -274,7 +274,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2734
+			// Method begins at RVA 0x2754
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -307,7 +307,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29d0
+				// Method begins at RVA 0x29f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -330,7 +330,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2760
+			// Method begins at RVA 0x2780
 			// Header size: 12
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -360,7 +360,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29d9
+				// Method begins at RVA 0x29f9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -383,7 +383,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2788
+			// Method begins at RVA 0x27a8
 			// Header size: 12
 			// Code size: 29 (0x1d)
 			.maxstack 8
@@ -416,7 +416,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29e2
+				// Method begins at RVA 0x2a02
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -439,7 +439,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x27b1
+			// Method begins at RVA 0x27d1
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -461,7 +461,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29eb
+				// Method begins at RVA 0x2a0b
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -487,7 +487,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x27b8
+			// Method begins at RVA 0x27d8
 			// Header size: 12
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -522,7 +522,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29f4
+				// Method begins at RVA 0x2a14
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -548,7 +548,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x27dc
+			// Method begins at RVA 0x27fc
 			// Header size: 1
 			// Code size: 18 (0x12)
 			.maxstack 8
@@ -574,7 +574,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x29fd
+				// Method begins at RVA 0x2a1d
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -600,7 +600,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x27f0
+			// Method begins at RVA 0x2810
 			// Header size: 12
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -638,7 +638,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a06
+				// Method begins at RVA 0x2a26
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -661,7 +661,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2810
+			// Method begins at RVA 0x2830
 			// Header size: 12
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -691,7 +691,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a0f
+				// Method begins at RVA 0x2a2f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -714,7 +714,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2826
+			// Method begins at RVA 0x2846
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -736,7 +736,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a18
+				// Method begins at RVA 0x2a38
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -762,7 +762,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2834
+			// Method begins at RVA 0x2854
 			// Header size: 12
 			// Code size: 20 (0x14)
 			.maxstack 8
@@ -793,7 +793,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a21
+				// Method begins at RVA 0x2a41
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -816,7 +816,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2854
+			// Method begins at RVA 0x2874
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -839,7 +839,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a2a
+				// Method begins at RVA 0x2a4a
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -862,7 +862,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x285c
+			// Method begins at RVA 0x287c
 			// Header size: 1
 			// Code size: 10 (0xa)
 			.maxstack 8
@@ -884,7 +884,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a33
+				// Method begins at RVA 0x2a53
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -910,7 +910,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2868
+			// Method begins at RVA 0x2888
 			// Header size: 12
 			// Code size: 14 (0xe)
 			.maxstack 8
@@ -939,7 +939,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a3c
+				// Method begins at RVA 0x2a5c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -965,7 +965,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2882
+			// Method begins at RVA 0x28a2
 			// Header size: 1
 			// Code size: 58 (0x3a)
 			.maxstack 8
@@ -999,7 +999,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a45
+				// Method begins at RVA 0x2a65
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1025,7 +1025,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x28c0
+			// Method begins at RVA 0x28e0
 			// Header size: 12
 			// Code size: 67 (0x43)
 			.maxstack 8
@@ -1068,7 +1068,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a4e
+				// Method begins at RVA 0x2a6e
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1091,7 +1091,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x290f
+			// Method begins at RVA 0x292f
 			// Header size: 1
 			// Code size: 6 (0x6)
 			.maxstack 8
@@ -1113,7 +1113,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a57
+				// Method begins at RVA 0x2a77
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1139,7 +1139,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2918
+			// Method begins at RVA 0x2938
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1176,7 +1176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a60
+				// Method begins at RVA 0x2a80
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1199,7 +1199,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x294a
+			// Method begins at RVA 0x296a
 			// Header size: 1
 			// Code size: 27 (0x1b)
 			.maxstack 8
@@ -1226,7 +1226,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2a69
+				// Method begins at RVA 0x2a89
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -1252,7 +1252,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 18 00 00 02
 			)
-			// Method begins at RVA 0x2968
+			// Method begins at RVA 0x2988
 			// Header size: 12
 			// Code size: 38 (0x26)
 			.maxstack 8
@@ -1312,7 +1312,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x299a
+			// Method begins at RVA 0x29ba
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -1338,7 +1338,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 1500 (0x5dc)
+		// Code size: 1530 (0x5fa)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Validation_EdgeCases/Scope,
@@ -1347,12 +1347,13 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] object[],
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
-			[9] object,
-			[10] bool,
-			[11] object
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
+			[10] object,
+			[11] bool,
+			[12] object
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1378,524 +1379,534 @@
 		IL_0035: stloc.s 5
 		IL_0037: ldloc.s 5
 		IL_0039: stloc.1
-		IL_003a: ldnull
-		IL_003b: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
-		IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0046: ldc.i4.0
-		IL_0047: conv.r8
-		IL_0048: ldstr ""
+		IL_003a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003f: stloc.s 6
+		IL_0041: ldnull
+		IL_0042: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
+		IL_0048: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
 		IL_004d: ldc.i4.0
-		IL_004e: ldc.i4.1
-		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0054: stloc.s 5
-		IL_0056: ldloc.0
-		IL_0057: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_005c: ldnull
-		IL_005d: ldstr "proxy-target"
-		IL_0062: ldloc.s 5
-		IL_0064: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0069: pop
-		IL_006a: ldnull
-		IL_006b: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
-		IL_0071: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0076: ldc.i4.0
-		IL_0077: conv.r8
-		IL_0078: ldstr ""
-		IL_007d: ldc.i4.0
-		IL_007e: ldc.i4.1
-		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0084: stloc.s 5
-		IL_0086: ldloc.0
-		IL_0087: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_008c: ldnull
-		IL_008d: ldstr "proxy-handler"
-		IL_0092: ldloc.s 5
-		IL_0094: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0099: pop
-		IL_009a: ldnull
-		IL_009b: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
-		IL_00a1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00a6: ldc.i4.0
-		IL_00a7: conv.r8
-		IL_00a8: ldstr ""
-		IL_00ad: ldc.i4.0
-		IL_00ae: ldc.i4.1
-		IL_00af: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00b4: stloc.s 5
-		IL_00b6: ldloc.0
-		IL_00b7: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_00bc: ldnull
-		IL_00bd: ldstr "revocable-target"
-		IL_00c2: ldloc.s 5
-		IL_00c4: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_00c9: pop
-		IL_00ca: ldnull
-		IL_00cb: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
-		IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00d6: ldc.i4.0
-		IL_00d7: conv.r8
-		IL_00d8: ldstr ""
-		IL_00dd: ldc.i4.0
-		IL_00de: ldc.i4.1
-		IL_00df: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00e4: stloc.s 5
-		IL_00e6: ldloc.0
-		IL_00e7: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_00ec: ldnull
-		IL_00ed: ldstr "revocable-handler"
-		IL_00f2: ldloc.s 5
-		IL_00f4: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_00f9: pop
-		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00ff: stloc.s 6
-		IL_0101: ldnull
-		IL_0102: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
-		IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_010d: ldc.i4.0
-		IL_010e: conv.r8
-		IL_010f: ldstr ""
-		IL_0114: ldc.i4.0
-		IL_0115: ldc.i4.1
-		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_011b: stloc.s 5
-		IL_011d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0122: dup
-		IL_0123: ldstr "apply"
-		IL_0128: ldloc.s 5
-		IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_012f: stloc.s 7
-		IL_0131: ldloc.s 6
-		IL_0133: ldloc.s 7
-		IL_0135: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_013a: stloc.s 8
-		IL_013c: ldloc.0
-		IL_013d: ldloc.s 8
-		IL_013f: stfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
-		IL_0144: ldc.i4.1
-		IL_0145: newarr [System.Runtime]System.Object
-		IL_014a: dup
-		IL_014b: ldc.i4.0
-		IL_014c: ldloc.0
-		IL_014d: stelem.ref
-		IL_014e: ldc.i4.0
-		IL_014f: ldelem.ref
-		IL_0150: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0155: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_015b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0160: ldc.i4.0
-		IL_0161: conv.r8
-		IL_0162: ldstr ""
-		IL_0167: ldc.i4.0
-		IL_0168: ldc.i4.1
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_016e: stloc.s 5
-		IL_0170: ldloc.0
-		IL_0171: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0176: ldnull
-		IL_0177: ldstr "apply-noncallable"
-		IL_017c: ldloc.s 5
-		IL_017e: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0183: pop
-		IL_0184: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0189: stloc.s 7
-		IL_018b: ldc.i4.1
-		IL_018c: newarr [System.Runtime]System.Object
-		IL_0191: dup
-		IL_0192: ldc.i4.0
-		IL_0193: ldloc.0
-		IL_0194: stelem.ref
-		IL_0195: ldc.i4.0
-		IL_0196: ldelem.ref
-		IL_0197: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_019c: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_01a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01a7: ldc.i4.0
-		IL_01a8: conv.r8
-		IL_01a9: ldstr ""
-		IL_01ae: ldc.i4.0
-		IL_01af: ldc.i4.1
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_01b5: stloc.s 5
-		IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01bc: dup
-		IL_01bd: ldstr "construct"
-		IL_01c2: ldloc.s 5
-		IL_01c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_01c9: stloc.s 6
-		IL_01cb: ldloc.s 7
-		IL_01cd: ldloc.s 6
-		IL_01cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_01d4: stloc.s 8
-		IL_01d6: ldloc.0
-		IL_01d7: ldloc.s 8
-		IL_01d9: stfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
-		IL_01de: ldc.i4.1
-		IL_01df: newarr [System.Runtime]System.Object
-		IL_01e4: dup
-		IL_01e5: ldc.i4.0
-		IL_01e6: ldloc.0
-		IL_01e7: stelem.ref
-		IL_01e8: ldc.i4.0
-		IL_01e9: ldelem.ref
-		IL_01ea: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_01ef: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_01f5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_01fa: ldc.i4.0
-		IL_01fb: conv.r8
-		IL_01fc: ldstr ""
-		IL_0201: ldc.i4.0
-		IL_0202: ldc.i4.1
-		IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0208: stloc.s 5
-		IL_020a: ldloc.0
-		IL_020b: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0210: ldnull
-		IL_0211: ldstr "construct-nonconstructible"
-		IL_0216: ldloc.s 5
-		IL_0218: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_021d: pop
-		IL_021e: ldnull
-		IL_021f: ldftn object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
-		IL_0225: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_022a: ldc.i4.0
-		IL_022b: conv.r8
-		IL_022c: ldstr "Base"
-		IL_0231: ldc.i4.1
-		IL_0232: ldc.i4.1
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0238: stloc.s 5
-		IL_023a: ldnull
-		IL_023b: ldftn float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
-		IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
-		IL_0246: ldc.i4.0
-		IL_0247: conv.r8
-		IL_0248: ldstr ""
-		IL_024d: ldc.i4.0
-		IL_024e: ldc.i4.1
-		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0254: stloc.s 9
-		IL_0256: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_025b: dup
-		IL_025c: ldstr "construct"
-		IL_0261: ldloc.s 9
-		IL_0263: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0268: stloc.s 6
-		IL_026a: ldloc.s 5
-		IL_026c: ldloc.s 6
-		IL_026e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0273: stloc.s 8
-		IL_0275: ldloc.0
-		IL_0276: ldloc.s 8
-		IL_0278: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
-		IL_027d: ldc.i4.1
-		IL_027e: newarr [System.Runtime]System.Object
-		IL_0283: dup
-		IL_0284: ldc.i4.0
-		IL_0285: ldloc.0
-		IL_0286: stelem.ref
-		IL_0287: ldc.i4.0
-		IL_0288: ldelem.ref
-		IL_0289: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_028e: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0294: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0299: ldc.i4.0
-		IL_029a: conv.r8
-		IL_029b: ldstr ""
+		IL_004e: conv.r8
+		IL_004f: ldstr ""
+		IL_0054: ldc.i4.0
+		IL_0055: ldc.i4.1
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_005b: stloc.s 5
+		IL_005d: ldloc.1
+		IL_005e: ldloc.s 6
+		IL_0060: ldstr "proxy-target"
+		IL_0065: ldloc.s 5
+		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_006c: pop
+		IL_006d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0072: stloc.s 6
+		IL_0074: ldnull
+		IL_0075: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
+		IL_007b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0080: ldc.i4.0
+		IL_0081: conv.r8
+		IL_0082: ldstr ""
+		IL_0087: ldc.i4.0
+		IL_0088: ldc.i4.1
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_008e: stloc.s 5
+		IL_0090: ldloc.1
+		IL_0091: ldloc.s 6
+		IL_0093: ldstr "proxy-handler"
+		IL_0098: ldloc.s 5
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_009f: pop
+		IL_00a0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00a5: stloc.s 6
+		IL_00a7: ldnull
+		IL_00a8: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
+		IL_00ae: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00b3: ldc.i4.0
+		IL_00b4: conv.r8
+		IL_00b5: ldstr ""
+		IL_00ba: ldc.i4.0
+		IL_00bb: ldc.i4.1
+		IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00c1: stloc.s 5
+		IL_00c3: ldloc.1
+		IL_00c4: ldloc.s 6
+		IL_00c6: ldstr "revocable-target"
+		IL_00cb: ldloc.s 5
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00d2: pop
+		IL_00d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00d8: stloc.s 6
+		IL_00da: ldnull
+		IL_00db: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
+		IL_00e1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00e6: ldc.i4.0
+		IL_00e7: conv.r8
+		IL_00e8: ldstr ""
+		IL_00ed: ldc.i4.0
+		IL_00ee: ldc.i4.1
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00f4: stloc.s 5
+		IL_00f6: ldloc.1
+		IL_00f7: ldloc.s 6
+		IL_00f9: ldstr "revocable-handler"
+		IL_00fe: ldloc.s 5
+		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0105: pop
+		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_010b: stloc.s 7
+		IL_010d: ldnull
+		IL_010e: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
+		IL_0114: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0119: ldc.i4.0
+		IL_011a: conv.r8
+		IL_011b: ldstr ""
+		IL_0120: ldc.i4.0
+		IL_0121: ldc.i4.1
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0127: stloc.s 5
+		IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_012e: dup
+		IL_012f: ldstr "apply"
+		IL_0134: ldloc.s 5
+		IL_0136: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_013b: stloc.s 8
+		IL_013d: ldloc.s 7
+		IL_013f: ldloc.s 8
+		IL_0141: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0146: stloc.s 9
+		IL_0148: ldloc.0
+		IL_0149: ldloc.s 9
+		IL_014b: stfld object Modules.Proxy_Validation_EdgeCases/Scope::applyProxy
+		IL_0150: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0155: stloc.s 6
+		IL_0157: ldc.i4.1
+		IL_0158: newarr [System.Runtime]System.Object
+		IL_015d: dup
+		IL_015e: ldc.i4.0
+		IL_015f: ldloc.0
+		IL_0160: stelem.ref
+		IL_0161: ldc.i4.0
+		IL_0162: ldelem.ref
+		IL_0163: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0168: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_016e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0173: ldc.i4.0
+		IL_0174: conv.r8
+		IL_0175: ldstr ""
+		IL_017a: ldc.i4.0
+		IL_017b: ldc.i4.1
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0181: stloc.s 5
+		IL_0183: ldloc.1
+		IL_0184: ldloc.s 6
+		IL_0186: ldstr "apply-noncallable"
+		IL_018b: ldloc.s 5
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0192: pop
+		IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0198: stloc.s 8
+		IL_019a: ldc.i4.1
+		IL_019b: newarr [System.Runtime]System.Object
+		IL_01a0: dup
+		IL_01a1: ldc.i4.0
+		IL_01a2: ldloc.0
+		IL_01a3: stelem.ref
+		IL_01a4: ldc.i4.0
+		IL_01a5: ldelem.ref
+		IL_01a6: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_01ab: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_01b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_01b6: ldc.i4.0
+		IL_01b7: conv.r8
+		IL_01b8: ldstr ""
+		IL_01bd: ldc.i4.0
+		IL_01be: ldc.i4.1
+		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_01c4: stloc.s 5
+		IL_01c6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01cb: dup
+		IL_01cc: ldstr "construct"
+		IL_01d1: ldloc.s 5
+		IL_01d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01d8: stloc.s 7
+		IL_01da: ldloc.s 8
+		IL_01dc: ldloc.s 7
+		IL_01de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_01e3: stloc.s 9
+		IL_01e5: ldloc.0
+		IL_01e6: ldloc.s 9
+		IL_01e8: stfld object Modules.Proxy_Validation_EdgeCases/Scope::constructProxy
+		IL_01ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f2: stloc.s 6
+		IL_01f4: ldc.i4.1
+		IL_01f5: newarr [System.Runtime]System.Object
+		IL_01fa: dup
+		IL_01fb: ldc.i4.0
+		IL_01fc: ldloc.0
+		IL_01fd: stelem.ref
+		IL_01fe: ldc.i4.0
+		IL_01ff: ldelem.ref
+		IL_0200: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0205: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_020b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0210: ldc.i4.0
+		IL_0211: conv.r8
+		IL_0212: ldstr ""
+		IL_0217: ldc.i4.0
+		IL_0218: ldc.i4.1
+		IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_021e: stloc.s 5
+		IL_0220: ldloc.1
+		IL_0221: ldloc.s 6
+		IL_0223: ldstr "construct-nonconstructible"
+		IL_0228: ldloc.s 5
+		IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_022f: pop
+		IL_0230: ldnull
+		IL_0231: ldftn object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
+		IL_0237: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_023c: ldc.i4.0
+		IL_023d: conv.r8
+		IL_023e: ldstr "Base"
+		IL_0243: ldc.i4.1
+		IL_0244: ldc.i4.1
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_024a: stloc.s 5
+		IL_024c: ldnull
+		IL_024d: ldftn float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
+		IL_0253: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
+		IL_0258: ldc.i4.0
+		IL_0259: conv.r8
+		IL_025a: ldstr ""
+		IL_025f: ldc.i4.0
+		IL_0260: ldc.i4.1
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0266: stloc.s 10
+		IL_0268: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_026d: dup
+		IL_026e: ldstr "construct"
+		IL_0273: ldloc.s 10
+		IL_0275: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_027a: stloc.s 7
+		IL_027c: ldloc.s 5
+		IL_027e: ldloc.s 7
+		IL_0280: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0285: stloc.s 9
+		IL_0287: ldloc.0
+		IL_0288: ldloc.s 9
+		IL_028a: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badConstructResultProxy
+		IL_028f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0294: stloc.s 6
+		IL_0296: ldc.i4.1
+		IL_0297: newarr [System.Runtime]System.Object
+		IL_029c: dup
+		IL_029d: ldc.i4.0
+		IL_029e: ldloc.0
+		IL_029f: stelem.ref
 		IL_02a0: ldc.i4.0
-		IL_02a1: ldc.i4.1
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02a7: stloc.s 5
-		IL_02a9: ldloc.0
-		IL_02aa: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_02af: ldnull
-		IL_02b0: ldstr "construct-primitive-result"
-		IL_02b5: ldloc.s 5
-		IL_02b7: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_02bc: pop
-		IL_02bd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02c2: stloc.s 6
-		IL_02c4: ldnull
-		IL_02c5: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
-		IL_02cb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_02d0: ldc.i4.0
-		IL_02d1: conv.r8
-		IL_02d2: ldstr ""
-		IL_02d7: ldc.i4.0
-		IL_02d8: ldc.i4.1
-		IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_02de: stloc.s 5
-		IL_02e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02e5: dup
-		IL_02e6: ldstr "getPrototypeOf"
-		IL_02eb: ldloc.s 5
-		IL_02ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_02f2: stloc.s 7
-		IL_02f4: ldloc.s 6
-		IL_02f6: ldloc.s 7
-		IL_02f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_02fd: stloc.s 8
-		IL_02ff: ldloc.s 8
-		IL_0301: stloc.2
-		IL_0302: ldloc.2
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0308: stloc.s 5
-		IL_030a: ldloc.s 5
-		IL_030c: ldc.i4.0
-		IL_030d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0312: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0317: stloc.s 10
-		IL_0319: ldloc.s 10
-		IL_031b: box [System.Runtime]System.Boolean
-		IL_0320: stloc.s 11
-		IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0327: ldloc.s 11
-		IL_0329: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_032e: pop
-		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0334: stloc.s 7
-		IL_0336: ldnull
-		IL_0337: ldftn float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
-		IL_033d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
-		IL_0342: ldc.i4.0
-		IL_0343: conv.r8
-		IL_0344: ldstr ""
-		IL_0349: ldc.i4.0
-		IL_034a: ldc.i4.1
-		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0350: stloc.s 5
-		IL_0352: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0357: dup
-		IL_0358: ldstr "getPrototypeOf"
-		IL_035d: ldloc.s 5
-		IL_035f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0364: stloc.s 6
-		IL_0366: ldloc.s 7
-		IL_0368: ldloc.s 6
-		IL_036a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_036f: stloc.s 8
-		IL_0371: ldloc.0
-		IL_0372: ldloc.s 8
-		IL_0374: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
-		IL_0379: ldc.i4.1
-		IL_037a: newarr [System.Runtime]System.Object
-		IL_037f: dup
-		IL_0380: ldc.i4.0
-		IL_0381: ldloc.0
-		IL_0382: stelem.ref
-		IL_0383: ldc.i4.0
-		IL_0384: ldelem.ref
-		IL_0385: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_038a: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0390: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0395: ldc.i4.0
-		IL_0396: conv.r8
-		IL_0397: ldstr ""
+		IL_02a1: ldelem.ref
+		IL_02a2: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_02a7: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_02ad: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02b2: ldc.i4.0
+		IL_02b3: conv.r8
+		IL_02b4: ldstr ""
+		IL_02b9: ldc.i4.0
+		IL_02ba: ldc.i4.1
+		IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02c0: stloc.s 5
+		IL_02c2: ldloc.1
+		IL_02c3: ldloc.s 6
+		IL_02c5: ldstr "construct-primitive-result"
+		IL_02ca: ldloc.s 5
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02d1: pop
+		IL_02d2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02d7: stloc.s 7
+		IL_02d9: ldnull
+		IL_02da: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
+		IL_02e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_02e5: ldc.i4.0
+		IL_02e6: conv.r8
+		IL_02e7: ldstr ""
+		IL_02ec: ldc.i4.0
+		IL_02ed: ldc.i4.1
+		IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_02f3: stloc.s 5
+		IL_02f5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02fa: dup
+		IL_02fb: ldstr "getPrototypeOf"
+		IL_0300: ldloc.s 5
+		IL_0302: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0307: stloc.s 8
+		IL_0309: ldloc.s 7
+		IL_030b: ldloc.s 8
+		IL_030d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0312: stloc.s 9
+		IL_0314: ldloc.s 9
+		IL_0316: stloc.2
+		IL_0317: ldloc.2
+		IL_0318: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_031d: stloc.s 5
+		IL_031f: ldloc.s 5
+		IL_0321: ldc.i4.0
+		IL_0322: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0327: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_032c: stloc.s 11
+		IL_032e: ldloc.s 11
+		IL_0330: box [System.Runtime]System.Boolean
+		IL_0335: stloc.s 12
+		IL_0337: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_033c: ldloc.s 12
+		IL_033e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0343: pop
+		IL_0344: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0349: stloc.s 8
+		IL_034b: ldnull
+		IL_034c: ldftn float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
+		IL_0352: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsDoubleFuncNoScopes0::.ctor(object, native int)
+		IL_0357: ldc.i4.0
+		IL_0358: conv.r8
+		IL_0359: ldstr ""
+		IL_035e: ldc.i4.0
+		IL_035f: ldc.i4.1
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0365: stloc.s 5
+		IL_0367: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_036c: dup
+		IL_036d: ldstr "getPrototypeOf"
+		IL_0372: ldloc.s 5
+		IL_0374: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0379: stloc.s 7
+		IL_037b: ldloc.s 8
+		IL_037d: ldloc.s 7
+		IL_037f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0384: stloc.s 9
+		IL_0386: ldloc.0
+		IL_0387: ldloc.s 9
+		IL_0389: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badGetPrototypeProxy
+		IL_038e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0393: stloc.s 6
+		IL_0395: ldc.i4.1
+		IL_0396: newarr [System.Runtime]System.Object
+		IL_039b: dup
 		IL_039c: ldc.i4.0
-		IL_039d: ldc.i4.1
-		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03a3: stloc.s 5
-		IL_03a5: ldloc.0
-		IL_03a6: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_03ab: ldnull
-		IL_03ac: ldstr "getPrototypeOf-primitive"
-		IL_03b1: ldloc.s 5
-		IL_03b3: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_03b8: pop
-		IL_03b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03be: stloc.s 6
-		IL_03c0: ldc.i4.1
-		IL_03c1: newarr [System.Runtime]System.Object
-		IL_03c6: dup
-		IL_03c7: ldc.i4.0
-		IL_03c8: ldloc.0
-		IL_03c9: stelem.ref
-		IL_03ca: ldc.i4.0
-		IL_03cb: ldelem.ref
-		IL_03cc: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_03d1: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_03d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_03dc: ldc.i4.0
-		IL_03dd: conv.r8
-		IL_03de: ldstr ""
-		IL_03e3: ldc.i4.0
-		IL_03e4: ldc.i4.1
-		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_03ea: stloc.s 5
-		IL_03ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03f1: dup
-		IL_03f2: ldstr "ownKeys"
-		IL_03f7: ldloc.s 5
-		IL_03f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_03fe: stloc.s 7
-		IL_0400: ldloc.s 6
-		IL_0402: ldloc.s 7
-		IL_0404: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0409: stloc.s 8
-		IL_040b: ldloc.s 8
-		IL_040d: stloc.3
-		IL_040e: ldloc.3
-		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_0414: stloc.s 5
-		IL_0416: ldloc.s 5
-		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_041d: stloc.s 5
-		IL_041f: ldloc.s 5
-		IL_0421: ldstr "join"
-		IL_0426: ldstr ","
-		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_0430: stloc.s 5
-		IL_0432: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_039d: ldloc.0
+		IL_039e: stelem.ref
+		IL_039f: ldc.i4.0
+		IL_03a0: ldelem.ref
+		IL_03a1: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_03a6: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_03ac: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_03b1: ldc.i4.0
+		IL_03b2: conv.r8
+		IL_03b3: ldstr ""
+		IL_03b8: ldc.i4.0
+		IL_03b9: ldc.i4.1
+		IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_03bf: stloc.s 5
+		IL_03c1: ldloc.1
+		IL_03c2: ldloc.s 6
+		IL_03c4: ldstr "getPrototypeOf-primitive"
+		IL_03c9: ldloc.s 5
+		IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_03d0: pop
+		IL_03d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03d6: stloc.s 7
+		IL_03d8: ldc.i4.1
+		IL_03d9: newarr [System.Runtime]System.Object
+		IL_03de: dup
+		IL_03df: ldc.i4.0
+		IL_03e0: ldloc.0
+		IL_03e1: stelem.ref
+		IL_03e2: ldc.i4.0
+		IL_03e3: ldelem.ref
+		IL_03e4: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_03e9: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_03ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_03f4: ldc.i4.0
+		IL_03f5: conv.r8
+		IL_03f6: ldstr ""
+		IL_03fb: ldc.i4.0
+		IL_03fc: ldc.i4.1
+		IL_03fd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0402: stloc.s 5
+		IL_0404: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0409: dup
+		IL_040a: ldstr "ownKeys"
+		IL_040f: ldloc.s 5
+		IL_0411: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0416: stloc.s 8
+		IL_0418: ldloc.s 7
+		IL_041a: ldloc.s 8
+		IL_041c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0421: stloc.s 9
+		IL_0423: ldloc.s 9
+		IL_0425: stloc.3
+		IL_0426: ldloc.3
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_042c: stloc.s 5
+		IL_042e: ldloc.s 5
+		IL_0430: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0435: stloc.s 5
 		IL_0437: ldloc.s 5
-		IL_0439: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_043e: pop
-		IL_043f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0444: stloc.s 7
-		IL_0446: ldc.i4.1
-		IL_0447: newarr [System.Runtime]System.Object
-		IL_044c: dup
-		IL_044d: ldc.i4.0
-		IL_044e: ldloc.0
-		IL_044f: stelem.ref
-		IL_0450: ldc.i4.0
-		IL_0451: ldelem.ref
-		IL_0452: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0457: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_045d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0462: ldc.i4.0
-		IL_0463: conv.r8
-		IL_0464: ldstr ""
-		IL_0469: ldc.i4.0
-		IL_046a: ldc.i4.1
-		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0470: stloc.s 5
-		IL_0472: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0477: dup
-		IL_0478: ldstr "ownKeys"
-		IL_047d: ldloc.s 5
-		IL_047f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0484: stloc.s 6
-		IL_0486: ldloc.s 7
-		IL_0488: ldloc.s 6
-		IL_048a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_048f: stloc.s 8
-		IL_0491: ldloc.s 8
-		IL_0493: stloc.s 4
-		IL_0495: ldloc.s 4
-		IL_0497: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
-		IL_049c: stloc.s 5
-		IL_049e: ldloc.s 5
-		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_04a5: stloc.s 5
-		IL_04a7: ldloc.s 5
-		IL_04a9: ldstr "join"
-		IL_04ae: ldstr ","
-		IL_04b3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_04b8: stloc.s 5
-		IL_04ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0439: ldstr "join"
+		IL_043e: ldstr ","
+		IL_0443: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_0448: stloc.s 5
+		IL_044a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_044f: ldloc.s 5
+		IL_0451: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0456: pop
+		IL_0457: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_045c: stloc.s 8
+		IL_045e: ldc.i4.1
+		IL_045f: newarr [System.Runtime]System.Object
+		IL_0464: dup
+		IL_0465: ldc.i4.0
+		IL_0466: ldloc.0
+		IL_0467: stelem.ref
+		IL_0468: ldc.i4.0
+		IL_0469: ldelem.ref
+		IL_046a: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_046f: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_0475: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_047a: ldc.i4.0
+		IL_047b: conv.r8
+		IL_047c: ldstr ""
+		IL_0481: ldc.i4.0
+		IL_0482: ldc.i4.1
+		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0488: stloc.s 5
+		IL_048a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_048f: dup
+		IL_0490: ldstr "ownKeys"
+		IL_0495: ldloc.s 5
+		IL_0497: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_049c: stloc.s 7
+		IL_049e: ldloc.s 8
+		IL_04a0: ldloc.s 7
+		IL_04a2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_04a7: stloc.s 9
+		IL_04a9: ldloc.s 9
+		IL_04ab: stloc.s 4
+		IL_04ad: ldloc.s 4
+		IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.Object::keys(object)
+		IL_04b4: stloc.s 5
+		IL_04b6: ldloc.s 5
+		IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04bd: stloc.s 5
 		IL_04bf: ldloc.s 5
-		IL_04c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_04c6: pop
-		IL_04c7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04cc: stloc.s 6
-		IL_04ce: ldnull
-		IL_04cf: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
-		IL_04d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_04da: ldc.i4.0
-		IL_04db: conv.r8
-		IL_04dc: ldstr ""
-		IL_04e1: ldc.i4.0
-		IL_04e2: ldc.i4.1
-		IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_04e8: stloc.s 5
-		IL_04ea: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04ef: dup
-		IL_04f0: ldstr "ownKeys"
-		IL_04f5: ldloc.s 5
-		IL_04f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_04fc: stloc.s 7
-		IL_04fe: ldloc.s 6
-		IL_0500: ldloc.s 7
-		IL_0502: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0507: stloc.s 8
-		IL_0509: ldloc.0
-		IL_050a: ldloc.s 8
-		IL_050c: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
-		IL_0511: ldc.i4.1
-		IL_0512: newarr [System.Runtime]System.Object
-		IL_0517: dup
-		IL_0518: ldc.i4.0
-		IL_0519: ldloc.0
-		IL_051a: stelem.ref
-		IL_051b: ldc.i4.0
-		IL_051c: ldelem.ref
-		IL_051d: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0522: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0528: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_052d: ldc.i4.0
-		IL_052e: conv.r8
-		IL_052f: ldstr ""
-		IL_0534: ldc.i4.0
-		IL_0535: ldc.i4.1
-		IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_053b: stloc.s 5
-		IL_053d: ldloc.0
-		IL_053e: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0543: ldnull
-		IL_0544: ldstr "ownKeys-primitive"
-		IL_0549: ldloc.s 5
-		IL_054b: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_0550: pop
-		IL_0551: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0556: stloc.s 7
-		IL_0558: ldnull
-		IL_0559: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
-		IL_055f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0564: ldc.i4.0
-		IL_0565: conv.r8
-		IL_0566: ldstr ""
-		IL_056b: ldc.i4.0
-		IL_056c: ldc.i4.1
-		IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0572: stloc.s 5
-		IL_0574: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0579: dup
-		IL_057a: ldstr "ownKeys"
-		IL_057f: ldloc.s 5
-		IL_0581: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0586: stloc.s 6
-		IL_0588: ldloc.s 7
-		IL_058a: ldloc.s 6
-		IL_058c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0591: stloc.s 8
-		IL_0593: ldloc.0
-		IL_0594: ldloc.s 8
-		IL_0596: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
-		IL_059b: ldc.i4.1
-		IL_059c: newarr [System.Runtime]System.Object
-		IL_05a1: dup
-		IL_05a2: ldc.i4.0
-		IL_05a3: ldloc.0
-		IL_05a4: stelem.ref
-		IL_05a5: ldc.i4.0
-		IL_05a6: ldelem.ref
-		IL_05a7: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_05ac: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_05b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_05b7: ldc.i4.0
-		IL_05b8: conv.r8
-		IL_05b9: ldstr ""
-		IL_05be: ldc.i4.0
-		IL_05bf: ldc.i4.1
-		IL_05c0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_05c5: stloc.s 5
-		IL_05c7: ldloc.0
-		IL_05c8: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_05cd: ldnull
-		IL_05ce: ldstr "ownKeys-entry"
-		IL_05d3: ldloc.s 5
-		IL_05d5: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, object, object)
-		IL_05da: pop
-		IL_05db: ret
+		IL_04c1: ldstr "join"
+		IL_04c6: ldstr ","
+		IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_04d0: stloc.s 5
+		IL_04d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04d7: ldloc.s 5
+		IL_04d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04de: pop
+		IL_04df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04e4: stloc.s 7
+		IL_04e6: ldnull
+		IL_04e7: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
+		IL_04ed: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_04f2: ldc.i4.0
+		IL_04f3: conv.r8
+		IL_04f4: ldstr ""
+		IL_04f9: ldc.i4.0
+		IL_04fa: ldc.i4.1
+		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0500: stloc.s 5
+		IL_0502: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0507: dup
+		IL_0508: ldstr "ownKeys"
+		IL_050d: ldloc.s 5
+		IL_050f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0514: stloc.s 8
+		IL_0516: ldloc.s 7
+		IL_0518: ldloc.s 8
+		IL_051a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_051f: stloc.s 9
+		IL_0521: ldloc.0
+		IL_0522: ldloc.s 9
+		IL_0524: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysProxy
+		IL_0529: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_052e: stloc.s 6
+		IL_0530: ldc.i4.1
+		IL_0531: newarr [System.Runtime]System.Object
+		IL_0536: dup
+		IL_0537: ldc.i4.0
+		IL_0538: ldloc.0
+		IL_0539: stelem.ref
+		IL_053a: ldc.i4.0
+		IL_053b: ldelem.ref
+		IL_053c: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_0541: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_0547: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_054c: ldc.i4.0
+		IL_054d: conv.r8
+		IL_054e: ldstr ""
+		IL_0553: ldc.i4.0
+		IL_0554: ldc.i4.1
+		IL_0555: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_055a: stloc.s 5
+		IL_055c: ldloc.1
+		IL_055d: ldloc.s 6
+		IL_055f: ldstr "ownKeys-primitive"
+		IL_0564: ldloc.s 5
+		IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_056b: pop
+		IL_056c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0571: stloc.s 8
+		IL_0573: ldnull
+		IL_0574: ldftn class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
+		IL_057a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_057f: ldc.i4.0
+		IL_0580: conv.r8
+		IL_0581: ldstr ""
+		IL_0586: ldc.i4.0
+		IL_0587: ldc.i4.1
+		IL_0588: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_058d: stloc.s 5
+		IL_058f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0594: dup
+		IL_0595: ldstr "ownKeys"
+		IL_059a: ldloc.s 5
+		IL_059c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_05a1: stloc.s 7
+		IL_05a3: ldloc.s 8
+		IL_05a5: ldloc.s 7
+		IL_05a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_05ac: stloc.s 9
+		IL_05ae: ldloc.0
+		IL_05af: ldloc.s 9
+		IL_05b1: stfld object Modules.Proxy_Validation_EdgeCases/Scope::badOwnKeysEntryProxy
+		IL_05b6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05bb: stloc.s 6
+		IL_05bd: ldc.i4.1
+		IL_05be: newarr [System.Runtime]System.Object
+		IL_05c3: dup
+		IL_05c4: ldc.i4.0
+		IL_05c5: ldloc.0
+		IL_05c6: stelem.ref
+		IL_05c7: ldc.i4.0
+		IL_05c8: ldelem.ref
+		IL_05c9: castclass Modules.Proxy_Validation_EdgeCases/Scope
+		IL_05ce: ldftn object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+		IL_05d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_05d9: ldc.i4.0
+		IL_05da: conv.r8
+		IL_05db: ldstr ""
+		IL_05e0: ldc.i4.0
+		IL_05e1: ldc.i4.1
+		IL_05e2: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_05e7: stloc.s 5
+		IL_05e9: ldloc.1
+		IL_05ea: ldloc.s 6
+		IL_05ec: ldstr "ownKeys-entry"
+		IL_05f1: ldloc.s 5
+		IL_05f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_05f8: pop
+		IL_05f9: ret
 	} // end of method Proxy_Validation_EdgeCases::__js_module_init__
 
 } // end of class Modules.Proxy_Validation_EdgeCases
@@ -1907,7 +1918,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2a72
+		// Method begins at RVA 0x2a92
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x212c
+				// Method begins at RVA 0x2148
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x211b
+			// Method begins at RVA 0x2137
 			// Header size: 1
 			// Code size: 7 (0x7)
 			.maxstack 8
@@ -68,7 +68,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2123
+			// Method begins at RVA 0x213f
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -94,7 +94,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 191 (0xbf)
+		// Code size: 219 (0xdb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/Scope,
@@ -102,7 +102,8 @@
 			[2] float64,
 			[3] float64,
 			[4] object,
-			[5] float64
+			[5] object[],
+			[6] float64
 		)
 
 		IL_0000: newobj instance void Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/Scope::.ctor()
@@ -119,60 +120,68 @@
 		IL_0020: stloc.s 4
 		IL_0022: ldloc.s 4
 		IL_0024: stloc.1
-		IL_0025: ldnull
-		IL_0026: ldc.r8 3
-		IL_002f: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
-		IL_0034: stloc.s 4
-		IL_0036: ldloc.s 4
-		IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_003d: stloc.s 5
-		IL_003f: ldloc.s 5
-		IL_0041: stloc.2
-		IL_0042: ldnull
-		IL_0043: ldc.r8 4
-		IL_004c: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
-		IL_0051: stloc.s 4
-		IL_0053: ldloc.s 4
-		IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_005a: stloc.s 5
-		IL_005c: ldloc.s 5
-		IL_005e: stloc.3
-		IL_005f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0064: ldloc.2
-		IL_0065: ldloc.3
-		IL_0066: add
-		IL_0067: box [System.Runtime]System.Double
-		IL_006c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0071: pop
-		IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0077: ldloc.2
-		IL_0078: ldloc.3
-		IL_0079: sub
-		IL_007a: box [System.Runtime]System.Double
-		IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0084: pop
-		IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_008a: ldloc.2
-		IL_008b: ldloc.3
-		IL_008c: mul
-		IL_008d: box [System.Runtime]System.Double
-		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0097: pop
-		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009d: ldloc.2
-		IL_009e: ldloc.3
-		IL_009f: div
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00aa: pop
-		IL_00ab: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b0: ldloc.2
-		IL_00b1: ldloc.3
-		IL_00b2: rem
-		IL_00b3: box [System.Runtime]System.Double
-		IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bd: pop
-		IL_00be: ret
+		IL_0025: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_002a: stloc.s 5
+		IL_002c: ldloc.1
+		IL_002d: ldloc.s 5
+		IL_002f: ldc.r8 3
+		IL_0038: box [System.Runtime]System.Double
+		IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0042: stloc.s 4
+		IL_0044: ldloc.s 4
+		IL_0046: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_004b: stloc.s 6
+		IL_004d: ldloc.s 6
+		IL_004f: stloc.2
+		IL_0050: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0055: stloc.s 5
+		IL_0057: ldloc.1
+		IL_0058: ldloc.s 5
+		IL_005a: ldc.r8 4
+		IL_0063: box [System.Runtime]System.Double
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_006d: stloc.s 4
+		IL_006f: ldloc.s 4
+		IL_0071: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0076: stloc.s 6
+		IL_0078: ldloc.s 6
+		IL_007a: stloc.3
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: ldloc.2
+		IL_0081: ldloc.3
+		IL_0082: add
+		IL_0083: box [System.Runtime]System.Double
+		IL_0088: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008d: pop
+		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0093: ldloc.2
+		IL_0094: ldloc.3
+		IL_0095: sub
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a0: pop
+		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00a6: ldloc.2
+		IL_00a7: ldloc.3
+		IL_00a8: mul
+		IL_00a9: box [System.Runtime]System.Double
+		IL_00ae: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b3: pop
+		IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b9: ldloc.2
+		IL_00ba: ldloc.3
+		IL_00bb: div
+		IL_00bc: box [System.Runtime]System.Double
+		IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c6: pop
+		IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cc: ldloc.2
+		IL_00cd: ldloc.3
+		IL_00ce: rem
+		IL_00cf: box [System.Runtime]System.Double
+		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d9: pop
+		IL_00da: ret
 	} // end of method ShapeCoverage_MixedNumeric_BoxedArithmetic::__js_module_init__
 
 } // end of class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic
@@ -184,7 +193,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2135
+		// Method begins at RVA 0x2151
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c3
+				// Method begins at RVA 0x23c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -42,7 +42,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2184
+			// Method begins at RVA 0x2188
 			// Header size: 12
 			// Code size: 554 (0x22a)
 			.maxstack 8
@@ -243,7 +243,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ba
+			// Method begins at RVA 0x23be
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -269,12 +269,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 293 (0x125)
+		// Code size: 300 (0x12c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_FastPath_CommonMethods/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.String_MemberCall_FastPath_CommonMethods/Scope::.ctor()
@@ -291,88 +292,91 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "abcdef"
-		IL_0029: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldstr "  x  "
-		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0039: stloc.2
-		IL_003a: ldloc.2
-		IL_003b: ldstr "trim"
-		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0045: stloc.2
-		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004b: ldloc.2
-		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0051: pop
-		IL_0052: ldstr "  x  "
-		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005c: stloc.2
-		IL_005d: ldloc.2
-		IL_005e: ldstr "trimStart"
-		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0068: stloc.2
-		IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006e: ldloc.2
-		IL_006f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0074: pop
-		IL_0075: ldstr "x  "
-		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_007f: stloc.2
-		IL_0080: ldloc.2
-		IL_0081: ldstr "trimEnd"
-		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_008b: stloc.2
-		IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0091: ldloc.2
-		IL_0092: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0097: pop
-		IL_0098: ldstr "  x  "
-		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00a2: stloc.2
-		IL_00a3: ldloc.2
-		IL_00a4: ldstr "trimLeft"
-		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00ae: stloc.2
-		IL_00af: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b4: ldloc.2
-		IL_00b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ba: pop
-		IL_00bb: ldstr "x  "
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00c5: stloc.2
-		IL_00c6: ldloc.2
-		IL_00c7: ldstr "trimRight"
-		IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00d1: stloc.2
-		IL_00d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00d7: ldloc.2
-		IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00dd: pop
-		IL_00de: ldstr "A"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00e8: stloc.2
-		IL_00e9: ldloc.2
-		IL_00ea: ldstr "toLowerCase"
-		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_00f4: stloc.2
-		IL_00f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fa: ldloc.2
-		IL_00fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0100: pop
-		IL_0101: ldstr "a"
-		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010b: stloc.2
-		IL_010c: ldloc.2
-		IL_010d: ldstr "toUpperCase"
-		IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
-		IL_0117: stloc.2
-		IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011d: ldloc.2
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0123: pop
-		IL_0124: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "abcdef"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldstr "  x  "
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0040: stloc.2
+		IL_0041: ldloc.2
+		IL_0042: ldstr "trim"
+		IL_0047: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_004c: stloc.2
+		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0052: ldloc.2
+		IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0058: pop
+		IL_0059: ldstr "  x  "
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0063: stloc.2
+		IL_0064: ldloc.2
+		IL_0065: ldstr "trimStart"
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_006f: stloc.2
+		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0075: ldloc.2
+		IL_0076: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007b: pop
+		IL_007c: ldstr "x  "
+		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0086: stloc.2
+		IL_0087: ldloc.2
+		IL_0088: ldstr "trimEnd"
+		IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_0092: stloc.2
+		IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0098: ldloc.2
+		IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009e: pop
+		IL_009f: ldstr "  x  "
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a9: stloc.2
+		IL_00aa: ldloc.2
+		IL_00ab: ldstr "trimLeft"
+		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00b5: stloc.2
+		IL_00b6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00bb: ldloc.2
+		IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c1: pop
+		IL_00c2: ldstr "x  "
+		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cc: stloc.2
+		IL_00cd: ldloc.2
+		IL_00ce: ldstr "trimRight"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00d8: stloc.2
+		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00de: ldloc.2
+		IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e4: pop
+		IL_00e5: ldstr "A"
+		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ef: stloc.2
+		IL_00f0: ldloc.2
+		IL_00f1: ldstr "toLowerCase"
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_00fb: stloc.2
+		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0101: ldloc.2
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: ldstr "a"
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0112: stloc.2
+		IL_0113: ldloc.2
+		IL_0114: ldstr "toUpperCase"
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember0(object, string)
+		IL_011e: stloc.2
+		IL_011f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0124: ldloc.2
+		IL_0125: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_012a: pop
+		IL_012b: ret
 	} // end of method String_MemberCall_FastPath_CommonMethods::__js_module_init__
 
 } // end of class Modules.String_MemberCall_FastPath_CommonMethods
@@ -384,7 +388,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23cc
+		// Method begins at RVA 0x23d0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x227a
+					// Method begins at RVA 0x227e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2283
+					// Method begins at RVA 0x2287
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2271
+				// Method begins at RVA 0x2275
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -88,7 +88,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x2154
+			// Method begins at RVA 0x2158
 			// Header size: 12
 			// Code size: 247 (0xf7)
 			.maxstack 8
@@ -230,7 +230,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2268
+			// Method begins at RVA 0x226c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -256,13 +256,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 247 (0xf7)
+		// Code size: 251 (0xfb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Repeat_Basic/Scope,
 			[1] object,
 			[2] object,
-			[3] object
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.String_Repeat_Basic/Scope::.ctor()
@@ -287,58 +287,62 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.String_Repeat_Basic/Scope
-		IL_0039: ldnull
-		IL_003a: ldstr "ab"
-		IL_003f: ldc.r8 3
-		IL_0048: box [System.Runtime]System.Double
-		IL_004d: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_0052: pop
-		IL_0053: ldloc.0
-		IL_0054: castclass Modules.String_Repeat_Basic/Scope
-		IL_0059: ldnull
-		IL_005a: ldstr "x"
-		IL_005f: ldc.r8 0.0
-		IL_0068: box [System.Runtime]System.Double
-		IL_006d: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_0072: pop
-		IL_0073: ldloc.0
-		IL_0074: castclass Modules.String_Repeat_Basic/Scope
-		IL_0079: ldnull
-		IL_007a: ldstr "x"
-		IL_007f: ldc.r8 1
-		IL_0088: box [System.Runtime]System.Double
-		IL_008d: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_0092: pop
-		IL_0093: ldloc.0
-		IL_0094: castclass Modules.String_Repeat_Basic/Scope
-		IL_0099: ldnull
-		IL_009a: ldstr "x"
-		IL_009f: ldc.r8 2.9
-		IL_00a8: box [System.Runtime]System.Double
-		IL_00ad: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_00b2: pop
-		IL_00b3: ldc.r8 1
-		IL_00bc: neg
-		IL_00bd: box [System.Runtime]System.Double
-		IL_00c2: stloc.3
-		IL_00c3: ldloc.0
-		IL_00c4: castclass Modules.String_Repeat_Basic/Scope
-		IL_00c9: ldnull
-		IL_00ca: ldstr "x"
-		IL_00cf: ldloc.3
-		IL_00d0: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_00d5: pop
-		IL_00d6: ldloc.0
-		IL_00d7: castclass Modules.String_Repeat_Basic/Scope
-		IL_00dc: ldnull
-		IL_00dd: ldstr "x"
-		IL_00e2: ldc.r8 (00 00 00 00 00 00 F0 7F)
-		IL_00eb: box [System.Runtime]System.Double
-		IL_00f0: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, object, object)
-		IL_00f5: pop
-		IL_00f6: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldloc.1
+		IL_003a: ldloc.3
+		IL_003b: ldstr "ab"
+		IL_0040: ldc.r8 3
+		IL_0049: box [System.Runtime]System.Double
+		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0053: pop
+		IL_0054: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0059: stloc.3
+		IL_005a: ldloc.1
+		IL_005b: ldloc.3
+		IL_005c: ldstr "x"
+		IL_0061: ldc.r8 0.0
+		IL_006a: box [System.Runtime]System.Double
+		IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0074: pop
+		IL_0075: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_007a: stloc.3
+		IL_007b: ldloc.1
+		IL_007c: ldloc.3
+		IL_007d: ldstr "x"
+		IL_0082: ldc.r8 1
+		IL_008b: box [System.Runtime]System.Double
+		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0095: pop
+		IL_0096: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_009b: stloc.3
+		IL_009c: ldloc.1
+		IL_009d: ldloc.3
+		IL_009e: ldstr "x"
+		IL_00a3: ldc.r8 2.9
+		IL_00ac: box [System.Runtime]System.Double
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00b6: pop
+		IL_00b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00bc: stloc.3
+		IL_00bd: ldloc.1
+		IL_00be: ldloc.3
+		IL_00bf: ldstr "x"
+		IL_00c4: ldc.r8 1
+		IL_00cd: neg
+		IL_00ce: box [System.Runtime]System.Double
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00d8: pop
+		IL_00d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00de: stloc.3
+		IL_00df: ldloc.1
+		IL_00e0: ldloc.3
+		IL_00e1: ldstr "x"
+		IL_00e6: ldc.r8 (00 00 00 00 00 00 F0 7F)
+		IL_00ef: box [System.Runtime]System.Double
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00f9: pop
+		IL_00fa: ret
 	} // end of method String_Repeat_Basic::__js_module_init__
 
 } // end of class Modules.String_Repeat_Basic
@@ -350,7 +354,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x228c
+		// Method begins at RVA 0x2290
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -213,12 +213,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 82 (0x52)
+		// Code size: 83 (0x53)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_NestedParam/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.String_StartsWith_NestedParam/Scope::.ctor()
@@ -243,17 +244,18 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.String_StartsWith_NestedParam/Scope
-		IL_0039: ldnull
-		IL_003a: ldstr "abc"
-		IL_003f: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
-		IL_0044: stloc.2
-		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_004a: ldloc.2
-		IL_004b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0050: pop
-		IL_0051: ret
+		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0038: stloc.3
+		IL_0039: ldloc.1
+		IL_003a: ldloc.3
+		IL_003b: ldstr "abc"
+		IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0045: stloc.2
+		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004b: ldloc.2
+		IL_004c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0051: pop
+		IL_0052: ret
 	} // end of method String_StartsWith_NestedParam::__js_module_init__
 
 } // end of class Modules.String_StartsWith_NestedParam

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
@@ -179,7 +179,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 280 (0x118)
+		// Code size: 278 (0x116)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_EvaluationOrder/Scope,
@@ -267,49 +267,47 @@
 		IL_00af: ldloc.s 6
 		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateTemplateObject(object, object, object)
 		IL_00b6: stloc.s 7
-		IL_00b8: ldloc.0
-		IL_00b9: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
-		IL_00be: ldnull
-		IL_00bf: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
-		IL_00c4: stloc.s 4
-		IL_00c6: ldloc.s 4
-		IL_00c8: stloc.s 8
-		IL_00ca: ldloc.0
-		IL_00cb: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
-		IL_00d0: ldnull
-		IL_00d1: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
-		IL_00d6: stloc.s 4
-		IL_00d8: ldloc.s 4
-		IL_00da: stloc.s 9
-		IL_00dc: ldc.i4.3
-		IL_00dd: newarr [System.Runtime]System.Object
-		IL_00e2: dup
-		IL_00e3: ldc.i4.0
-		IL_00e4: ldloc.s 7
-		IL_00e6: stelem.ref
-		IL_00e7: dup
-		IL_00e8: ldc.i4.1
-		IL_00e9: ldloc.s 8
-		IL_00eb: stelem.ref
-		IL_00ec: dup
-		IL_00ed: ldc.i4.2
-		IL_00ee: ldloc.s 9
-		IL_00f0: stelem.ref
-		IL_00f1: stloc.s 6
-		IL_00f3: ldloc.1
-		IL_00f4: ldc.i4.0
-		IL_00f5: newarr [System.Runtime]System.Object
-		IL_00fa: ldloc.s 6
-		IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
-		IL_0101: stloc.s 4
-		IL_0103: ldloc.s 4
-		IL_0105: stloc.3
-		IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010b: ldstr "final result:"
-		IL_0110: ldloc.3
-		IL_0111: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0116: pop
-		IL_0117: ret
+		IL_00b8: ldloc.2
+		IL_00b9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00c3: stloc.s 4
+		IL_00c5: ldloc.s 4
+		IL_00c7: stloc.s 8
+		IL_00c9: ldloc.2
+		IL_00ca: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00d4: stloc.s 4
+		IL_00d6: ldloc.s 4
+		IL_00d8: stloc.s 9
+		IL_00da: ldc.i4.3
+		IL_00db: newarr [System.Runtime]System.Object
+		IL_00e0: dup
+		IL_00e1: ldc.i4.0
+		IL_00e2: ldloc.s 7
+		IL_00e4: stelem.ref
+		IL_00e5: dup
+		IL_00e6: ldc.i4.1
+		IL_00e7: ldloc.s 8
+		IL_00e9: stelem.ref
+		IL_00ea: dup
+		IL_00eb: ldc.i4.2
+		IL_00ec: ldloc.s 9
+		IL_00ee: stelem.ref
+		IL_00ef: stloc.s 6
+		IL_00f1: ldloc.1
+		IL_00f2: ldc.i4.0
+		IL_00f3: newarr [System.Runtime]System.Object
+		IL_00f8: ldloc.s 6
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_00ff: stloc.s 4
+		IL_0101: ldloc.s 4
+		IL_0103: stloc.3
+		IL_0104: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0109: ldstr "final result:"
+		IL_010e: ldloc.3
+		IL_010f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0114: pop
+		IL_0115: ret
 	} // end of method String_TaggedTemplate_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.String_TaggedTemplate_EvaluationOrder

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
@@ -1,4 +1,4 @@
-// IL code: TryFinally_Return
+﻿// IL code: TryFinally_Return
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x20f6
+					// Method begins at RVA 0x20fa
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x20ff
+					// Method begins at RVA 0x2103
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20ed
+				// Method begins at RVA 0x20f1
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -83,7 +83,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2088
+			// Method begins at RVA 0x208c
 			// Header size: 12
 			// Code size: 61 (0x3d)
 			.maxstack 8
@@ -139,7 +139,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20e4
+			// Method begins at RVA 0x20e8
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -165,7 +165,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 43 (0x2b)
+		// Code size: 48 (0x30)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryFinally_Return/Scope,
@@ -187,10 +187,11 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: call object Modules.TryFinally_Return/f::__js_call__(object)
-		IL_0029: pop
-		IL_002a: ret
+		IL_0023: ldloc.1
+		IL_0024: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_002e: pop
+		IL_002f: ret
 	} // end of method TryFinally_Return::__js_module_init__
 
 } // end of class Modules.TryFinally_Return
@@ -202,7 +203,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2108
+		// Method begins at RVA 0x210c
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23de
+				// Method begins at RVA 0x24eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2256
+			// Method begins at RVA 0x22ab
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23e7
+				// Method begins at RVA 0x24f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,9 +114,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x227c
+			// Method begins at RVA 0x22d0
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 149 (0x95)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -124,8 +124,10 @@
 				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object[],
+				[6] object,
+				[7] object,
+				[8] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -151,21 +153,48 @@
 			IL_003a: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
 			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0044: stloc.2
-			IL_0045: ldloc.0
-			IL_0046: box [System.Runtime]System.Double
-			IL_004b: stloc.s 5
-			IL_004d: ldloc.2
-			IL_004e: box [System.Runtime]System.Double
-			IL_0053: stloc.s 6
-			IL_0055: ldnull
-			IL_0056: ldstr "captured-double"
-			IL_005b: ldloc.s 5
-			IL_005d: ldloc.1
-			IL_005e: ldloc.s 6
-			IL_0060: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_0045: ldarg.0
+			IL_0046: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_004b: stloc.s 4
+			IL_004d: ldc.i4.1
+			IL_004e: newarr [System.Runtime]System.Object
+			IL_0053: dup
+			IL_0054: ldc.i4.0
+			IL_0055: ldarg.0
+			IL_0056: stelem.ref
+			IL_0057: stloc.s 5
+			IL_0059: ldloc.0
+			IL_005a: box [System.Runtime]System.Double
+			IL_005f: stloc.s 6
+			IL_0061: ldloc.2
+			IL_0062: box [System.Runtime]System.Double
+			IL_0067: stloc.s 7
+			IL_0069: ldc.i4.4
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldstr "captured-double"
+			IL_0076: stelem.ref
+			IL_0077: dup
+			IL_0078: ldc.i4.1
+			IL_0079: ldloc.s 6
+			IL_007b: stelem.ref
+			IL_007c: dup
+			IL_007d: ldc.i4.2
+			IL_007e: ldloc.1
+			IL_007f: stelem.ref
+			IL_0080: dup
+			IL_0081: ldc.i4.3
+			IL_0082: ldloc.s 7
+			IL_0084: stelem.ref
+			IL_0085: stloc.s 8
+			IL_0087: ldloc.s 4
+			IL_0089: ldloc.s 5
+			IL_008b: ldloc.s 8
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0092: pop
+			IL_0093: ldnull
+			IL_0094: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -181,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f0
+				// Method begins at RVA 0x24fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -208,16 +237,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22f0
+			// Method begins at RVA 0x2374
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] float64,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -237,15 +268,42 @@
 			IL_0025: stloc.1
 			IL_0026: ldarg.2
 			IL_0027: stloc.2
-			IL_0028: ldnull
-			IL_0029: ldstr "arg-double"
-			IL_002e: ldloc.0
-			IL_002f: ldloc.1
-			IL_0030: ldloc.2
-			IL_0031: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0036: pop
-			IL_0037: ldnull
-			IL_0038: ret
+			IL_0028: ldarg.0
+			IL_0029: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_002e: stloc.s 4
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-double"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -261,7 +319,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f9
+				// Method begins at RVA 0x2506
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -287,16 +345,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2338
+			// Method begins at RVA 0x23e8
 			// Header size: 12
-			// Code size: 76 (0x4c)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] float64,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -320,15 +380,42 @@
 			IL_0034: ldarg.0
 			IL_0035: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
 			IL_003a: stloc.2
-			IL_003b: ldnull
-			IL_003c: ldstr "captured-string"
-			IL_0041: ldloc.0
-			IL_0042: ldloc.1
-			IL_0043: ldloc.2
-			IL_0044: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0049: pop
-			IL_004a: ldnull
-			IL_004b: ret
+			IL_003b: ldarg.0
+			IL_003c: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_0041: stloc.s 4
+			IL_0043: ldc.i4.1
+			IL_0044: newarr [System.Runtime]System.Object
+			IL_0049: dup
+			IL_004a: ldc.i4.0
+			IL_004b: ldarg.0
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 5
+			IL_004f: ldc.i4.4
+			IL_0050: newarr [System.Runtime]System.Object
+			IL_0055: dup
+			IL_0056: ldc.i4.0
+			IL_0057: ldstr "captured-string"
+			IL_005c: stelem.ref
+			IL_005d: dup
+			IL_005e: ldc.i4.1
+			IL_005f: ldloc.0
+			IL_0060: stelem.ref
+			IL_0061: dup
+			IL_0062: ldc.i4.2
+			IL_0063: ldloc.1
+			IL_0064: stelem.ref
+			IL_0065: dup
+			IL_0066: ldc.i4.3
+			IL_0067: ldloc.2
+			IL_0068: stelem.ref
+			IL_0069: stloc.s 6
+			IL_006b: ldloc.s 4
+			IL_006d: ldloc.s 5
+			IL_006f: ldloc.s 6
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0076: pop
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -344,7 +431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2402
+				// Method begins at RVA 0x250f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -371,16 +458,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2390
+			// Method begins at RVA 0x2470
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] float64,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -400,15 +489,42 @@
 			IL_0025: stloc.1
 			IL_0026: ldarg.2
 			IL_0027: stloc.2
-			IL_0028: ldnull
-			IL_0029: ldstr "arg-string"
-			IL_002e: ldloc.0
-			IL_002f: ldloc.1
-			IL_0030: ldloc.2
-			IL_0031: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0036: pop
-			IL_0037: ldnull
-			IL_0038: ret
+			IL_0028: ldarg.0
+			IL_0029: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+			IL_002e: stloc.s 4
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-string"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -446,7 +562,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23d5
+			// Method begins at RVA 0x24e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -472,7 +588,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 506 (0x1fa)
+		// Code size: 591 (0x24f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix/Scope,
@@ -487,9 +603,11 @@
 			[9] string,
 			[10] object,
 			[11] object,
-			[12] string,
-			[13] float64,
-			[14] object
+			[12] object[],
+			[13] object[],
+			[14] string,
+			[15] float64,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/Scope::.ctor()
@@ -608,78 +726,122 @@
 		IL_0121: stloc.s 11
 		IL_0123: ldloc.s 11
 		IL_0125: stloc.s 8
-		IL_0127: ldnull
-		IL_0128: ldstr "global-double"
-		IL_012d: ldloc.s 6
-		IL_012f: ldloc.s 7
-		IL_0131: ldloc.s 8
-		IL_0133: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_0138: pop
-		IL_0139: ldloc.0
-		IL_013a: ldc.r8 3
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
-		IL_014d: ldloc.0
-		IL_014e: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0153: ldnull
-		IL_0154: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_0159: pop
-		IL_015a: ldloc.0
-		IL_015b: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0160: ldnull
-		IL_0161: ldc.r8 3
-		IL_016a: box [System.Runtime]System.Double
-		IL_016f: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
-		IL_0174: pop
-		IL_0175: ldstr "3"
-		IL_017a: stloc.s 9
-		IL_017c: ldloc.s 9
-		IL_017e: stloc.s 12
-		IL_0180: ldloc.s 12
-		IL_0182: stloc.s 6
-		IL_0184: ldloc.s 9
-		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_018b: stloc.s 13
-		IL_018d: ldloc.s 13
-		IL_018f: box [System.Runtime]System.Double
-		IL_0194: stloc.s 11
-		IL_0196: ldloc.s 13
-		IL_0198: ldc.r8 1
-		IL_01a1: sub
-		IL_01a2: stloc.s 13
-		IL_01a4: ldloc.s 13
-		IL_01a6: box [System.Runtime]System.Double
-		IL_01ab: stloc.s 14
-		IL_01ad: ldloc.s 14
-		IL_01af: stloc.s 9
-		IL_01b1: ldloc.s 11
-		IL_01b3: stloc.s 7
-		IL_01b5: ldloc.s 9
-		IL_01b7: stloc.s 11
-		IL_01b9: ldloc.s 11
-		IL_01bb: stloc.s 8
-		IL_01bd: ldnull
-		IL_01be: ldstr "global-string"
-		IL_01c3: ldloc.s 6
-		IL_01c5: ldloc.s 7
-		IL_01c7: ldloc.s 8
-		IL_01c9: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_01ce: pop
-		IL_01cf: ldloc.0
-		IL_01d0: ldstr "3"
-		IL_01d5: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
-		IL_01da: ldloc.0
-		IL_01db: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_01e0: ldnull
-		IL_01e1: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_01e6: pop
+		IL_0127: ldloc.0
+		IL_0128: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+		IL_012d: stloc.s 10
+		IL_012f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0134: stloc.s 12
+		IL_0136: ldc.i4.4
+		IL_0137: newarr [System.Runtime]System.Object
+		IL_013c: dup
+		IL_013d: ldc.i4.0
+		IL_013e: ldstr "global-double"
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.1
+		IL_0146: ldloc.s 6
+		IL_0148: stelem.ref
+		IL_0149: dup
+		IL_014a: ldc.i4.2
+		IL_014b: ldloc.s 7
+		IL_014d: stelem.ref
+		IL_014e: dup
+		IL_014f: ldc.i4.3
+		IL_0150: ldloc.s 8
+		IL_0152: stelem.ref
+		IL_0153: stloc.s 13
+		IL_0155: ldloc.s 10
+		IL_0157: ldloc.s 12
+		IL_0159: ldloc.s 13
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0160: pop
+		IL_0161: ldloc.0
+		IL_0162: ldc.r8 3
+		IL_016b: box [System.Runtime]System.Double
+		IL_0170: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalDouble
+		IL_0175: ldloc.1
+		IL_0176: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0180: pop
+		IL_0181: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0186: stloc.s 13
+		IL_0188: ldloc.2
+		IL_0189: ldloc.s 13
+		IL_018b: ldc.r8 3
+		IL_0194: box [System.Runtime]System.Double
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_019e: pop
+		IL_019f: ldstr "3"
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 9
+		IL_01a8: stloc.s 14
+		IL_01aa: ldloc.s 14
+		IL_01ac: stloc.s 6
+		IL_01ae: ldloc.s 9
+		IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01b5: stloc.s 15
+		IL_01b7: ldloc.s 15
+		IL_01b9: box [System.Runtime]System.Double
+		IL_01be: stloc.s 11
+		IL_01c0: ldloc.s 15
+		IL_01c2: ldc.r8 1
+		IL_01cb: sub
+		IL_01cc: stloc.s 15
+		IL_01ce: ldloc.s 15
+		IL_01d0: box [System.Runtime]System.Double
+		IL_01d5: stloc.s 16
+		IL_01d7: ldloc.s 16
+		IL_01d9: stloc.s 9
+		IL_01db: ldloc.s 11
+		IL_01dd: stloc.s 7
+		IL_01df: ldloc.s 9
+		IL_01e1: stloc.s 11
+		IL_01e3: ldloc.s 11
+		IL_01e5: stloc.s 8
 		IL_01e7: ldloc.0
-		IL_01e8: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_01ed: ldnull
-		IL_01ee: ldstr "3"
-		IL_01f3: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
-		IL_01f8: pop
-		IL_01f9: ret
+		IL_01e8: ldfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::logCase
+		IL_01ed: stloc.s 10
+		IL_01ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f4: stloc.s 13
+		IL_01f6: ldc.i4.4
+		IL_01f7: newarr [System.Runtime]System.Object
+		IL_01fc: dup
+		IL_01fd: ldc.i4.0
+		IL_01fe: ldstr "global-string"
+		IL_0203: stelem.ref
+		IL_0204: dup
+		IL_0205: ldc.i4.1
+		IL_0206: ldloc.s 6
+		IL_0208: stelem.ref
+		IL_0209: dup
+		IL_020a: ldc.i4.2
+		IL_020b: ldloc.s 7
+		IL_020d: stelem.ref
+		IL_020e: dup
+		IL_020f: ldc.i4.3
+		IL_0210: ldloc.s 8
+		IL_0212: stelem.ref
+		IL_0213: stloc.s 12
+		IL_0215: ldloc.s 10
+		IL_0217: ldloc.s 13
+		IL_0219: ldloc.s 12
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0220: pop
+		IL_0221: ldloc.0
+		IL_0222: ldstr "3"
+		IL_0227: stfld object Modules.UnaryOperator_MinusMinusPostfix/Scope::capturedGlobalString
+		IL_022c: ldloc.3
+		IL_022d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0237: pop
+		IL_0238: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_023d: stloc.s 12
+		IL_023f: ldloc.s 4
+		IL_0241: ldloc.s 12
+		IL_0243: ldstr "3"
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_024d: pop
+		IL_024e: ret
 	} // end of method UnaryOperator_MinusMinusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix
@@ -691,7 +853,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x240b
+		// Method begins at RVA 0x2518
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d4
+					// Method begins at RVA 0x21ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 274 (0x112)
 			.maxstack 8
@@ -200,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c2
+			// Method begins at RVA 0x21da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -226,12 +226,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/Scope::.ctor()
@@ -248,19 +249,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
@@ -272,7 +282,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dd
+		// Method begins at RVA 0x21f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e3
+					// Method begins at RVA 0x21fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 289 (0x121)
 			.maxstack 8
@@ -214,7 +214,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d1
+			// Method begins at RVA 0x21e9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -240,12 +240,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/Scope::.ctor()
@@ -262,19 +263,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
@@ -286,7 +296,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ec
+		// Method begins at RVA 0x2204
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b5
+				// Method begins at RVA 0x24be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2251
+			// Method begins at RVA 0x22a6
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23be
+				// Method begins at RVA 0x24c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,16 +114,19 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x22cc
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 138 (0x8a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
 				[3] object,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object,
+				[7] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -146,21 +149,48 @@
 			IL_0031: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
 			IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_003b: stloc.2
-			IL_003c: ldloc.0
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: stloc.3
-			IL_0043: ldloc.2
-			IL_0044: box [System.Runtime]System.Double
-			IL_0049: stloc.s 4
-			IL_004b: ldnull
-			IL_004c: ldstr "captured-double"
-			IL_0051: ldloc.3
-			IL_0052: ldloc.1
-			IL_0053: ldloc.s 4
-			IL_0055: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_003c: ldarg.0
+			IL_003d: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_0042: stloc.s 4
+			IL_0044: ldc.i4.1
+			IL_0045: newarr [System.Runtime]System.Object
+			IL_004a: dup
+			IL_004b: ldc.i4.0
+			IL_004c: ldarg.0
+			IL_004d: stelem.ref
+			IL_004e: stloc.s 5
+			IL_0050: ldloc.0
+			IL_0051: box [System.Runtime]System.Double
+			IL_0056: stloc.3
+			IL_0057: ldloc.2
+			IL_0058: box [System.Runtime]System.Double
+			IL_005d: stloc.s 6
+			IL_005f: ldc.i4.4
+			IL_0060: newarr [System.Runtime]System.Object
+			IL_0065: dup
+			IL_0066: ldc.i4.0
+			IL_0067: ldstr "captured-double"
+			IL_006c: stelem.ref
+			IL_006d: dup
+			IL_006e: ldc.i4.1
+			IL_006f: ldloc.3
+			IL_0070: stelem.ref
+			IL_0071: dup
+			IL_0072: ldc.i4.2
+			IL_0073: ldloc.1
+			IL_0074: stelem.ref
+			IL_0075: dup
+			IL_0076: ldc.i4.3
+			IL_0077: ldloc.s 6
+			IL_0079: stelem.ref
+			IL_007a: stloc.s 7
+			IL_007c: ldloc.s 4
+			IL_007e: ldloc.s 5
+			IL_0080: ldloc.s 7
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0087: pop
+			IL_0088: ldnull
+			IL_0089: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -176,7 +206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c7
+				// Method begins at RVA 0x24d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,15 +233,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22e4
+			// Method begins at RVA 0x2364
 			// Header size: 12
-			// Code size: 48 (0x30)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object
+				[3] object,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -228,15 +261,42 @@
 			IL_001c: stloc.1
 			IL_001d: ldarg.2
 			IL_001e: stloc.2
-			IL_001f: ldnull
-			IL_0020: ldstr "arg-double"
-			IL_0025: ldloc.0
-			IL_0026: ldloc.1
-			IL_0027: ldloc.2
-			IL_0028: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_002d: pop
-			IL_002e: ldnull
-			IL_002f: ret
+			IL_001f: ldarg.0
+			IL_0020: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_0025: stloc.s 4
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-double"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -252,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d0
+				// Method begins at RVA 0x24d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,15 +338,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2320
+			// Method begins at RVA 0x23d0
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object
+				[3] object,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -307,15 +370,42 @@
 			IL_002b: ldarg.0
 			IL_002c: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
 			IL_0031: stloc.2
-			IL_0032: ldnull
-			IL_0033: ldstr "captured-string"
-			IL_0038: ldloc.0
-			IL_0039: ldloc.1
-			IL_003a: ldloc.2
-			IL_003b: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_0040: pop
-			IL_0041: ldnull
-			IL_0042: ret
+			IL_0032: ldarg.0
+			IL_0033: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_0038: stloc.s 4
+			IL_003a: ldc.i4.1
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: stloc.s 5
+			IL_0046: ldc.i4.4
+			IL_0047: newarr [System.Runtime]System.Object
+			IL_004c: dup
+			IL_004d: ldc.i4.0
+			IL_004e: ldstr "captured-string"
+			IL_0053: stelem.ref
+			IL_0054: dup
+			IL_0055: ldc.i4.1
+			IL_0056: ldloc.0
+			IL_0057: stelem.ref
+			IL_0058: dup
+			IL_0059: ldc.i4.2
+			IL_005a: ldloc.1
+			IL_005b: stelem.ref
+			IL_005c: dup
+			IL_005d: ldc.i4.3
+			IL_005e: ldloc.2
+			IL_005f: stelem.ref
+			IL_0060: stloc.s 6
+			IL_0062: ldloc.s 4
+			IL_0064: ldloc.s 5
+			IL_0066: ldloc.s 6
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_006d: pop
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -331,7 +421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d9
+				// Method begins at RVA 0x24e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,15 +448,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2370
+			// Method begins at RVA 0x244c
 			// Header size: 12
-			// Code size: 48 (0x30)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object
+				[3] object,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -383,15 +476,42 @@
 			IL_001c: stloc.1
 			IL_001d: ldarg.2
 			IL_001e: stloc.2
-			IL_001f: ldnull
-			IL_0020: ldstr "arg-string"
-			IL_0025: ldloc.0
-			IL_0026: ldloc.1
-			IL_0027: ldloc.2
-			IL_0028: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_002d: pop
-			IL_002e: ldnull
-			IL_002f: ret
+			IL_001f: ldarg.0
+			IL_0020: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+			IL_0025: stloc.s 4
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-string"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -429,7 +549,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ac
+			// Method begins at RVA 0x24b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -455,7 +575,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 501 (0x1f5)
+		// Code size: 586 (0x24a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix/Scope,
@@ -470,8 +590,10 @@
 			[9] string,
 			[10] object,
 			[11] object,
-			[12] string,
-			[13] float64
+			[12] object[],
+			[13] object[],
+			[14] string,
+			[15] float64
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/Scope::.ctor()
@@ -590,77 +712,121 @@
 		IL_0121: stloc.s 11
 		IL_0123: ldloc.s 11
 		IL_0125: stloc.s 8
-		IL_0127: ldnull
-		IL_0128: ldstr "global-double"
-		IL_012d: ldloc.s 6
-		IL_012f: ldloc.s 7
-		IL_0131: ldloc.s 8
-		IL_0133: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_0138: pop
-		IL_0139: ldloc.0
-		IL_013a: ldc.r8 3
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
-		IL_014d: ldloc.0
-		IL_014e: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0153: ldnull
-		IL_0154: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_0159: pop
-		IL_015a: ldloc.0
-		IL_015b: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0160: ldnull
-		IL_0161: ldc.r8 3
-		IL_016a: box [System.Runtime]System.Double
-		IL_016f: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
-		IL_0174: pop
-		IL_0175: ldstr "3"
-		IL_017a: stloc.s 9
-		IL_017c: ldloc.s 9
-		IL_017e: stloc.s 12
-		IL_0180: ldloc.s 12
-		IL_0182: stloc.s 6
-		IL_0184: ldloc.s 9
-		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_018b: stloc.s 13
-		IL_018d: ldloc.s 13
-		IL_018f: ldc.r8 1
-		IL_0198: sub
-		IL_0199: stloc.s 13
-		IL_019b: ldloc.s 13
-		IL_019d: box [System.Runtime]System.Double
-		IL_01a2: stloc.s 11
-		IL_01a4: ldloc.s 11
-		IL_01a6: stloc.s 9
-		IL_01a8: ldloc.s 9
-		IL_01aa: stloc.s 11
-		IL_01ac: ldloc.s 11
-		IL_01ae: stloc.s 7
-		IL_01b0: ldloc.s 9
-		IL_01b2: stloc.s 11
-		IL_01b4: ldloc.s 11
-		IL_01b6: stloc.s 8
-		IL_01b8: ldnull
-		IL_01b9: ldstr "global-string"
-		IL_01be: ldloc.s 6
-		IL_01c0: ldloc.s 7
-		IL_01c2: ldloc.s 8
-		IL_01c4: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_01c9: pop
-		IL_01ca: ldloc.0
-		IL_01cb: ldstr "3"
-		IL_01d0: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
-		IL_01d5: ldloc.0
-		IL_01d6: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_01db: ldnull
-		IL_01dc: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_01e1: pop
+		IL_0127: ldloc.0
+		IL_0128: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+		IL_012d: stloc.s 10
+		IL_012f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0134: stloc.s 12
+		IL_0136: ldc.i4.4
+		IL_0137: newarr [System.Runtime]System.Object
+		IL_013c: dup
+		IL_013d: ldc.i4.0
+		IL_013e: ldstr "global-double"
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.1
+		IL_0146: ldloc.s 6
+		IL_0148: stelem.ref
+		IL_0149: dup
+		IL_014a: ldc.i4.2
+		IL_014b: ldloc.s 7
+		IL_014d: stelem.ref
+		IL_014e: dup
+		IL_014f: ldc.i4.3
+		IL_0150: ldloc.s 8
+		IL_0152: stelem.ref
+		IL_0153: stloc.s 13
+		IL_0155: ldloc.s 10
+		IL_0157: ldloc.s 12
+		IL_0159: ldloc.s 13
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0160: pop
+		IL_0161: ldloc.0
+		IL_0162: ldc.r8 3
+		IL_016b: box [System.Runtime]System.Double
+		IL_0170: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalDouble
+		IL_0175: ldloc.1
+		IL_0176: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0180: pop
+		IL_0181: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0186: stloc.s 13
+		IL_0188: ldloc.2
+		IL_0189: ldloc.s 13
+		IL_018b: ldc.r8 3
+		IL_0194: box [System.Runtime]System.Double
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_019e: pop
+		IL_019f: ldstr "3"
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 9
+		IL_01a8: stloc.s 14
+		IL_01aa: ldloc.s 14
+		IL_01ac: stloc.s 6
+		IL_01ae: ldloc.s 9
+		IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01b5: stloc.s 15
+		IL_01b7: ldloc.s 15
+		IL_01b9: ldc.r8 1
+		IL_01c2: sub
+		IL_01c3: stloc.s 15
+		IL_01c5: ldloc.s 15
+		IL_01c7: box [System.Runtime]System.Double
+		IL_01cc: stloc.s 11
+		IL_01ce: ldloc.s 11
+		IL_01d0: stloc.s 9
+		IL_01d2: ldloc.s 9
+		IL_01d4: stloc.s 11
+		IL_01d6: ldloc.s 11
+		IL_01d8: stloc.s 7
+		IL_01da: ldloc.s 9
+		IL_01dc: stloc.s 11
+		IL_01de: ldloc.s 11
+		IL_01e0: stloc.s 8
 		IL_01e2: ldloc.0
-		IL_01e3: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_01e8: ldnull
-		IL_01e9: ldstr "3"
-		IL_01ee: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
-		IL_01f3: pop
-		IL_01f4: ret
+		IL_01e3: ldfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::logCase
+		IL_01e8: stloc.s 10
+		IL_01ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01ef: stloc.s 13
+		IL_01f1: ldc.i4.4
+		IL_01f2: newarr [System.Runtime]System.Object
+		IL_01f7: dup
+		IL_01f8: ldc.i4.0
+		IL_01f9: ldstr "global-string"
+		IL_01fe: stelem.ref
+		IL_01ff: dup
+		IL_0200: ldc.i4.1
+		IL_0201: ldloc.s 6
+		IL_0203: stelem.ref
+		IL_0204: dup
+		IL_0205: ldc.i4.2
+		IL_0206: ldloc.s 7
+		IL_0208: stelem.ref
+		IL_0209: dup
+		IL_020a: ldc.i4.3
+		IL_020b: ldloc.s 8
+		IL_020d: stelem.ref
+		IL_020e: stloc.s 12
+		IL_0210: ldloc.s 10
+		IL_0212: ldloc.s 13
+		IL_0214: ldloc.s 12
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_021b: pop
+		IL_021c: ldloc.0
+		IL_021d: ldstr "3"
+		IL_0222: stfld object Modules.UnaryOperator_MinusMinusPrefix/Scope::capturedGlobalString
+		IL_0227: ldloc.3
+		IL_0228: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0232: pop
+		IL_0233: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0238: stloc.s 12
+		IL_023a: ldloc.s 4
+		IL_023c: ldloc.s 12
+		IL_023e: ldstr "3"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0248: pop
+		IL_0249: ret
 	} // end of method UnaryOperator_MinusMinusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix
@@ -672,7 +838,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23e2
+		// Method begins at RVA 0x24eb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d4
+					// Method begins at RVA 0x21ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 274 (0x112)
 			.maxstack 8
@@ -200,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c2
+			// Method begins at RVA 0x21da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -226,12 +226,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/Scope::.ctor()
@@ -248,19 +249,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
@@ -272,7 +282,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dd
+		// Method begins at RVA 0x21f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e3
+					// Method begins at RVA 0x21fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 289 (0x121)
 			.maxstack 8
@@ -214,7 +214,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d1
+			// Method begins at RVA 0x21e9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -240,12 +240,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/Scope::.ctor()
@@ -262,19 +263,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
@@ -286,7 +296,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ec
+		// Method begins at RVA 0x2204
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2236
+					// Method begins at RVA 0x222e
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -46,7 +46,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 02 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2118
+				// Method begins at RVA 0x2110
 				// Header size: 12
 				// Code size: 256 (0x100)
 				.maxstack 8
@@ -163,7 +163,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x222d
+				// Method begins at RVA 0x2225
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -189,9 +189,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x20a0
+			// Method begins at RVA 0x209c
 			// Header size: 12
-			// Code size: 108 (0x6c)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope,
@@ -226,26 +226,22 @@
 			IL_0031: ldc.r8 3
 			IL_003a: box [System.Runtime]System.Double
 			IL_003f: stfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-			IL_0044: ldc.i4.2
-			IL_0045: newarr [System.Runtime]System.Object
-			IL_004a: dup
-			IL_004b: ldc.i4.0
-			IL_004c: ldarg.0
-			IL_004d: stelem.ref
-			IL_004e: dup
-			IL_004f: ldc.i4.1
-			IL_0050: ldloc.0
-			IL_0051: stelem.ref
-			IL_0052: ldnull
-			IL_0053: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
-			IL_0058: pop
-			IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_005e: ldloc.0
-			IL_005f: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
-			IL_0064: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0069: pop
-			IL_006a: ldnull
-			IL_006b: ret
+			IL_0044: ldloc.1
+			IL_0045: ldc.i4.1
+			IL_0046: newarr [System.Runtime]System.Object
+			IL_004b: dup
+			IL_004c: ldc.i4.0
+			IL_004d: ldarg.0
+			IL_004e: stelem.ref
+			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0054: pop
+			IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_005a: ldloc.0
+			IL_005b: ldfld object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope::x
+			IL_0060: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0065: pop
+			IL_0066: ldnull
+			IL_0067: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -264,7 +260,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x2224
+			// Method begins at RVA 0x221c
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -290,7 +286,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 65 (0x41)
+		// Code size: 64 (0x40)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope,
@@ -320,12 +316,11 @@
 		IL_0030: stloc.2
 		IL_0031: ldloc.2
 		IL_0032: stloc.1
-		IL_0033: ldloc.0
-		IL_0034: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope
-		IL_0039: ldnull
-		IL_003a: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
-		IL_003f: pop
-		IL_0040: ret
+		IL_0033: ldloc.1
+		IL_0034: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_003e: pop
+		IL_003f: ret
 	} // end of method UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
@@ -337,7 +332,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x223f
+		// Method begins at RVA 0x2237
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23de
+				// Method begins at RVA 0x24eb
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2256
+			// Method begins at RVA 0x22ab
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23e7
+				// Method begins at RVA 0x24f4
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,9 +114,9 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x227c
+			// Method begins at RVA 0x22d0
 			// Header size: 12
-			// Code size: 104 (0x68)
+			// Code size: 149 (0x95)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -124,8 +124,10 @@
 				[2] float64,
 				[3] float64,
 				[4] object,
-				[5] object,
-				[6] object
+				[5] object[],
+				[6] object,
+				[7] object,
+				[8] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -151,21 +153,48 @@
 			IL_003a: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
 			IL_003f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_0044: stloc.2
-			IL_0045: ldloc.0
-			IL_0046: box [System.Runtime]System.Double
-			IL_004b: stloc.s 5
-			IL_004d: ldloc.2
-			IL_004e: box [System.Runtime]System.Double
-			IL_0053: stloc.s 6
-			IL_0055: ldnull
-			IL_0056: ldstr "captured-double"
-			IL_005b: ldloc.s 5
-			IL_005d: ldloc.1
-			IL_005e: ldloc.s 6
-			IL_0060: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0065: pop
-			IL_0066: ldnull
-			IL_0067: ret
+			IL_0045: ldarg.0
+			IL_0046: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_004b: stloc.s 4
+			IL_004d: ldc.i4.1
+			IL_004e: newarr [System.Runtime]System.Object
+			IL_0053: dup
+			IL_0054: ldc.i4.0
+			IL_0055: ldarg.0
+			IL_0056: stelem.ref
+			IL_0057: stloc.s 5
+			IL_0059: ldloc.0
+			IL_005a: box [System.Runtime]System.Double
+			IL_005f: stloc.s 6
+			IL_0061: ldloc.2
+			IL_0062: box [System.Runtime]System.Double
+			IL_0067: stloc.s 7
+			IL_0069: ldc.i4.4
+			IL_006a: newarr [System.Runtime]System.Object
+			IL_006f: dup
+			IL_0070: ldc.i4.0
+			IL_0071: ldstr "captured-double"
+			IL_0076: stelem.ref
+			IL_0077: dup
+			IL_0078: ldc.i4.1
+			IL_0079: ldloc.s 6
+			IL_007b: stelem.ref
+			IL_007c: dup
+			IL_007d: ldc.i4.2
+			IL_007e: ldloc.1
+			IL_007f: stelem.ref
+			IL_0080: dup
+			IL_0081: ldc.i4.3
+			IL_0082: ldloc.s 7
+			IL_0084: stelem.ref
+			IL_0085: stloc.s 8
+			IL_0087: ldloc.s 4
+			IL_0089: ldloc.s 5
+			IL_008b: ldloc.s 8
+			IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0092: pop
+			IL_0093: ldnull
+			IL_0094: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -181,7 +210,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f0
+				// Method begins at RVA 0x24fd
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -208,16 +237,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22f0
+			// Method begins at RVA 0x2374
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] float64,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -237,15 +268,42 @@
 			IL_0025: stloc.1
 			IL_0026: ldarg.2
 			IL_0027: stloc.2
-			IL_0028: ldnull
-			IL_0029: ldstr "arg-double"
-			IL_002e: ldloc.0
-			IL_002f: ldloc.1
-			IL_0030: ldloc.2
-			IL_0031: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0036: pop
-			IL_0037: ldnull
-			IL_0038: ret
+			IL_0028: ldarg.0
+			IL_0029: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_002e: stloc.s 4
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-double"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -261,7 +319,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23f9
+				// Method begins at RVA 0x2506
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -287,16 +345,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2338
+			// Method begins at RVA 0x23e8
 			// Header size: 12
-			// Code size: 76 (0x4c)
+			// Code size: 121 (0x79)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] float64,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -320,15 +380,42 @@
 			IL_0034: ldarg.0
 			IL_0035: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
 			IL_003a: stloc.2
-			IL_003b: ldnull
-			IL_003c: ldstr "captured-string"
-			IL_0041: ldloc.0
-			IL_0042: ldloc.1
-			IL_0043: ldloc.2
-			IL_0044: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0049: pop
-			IL_004a: ldnull
-			IL_004b: ret
+			IL_003b: ldarg.0
+			IL_003c: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_0041: stloc.s 4
+			IL_0043: ldc.i4.1
+			IL_0044: newarr [System.Runtime]System.Object
+			IL_0049: dup
+			IL_004a: ldc.i4.0
+			IL_004b: ldarg.0
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 5
+			IL_004f: ldc.i4.4
+			IL_0050: newarr [System.Runtime]System.Object
+			IL_0055: dup
+			IL_0056: ldc.i4.0
+			IL_0057: ldstr "captured-string"
+			IL_005c: stelem.ref
+			IL_005d: dup
+			IL_005e: ldc.i4.1
+			IL_005f: ldloc.0
+			IL_0060: stelem.ref
+			IL_0061: dup
+			IL_0062: ldc.i4.2
+			IL_0063: ldloc.1
+			IL_0064: stelem.ref
+			IL_0065: dup
+			IL_0066: ldc.i4.3
+			IL_0067: ldloc.2
+			IL_0068: stelem.ref
+			IL_0069: stloc.s 6
+			IL_006b: ldloc.s 4
+			IL_006d: ldloc.s 5
+			IL_006f: ldloc.s 6
+			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0076: pop
+			IL_0077: ldnull
+			IL_0078: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -344,7 +431,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2402
+				// Method begins at RVA 0x250f
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -371,16 +458,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2390
+			// Method begins at RVA 0x2470
 			// Header size: 12
-			// Code size: 57 (0x39)
+			// Code size: 102 (0x66)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] float64,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -400,15 +489,42 @@
 			IL_0025: stloc.1
 			IL_0026: ldarg.2
 			IL_0027: stloc.2
-			IL_0028: ldnull
-			IL_0029: ldstr "arg-string"
-			IL_002e: ldloc.0
-			IL_002f: ldloc.1
-			IL_0030: ldloc.2
-			IL_0031: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-			IL_0036: pop
-			IL_0037: ldnull
-			IL_0038: ret
+			IL_0028: ldarg.0
+			IL_0029: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+			IL_002e: stloc.s 4
+			IL_0030: ldc.i4.1
+			IL_0031: newarr [System.Runtime]System.Object
+			IL_0036: dup
+			IL_0037: ldc.i4.0
+			IL_0038: ldarg.0
+			IL_0039: stelem.ref
+			IL_003a: stloc.s 5
+			IL_003c: ldc.i4.4
+			IL_003d: newarr [System.Runtime]System.Object
+			IL_0042: dup
+			IL_0043: ldc.i4.0
+			IL_0044: ldstr "arg-string"
+			IL_0049: stelem.ref
+			IL_004a: dup
+			IL_004b: ldc.i4.1
+			IL_004c: ldloc.0
+			IL_004d: stelem.ref
+			IL_004e: dup
+			IL_004f: ldc.i4.2
+			IL_0050: ldloc.1
+			IL_0051: stelem.ref
+			IL_0052: dup
+			IL_0053: ldc.i4.3
+			IL_0054: ldloc.2
+			IL_0055: stelem.ref
+			IL_0056: stloc.s 6
+			IL_0058: ldloc.s 4
+			IL_005a: ldloc.s 5
+			IL_005c: ldloc.s 6
+			IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0063: pop
+			IL_0064: ldnull
+			IL_0065: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -446,7 +562,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23d5
+			// Method begins at RVA 0x24e2
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -472,7 +588,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 506 (0x1fa)
+		// Code size: 591 (0x24f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix/Scope,
@@ -487,9 +603,11 @@
 			[9] string,
 			[10] object,
 			[11] object,
-			[12] string,
-			[13] float64,
-			[14] object
+			[12] object[],
+			[13] object[],
+			[14] string,
+			[15] float64,
+			[16] object
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/Scope::.ctor()
@@ -608,78 +726,122 @@
 		IL_0121: stloc.s 11
 		IL_0123: ldloc.s 11
 		IL_0125: stloc.s 8
-		IL_0127: ldnull
-		IL_0128: ldstr "global-double"
-		IL_012d: ldloc.s 6
-		IL_012f: ldloc.s 7
-		IL_0131: ldloc.s 8
-		IL_0133: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_0138: pop
-		IL_0139: ldloc.0
-		IL_013a: ldc.r8 3
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
-		IL_014d: ldloc.0
-		IL_014e: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0153: ldnull
-		IL_0154: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_0159: pop
-		IL_015a: ldloc.0
-		IL_015b: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0160: ldnull
-		IL_0161: ldc.r8 3
-		IL_016a: box [System.Runtime]System.Double
-		IL_016f: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
-		IL_0174: pop
-		IL_0175: ldstr "3"
-		IL_017a: stloc.s 9
-		IL_017c: ldloc.s 9
-		IL_017e: stloc.s 12
-		IL_0180: ldloc.s 12
-		IL_0182: stloc.s 6
-		IL_0184: ldloc.s 9
-		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_018b: stloc.s 13
-		IL_018d: ldloc.s 13
-		IL_018f: box [System.Runtime]System.Double
-		IL_0194: stloc.s 11
-		IL_0196: ldloc.s 13
-		IL_0198: ldc.r8 1
-		IL_01a1: add
-		IL_01a2: stloc.s 13
-		IL_01a4: ldloc.s 13
-		IL_01a6: box [System.Runtime]System.Double
-		IL_01ab: stloc.s 14
-		IL_01ad: ldloc.s 14
-		IL_01af: stloc.s 9
-		IL_01b1: ldloc.s 11
-		IL_01b3: stloc.s 7
-		IL_01b5: ldloc.s 9
-		IL_01b7: stloc.s 11
-		IL_01b9: ldloc.s 11
-		IL_01bb: stloc.s 8
-		IL_01bd: ldnull
-		IL_01be: ldstr "global-string"
-		IL_01c3: ldloc.s 6
-		IL_01c5: ldloc.s 7
-		IL_01c7: ldloc.s 8
-		IL_01c9: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, object, object, object, object)
-		IL_01ce: pop
-		IL_01cf: ldloc.0
-		IL_01d0: ldstr "3"
-		IL_01d5: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
-		IL_01da: ldloc.0
-		IL_01db: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_01e0: ldnull
-		IL_01e1: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_01e6: pop
+		IL_0127: ldloc.0
+		IL_0128: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+		IL_012d: stloc.s 10
+		IL_012f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0134: stloc.s 12
+		IL_0136: ldc.i4.4
+		IL_0137: newarr [System.Runtime]System.Object
+		IL_013c: dup
+		IL_013d: ldc.i4.0
+		IL_013e: ldstr "global-double"
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.1
+		IL_0146: ldloc.s 6
+		IL_0148: stelem.ref
+		IL_0149: dup
+		IL_014a: ldc.i4.2
+		IL_014b: ldloc.s 7
+		IL_014d: stelem.ref
+		IL_014e: dup
+		IL_014f: ldc.i4.3
+		IL_0150: ldloc.s 8
+		IL_0152: stelem.ref
+		IL_0153: stloc.s 13
+		IL_0155: ldloc.s 10
+		IL_0157: ldloc.s 12
+		IL_0159: ldloc.s 13
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0160: pop
+		IL_0161: ldloc.0
+		IL_0162: ldc.r8 3
+		IL_016b: box [System.Runtime]System.Double
+		IL_0170: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalDouble
+		IL_0175: ldloc.1
+		IL_0176: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0180: pop
+		IL_0181: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0186: stloc.s 13
+		IL_0188: ldloc.2
+		IL_0189: ldloc.s 13
+		IL_018b: ldc.r8 3
+		IL_0194: box [System.Runtime]System.Double
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_019e: pop
+		IL_019f: ldstr "3"
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 9
+		IL_01a8: stloc.s 14
+		IL_01aa: ldloc.s 14
+		IL_01ac: stloc.s 6
+		IL_01ae: ldloc.s 9
+		IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01b5: stloc.s 15
+		IL_01b7: ldloc.s 15
+		IL_01b9: box [System.Runtime]System.Double
+		IL_01be: stloc.s 11
+		IL_01c0: ldloc.s 15
+		IL_01c2: ldc.r8 1
+		IL_01cb: add
+		IL_01cc: stloc.s 15
+		IL_01ce: ldloc.s 15
+		IL_01d0: box [System.Runtime]System.Double
+		IL_01d5: stloc.s 16
+		IL_01d7: ldloc.s 16
+		IL_01d9: stloc.s 9
+		IL_01db: ldloc.s 11
+		IL_01dd: stloc.s 7
+		IL_01df: ldloc.s 9
+		IL_01e1: stloc.s 11
+		IL_01e3: ldloc.s 11
+		IL_01e5: stloc.s 8
 		IL_01e7: ldloc.0
-		IL_01e8: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_01ed: ldnull
-		IL_01ee: ldstr "3"
-		IL_01f3: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
-		IL_01f8: pop
-		IL_01f9: ret
+		IL_01e8: ldfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::logCase
+		IL_01ed: stloc.s 10
+		IL_01ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01f4: stloc.s 13
+		IL_01f6: ldc.i4.4
+		IL_01f7: newarr [System.Runtime]System.Object
+		IL_01fc: dup
+		IL_01fd: ldc.i4.0
+		IL_01fe: ldstr "global-string"
+		IL_0203: stelem.ref
+		IL_0204: dup
+		IL_0205: ldc.i4.1
+		IL_0206: ldloc.s 6
+		IL_0208: stelem.ref
+		IL_0209: dup
+		IL_020a: ldc.i4.2
+		IL_020b: ldloc.s 7
+		IL_020d: stelem.ref
+		IL_020e: dup
+		IL_020f: ldc.i4.3
+		IL_0210: ldloc.s 8
+		IL_0212: stelem.ref
+		IL_0213: stloc.s 12
+		IL_0215: ldloc.s 10
+		IL_0217: ldloc.s 13
+		IL_0219: ldloc.s 12
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0220: pop
+		IL_0221: ldloc.0
+		IL_0222: ldstr "3"
+		IL_0227: stfld object Modules.UnaryOperator_PlusPlusPostfix/Scope::capturedGlobalString
+		IL_022c: ldloc.3
+		IL_022d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0237: pop
+		IL_0238: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_023d: stloc.s 12
+		IL_023f: ldloc.s 4
+		IL_0241: ldloc.s 12
+		IL_0243: ldstr "3"
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_024d: pop
+		IL_024e: ret
 	} // end of method UnaryOperator_PlusPlusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix
@@ -691,7 +853,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x240b
+		// Method begins at RVA 0x2518
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d4
+					// Method begins at RVA 0x21ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 274 (0x112)
 			.maxstack 8
@@ -200,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c2
+			// Method begins at RVA 0x21da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -226,12 +226,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/Scope::.ctor()
@@ -248,19 +249,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
@@ -272,7 +282,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dd
+		// Method begins at RVA 0x21f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e3
+					// Method begins at RVA 0x21fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 289 (0x121)
 			.maxstack 8
@@ -214,7 +214,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d1
+			// Method begins at RVA 0x21e9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -240,12 +240,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/Scope::.ctor()
@@ -262,19 +263,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
@@ -286,7 +296,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ec
+		// Method begins at RVA 0x2204
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23b5
+				// Method begins at RVA 0x24be
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -45,7 +45,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x2251
+			// Method begins at RVA 0x22a6
 			// Header size: 1
 			// Code size: 36 (0x24)
 			.maxstack 8
@@ -88,7 +88,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23be
+				// Method begins at RVA 0x24c7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -114,16 +114,19 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2278
+			// Method begins at RVA 0x22cc
 			// Header size: 12
-			// Code size: 93 (0x5d)
+			// Code size: 138 (0x8a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] object,
 				[2] float64,
 				[3] object,
-				[4] object
+				[4] object,
+				[5] object[],
+				[6] object,
+				[7] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -146,21 +149,48 @@
 			IL_0031: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
 			IL_0036: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 			IL_003b: stloc.2
-			IL_003c: ldloc.0
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: stloc.3
-			IL_0043: ldloc.2
-			IL_0044: box [System.Runtime]System.Double
-			IL_0049: stloc.s 4
-			IL_004b: ldnull
-			IL_004c: ldstr "captured-double"
-			IL_0051: ldloc.3
-			IL_0052: ldloc.1
-			IL_0053: ldloc.s 4
-			IL_0055: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_005a: pop
-			IL_005b: ldnull
-			IL_005c: ret
+			IL_003c: ldarg.0
+			IL_003d: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_0042: stloc.s 4
+			IL_0044: ldc.i4.1
+			IL_0045: newarr [System.Runtime]System.Object
+			IL_004a: dup
+			IL_004b: ldc.i4.0
+			IL_004c: ldarg.0
+			IL_004d: stelem.ref
+			IL_004e: stloc.s 5
+			IL_0050: ldloc.0
+			IL_0051: box [System.Runtime]System.Double
+			IL_0056: stloc.3
+			IL_0057: ldloc.2
+			IL_0058: box [System.Runtime]System.Double
+			IL_005d: stloc.s 6
+			IL_005f: ldc.i4.4
+			IL_0060: newarr [System.Runtime]System.Object
+			IL_0065: dup
+			IL_0066: ldc.i4.0
+			IL_0067: ldstr "captured-double"
+			IL_006c: stelem.ref
+			IL_006d: dup
+			IL_006e: ldc.i4.1
+			IL_006f: ldloc.3
+			IL_0070: stelem.ref
+			IL_0071: dup
+			IL_0072: ldc.i4.2
+			IL_0073: ldloc.1
+			IL_0074: stelem.ref
+			IL_0075: dup
+			IL_0076: ldc.i4.3
+			IL_0077: ldloc.s 6
+			IL_0079: stelem.ref
+			IL_007a: stloc.s 7
+			IL_007c: ldloc.s 4
+			IL_007e: ldloc.s 5
+			IL_0080: ldloc.s 7
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_0087: pop
+			IL_0088: ldnull
+			IL_0089: ret
 		} // end of method capturedDouble::__js_call__
 
 	} // end of class capturedDouble
@@ -176,7 +206,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23c7
+				// Method begins at RVA 0x24d0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -203,15 +233,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22e4
+			// Method begins at RVA 0x2364
 			// Header size: 12
-			// Code size: 48 (0x30)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object
+				[3] object,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -228,15 +261,42 @@
 			IL_001c: stloc.1
 			IL_001d: ldarg.2
 			IL_001e: stloc.2
-			IL_001f: ldnull
-			IL_0020: ldstr "arg-double"
-			IL_0025: ldloc.0
-			IL_0026: ldloc.1
-			IL_0027: ldloc.2
-			IL_0028: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_002d: pop
-			IL_002e: ldnull
-			IL_002f: ret
+			IL_001f: ldarg.0
+			IL_0020: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_0025: stloc.s 4
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-double"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argDouble::__js_call__
 
 	} // end of class argDouble
@@ -252,7 +312,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d0
+				// Method begins at RVA 0x24d9
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -278,15 +338,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2320
+			// Method begins at RVA 0x23d0
 			// Header size: 12
-			// Code size: 67 (0x43)
+			// Code size: 112 (0x70)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object
+				[3] object,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.0
@@ -307,15 +370,42 @@
 			IL_002b: ldarg.0
 			IL_002c: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
 			IL_0031: stloc.2
-			IL_0032: ldnull
-			IL_0033: ldstr "captured-string"
-			IL_0038: ldloc.0
-			IL_0039: ldloc.1
-			IL_003a: ldloc.2
-			IL_003b: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_0040: pop
-			IL_0041: ldnull
-			IL_0042: ret
+			IL_0032: ldarg.0
+			IL_0033: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_0038: stloc.s 4
+			IL_003a: ldc.i4.1
+			IL_003b: newarr [System.Runtime]System.Object
+			IL_0040: dup
+			IL_0041: ldc.i4.0
+			IL_0042: ldarg.0
+			IL_0043: stelem.ref
+			IL_0044: stloc.s 5
+			IL_0046: ldc.i4.4
+			IL_0047: newarr [System.Runtime]System.Object
+			IL_004c: dup
+			IL_004d: ldc.i4.0
+			IL_004e: ldstr "captured-string"
+			IL_0053: stelem.ref
+			IL_0054: dup
+			IL_0055: ldc.i4.1
+			IL_0056: ldloc.0
+			IL_0057: stelem.ref
+			IL_0058: dup
+			IL_0059: ldc.i4.2
+			IL_005a: ldloc.1
+			IL_005b: stelem.ref
+			IL_005c: dup
+			IL_005d: ldc.i4.3
+			IL_005e: ldloc.2
+			IL_005f: stelem.ref
+			IL_0060: stloc.s 6
+			IL_0062: ldloc.s 4
+			IL_0064: ldloc.s 5
+			IL_0066: ldloc.s 6
+			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_006d: pop
+			IL_006e: ldnull
+			IL_006f: ret
 		} // end of method capturedString::__js_call__
 
 	} // end of class capturedString
@@ -331,7 +421,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x23d9
+				// Method begins at RVA 0x24e2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -358,15 +448,18 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2370
+			// Method begins at RVA 0x244c
 			// Header size: 12
-			// Code size: 48 (0x30)
+			// Code size: 93 (0x5d)
 			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
-				[3] object
+				[3] object,
+				[4] object,
+				[5] object[],
+				[6] object[]
 			)
 
 			IL_0000: ldarg.2
@@ -383,15 +476,42 @@
 			IL_001c: stloc.1
 			IL_001d: ldarg.2
 			IL_001e: stloc.2
-			IL_001f: ldnull
-			IL_0020: ldstr "arg-string"
-			IL_0025: ldloc.0
-			IL_0026: ldloc.1
-			IL_0027: ldloc.2
-			IL_0028: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-			IL_002d: pop
-			IL_002e: ldnull
-			IL_002f: ret
+			IL_001f: ldarg.0
+			IL_0020: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+			IL_0025: stloc.s 4
+			IL_0027: ldc.i4.1
+			IL_0028: newarr [System.Runtime]System.Object
+			IL_002d: dup
+			IL_002e: ldc.i4.0
+			IL_002f: ldarg.0
+			IL_0030: stelem.ref
+			IL_0031: stloc.s 5
+			IL_0033: ldc.i4.4
+			IL_0034: newarr [System.Runtime]System.Object
+			IL_0039: dup
+			IL_003a: ldc.i4.0
+			IL_003b: ldstr "arg-string"
+			IL_0040: stelem.ref
+			IL_0041: dup
+			IL_0042: ldc.i4.1
+			IL_0043: ldloc.0
+			IL_0044: stelem.ref
+			IL_0045: dup
+			IL_0046: ldc.i4.2
+			IL_0047: ldloc.1
+			IL_0048: stelem.ref
+			IL_0049: dup
+			IL_004a: ldc.i4.3
+			IL_004b: ldloc.2
+			IL_004c: stelem.ref
+			IL_004d: stloc.s 6
+			IL_004f: ldloc.s 4
+			IL_0051: ldloc.s 5
+			IL_0053: ldloc.s 6
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+			IL_005a: pop
+			IL_005b: ldnull
+			IL_005c: ret
 		} // end of method argString::__js_call__
 
 	} // end of class argString
@@ -429,7 +549,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x23ac
+			// Method begins at RVA 0x24b5
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -455,7 +575,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 501 (0x1f5)
+		// Code size: 586 (0x24a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix/Scope,
@@ -470,8 +590,10 @@
 			[9] string,
 			[10] object,
 			[11] object,
-			[12] string,
-			[13] float64
+			[12] object[],
+			[13] object[],
+			[14] string,
+			[15] float64
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/Scope::.ctor()
@@ -590,77 +712,121 @@
 		IL_0121: stloc.s 11
 		IL_0123: ldloc.s 11
 		IL_0125: stloc.s 8
-		IL_0127: ldnull
-		IL_0128: ldstr "global-double"
-		IL_012d: ldloc.s 6
-		IL_012f: ldloc.s 7
-		IL_0131: ldloc.s 8
-		IL_0133: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_0138: pop
-		IL_0139: ldloc.0
-		IL_013a: ldc.r8 3
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
-		IL_014d: ldloc.0
-		IL_014e: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0153: ldnull
-		IL_0154: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_0159: pop
-		IL_015a: ldloc.0
-		IL_015b: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0160: ldnull
-		IL_0161: ldc.r8 3
-		IL_016a: box [System.Runtime]System.Double
-		IL_016f: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
-		IL_0174: pop
-		IL_0175: ldstr "3"
-		IL_017a: stloc.s 9
-		IL_017c: ldloc.s 9
-		IL_017e: stloc.s 12
-		IL_0180: ldloc.s 12
-		IL_0182: stloc.s 6
-		IL_0184: ldloc.s 9
-		IL_0186: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_018b: stloc.s 13
-		IL_018d: ldloc.s 13
-		IL_018f: ldc.r8 1
-		IL_0198: add
-		IL_0199: stloc.s 13
-		IL_019b: ldloc.s 13
-		IL_019d: box [System.Runtime]System.Double
-		IL_01a2: stloc.s 11
-		IL_01a4: ldloc.s 11
-		IL_01a6: stloc.s 9
-		IL_01a8: ldloc.s 9
-		IL_01aa: stloc.s 11
-		IL_01ac: ldloc.s 11
-		IL_01ae: stloc.s 7
-		IL_01b0: ldloc.s 9
-		IL_01b2: stloc.s 11
-		IL_01b4: ldloc.s 11
-		IL_01b6: stloc.s 8
-		IL_01b8: ldnull
-		IL_01b9: ldstr "global-string"
-		IL_01be: ldloc.s 6
-		IL_01c0: ldloc.s 7
-		IL_01c2: ldloc.s 8
-		IL_01c4: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, object, object, object, object)
-		IL_01c9: pop
-		IL_01ca: ldloc.0
-		IL_01cb: ldstr "3"
-		IL_01d0: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
-		IL_01d5: ldloc.0
-		IL_01d6: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_01db: ldnull
-		IL_01dc: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_01e1: pop
+		IL_0127: ldloc.0
+		IL_0128: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+		IL_012d: stloc.s 10
+		IL_012f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0134: stloc.s 12
+		IL_0136: ldc.i4.4
+		IL_0137: newarr [System.Runtime]System.Object
+		IL_013c: dup
+		IL_013d: ldc.i4.0
+		IL_013e: ldstr "global-double"
+		IL_0143: stelem.ref
+		IL_0144: dup
+		IL_0145: ldc.i4.1
+		IL_0146: ldloc.s 6
+		IL_0148: stelem.ref
+		IL_0149: dup
+		IL_014a: ldc.i4.2
+		IL_014b: ldloc.s 7
+		IL_014d: stelem.ref
+		IL_014e: dup
+		IL_014f: ldc.i4.3
+		IL_0150: ldloc.s 8
+		IL_0152: stelem.ref
+		IL_0153: stloc.s 13
+		IL_0155: ldloc.s 10
+		IL_0157: ldloc.s 12
+		IL_0159: ldloc.s 13
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_0160: pop
+		IL_0161: ldloc.0
+		IL_0162: ldc.r8 3
+		IL_016b: box [System.Runtime]System.Double
+		IL_0170: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalDouble
+		IL_0175: ldloc.1
+		IL_0176: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0180: pop
+		IL_0181: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0186: stloc.s 13
+		IL_0188: ldloc.2
+		IL_0189: ldloc.s 13
+		IL_018b: ldc.r8 3
+		IL_0194: box [System.Runtime]System.Double
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_019e: pop
+		IL_019f: ldstr "3"
+		IL_01a4: stloc.s 9
+		IL_01a6: ldloc.s 9
+		IL_01a8: stloc.s 14
+		IL_01aa: ldloc.s 14
+		IL_01ac: stloc.s 6
+		IL_01ae: ldloc.s 9
+		IL_01b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01b5: stloc.s 15
+		IL_01b7: ldloc.s 15
+		IL_01b9: ldc.r8 1
+		IL_01c2: add
+		IL_01c3: stloc.s 15
+		IL_01c5: ldloc.s 15
+		IL_01c7: box [System.Runtime]System.Double
+		IL_01cc: stloc.s 11
+		IL_01ce: ldloc.s 11
+		IL_01d0: stloc.s 9
+		IL_01d2: ldloc.s 9
+		IL_01d4: stloc.s 11
+		IL_01d6: ldloc.s 11
+		IL_01d8: stloc.s 7
+		IL_01da: ldloc.s 9
+		IL_01dc: stloc.s 11
+		IL_01de: ldloc.s 11
+		IL_01e0: stloc.s 8
 		IL_01e2: ldloc.0
-		IL_01e3: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_01e8: ldnull
-		IL_01e9: ldstr "3"
-		IL_01ee: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
-		IL_01f3: pop
-		IL_01f4: ret
+		IL_01e3: ldfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::logCase
+		IL_01e8: stloc.s 10
+		IL_01ea: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01ef: stloc.s 13
+		IL_01f1: ldc.i4.4
+		IL_01f2: newarr [System.Runtime]System.Object
+		IL_01f7: dup
+		IL_01f8: ldc.i4.0
+		IL_01f9: ldstr "global-string"
+		IL_01fe: stelem.ref
+		IL_01ff: dup
+		IL_0200: ldc.i4.1
+		IL_0201: ldloc.s 6
+		IL_0203: stelem.ref
+		IL_0204: dup
+		IL_0205: ldc.i4.2
+		IL_0206: ldloc.s 7
+		IL_0208: stelem.ref
+		IL_0209: dup
+		IL_020a: ldc.i4.3
+		IL_020b: ldloc.s 8
+		IL_020d: stelem.ref
+		IL_020e: stloc.s 12
+		IL_0210: ldloc.s 10
+		IL_0212: ldloc.s 13
+		IL_0214: ldloc.s 12
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs(object, object[], object[])
+		IL_021b: pop
+		IL_021c: ldloc.0
+		IL_021d: ldstr "3"
+		IL_0222: stfld object Modules.UnaryOperator_PlusPlusPrefix/Scope::capturedGlobalString
+		IL_0227: ldloc.3
+		IL_0228: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_022d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0232: pop
+		IL_0233: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0238: stloc.s 12
+		IL_023a: ldloc.s 4
+		IL_023c: ldloc.s 12
+		IL_023e: ldstr "3"
+		IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0248: pop
+		IL_0249: ret
 	} // end of method UnaryOperator_PlusPlusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix
@@ -672,7 +838,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x23e2
+		// Method begins at RVA 0x24eb
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21d4
+					// Method begins at RVA 0x21ec
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21cb
+				// Method begins at RVA 0x21e3
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 274 (0x112)
 			.maxstack 8
@@ -200,7 +200,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21c2
+			// Method begins at RVA 0x21da
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -226,12 +226,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/Scope::.ctor()
@@ -248,19 +249,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
@@ -272,7 +282,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21dd
+		// Method begins at RVA 0x21f5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x21e3
+					// Method begins at RVA 0x21fb
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -40,7 +40,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x21da
+				// Method begins at RVA 0x21f2
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -64,7 +64,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a4
+			// Method begins at RVA 0x20bc
 			// Header size: 12
 			// Code size: 289 (0x121)
 			.maxstack 8
@@ -214,7 +214,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x21d1
+			// Method begins at RVA 0x21e9
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -240,12 +240,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 72 (0x48)
+		// Code size: 93 (0x5d)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/Scope::.ctor()
@@ -262,19 +263,28 @@
 		IL_0020: stloc.2
 		IL_0021: ldloc.2
 		IL_0022: stloc.1
-		IL_0023: ldnull
-		IL_0024: ldstr "major"
-		IL_0029: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_002e: pop
-		IL_002f: ldnull
-		IL_0030: ldstr "minor"
-		IL_0035: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_003a: pop
-		IL_003b: ldnull
-		IL_003c: ldstr "patch"
-		IL_0041: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0046: pop
-		IL_0047: ret
+		IL_0023: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0028: stloc.3
+		IL_0029: ldloc.1
+		IL_002a: ldloc.3
+		IL_002b: ldstr "major"
+		IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0035: pop
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: stloc.3
+		IL_003c: ldloc.1
+		IL_003d: ldloc.3
+		IL_003e: ldstr "minor"
+		IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0048: pop
+		IL_0049: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004e: stloc.3
+		IL_004f: ldloc.1
+		IL_0050: ldloc.3
+		IL_0051: ldstr "patch"
+		IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_005b: pop
+		IL_005c: ret
 	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
@@ -286,7 +296,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x21ec
+		// Method begins at RVA 0x2204
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20dd
+				// Method begins at RVA 0x20dc
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20bb
+			// Method begins at RVA 0x20ba
 			// Header size: 1
 			// Code size: 24 (0x18)
 			.maxstack 8
@@ -80,7 +80,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d4
+			// Method begins at RVA 0x20d3
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -106,7 +106,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 95 (0x5f)
+		// Code size: 94 (0x5e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_BoolStringFieldType/Scope,
@@ -142,16 +142,15 @@
 		IL_003a: ldloc.0
 		IL_003b: ldstr "typed"
 		IL_0040: stfld string Modules.Variable_CapturedConst_BoolStringFieldType/Scope::NAME
-		IL_0045: ldloc.0
-		IL_0046: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
-		IL_004b: ldnull
-		IL_004c: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
-		IL_0051: stloc.2
-		IL_0052: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0057: ldloc.2
-		IL_0058: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005d: pop
-		IL_005e: ret
+		IL_0045: ldloc.1
+		IL_0046: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0050: stloc.2
+		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0056: ldloc.2
+		IL_0057: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005c: pop
+		IL_005d: ret
 	} // end of method Variable_CapturedConst_BoolStringFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_BoolStringFieldType
@@ -163,7 +162,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e6
+		// Method begins at RVA 0x20e5
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20d8
+				// Method begins at RVA 0x20d7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
-			// Method begins at RVA 0x20b8
+			// Method begins at RVA 0x20b7
 			// Header size: 1
 			// Code size: 22 (0x16)
 			.maxstack 8
@@ -76,7 +76,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20cf
+			// Method begins at RVA 0x20ce
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -102,7 +102,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 92 (0x5c)
+		// Code size: 91 (0x5b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_NumberFieldType/Scope,
@@ -135,16 +135,15 @@
 		IL_0033: ldloc.0
 		IL_0034: ldc.r8 1000
 		IL_003d: stfld float64 Modules.Variable_CapturedConst_NumberFieldType/Scope::NOW_UNITS_PER_SECOND
-		IL_0042: ldloc.0
-		IL_0043: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
-		IL_0048: ldnull
-		IL_0049: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
-		IL_004e: stloc.2
-		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0054: ldloc.2
-		IL_0055: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005a: pop
-		IL_005b: ret
+		IL_0042: ldloc.1
+		IL_0043: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_004d: stloc.2
+		IL_004e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0053: ldloc.2
+		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0059: pop
+		IL_005a: ret
 	} // end of method Variable_CapturedConst_NumberFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_NumberFieldType
@@ -156,7 +155,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e1
+		// Method begins at RVA 0x20e0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage
+﻿// IL code: Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x246e
+					// Method begins at RVA 0x248a
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -42,7 +42,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x2477
+					// Method begins at RVA 0x2493
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -60,7 +60,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2465
+				// Method begins at RVA 0x2481
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -84,7 +84,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x21d8
+			// Method begins at RVA 0x21f4
 			// Header size: 12
 			// Code size: 144 (0x90)
 			.maxstack 8
@@ -176,7 +176,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2480
+				// Method begins at RVA 0x249c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -202,7 +202,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x22a0
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -247,7 +247,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2489
+				// Method begins at RVA 0x24a5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -273,7 +273,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x22c8
+			// Method begins at RVA 0x22e4
 			// Header size: 12
 			// Code size: 54 (0x36)
 			.maxstack 8
@@ -318,7 +318,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2492
+				// Method begins at RVA 0x24ae
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -344,7 +344,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x230c
+			// Method begins at RVA 0x2328
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -445,7 +445,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x249b
+				// Method begins at RVA 0x24b7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -471,7 +471,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 08 00 00 02
 			)
-			// Method begins at RVA 0x23b4
+			// Method begins at RVA 0x23d0
 			// Header size: 12
 			// Code size: 140 (0x8c)
 			.maxstack 8
@@ -578,7 +578,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x245c
+			// Method begins at RVA 0x2478
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -604,12 +604,13 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 378 (0x17a)
+		// Code size: 406 (0x196)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope,
 			[1] object,
-			[2] object
+			[2] object,
+			[3] object[]
 		)
 
 		IL_0000: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::.ctor()
@@ -630,141 +631,153 @@
 		IL_0024: ldc.i4.0
 		IL_0025: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
 		IL_002a: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
-		IL_002f: ldc.i4.1
-		IL_0030: newarr [System.Runtime]System.Object
-		IL_0035: dup
-		IL_0036: ldc.i4.0
-		IL_0037: ldloc.0
-		IL_0038: stelem.ref
-		IL_0039: ldc.i4.0
-		IL_003a: ldelem.ref
-		IL_003b: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_0040: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
-		IL_0046: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_004b: ldc.i4.1
-		IL_004c: newarr [System.Runtime]System.Object
-		IL_0051: dup
-		IL_0052: ldc.i4.0
-		IL_0053: ldloc.0
-		IL_0054: stelem.ref
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_005f: ldc.i4.0
-		IL_0060: conv.r8
-		IL_0061: ldstr ""
-		IL_0066: ldc.i4.0
-		IL_0067: ldc.i4.1
-		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0072: stloc.2
-		IL_0073: ldnull
-		IL_0074: ldloc.2
-		IL_0075: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
-		IL_007a: pop
-		IL_007b: ldloc.0
-		IL_007c: ldnull
-		IL_007d: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
-		IL_0082: ldc.i4.1
-		IL_0083: newarr [System.Runtime]System.Object
-		IL_0088: dup
-		IL_0089: ldc.i4.0
-		IL_008a: ldloc.0
-		IL_008b: stelem.ref
-		IL_008c: ldc.i4.0
-		IL_008d: ldelem.ref
-		IL_008e: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_0093: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
-		IL_0099: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_009e: ldc.i4.1
-		IL_009f: newarr [System.Runtime]System.Object
-		IL_00a4: dup
-		IL_00a5: ldc.i4.0
-		IL_00a6: ldloc.0
-		IL_00a7: stelem.ref
-		IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0034: stloc.3
+		IL_0035: ldc.i4.1
+		IL_0036: newarr [System.Runtime]System.Object
+		IL_003b: dup
+		IL_003c: ldc.i4.0
+		IL_003d: ldloc.0
+		IL_003e: stelem.ref
+		IL_003f: ldc.i4.0
+		IL_0040: ldelem.ref
+		IL_0041: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_0046: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
+		IL_004c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0051: ldc.i4.1
+		IL_0052: newarr [System.Runtime]System.Object
+		IL_0057: dup
+		IL_0058: ldc.i4.0
+		IL_0059: ldloc.0
+		IL_005a: stelem.ref
+		IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0065: ldc.i4.0
+		IL_0066: conv.r8
+		IL_0067: ldstr ""
+		IL_006c: ldc.i4.0
+		IL_006d: ldc.i4.1
+		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0078: stloc.2
+		IL_0079: ldloc.1
+		IL_007a: ldloc.3
+		IL_007b: ldloc.2
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0081: pop
+		IL_0082: ldloc.0
+		IL_0083: ldnull
+		IL_0084: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::x
+		IL_0089: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_008e: stloc.3
+		IL_008f: ldc.i4.1
+		IL_0090: newarr [System.Runtime]System.Object
+		IL_0095: dup
+		IL_0096: ldc.i4.0
+		IL_0097: ldloc.0
+		IL_0098: stelem.ref
+		IL_0099: ldc.i4.0
+		IL_009a: ldelem.ref
+		IL_009b: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_00a0: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L18C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
+		IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_00ab: ldc.i4.1
+		IL_00ac: newarr [System.Runtime]System.Object
+		IL_00b1: dup
 		IL_00b2: ldc.i4.0
-		IL_00b3: conv.r8
-		IL_00b4: ldstr ""
-		IL_00b9: ldc.i4.0
-		IL_00ba: ldc.i4.1
-		IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_00c5: stloc.2
-		IL_00c6: ldnull
-		IL_00c7: ldloc.2
-		IL_00c8: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
-		IL_00cd: pop
-		IL_00ce: ldloc.0
-		IL_00cf: ldc.i4.0
-		IL_00d0: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_00d5: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
-		IL_00da: ldc.i4.1
-		IL_00db: newarr [System.Runtime]System.Object
-		IL_00e0: dup
-		IL_00e1: ldc.i4.0
-		IL_00e2: ldloc.0
-		IL_00e3: stelem.ref
-		IL_00e4: ldc.i4.0
-		IL_00e5: ldelem.ref
-		IL_00e6: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_00eb: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
-		IL_00f1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_00f6: ldc.i4.1
-		IL_00f7: newarr [System.Runtime]System.Object
-		IL_00fc: dup
-		IL_00fd: ldc.i4.0
-		IL_00fe: ldloc.0
-		IL_00ff: stelem.ref
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_010a: ldc.i4.0
-		IL_010b: conv.r8
-		IL_010c: ldstr ""
+		IL_00b3: ldloc.0
+		IL_00b4: stelem.ref
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_00bf: ldc.i4.0
+		IL_00c0: conv.r8
+		IL_00c1: ldstr ""
+		IL_00c6: ldc.i4.0
+		IL_00c7: ldc.i4.1
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_00d2: stloc.2
+		IL_00d3: ldloc.1
+		IL_00d4: ldloc.3
+		IL_00d5: ldloc.2
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_00db: pop
+		IL_00dc: ldloc.0
+		IL_00dd: ldc.i4.0
+		IL_00de: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_00e3: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
+		IL_00e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00ed: stloc.3
+		IL_00ee: ldc.i4.1
+		IL_00ef: newarr [System.Runtime]System.Object
+		IL_00f4: dup
+		IL_00f5: ldc.i4.0
+		IL_00f6: ldloc.0
+		IL_00f7: stelem.ref
+		IL_00f8: ldc.i4.0
+		IL_00f9: ldelem.ref
+		IL_00fa: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_00ff: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L24C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
+		IL_0105: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_010a: ldc.i4.1
+		IL_010b: newarr [System.Runtime]System.Object
+		IL_0110: dup
 		IL_0111: ldc.i4.0
-		IL_0112: ldc.i4.1
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_011d: stloc.2
-		IL_011e: ldnull
-		IL_011f: ldloc.2
-		IL_0120: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
-		IL_0125: pop
-		IL_0126: ldloc.0
-		IL_0127: ldnull
-		IL_0128: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
-		IL_012d: ldc.i4.1
-		IL_012e: newarr [System.Runtime]System.Object
-		IL_0133: dup
-		IL_0134: ldc.i4.0
-		IL_0135: ldloc.0
-		IL_0136: stelem.ref
-		IL_0137: ldc.i4.0
-		IL_0138: ldelem.ref
-		IL_0139: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
-		IL_013e: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
-		IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_0149: ldc.i4.1
-		IL_014a: newarr [System.Runtime]System.Object
-		IL_014f: dup
-		IL_0150: ldc.i4.0
-		IL_0151: ldloc.0
-		IL_0152: stelem.ref
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_015d: ldc.i4.0
-		IL_015e: conv.r8
-		IL_015f: ldstr ""
-		IL_0164: ldc.i4.0
-		IL_0165: ldc.i4.1
-		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0170: stloc.2
-		IL_0171: ldnull
-		IL_0172: ldloc.2
-		IL_0173: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
-		IL_0178: pop
-		IL_0179: ret
+		IL_0112: ldloc.0
+		IL_0113: stelem.ref
+		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_011e: ldc.i4.0
+		IL_011f: conv.r8
+		IL_0120: ldstr ""
+		IL_0125: ldc.i4.0
+		IL_0126: ldc.i4.1
+		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_012c: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0131: stloc.2
+		IL_0132: ldloc.1
+		IL_0133: ldloc.3
+		IL_0134: ldloc.2
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_013a: pop
+		IL_013b: ldloc.0
+		IL_013c: ldnull
+		IL_013d: stfld object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope::y
+		IL_0142: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0147: stloc.3
+		IL_0148: ldc.i4.1
+		IL_0149: newarr [System.Runtime]System.Object
+		IL_014e: dup
+		IL_014f: ldc.i4.0
+		IL_0150: ldloc.0
+		IL_0151: stelem.ref
+		IL_0152: ldc.i4.0
+		IL_0153: ldelem.ref
+		IL_0154: castclass Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope
+		IL_0159: ldftn object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L30C10::__js_call__(class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope, object)
+		IL_015f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_0164: ldc.i4.1
+		IL_0165: newarr [System.Runtime]System.Object
+		IL_016a: dup
+		IL_016b: ldc.i4.0
+		IL_016c: ldloc.0
+		IL_016d: stelem.ref
+		IL_016e: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0178: ldc.i4.0
+		IL_0179: conv.r8
+		IL_017a: ldstr ""
+		IL_017f: ldc.i4.0
+		IL_0180: ldc.i4.1
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_018b: stloc.2
+		IL_018c: ldloc.1
+		IL_018d: ldloc.3
+		IL_018e: ldloc.2
+		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0194: pop
+		IL_0195: ret
 	} // end of method Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage::__js_module_init__
 
 } // end of class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage
@@ -776,7 +789,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x24a4
+		// Method begins at RVA 0x24c0
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_LetFunctionNestedShadowing
+﻿// IL code: Variable_LetFunctionNestedShadowing
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -22,7 +22,7 @@
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
 				{
-					// Method begins at RVA 0x213d
+					// Method begins at RVA 0x2145
 					// Header size: 1
 					// Code size: 8 (0x8)
 					.maxstack 8
@@ -45,7 +45,7 @@
 				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 					01 00 00 00 00 00 00 00
 				)
-				// Method begins at RVA 0x2100
+				// Method begins at RVA 0x2108
 				// Header size: 12
 				// Code size: 31 (0x1f)
 				.maxstack 8
@@ -83,7 +83,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x2134
+				// Method begins at RVA 0x213c
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -106,9 +106,9 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a8
+			// Method begins at RVA 0x20ac
 			// Header size: 12
-			// Code size: 75 (0x4b)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Variable_LetFunctionNestedShadowing/outer/Scope,
@@ -134,18 +134,19 @@
 			IL_0022: stloc.1
 			IL_0023: ldc.r8 1
 			IL_002c: stloc.2
-			IL_002d: ldnull
-			IL_002e: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
-			IL_0033: pop
-			IL_0034: ldloc.2
-			IL_0035: box [System.Runtime]System.Double
-			IL_003a: stloc.s 4
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: ldloc.s 4
-			IL_0043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0048: pop
-			IL_0049: ldnull
-			IL_004a: ret
+			IL_002d: ldloc.1
+			IL_002e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0038: pop
+			IL_0039: ldloc.2
+			IL_003a: box [System.Runtime]System.Double
+			IL_003f: stloc.s 4
+			IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0046: ldloc.s 4
+			IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_004d: pop
+			IL_004e: ldnull
+			IL_004f: ret
 		} // end of method outer::__js_call__
 
 	} // end of class outer
@@ -164,7 +165,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x212b
+			// Method begins at RVA 0x2133
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -190,7 +191,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 74 (0x4a)
+		// Code size: 79 (0x4f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetFunctionNestedShadowing/Scope,
@@ -216,17 +217,18 @@
 		IL_0022: stloc.1
 		IL_0023: ldc.r8 0.0
 		IL_002c: stloc.2
-		IL_002d: ldnull
-		IL_002e: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
-		IL_0033: pop
-		IL_0034: ldloc.2
-		IL_0035: box [System.Runtime]System.Double
-		IL_003a: stloc.s 4
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: ldloc.s 4
-		IL_0043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0048: pop
-		IL_0049: ret
+		IL_002d: ldloc.1
+		IL_002e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0038: pop
+		IL_0039: ldloc.2
+		IL_003a: box [System.Runtime]System.Double
+		IL_003f: stloc.s 4
+		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0046: ldloc.s 4
+		IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004d: pop
+		IL_004e: ret
 	} // end of method Variable_LetFunctionNestedShadowing::__js_module_init__
 
 } // end of class Modules.Variable_LetFunctionNestedShadowing
@@ -238,7 +240,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x2146
+		// Method begins at RVA 0x214e
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
@@ -1,4 +1,4 @@
-// IL code: Variable_LetShadowing
+﻿// IL code: Variable_LetShadowing
 .class private auto ansi '<Module>'
 {
 } // end of class <Module>
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x20dc
+				// Method begins at RVA 0x20e0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -41,7 +41,7 @@
 			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
 				01 00 00 00 00 00 00 00
 			)
-			// Method begins at RVA 0x20a8
+			// Method begins at RVA 0x20ac
 			// Header size: 12
 			// Code size: 31 (0x1f)
 			.maxstack 8
@@ -78,7 +78,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x20d3
+			// Method begins at RVA 0x20d7
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -104,7 +104,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 74 (0x4a)
+		// Code size: 79 (0x4f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetShadowing/Scope,
@@ -130,17 +130,18 @@
 		IL_0022: stloc.1
 		IL_0023: ldc.r8 1
 		IL_002c: stloc.2
-		IL_002d: ldnull
-		IL_002e: call object Modules.Variable_LetShadowing/f::__js_call__(object)
-		IL_0033: pop
-		IL_0034: ldloc.2
-		IL_0035: box [System.Runtime]System.Double
-		IL_003a: stloc.s 4
-		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0041: ldloc.s 4
-		IL_0043: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0048: pop
-		IL_0049: ret
+		IL_002d: ldloc.1
+		IL_002e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0038: pop
+		IL_0039: ldloc.2
+		IL_003a: box [System.Runtime]System.Double
+		IL_003f: stloc.s 4
+		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0046: ldloc.s 4
+		IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004d: pop
+		IL_004e: ret
 	} // end of method Variable_LetShadowing::__js_module_init__
 
 } // end of class Modules.Variable_LetShadowing
@@ -152,7 +153,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x20e5
+		// Method begins at RVA 0x20e9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
@@ -113,7 +113,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 239 (0xef)
+		// Code size: 238 (0xee)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ObjectDestructuring_Captured/Scope,
@@ -188,17 +188,16 @@
 		IL_00c5: ldfld object Modules.Variable_ObjectDestructuring_Captured/Scope::b
 		IL_00ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
 		IL_00cf: pop
-		IL_00d0: ldloc.0
-		IL_00d1: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
-		IL_00d6: ldnull
-		IL_00d7: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
-		IL_00dc: stloc.3
-		IL_00dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e2: ldstr "compute()="
-		IL_00e7: ldloc.3
-		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00ed: pop
-		IL_00ee: ret
+		IL_00d0: ldloc.1
+		IL_00d1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_00db: stloc.3
+		IL_00dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e1: ldstr "compute()="
+		IL_00e6: ldloc.3
+		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00ec: pop
+		IL_00ed: ret
 	} // end of method Variable_ObjectDestructuring_Captured::__js_module_init__
 
 } // end of class Modules.Variable_ObjectDestructuring_Captured

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
@@ -154,7 +154,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 218 (0xda)
+		// Code size: 217 (0xd9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneCapturedRead/Scope,
@@ -194,68 +194,67 @@
 		{
 			IL_0035: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L7C4::.ctor()
 			IL_003a: stloc.2
-			IL_003b: ldloc.0
-			IL_003c: castclass Modules.Variable_TemporalDeadZoneCapturedRead/Scope
-			IL_0041: ldnull
-			IL_0042: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
-			IL_0047: pop
-			IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_004d: ldstr "NO_TDZ"
-			IL_0052: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0057: pop
-			IL_0058: leave IL_00ac
+			IL_003b: ldloc.1
+			IL_003c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0046: pop
+			IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_004c: ldstr "NO_TDZ"
+			IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0056: pop
+			IL_0057: leave IL_00ab
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_005d: stloc.3
-			IL_005e: ldloc.3
-			IL_005f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0064: dup
-			IL_0065: brtrue IL_007a
+			IL_005c: stloc.3
+			IL_005d: ldloc.3
+			IL_005e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0063: dup
+			IL_0064: brtrue IL_0079
 
-			IL_006a: pop
-			IL_006b: ldloc.3
-			IL_006c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0071: dup
-			IL_0072: brtrue IL_0086
+			IL_0069: pop
+			IL_006a: ldloc.3
+			IL_006b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0070: dup
+			IL_0071: brtrue IL_0085
 
-			IL_0077: pop
-			IL_0078: rethrow
+			IL_0076: pop
+			IL_0077: rethrow
 
-			IL_007a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_007f: stloc.s 4
-			IL_0081: br IL_0088
+			IL_0079: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_007e: stloc.s 4
+			IL_0080: br IL_0087
 
-			IL_0086: stloc.s 4
+			IL_0085: stloc.s 4
 
-			IL_0088: ldloc.s 4
-			IL_008a: stloc.s 8
-			IL_008c: ldloc.s 8
-			IL_008e: stloc.s 5
-			IL_0090: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L10C12::.ctor()
-			IL_0095: stloc.s 6
-			IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_009c: ldstr "TDZ_CAPTURED"
-			IL_00a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00a6: pop
-			IL_00a7: leave IL_00ac
+			IL_0087: ldloc.s 4
+			IL_0089: stloc.s 8
+			IL_008b: ldloc.s 8
+			IL_008d: stloc.s 5
+			IL_008f: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/Scope/Block_L10C12::.ctor()
+			IL_0094: stloc.s 6
+			IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_009b: ldstr "TDZ_CAPTURED"
+			IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00a5: pop
+			IL_00a6: leave IL_00ab
 		} // end handler
 
-		IL_00ac: ldloc.0
-		IL_00ad: ldstr "ready"
-		IL_00b2: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00b7: ldloc.0
-		IL_00b8: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
-		IL_00bd: ldstr "Cannot access 'value' before initialization"
-		IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_00c7: stloc.s 8
-		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ce: ldloc.s 8
-		IL_00d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d5: pop
-		IL_00d6: ldnull
-		IL_00d7: stloc.s 7
-		IL_00d9: ret
+		IL_00ab: ldloc.0
+		IL_00ac: ldstr "ready"
+		IL_00b1: stfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00b6: ldloc.0
+		IL_00b7: ldfld object Modules.Variable_TemporalDeadZoneCapturedRead/Scope::'value'
+		IL_00bc: ldstr "Cannot access 'value' before initialization"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_00c6: stloc.s 8
+		IL_00c8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00cd: ldloc.s 8
+		IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d4: pop
+		IL_00d5: ldnull
+		IL_00d6: stloc.s 7
+		IL_00d8: ret
 	} // end of method Variable_TemporalDeadZoneCapturedRead::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneCapturedRead

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -18,7 +18,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22d9
+				// Method begins at RVA 0x22d5
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -44,7 +44,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x21f8
+			// Method begins at RVA 0x21f4
 			// Header size: 12
 			// Code size: 125 (0x7d)
 			.maxstack 8
@@ -115,7 +115,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22f4
+				// Method begins at RVA 0x22f0
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -141,7 +141,7 @@
 				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
-			// Method begins at RVA 0x2284
+			// Method begins at RVA 0x2280
 			// Header size: 12
 			// Code size: 64 (0x40)
 			.maxstack 8
@@ -196,7 +196,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22e2
+				// Method begins at RVA 0x22de
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -216,7 +216,7 @@
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
-				// Method begins at RVA 0x22eb
+				// Method begins at RVA 0x22e7
 				// Header size: 1
 				// Code size: 8 (0x8)
 				.maxstack 8
@@ -238,7 +238,7 @@
 		.method public hidebysig specialname rtspecialname 
 			instance void .ctor () cil managed 
 		{
-			// Method begins at RVA 0x22d0
+			// Method begins at RVA 0x22cc
 			// Header size: 1
 			// Code size: 8 (0x8)
 			.maxstack 8
@@ -264,7 +264,7 @@
 	{
 		// Method begins at RVA 0x2050
 		// Header size: 12
-		// Code size: 393 (0x189)
+		// Code size: 392 (0x188)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
@@ -300,127 +300,126 @@
 		IL_0030: stloc.s 8
 		IL_0032: ldloc.s 8
 		IL_0034: stloc.1
-		IL_0035: ldloc.0
-		IL_0036: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_003b: ldnull
-		IL_003c: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_0041: stloc.s 8
-		IL_0043: ldloc.0
-		IL_0044: ldloc.s 8
-		IL_0046: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_004b: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
-		IL_0050: ldstr "prototype"
-		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_005a: ldstr "toString"
-		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0069: stloc.s 8
-		IL_006b: ldloc.s 8
-		IL_006d: ldstr "call"
-		IL_0072: ldloc.0
-		IL_0073: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
-		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
-		IL_007d: stloc.s 8
-		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0084: ldloc.s 8
-		IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008b: pop
+		IL_0035: ldloc.1
+		IL_0036: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0040: stloc.s 8
+		IL_0042: ldloc.0
+		IL_0043: ldloc.s 8
+		IL_0045: stfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
+		IL_004a: call class [System.Runtime]System.Func`3<object[], object, object> [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_Object()
+		IL_004f: ldstr "prototype"
+		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0059: ldstr "toString"
+		IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0068: stloc.s 8
+		IL_006a: ldloc.s 8
+		IL_006c: ldstr "call"
+		IL_0071: ldloc.0
+		IL_0072: ldfld object Modules.WeakRef_Deref_KeptObjects/Scope::ref
+		IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.Object::CallMember1(object, string, object)
+		IL_007c: stloc.s 8
+		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0083: ldloc.s 8
+		IL_0085: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_008a: pop
 		.try
 		{
-			IL_008c: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L15C4::.ctor()
-			IL_0091: stloc.2
-			IL_0092: ldc.r8 123
-			IL_009b: box [System.Runtime]System.Double
-			IL_00a0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
-			IL_00a5: pop
-			IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00ab: ldstr "primitive target threw:"
-			IL_00b0: ldc.i4.0
-			IL_00b1: box [System.Runtime]System.Boolean
-			IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00bb: pop
-			IL_00bc: leave IL_0132
+			IL_008b: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L15C4::.ctor()
+			IL_0090: stloc.2
+			IL_0091: ldc.r8 123
+			IL_009a: box [System.Runtime]System.Double
+			IL_009f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.WeakRef::.ctor(object)
+			IL_00a4: pop
+			IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00aa: ldstr "primitive target threw:"
+			IL_00af: ldc.i4.0
+			IL_00b0: box [System.Runtime]System.Boolean
+			IL_00b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00ba: pop
+			IL_00bb: leave IL_0131
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00c1: stloc.3
-			IL_00c2: ldloc.3
-			IL_00c3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00c8: dup
-			IL_00c9: brtrue IL_00de
+			IL_00c0: stloc.3
+			IL_00c1: ldloc.3
+			IL_00c2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_00c7: dup
+			IL_00c8: brtrue IL_00dd
 
-			IL_00ce: pop
-			IL_00cf: ldloc.3
-			IL_00d0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00d5: dup
-			IL_00d6: brtrue IL_00ea
+			IL_00cd: pop
+			IL_00ce: ldloc.3
+			IL_00cf: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_00d4: dup
+			IL_00d5: brtrue IL_00e9
 
-			IL_00db: pop
-			IL_00dc: rethrow
+			IL_00da: pop
+			IL_00db: rethrow
 
-			IL_00de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00e3: stloc.s 4
-			IL_00e5: br IL_00ec
+			IL_00dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_00e2: stloc.s 4
+			IL_00e4: br IL_00eb
 
-			IL_00ea: stloc.s 4
+			IL_00e9: stloc.s 4
 
-			IL_00ec: ldloc.s 4
-			IL_00ee: stloc.s 8
-			IL_00f0: ldloc.s 8
-			IL_00f2: stloc.s 5
-			IL_00f4: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16::.ctor()
-			IL_00f9: stloc.s 6
-			IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0100: ldstr "primitive target threw:"
-			IL_0105: ldc.i4.1
-			IL_0106: box [System.Runtime]System.Boolean
-			IL_010b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0110: pop
-			IL_0111: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0116: ldstr "primitive target name:"
-			IL_011b: ldloc.s 5
-			IL_011d: ldstr "name"
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0127: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_012c: pop
-			IL_012d: leave IL_0132
+			IL_00eb: ldloc.s 4
+			IL_00ed: stloc.s 8
+			IL_00ef: ldloc.s 8
+			IL_00f1: stloc.s 5
+			IL_00f3: newobj instance void Modules.WeakRef_Deref_KeptObjects/Scope/Block_L18C16::.ctor()
+			IL_00f8: stloc.s 6
+			IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00ff: ldstr "primitive target threw:"
+			IL_0104: ldc.i4.1
+			IL_0105: box [System.Runtime]System.Boolean
+			IL_010a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_010f: pop
+			IL_0110: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0115: ldstr "primitive target name:"
+			IL_011a: ldloc.s 5
+			IL_011c: ldstr "name"
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_012b: pop
+			IL_012c: leave IL_0131
 		} // end handler
 
-		IL_0132: ldc.i4.1
-		IL_0133: newarr [System.Runtime]System.Object
-		IL_0138: dup
-		IL_0139: ldc.i4.0
-		IL_013a: ldloc.0
-		IL_013b: stelem.ref
-		IL_013c: ldc.i4.0
-		IL_013d: ldelem.ref
-		IL_013e: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_0143: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_0149: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
-		IL_014e: ldc.i4.1
-		IL_014f: newarr [System.Runtime]System.Object
-		IL_0154: dup
-		IL_0155: ldc.i4.0
-		IL_0156: ldloc.0
-		IL_0157: stelem.ref
-		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
-		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
-		IL_0162: ldc.i4.0
-		IL_0163: conv.r8
-		IL_0164: ldstr ""
-		IL_0169: ldc.i4.0
-		IL_016a: ldc.i4.1
-		IL_016b: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
-		IL_0175: stloc.s 8
-		IL_0177: ldloc.s 8
-		IL_0179: ldc.i4.0
-		IL_017a: newarr [System.Runtime]System.Object
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
-		IL_0184: pop
-		IL_0185: ldnull
-		IL_0186: stloc.s 7
-		IL_0188: ret
+		IL_0131: ldc.i4.1
+		IL_0132: newarr [System.Runtime]System.Object
+		IL_0137: dup
+		IL_0138: ldc.i4.0
+		IL_0139: ldloc.0
+		IL_013a: stelem.ref
+		IL_013b: ldc.i4.0
+		IL_013c: ldelem.ref
+		IL_013d: castclass Modules.WeakRef_Deref_KeptObjects/Scope
+		IL_0142: ldftn object Modules.WeakRef_Deref_KeptObjects/ArrowFunction_L23C14::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+		IL_0148: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0::.ctor(object, native int)
+		IL_014d: ldc.i4.1
+		IL_014e: newarr [System.Runtime]System.Object
+		IL_0153: dup
+		IL_0154: ldc.i4.0
+		IL_0155: ldloc.0
+		IL_0156: stelem.ref
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::BindArrow(object, object[], object)
+		IL_0161: ldc.i4.0
+		IL_0162: conv.r8
+		IL_0163: ldstr ""
+		IL_0168: ldc.i4.0
+		IL_0169: ldc.i4.1
+		IL_016a: call object [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance(object, float64, string, bool, bool)
+		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype(object)
+		IL_0174: stloc.s 8
+		IL_0176: ldloc.s 8
+		IL_0178: ldc.i4.0
+		IL_0179: newarr [System.Runtime]System.Object
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::setImmediate(object, object[])
+		IL_0183: pop
+		IL_0184: ldnull
+		IL_0185: stloc.s 7
+		IL_0187: ret
 	} // end of method WeakRef_Deref_KeptObjects::__js_module_init__
 
 } // end of class Modules.WeakRef_Deref_KeptObjects
@@ -432,7 +431,7 @@
 	.method public static 
 		void Main () cil managed 
 	{
-		// Method begins at RVA 0x22fd
+		// Method begins at RVA 0x22f9
 		// Header size: 1
 		// Code size: 23 (0x17)
 		.maxstack 8


### PR DESCRIPTION
## Summary
- split the language/function-code snapshot-only updates out of #1341
- keep this PR limited to the three verified snapshot files under tests/Jroc.Test262.Tests/language/function-code

## Testing
- not run (snapshot-only split)