### PR TITLE
test: include test262 generator snapshot tooling

### DIFF
--- a/.github/workflows/update-generator-snapshots.yml
+++ b/.github/workflows/update-generator-snapshots.yml
@@ -79,10 +79,10 @@ jobs:
           set -e
 
           echo "Initial generator test exit code: $test_exit"
-          node scripts/updateVerifiedFiles.js --root tests/Jroc.Tests --generator-only
+          node scripts/updateVerifiedFiles.js --root tests --generator-only
 
-          find tests/Jroc.Tests -name 'GeneratorTests.*.received.txt' -delete
-          find tests/Jroc.Tests -path '*/Snapshots/GeneratorTests.*.verified.txt' -print0 | xargs -r -0 git add --
+          find tests -name 'GeneratorTests.*.received.txt' -delete
+          find tests -path '*/Snapshots/GeneratorTests.*.verified.txt' -print0 | xargs -r -0 git add --
 
           if git diff --cached --quiet; then
             if [ "$test_exit" -ne 0 ]; then
@@ -98,7 +98,9 @@ jobs:
 
       - name: Verify generator tests after snapshot update
         if: steps.update.outputs.changed == 'true'
-        run: dotnet test tests/Jroc.Tests/Jroc.Tests.csproj -c Debug --filter "FullyQualifiedName~.GeneratorTests." --nologo
+        run: |
+          dotnet test tests/Jroc.Tests/Jroc.Tests.csproj -c Debug --filter "FullyQualifiedName~.GeneratorTests." --nologo
+          dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj -c Debug --filter "FullyQualifiedName~.GeneratorTests." --nologo
 
       - name: Commit and push generator snapshots
         if: steps.update.outputs.changed == 'true'

--- a/scripts/runGeneratorTestsAndUpdateFailures.js
+++ b/scripts/runGeneratorTestsAndUpdateFailures.js
@@ -1,5 +1,5 @@
 /*
-Runs generator tests and updates tests/Jroc.Tests/TestResults/failed-tests.txt based on TRX output.
+Runs generator tests and updates per-project failed-tests.txt files based on TRX output.
 
 Usage:
   node scripts/runGeneratorTestsAndUpdateFailures.js
@@ -7,13 +7,13 @@ Usage:
 Options:
   --configuration Debug|Release   (default: Debug)
   --filter <trx filter>           (default: FullyQualifiedName~.GeneratorTests.)
-  --project <path>               (default: tests/Jroc.Tests/Jroc.Tests.csproj)
-  --results <dir>                (default: tests/Jroc.Tests/TestResults)
+  --project <path>               (default: runs both Jroc.Tests and Jroc.Test262.Tests)
+  --results <dir>                (default: sibling TestResults directory for the selected project)
   --trx <filename>               (default: generator.trx)
 
 Exit code:
-  - Mirrors `dotnet test` exit code when possible.
-  - Still writes failed-tests.txt even if tests fail.
+  - Mirrors the first non-zero `dotnet test` exit code when possible.
+  - Still writes failed-tests.txt for each project even if tests fail.
 */
 
 const childProcess = require('node:child_process');
