### PR TITLE
fix(ci): resolve generator snapshot tooling repo root

### DIFF
--- a/.github/workflows/update-generator-snapshots.yml
+++ b/.github/workflows/update-generator-snapshots.yml
@@ -83,6 +83,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          export JROC_REPO_ROOT="$GITHUB_WORKSPACE"
+
           set +e
           node "$RUNNER_TEMP/generator-snapshot-tooling/runGeneratorTestsAndUpdateFailures.js"
           test_exit=$?

--- a/scripts/runGeneratorTestsAndUpdateFailures.js
+++ b/scripts/runGeneratorTestsAndUpdateFailures.js
@@ -141,8 +141,33 @@ function writeFailedTestsFile(outputPath, failedTests) {
   fs.writeFileSync(outputPath, content, 'utf8');
 }
 
+function looksLikeRepoRoot(candidate) {
+  if (!candidate) return false;
+
+  const normalized = path.resolve(candidate);
+  return fs.existsSync(path.join(normalized, 'tests', 'Jroc.Tests', 'Jroc.Tests.csproj'))
+    && fs.existsSync(path.join(normalized, 'tests', 'Jroc.Test262.Tests', 'Jroc.Test262.Tests.csproj'));
+}
+
+function resolveRepoRoot() {
+  const candidates = [
+    process.env.JROC_REPO_ROOT,
+    process.env.GITHUB_WORKSPACE,
+    process.cwd(),
+    path.resolve(__dirname, '..'),
+  ];
+
+  for (const candidate of candidates) {
+    if (looksLikeRepoRoot(candidate)) {
+      return path.resolve(candidate);
+    }
+  }
+
+  return path.resolve(__dirname, '..');
+}
+
 function main() {
-  const repoRoot = path.resolve(__dirname, '..');
+  const repoRoot = resolveRepoRoot();
   const args = parseArgs(process.argv.slice(2));
 
   if (args.help) {


### PR DESCRIPTION
## Summary
- fix generator snapshot helper path resolution when the script is loaded from \\\
- add robust repo-root detection in \scripts/runGeneratorTestsAndUpdateFailures.js\ (prefers \JROC_REPO_ROOT\, \GITHUB_WORKSPACE\, then cwd)
- export \JROC_REPO_ROOT=\\ in the update-generator-snapshots workflow step so temp-loaded tooling always resolves the repository correctly

## Why
The workflow job failed because the helper script used \__dirname\ to infer repo root while running from temp, so it attempted to run tests under \/home/runner/work/_temp/tests/...\ instead of the checked-out repository.
