### PR TITLE
ci: use master generator snapshot tooling

### DIFF
--- a/.github/workflows/update-generator-snapshots.yml
+++ b/.github/workflows/update-generator-snapshots.yml
@@ -68,18 +68,28 @@ jobs:
           dotnet tool restore
           dotnet restore
 
+      - name: Load generator snapshot tooling from master
+        run: |
+          set -euo pipefail
+
+          tooling_dir="$RUNNER_TEMP/generator-snapshot-tooling"
+          mkdir -p "$tooling_dir"
+
+          git show origin/master:scripts/runGeneratorTestsAndUpdateFailures.js > "$tooling_dir/runGeneratorTestsAndUpdateFailures.js"
+          git show origin/master:scripts/updateVerifiedFiles.js > "$tooling_dir/updateVerifiedFiles.js"
+
       - name: Run generator tests and update generator snapshots
         id: update
         run: |
           set -euo pipefail
 
           set +e
-          node scripts/runGeneratorTestsAndUpdateFailures.js
+          node "$RUNNER_TEMP/generator-snapshot-tooling/runGeneratorTestsAndUpdateFailures.js"
           test_exit=$?
           set -e
 
           echo "Initial generator test exit code: $test_exit"
-          node scripts/updateVerifiedFiles.js --root tests --generator-only
+          node "$RUNNER_TEMP/generator-snapshot-tooling/updateVerifiedFiles.js" --root tests --generator-only
 
           find tests -name 'GeneratorTests.*.received.txt' -delete
           find tests -path '*/Snapshots/GeneratorTests.*.verified.txt' -print0 | xargs -r -0 git add --


### PR DESCRIPTION
## Summary
- make update-generator-snapshots load its helper scripts from origin/master after checking out the PR branch
- ensure workflow_dispatch runs use the latest generator snapshot tooling even for older PR branches
- prevent stale branch-local script copies from silently skipping Jroc.Test262.Tests generator snapshots

## Testing
- investigated the successful workflow-dispatch run against PR #1347 and confirmed it executed the PR branch''s old one-project script copies after checkout