@@ -67,6 +67,35 @@ function parseArgs(argv) {
 
 function ensureDir(dirPath) {
   fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function getDefaultProjectConfigs(repoRoot, trxFileName) {
+  return [
+    {
+      projectPath: path.resolve(repoRoot, path.join('tests', 'Jroc.Tests', 'Jroc.Tests.csproj')),
+      resultsDir: path.resolve(repoRoot, path.join('tests', 'Jroc.Tests', 'TestResults')),
+      trxFileName,
+    },
+    {
+      projectPath: path.resolve(repoRoot, path.join('tests', 'Jroc.Test262.Tests', 'Jroc.Test262.Tests.csproj')),
+      resultsDir: path.resolve(repoRoot, path.join('tests', 'Jroc.Test262.Tests', 'TestResults')),
+      trxFileName,
+    },
+  ];
+}
+
+function getProjectConfigs(repoRoot, args) {
+  if (!args.project && !args.results) {
+    return getDefaultProjectConfigs(repoRoot, args.trx);
+  }
+
+  const projectPath = path.resolve(repoRoot, args.project ?? path.join('tests', 'Jroc.Tests', 'Jroc.Tests.csproj'));
+  const resultsDir = path.resolve(
+    repoRoot,
+    args.results ?? path.join(path.dirname(path.relative(repoRoot, projectPath)), 'TestResults')
+  );
+
+  return [{ projectPath, resultsDir, trxFileName: args.trx }];
 }
 
 function findTrxFile(resultsDir, preferredName) {
@@ -133,53 +162,57 @@ function main() {
     process.exit(0);
   }
 
-  const projectPath = path.resolve(repoRoot, args.project ?? path.join('tests', 'Jroc.Tests', 'Jroc.Tests.csproj'));
-  const resultsDir = path.resolve(repoRoot, args.results ?? path.join('tests', 'Jroc.Tests', 'TestResults'));
-  const trxFileName = args.trx;
+  const projectConfigs = getProjectConfigs(repoRoot, args);
+  let exitCode = 0;
 
-  ensureDir(resultsDir);
+  for (const config of projectConfigs) {
+    ensureDir(config.resultsDir);
 
-  const dotnetArgs = [
-    'test',
-    projectPath,
-    '-c',
-    args.configuration,
-    '--filter',
-    args.filter,
-    '--logger',
-    `trx;LogFileName=${trxFileName}`,
-    '--results-directory',
-    resultsDir,
-  ];
+    const dotnetArgs = [
+      'test',
+      config.projectPath,
+      '-c',
+      args.configuration,
+      '--filter',
+      args.filter,
+      '--logger',
+      `trx;LogFileName=${config.trxFileName}`,
+      '--results-directory',
+      config.resultsDir,
+    ];
 
-  console.log('Running:', 'dotnet ' + dotnetArgs.map((a) => (a.includes(' ') ? `"${a}"` : a)).join(' '));
+    console.log('Running:', 'dotnet ' + dotnetArgs.map((a) => (a.includes(' ') ? `"${a}"` : a)).join(' '));
 
-  const result = childProcess.spawnSync('dotnet', dotnetArgs, {
-    cwd: repoRoot,
-    // Suppress dotnet test output to avoid overwhelming the console (and hanging chat sessions).
-    // We rely on TRX parsing below to report failures.
-    stdio: ['ignore', 'ignore', 'ignore'],
-    shell: false,
-  });
+    const result = childProcess.spawnSync('dotnet', dotnetArgs, {
+      cwd: repoRoot,
+      // Suppress dotnet test output to avoid overwhelming the console (and hanging chat sessions).
+      // We rely on TRX parsing below to report failures.
+      stdio: ['ignore', 'ignore', 'ignore'],
+      shell: false,
+    });
 
-  const trxPath = findTrxFile(resultsDir, trxFileName);
-  if (!trxPath) {
-    console.error('Could not find TRX results under:', resultsDir);
-    process.exit(result.status ?? 1);
+    const trxPath = findTrxFile(config.resultsDir, config.trxFileName);
+    if (!trxPath) {
+      console.error('Could not find TRX results under:', config.resultsDir);
+      process.exit(result.status ?? 1);
+    }
+
+    const trxXml = fs.readFileSync(trxPath, 'utf8');
+    const failedTests = parseFailedTestsFromTrx(trxXml);
+
+    const failedTestsPath = path.join(config.resultsDir, 'failed-tests.txt');
+    writeFailedTestsFile(failedTestsPath, failedTests);
+
+    console.log(`Wrote ${failedTests.length} failing test(s) to: ${failedTestsPath}`);
+    if (result.status !== 0) {
+      console.log(`dotnet test exited with code: ${result.status}`);
+      if (exitCode === 0) {
+        exitCode = result.status ?? 1;
+      }
+    }
   }
 
-  const trxXml = fs.readFileSync(trxPath, 'utf8');
-  const failedTests = parseFailedTestsFromTrx(trxXml);
-
-  const failedTestsPath = path.join(resultsDir, 'failed-tests.txt');
-  writeFailedTestsFile(failedTestsPath, failedTests);
-
-  console.log(`Wrote ${failedTests.length} failing test(s) to: ${failedTestsPath}`);
-  if (result.status !== 0) {
-    console.log(`dotnet test exited with code: ${result.status}`);
-  }
-
-  process.exit(result.status ?? 0);
+  process.exit(exitCode);
 }
 
 main();

--- a/scripts/updateVerifiedFiles.js
+++ b/scripts/updateVerifiedFiles.js
@@ -13,7 +13,8 @@
   - Creates target directories as needed
 
   Defaults:
-  - By default, only GeneratorTests.* received files are updated (GeneratorTests-only mode).
+  - By default, only GeneratorTests.* received files from the generator snapshot projects are updated
+    (GeneratorTests-only mode).
   - Use --all to update all received files across the tree.
 */
 
@@ -44,6 +45,21 @@ function parseArgs(argv) {
         args.root = a;
       }
     }
+
+    function isGeneratorSnapshot(fullPath) {
+      const baseName = path.basename(fullPath).toLowerCase();
+      if (!baseName.startsWith('generatortests.')) {
+        return false;
+      }
+
+      const normalizedPath = fullPath.split(path.sep).join('/');
+      if (!normalizedPath.includes('/tests/')) {
+        return true;
+      }
+
+      return normalizedPath.includes('/tests/Jroc.Tests/')
+        || normalizedPath.includes('/tests/Jroc.Test262.Tests/');
+    }
   }
   return args;
 }
@@ -55,7 +71,8 @@ Options:
   --root, -r <dir>         Root directory to search (default: CWD)
   --verifyRoot <dir>       Alias for --root
   --all, -a                Update all received files (override default GeneratorTests-only)
-  --generator-only, --gen  Update only GeneratorTests.* (default behavior)
+  --generator-only, --gen  Update only GeneratorTests.* under Jroc.Tests / Jroc.Test262.Tests
+                           (default behavior)
   --quiet, -q              Minimal output
   --help, -h               Show help
 `;
@@ -85,6 +102,21 @@ async function* walk(dir) {
       yield fullPath;
     }
   }
+}
+
+function isGeneratorSnapshot(fullPath) {
+  const baseName = path.basename(fullPath).toLowerCase();
+  if (!baseName.startsWith('generatortests.')) {
+    return false;
+  }
+
+  const normalizedPath = fullPath.split(path.sep).join('/');
+  if (!normalizedPath.includes('/tests/')) {
+    return true;
+  }
+
+  return normalizedPath.includes('/tests/Jroc.Tests/')
+    || normalizedPath.includes('/tests/Jroc.Test262.Tests/');
 }
 
 function toVerifiedPath(fullPath) {
@@ -129,11 +161,7 @@ async function main() {
   // Default filter: only GeneratorTests.* snapshots unless --all specified
   let filtered = receivedFiles;
   if (args.generatorOnly) {
-    filtered = receivedFiles.filter((f) => {
-      const bn = path.basename(f).toLowerCase();
-      // Example: GeneratorTests.PerfHooks_PerformanceNow_Basic.received.txt
-      return bn.startsWith('generatortests.');
-    });
+    filtered = receivedFiles.filter((f) => isGeneratorSnapshot(f));
     if (!args.quiet) {
       console.log(`GeneratorTests-only mode: ${filtered.length} of ${receivedFiles.length} received files will be updated.`);
     }


### PR DESCRIPTION
## Summary
- teach the generator test runner to cover both Jroc.Tests and Jroc.Test262.Tests by default
- update the verified-file updater and generator snapshot workflow to scan both generator snapshot projects
- verify the multi-project generator tooling flow locally

## Testing
- node scripts/runGeneratorTestsAndUpdateFailures.js --trx generator-smoke.trx --filter "FullyQualifiedName~Jroc.Test262.Tests.Integration.GeneratorTests|FullyQualifiedName~Jroc.Tests.Function.GeneratorTests"
- node scripts/updateVerifiedFiles.js --root <temp fixture> --generator-only
